### PR TITLE
Add option to use cache fo seq2seq models

### DIFF
--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -167,16 +167,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         config = PretrainedConfig.from_dict(config_dict)
         local_files_only = kwargs.pop("local_files_only", False)
         use_cache = kwargs.pop("use_cache", True)
-        # TODO: Remove with next openvino release
-        if use_cache:
-            logger.warning(
-                "The `use_cache` argument is changed to `False`, its support will be enabled in the next release."
-            )
-            use_cache = False
         default_encoder_file_name = ONNX_ENCODER_NAME if from_onnx else OV_ENCODER_NAME
         default_decoder_file_name = ONNX_DECODER_NAME if from_onnx else OV_DECODER_NAME
         default_decoder_with_past_file_name = ONNX_DECODER_WITH_PAST_NAME if from_onnx else OV_DECODER_WITH_PAST_NAME
-
         encoder_file_name = encoder_file_name or default_encoder_file_name
         decoder_file_name = decoder_file_name or default_decoder_file_name
         decoder_with_past_file_name = decoder_with_past_file_name or default_decoder_with_past_file_name

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ QUALITY_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     "neural-compressor": "neural-compressor",
-    "openvino": "openvino",
+    "openvino": "openvino>=2022.2.0",
     "quality": QUALITY_REQUIRES,
     "tests": TESTS_REQUIRE,
 }

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -403,14 +403,13 @@ class OVModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
-    # TODO : Add test after use_cache support
-    # def test_compare_with_and_without_past_key_values_model_outputs(self):
-    #     model_id = MODEL_NAMES["t5"]
-    #     tokenizer = AutoTokenizer.from_pretrained(model_id)
-    #     text = "This is a sample input"
-    #     tokens = tokenizer(text, return_tensors="pt")
-    #     model_with_pkv = OVModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True, use_cache=True)
-    #     outputs_model_with_pkv = model_with_pkv.generate(**tokens)
-    #     model_without_pkv = OVModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True, use_cache=False)
-    #     outputs_model_without_pkv = model_without_pkv.generate(**tokens)
-    #     self.assertTrue(torch.equal(outputs_model_with_pkv, outputs_model_without_pkv))
+    def test_compare_with_and_without_past_key_values_model_outputs(self):
+        model_id = MODEL_NAMES["t5"]
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        text = "This is a sample input"
+        tokens = tokenizer(text, return_tensors="pt")
+        model_with_pkv = OVModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True, use_cache=True)
+        outputs_model_with_pkv = model_with_pkv.generate(**tokens)
+        model_without_pkv = OVModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True, use_cache=False)
+        outputs_model_without_pkv = model_without_pkv.generate(**tokens)
+        self.assertTrue(torch.equal(outputs_model_with_pkv, outputs_model_without_pkv))


### PR DESCRIPTION
In this PR we enable the `use_cache` option for `OVSeq2SeqModel`'s where an extra decoder with pre-computed key/values as one of its inputs is exported, allowing the usage of the pre-computed key/values hidden-states 

