### PR TITLE
Pass config_file_name to IncQuantizationConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ def eval_func(model):
 
 # Load the quantization configuration detailing the quantization we wish to apply
 config_path = "echarlaix/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic"
-quantization_config = IncQuantizationConfig.from_pretrained(config_path)
+quantization_config = IncQuantizationConfig.from_pretrained(
+    config_path, config_file_name="quantization.yml"
+)
 
 # Instantiate our IncQuantizer using the desired configuration and the evaluation function used
 # for the INC accuracy-driven tuning strategy

--- a/docs/source/optimization.mdx
+++ b/docs/source/optimization.mdx
@@ -37,7 +37,9 @@ def eval_func(model):
 
 # Load the quantization configuration detailing the quantization we wish to apply
 config_name_or_path = "echarlaix/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic"
-quantization_config = IncQuantizationConfig.from_pretrained(config_name_or_path)
+quantization_config = IncQuantizationConfig.from_pretrained(
+    config_name_or_path, config_file_name="quantization.yml"
+)
 
 # Instantiate our IncQuantizer using the desired configuration and the evaluation function used
 # for the INC accuracy-driven tuning strategy

--- a/docs/source/quickstart.mdx
+++ b/docs/source/quickstart.mdx
@@ -42,7 +42,9 @@ def eval_func(model):
 
 # Load the quantization configuration detailing the quantization we wish to apply
 config_path = "echarlaix/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic"
-quantization_config = IncQuantizationConfig.from_pretrained(config_path)
+quantization_config = IncQuantizationConfig.from_pretrained(
+    config_path, config_file_name="quantization.yml"
+)
 
 # Instantiate our IncQuantizer using the desired configuration and the evaluation function used
 # for the INC accuracy-driven tuning strategy


### PR DESCRIPTION
There is no `best_configure.yaml` file in `echarlaix/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic`. It does have [quantization.yml](https://huggingface.co/echarlaix/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic/tree/main) though. The default value for the `config_file_name` comes from [here](https://github.com/huggingface/optimum-intel/blob/main/optimum/intel/neural_compressor/utils.py#L25).

References https://github.com/huggingface/optimum-intel/pull/55

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

