### PR TITLE
Make do_train optional for static quantization

### DIFF
--- a/examples/neural_compressor/language-modeling/run_clm.py
+++ b/examples/neural_compressor/language-modeling/run_clm.py
@@ -299,6 +299,9 @@ def main():
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
 
+    if optim_args.apply_quantization and optim_args.quantization_approach == "static":
+        training_args.do_train = True
+
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
@@ -604,7 +607,7 @@ def main():
         # dynamic quantization will be added when torch FX is more mature
         if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
-                raise ValueError("do_train must be set to True for static and aware training quantization.")
+                raise ValueError("do_train must be set to True for quantization aware training.")
 
             q8_config.set_config("model.framework", "pytorch_fx")
 

--- a/examples/neural_compressor/language-modeling/run_mlm.py
+++ b/examples/neural_compressor/language-modeling/run_mlm.py
@@ -309,6 +309,9 @@ def main():
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
 
+    if optim_args.apply_quantization and optim_args.quantization_approach == "static":
+        training_args.do_train = True
+
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
@@ -640,7 +643,7 @@ def main():
         # dynamic quantization will be added when torch FX is more mature
         if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
-                raise ValueError("do_train must be set to True for static and aware training quantization.")
+                raise ValueError("do_train must be set to True for quantization aware training.")
 
             q8_config.set_config("model.framework", "pytorch_fx")
 

--- a/examples/neural_compressor/multiple-choice/README.md
+++ b/examples/neural_compressor/multiple-choice/README.md
@@ -28,7 +28,6 @@ python run_swag.py \
     --model_name_or_path ehdwns1516/bert-base-uncased_SWAG \
     --apply_quantization \
     --quantization_approach static \
-    --do_train \
     --do_eval \
     --verify_loading \
     --output_dir /tmp/swag_output

--- a/examples/neural_compressor/multiple-choice/run_swag.py
+++ b/examples/neural_compressor/multiple-choice/run_swag.py
@@ -328,6 +328,9 @@ def main():
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
 
+    if optim_args.apply_quantization and optim_args.quantization_approach == "static":
+        training_args.do_train = True
+
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
@@ -552,7 +555,8 @@ def main():
         # dynamic quantization will be added when torch FX is more mature
         if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
-                raise ValueError("do_train must be set to True for static and aware training quantization.")
+                raise ValueError("do_train must be set to True for quantization aware training.")
+
             q8_config.set_config("model.framework", "pytorch_fx")
 
         calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None

--- a/examples/neural_compressor/question-answering/README.md
+++ b/examples/neural_compressor/question-answering/README.md
@@ -33,7 +33,6 @@ python run_qa.py \
     --dataset_name squad \
     --apply_quantization \
     --quantization_approach static \
-    --do_train \
     --do_eval \
     --verify_loading \
     --output_dir /tmp/squad_output

--- a/examples/neural_compressor/question-answering/run_qa.py
+++ b/examples/neural_compressor/question-answering/run_qa.py
@@ -336,6 +336,9 @@ def main():
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
 
+    if optim_args.apply_quantization and optim_args.quantization_approach == "static":
+        training_args.do_train = True
+
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
@@ -806,7 +809,7 @@ def main():
         # dynamic quantization will be added when torch FX is more mature
         if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
-                raise ValueError("do_train must be set to True for static and aware training quantization.")
+                raise ValueError("do_train must be set to True for quantization aware training.")
 
             q8_config.set_config("model.framework", "pytorch_fx")
 

--- a/examples/neural_compressor/summarization/README.md
+++ b/examples/neural_compressor/summarization/README.md
@@ -30,7 +30,6 @@ python run_summarization.py \
     --apply_quantization \
     --quantization_approach static
     --tolerance_criterion 0.1 \
-    --do_train \
     --do_eval \
     --verify_loading \
     --predict_with_generate \

--- a/examples/neural_compressor/summarization/run_summarization.py
+++ b/examples/neural_compressor/summarization/run_summarization.py
@@ -414,6 +414,9 @@ def main():
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
 
+    if optim_args.apply_quantization and optim_args.quantization_approach == "static":
+        training_args.do_train = True
+
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
@@ -784,7 +787,8 @@ def main():
         # dynamic quantization will be added when torch FX is more mature
         if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
-                raise ValueError("do_train must be set to True for static and aware training quantization.")
+                raise ValueError("do_train must be set to True for quantization aware training.")
+
             q8_config.set_config("model.framework", "pytorch_fx")
 
         calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None

--- a/examples/neural_compressor/text-classification/README.md
+++ b/examples/neural_compressor/text-classification/README.md
@@ -31,7 +31,6 @@ python run_glue.py \
     --task_name sst2 \
     --apply_quantization \
     --quantization_approach static \
-    --do_train \
     --do_eval \
     --verify_loading \
     --output_dir /tmp/sst2_output

--- a/examples/neural_compressor/text-classification/run_glue.py
+++ b/examples/neural_compressor/text-classification/run_glue.py
@@ -314,6 +314,9 @@ def main():
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
 
+    if optim_args.apply_quantization and optim_args.quantization_approach == "static":
+        training_args.do_train = True
+
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
@@ -612,7 +615,7 @@ def main():
         # dynamic quantization will be added when torch FX is more mature
         if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
-                raise ValueError("do_train must be set to True for static and aware training quantization.")
+                raise ValueError("do_train must be set to True for quantization aware training.")
 
             q8_config.set_config("model.framework", "pytorch_fx")
 

--- a/examples/neural_compressor/token-classification/README.md
+++ b/examples/neural_compressor/token-classification/README.md
@@ -22,13 +22,13 @@ allows us to apply different quantization approaches (such as dynamic, static an
 using the [Intel Neural Compressor ](https://github.com/intel/neural-compressor) library for token classification tasks.
 
 The following example applies post-training static quantization on a DistilBERT fine-tuned on the CoNLL-2003 task.
+
 ```bash
 python run_ner.py \
     --model_name_or_path elastic/distilbert-base-uncased-finetuned-conll03-english \
     --dataset_name conll2003 \
     --apply_quantization \
     --quantization_approach static \
-    --do_train \
     --do_eval \
     --verify_loading \
     --output_dir /tmp/conll03_output

--- a/examples/neural_compressor/token-classification/run_ner.py
+++ b/examples/neural_compressor/token-classification/run_ner.py
@@ -311,6 +311,9 @@ def main():
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
 
+    if optim_args.apply_quantization and optim_args.quantization_approach == "static":
+        training_args.do_train = True
+
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
@@ -651,7 +654,8 @@ def main():
         # dynamic quantization will be added when torch FX is more mature
         if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
-                raise ValueError("do_train must be set to True for static and aware training quantization.")
+                raise ValueError("do_train must be set to True for quantization aware training.")
+
             q8_config.set_config("model.framework", "pytorch_fx")
 
         calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None

--- a/examples/neural_compressor/translation/README.md
+++ b/examples/neural_compressor/translation/README.md
@@ -33,7 +33,6 @@ python run_translation.py \
     --apply_quantization \
     --quantization_approach static \
     --tolerance_criterion 0.7 \
-    --do_train \
     --do_eval \
     --verify_loading \
     --predict_with_generate \
@@ -42,8 +41,7 @@ python run_translation.py \
     --output_dir /tmp/test_translation
 ```
 
-The following example fine-tunes a T5 model on the wmt16 dataset while applying magnitude pruning and then applies 
-dynamic quantization as a second step.
+The following example fine-tunes a T5 model on the wmt16 dataset while applying magnitude pruning and then applies dynamic quantization as a second step.
 
 ```bash
 

--- a/examples/neural_compressor/translation/run_translation.py
+++ b/examples/neural_compressor/translation/run_translation.py
@@ -372,6 +372,9 @@ def main():
                 "the `--output_dir` or add `--overwrite_output_dir` to train from scratch."
             )
 
+    if optim_args.apply_quantization and optim_args.quantization_approach == "static":
+        training_args.do_train = True
+
     # Set seed before initializing model.
     set_seed(training_args.seed)
 
@@ -709,7 +712,8 @@ def main():
         # dynamic quantization will be added when torch FX is more mature
         if quant_approach != IncQuantizationMode.DYNAMIC:
             if not training_args.do_train:
-                raise ValueError("do_train must be set to True for static and aware training quantization.")
+                raise ValueError("do_train must be set to True for quantization aware training.")
+
             q8_config.set_config("model.framework", "pytorch_fx")
 
         calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None


### PR DESCRIPTION
In this PR we make the flag `do_train` optional in the examples scripts for static quantization in order to improve clarity 