### PR TITLE
Fix internal links in example README files

### DIFF
--- a/examples/neural_compressor/language-modeling/README.md
+++ b/examples/neural_compressor/language-modeling/README.md
@@ -16,8 +16,8 @@ limitations under the License.
 
 # Language modeling training
 
-The scripts [`run_clm.py`](https://github.com/huggingface/optimum/blob/main/examples/language-modeling/run_clm.py) 
-and [`run_mlm.py`](https://github.com/huggingface/optimum/blob/main/examples/language-modeling/run_mlm.py)
+The scripts [`run_clm.py`](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/language-modeling/run_clm.py) 
+and [`run_mlm.py`](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/language-modeling/run_mlm.py)
 allow us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor ](https://github.com/intel/neural-compressor) library for language modeling tasks.
 
@@ -75,8 +75,8 @@ respectively `dynamic`, `static` or `aware_training`.
 
 The configuration file containing all the information related to the model quantization and pruning objectives can be 
 specified using respectively `quantization_config` and `pruning_config`. If not specified, the default
-[quantization](https://github.com/huggingface/optimum/blob/main/examples/config/quantization.yml) 
-and [pruning](https://github.com/huggingface/optimum/blob/main/examples/config/prune.yml) 
+[quantization](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/quantization.yml) 
+and [pruning](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/prune.yml) 
 config files will be used.
 
 The flag `--verify_loading` can be passed along to verify that the resulting quantized model can be loaded correctly.

--- a/examples/neural_compressor/multiple-choice/README.md
+++ b/examples/neural_compressor/multiple-choice/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Multiple choice 
 
-The script [`run_swag.py`](https://github.com/huggingface/optimum/blob/main/examples/multiple-choice/run_swag.py) 
+The script [`run_swag.py`](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/multiple-choice/run_swag.py) 
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor ](https://github.com/intel/neural-compressor) library for 
 multiple choice tasks.
@@ -70,9 +70,9 @@ respectively `dynamic`, `static` or `aware_training`.
 
 The configuration file containing all the information related to the model quantization, distillation and pruning objectives can be 
 specified using respectively `quantization_config`, `distillation_config` and `pruning_config`. If not specified, the default
-[quantization](https://github.com/huggingface/optimum/blob/main/examples/config/quantization.yml),
-[distillation](https://github.com/huggingface/optimum/blob/main/examples/config/distillation.yml),
-and [pruning](https://github.com/huggingface/optimum/blob/main/examples/config/prune.yml) 
+[quantization](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/quantization.yml),
+[distillation](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/distillation.yml),
+and [pruning](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/prune.yml) 
 configuration files will be used.
 
 The flag `--verify_loading` can be passed along to verify that the resulting quantized model can be loaded correctly.

--- a/examples/neural_compressor/question-answering/README.md
+++ b/examples/neural_compressor/question-answering/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 # Question answering
 
 
-The script [`run_qa.py`](https://github.com/huggingface/optimum/blob/main/examples/question-answering/run_qa.py)
+The script [`run_qa.py`](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/question-answering/run_qa.py)
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor ](https://github.com/intel/neural-compressor) library for
 question answering tasks.
@@ -77,9 +77,9 @@ respectively `dynamic`, `static` or `aware_training`.
 
 The configuration file containing all the information related to the model quantization, distillation and pruning objectives can be 
 specified using respectively `quantization_config`, `distillation_config` and `pruning_config`. If not specified, the default
-[quantization](https://github.com/huggingface/optimum/blob/main/examples/config/quantization.yml),
-[distillation](https://github.com/huggingface/optimum/blob/main/examples/config/distillation.yml),
-and [pruning](https://github.com/huggingface/optimum/blob/main/examples/config/prune.yml) 
+[quantization](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/quantization.yml),
+[distillation](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/distillation.yml),
+and [pruning](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/prune.yml) 
 configuration files will be used.
 
 The flag `--verify_loading` can be passed along to verify that the resulting quantized model can be loaded correctly.

--- a/examples/neural_compressor/summarization/README.md
+++ b/examples/neural_compressor/summarization/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Summarization
 
-The script [`run_summarization.py`](https://github.com/huggingface/optimum/blob/main/examples/summarization/run_summarization.py)
+The script [`run_summarization.py`](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/summarization/run_summarization.py)
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor (INC)](https://github.com/intel/neural-compressor) library for summarization tasks.
 
@@ -68,8 +68,8 @@ respectively `dynamic`, `static` or `aware_training`.
 
 The configuration file containing all the information related to the model quantization and pruning objectives can be 
 specified using respectively `quantization_config` and `pruning_config`. If not specified, the default
-[quantization](https://github.com/huggingface/optimum/blob/main/examples/config/quantization.yml),
-and [pruning](https://github.com/huggingface/optimum/blob/main/examples/config/prune.yml) 
+[quantization](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/quantization.yml),
+and [pruning](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/prune.yml) 
 configuration files will be used.
 
 The flag `--verify_loading` can be passed along to verify that the resulting quantized model can be loaded correctly.

--- a/examples/neural_compressor/text-classification/README.md
+++ b/examples/neural_compressor/text-classification/README.md
@@ -18,7 +18,7 @@ limitations under the License.
 
 ## GLUE tasks
 
-The script [`run_glue.py`](https://github.com/huggingface/optimum/blob/main/examples/text-classification/run_glue.py)
+The script [`run_glue.py`](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/text-classification/run_glue.py)
 allows us to apply different quantization approaches (such as dynamic, static and quantization-aware training) as well as pruning 
 using the [Intel Neural Compressor ](https://github.com/intel/neural-compressor) library for 
 sequence classification tasks such as the ones from the [GLUE benchmark](https://gluebenchmark.com/).
@@ -75,9 +75,9 @@ respectively `dynamic`, `static` or `aware_training`.
 
 The configuration file containing all the information related to the model quantization, distillation and pruning objectives can be 
 specified using respectively `quantization_config`, `distillation_config` and `pruning_config`. If not specified, the default
-[quantization](https://github.com/huggingface/optimum/blob/main/examples/config/quantization.yml),
-[distillation](https://github.com/huggingface/optimum/blob/main/examples/config/distillation.yml),
-and [pruning](https://github.com/huggingface/optimum/blob/main/examples/config/prune.yml) 
+[quantization](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/quantization.yml),
+[distillation](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/distillation.yml),
+and [pruning](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/prune.yml) 
 configuration files will be used.
 
 The flag `--verify_loading` can be passed along to verify that the resulting quantized model can be loaded correctly.

--- a/examples/neural_compressor/text-classification/README.md
+++ b/examples/neural_compressor/text-classification/README.md
@@ -19,7 +19,7 @@ limitations under the License.
 ## GLUE tasks
 
 The script [`run_glue.py`](https://github.com/huggingface/optimum/blob/main/examples/text-classification/run_glue.py)
-allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
+allows us to apply different quantization approaches (such as dynamic, static and quantization-aware training) as well as pruning 
 using the [Intel Neural Compressor ](https://github.com/intel/neural-compressor) library for 
 sequence classification tasks such as the ones from the [GLUE benchmark](https://gluebenchmark.com/).
 

--- a/examples/neural_compressor/token-classification/README.md
+++ b/examples/neural_compressor/token-classification/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 # Token classification
 
 
-The script [`run_ner.py`](https://github.com/huggingface/optimum/blob/main/examples/token-classification/run_ner.py)
+The script [`run_ner.py`](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/token-classification/run_ner.py)
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning
 using the [Intel Neural Compressor ](https://github.com/intel/neural-compressor) library for token classification tasks.
 
@@ -72,9 +72,9 @@ In order to apply dynamic, static or aware-training quantization, `quantization_
 
 The configuration file containing all the information related to the model quantization, distillation and pruning objectives can be 
 specified using respectively `quantization_config`, `distillation_config` and `pruning_config`. If not specified, the default
-[quantization](https://github.com/huggingface/optimum/blob/main/examples/config/quantization.yml),
-[distillation](https://github.com/huggingface/optimum/blob/main/examples/config/distillation.yml),
-and [pruning](https://github.com/huggingface/optimum/blob/main/examples/config/prune.yml) 
+[quantization](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/quantization.yml),
+[distillation](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/distillation.yml),
+and [pruning](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/prune.yml) 
 configuration files will be used.
 
 The flag `--verify_loading` can be passed along to verify that the resulting quantized model can be loaded correctly.

--- a/examples/neural_compressor/translation/README.md
+++ b/examples/neural_compressor/translation/README.md
@@ -16,7 +16,7 @@ limitations under the License.
 
 # Translation
 
-The script [`run_translation.py`](https://github.com/huggingface/optimum/blob/main/examples/translation/run_translation.py)
+The script [`run_translation.py`](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/translation/run_translation.py)
 allows us to apply different quantization approaches (such as dynamic, static and aware-training quantization) as well as pruning 
 using the [Intel Neural Compressor (INC)](https://github.com/intel/neural-compressor) library for translation tasks.
 
@@ -75,8 +75,8 @@ respectively `dynamic`, `static` or `aware_training`.
 
 The configuration file containing all the information related to the model quantization and pruning objectives can be 
 specified using respectively `quantization_config` and `pruning_config`. If not specified, the default
-[quantization](https://github.com/huggingface/optimum/blob/main/examples/config/quantization.yml),
-and [pruning](https://github.com/huggingface/optimum/blob/main/examples/config/prune.yml) 
+[quantization](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/quantization.yml),
+and [pruning](https://github.com/huggingface/optimum-intel/blob/main/examples/neural_compressor/config/prune.yml) 
 configuration files will be used.
 
 The flag `--verify_loading` can be passed along to verify that the resulting quantized model can be loaded correctly.


### PR DESCRIPTION
This repository was renamed or split from the huggingface/optimum and the examples were moved into a subdirectory. This has broken the links to the scripts and configuration files. This PR fixes that as well as performs one small text substitution.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

