### PR TITLE
fix variable name

### DIFF
--- a/examples/question-answering/run_qa.py
+++ b/examples/question-answering/run_qa.py
@@ -781,7 +781,7 @@ def main():
         )
 
         # Creation Distillation object used for IncTrainer training loop
-        distillation = IncDistiller(
+        distiller = IncDistiller(
             teacher_model=teacher_model, config=distillation_config, eval_func=eval_func, train_func=train_func
         )
 


### PR DESCRIPTION
The variable name of distillation should be distiller, otherwise the distiller parameter in optimizer would be a none parameter.

@echarlaix 