### PR TITLE
Remove warnings when loading a quantized model

### DIFF
--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -247,6 +247,11 @@ class IncQuantizedModel:
             r"constant",
             r"module",
             r"best_configure",
+            r"max_val",
+            r"min_val",
+            r"fake_quant_enabled",
+            r"eps",
+            r"observer_enabled",
         ]
         if keys_to_ignore_on_load_unexpected is None:
             model_class._keys_to_ignore_on_load_unexpected = quantized_keys_to_ignore_on_load

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -249,8 +249,8 @@ class IncQuantizedModel:
             r"best_configure",
             r"max_val",
             r"min_val",
-            r"fake_quant_enabled",
             r"eps",
+            r"fake_quant_enabled",
             r"observer_enabled",
         ]
         if keys_to_ignore_on_load_unexpected is None:


### PR DESCRIPTION
This PR disable unuseful warnings appearing when loading a quantized model.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

