### PR TITLE
Support PyTorch1.13 and above

### DIFF
--- a/examples/neural_compressor/language-modeling/run_clm.py
+++ b/examples/neural_compressor/language-modeling/run_clm.py
@@ -608,7 +608,7 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(
             q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/neural_compressor/language-modeling/run_mlm.py
+++ b/examples/neural_compressor/language-modeling/run_mlm.py
@@ -644,7 +644,7 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(
             q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/neural_compressor/multiple-choice/run_swag.py
+++ b/examples/neural_compressor/multiple-choice/run_swag.py
@@ -555,7 +555,7 @@ def main():
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(
             q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/neural_compressor/question-answering/run_qa.py
+++ b/examples/neural_compressor/question-answering/run_qa.py
@@ -810,7 +810,7 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(
             q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/neural_compressor/summarization/run_summarization.py
+++ b/examples/neural_compressor/summarization/run_summarization.py
@@ -787,7 +787,7 @@ def main():
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(
             q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/neural_compressor/text-classification/run_glue.py
+++ b/examples/neural_compressor/text-classification/run_glue.py
@@ -616,7 +616,7 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(
             q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/neural_compressor/token-classification/run_ner.py
+++ b/examples/neural_compressor/token-classification/run_ner.py
@@ -654,7 +654,7 @@ def main():
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(
             q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/examples/neural_compressor/translation/run_translation.py
+++ b/examples/neural_compressor/translation/run_translation.py
@@ -712,7 +712,7 @@ def main():
                 raise ValueError("do_train must be set to True for static and aware training quantization.")
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach == IncQuantizationMode.STATIC else None
+        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(
             q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
         )

--- a/optimum/intel/neural_compressor/optimization.py
+++ b/optimum/intel/neural_compressor/optimization.py
@@ -62,7 +62,7 @@ class IncOptimizer:
             train_func (`Callable`, *optional*):
                 Training function which will be combined with pruning.
         """
-        self.config = model.config if hasattr(model, "config") else None
+        self.config = getattr(model, "config", None)
         self.scheduler = Scheduler()
         self.scheduler.model = common.Model(model)
         self._model = None

--- a/optimum/intel/neural_compressor/optimization.py
+++ b/optimum/intel/neural_compressor/optimization.py
@@ -17,7 +17,7 @@ import os
 from typing import Callable, Optional, Union
 
 import torch
-from transformers import AutoModel, PreTrainedModel
+from transformers import AutoModel, PretrainedConfig, PreTrainedModel
 
 from neural_compressor.experimental import Pruning, Quantization, common
 from neural_compressor.experimental.scheduler import Scheduler
@@ -139,7 +139,7 @@ class IncOptimizer:
             return
 
         os.makedirs(save_directory, exist_ok=True)
-        if isinstance(self.config, PretrainedConfig)
+        if isinstance(self.config, PretrainedConfig):
             self.config.save_pretrained(save_directory)
         state_dict = self._model.model.state_dict()
         if hasattr(self._model, "q_config"):

--- a/optimum/intel/neural_compressor/optimization.py
+++ b/optimum/intel/neural_compressor/optimization.py
@@ -139,7 +139,7 @@ class IncOptimizer:
             return
 
         os.makedirs(save_directory, exist_ok=True)
-        if hasattr(self.config, "save_pretrained"):
+        if isinstance(self.config, PretrainedConfig)
             self.config.save_pretrained(save_directory)
         state_dict = self._model.model.state_dict()
         if hasattr(self._model, "q_config"):

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -113,7 +113,8 @@ class IncQuantizer:
                 raise ValueError("train_func must be provided for quantization aware training.")
             self.quantization.q_func = self.train_func
             if version.release >= Version("1.13.0").release:
-                assert self.calib_dataloader is not None, "calib_dataloader must be provided for PyTorch1.13 or above."
+                if self.calib_dataloader is None:
+                    raise ValueError("calib_dataloader must be provided for PyTorch1.13 or above.")
                 self.quantization._calib_dataloader = self.calib_dataloader
 
 

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Callable, ClassVar, Dict, Optional, Union
 
 import torch
+from packaging.version import Version
 from torch.quantization import add_observer_, convert
 from torch.quantization.quantize_fx import convert_fx, prepare_fx, prepare_qat_fx
 from torch.utils.data import DataLoader
@@ -41,7 +42,7 @@ from transformers.utils.versions import require_version
 
 import neural_compressor
 from huggingface_hub import hf_hub_download
-from neural_compressor.adaptor.pytorch import PyTorch_FXAdaptor, _cfg_to_qconfig, _propagate_qconfig
+from neural_compressor.adaptor.pytorch import PyTorch_FXAdaptor, _cfg_to_qconfig, _propagate_qconfig, get_torch_version
 from neural_compressor.adaptor.torch_utils.util import get_embedding_contiguous
 from neural_compressor.conf.config import Quantization_Conf
 from neural_compressor.experimental import Quantization
@@ -90,6 +91,7 @@ class IncQuantizer:
         self.approach = IncQuantizationMode(self.config.usr_cfg.quantization.approach)
         self.eval_func = eval_func
         self.train_func = train_func
+        version = get_torch_version()
         if calib_dataloader is not None:
             calib_dataloader = IncDataLoader.from_pytorch_dataloader(calib_dataloader)
         self.calib_dataloader = calib_dataloader
@@ -110,6 +112,9 @@ class IncQuantizer:
             if self.train_func is None:
                 raise ValueError("train_func must be provided for quantization aware training.")
             self.quantization.q_func = self.train_func
+            if version.release >= Version("1.13.0").release:
+                assert self.calib_dataloader is not None, "calib_dataloader must be provided for PyTorch1.13 or above."
+                self.quantization._calib_dataloader = self.calib_dataloader
 
 
 # Adapted from https://github.com/intel/neural-compressor/blob/master/neural_compressor/utils/pytorch.py#L96

--- a/optimum/intel/neural_compressor/utils.py
+++ b/optimum/intel/neural_compressor/utils.py
@@ -16,7 +16,10 @@ import logging
 from collections import UserDict
 from typing import Dict, List
 
+from packaging.version import Version
 from torch.utils.data import DataLoader
+
+from neural_compressor.adaptor.pytorch import get_torch_version
 
 
 logger = logging.getLogger(__name__)
@@ -56,13 +59,28 @@ def _cfgs_to_fx_cfgs(op_cfgs: Dict, observer_type: str = "post_training_static_q
         fx_op_cfgs (`dict`):
             Dictionary of quantization configure that meets the requirements of torch.fx.
     """
-    fx_op_cfgs = dict()
-    op_tuple_cfg_list = []
+    version = get_torch_version()
+    if version.release >= Version("1.13.0").release:
+        from torch.ao.quantization import QConfigMapping
+
+        fx_op_cfgs = QConfigMapping()
+    else:
+        fx_op_cfgs = dict()
+        op_tuple_cfg_list = []
     for key, value in op_cfgs.items():
         if key == "default_qconfig":
-            fx_op_cfgs[""] = value
+            if version.release >= Version("1.13.0").release:  # pragma: no cover
+                fx_op_cfgs.set_global(value)
+            else:
+                fx_op_cfgs[""] = value
             continue
-        op_tuple = (key, value)
-        op_tuple_cfg_list.append(op_tuple)
-    fx_op_cfgs["module_name"] = op_tuple_cfg_list
+        if version.release >= Version("1.13.0").release:  # pragma: no cover
+            fx_op_cfgs.set_module_name(key, value)
+        else:
+            op_tuple = (key, value)
+            op_tuple_cfg_list.append(op_tuple)
+
+    if version.release < Version("1.13.0").release:
+        fx_op_cfgs["module_name"] = op_tuple_cfg_list
+
     return fx_op_cfgs

--- a/tests/neural_compressor/test_optimization.py
+++ b/tests/neural_compressor/test_optimization.py
@@ -178,8 +178,6 @@ class IncQuantizationTest(unittest.TestCase):
         q8_config.set_config("quantization.approach", IncQuantizationMode.AWARE_TRAINING.value)
         q8_config.set_config("tuning.accuracy_criterion.relative", 0.2)
         q8_config.set_config("model.framework", "pytorch_fx")
-        quantizer = IncQuantizer(q8_config, eval_func=eval_func, train_func=train_func)
-        optimizer = IncOptimizer(model, quantizer=quantizer)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(tmp_dir, num_train_epochs=1.0)
@@ -193,6 +191,11 @@ class IncQuantizationTest(unittest.TestCase):
                 tokenizer=tokenizer,
                 data_collator=default_data_collator,
             )
+
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, calib_dataloader=trainer.get_eval_dataloader(), train_func=train_func
+            )
+            optimizer = IncOptimizer(model, quantizer=quantizer)
 
             model_result = eval_func(model)
             optimized_model = optimizer.fit()
@@ -365,40 +368,6 @@ class IncOptimizerTest(unittest.TestCase):
         def compute_metrics(p: EvalPrediction):
             return metric.compute(predictions=np.argmax(p.predictions, axis=1), references=p.label_ids)
 
-        def train_func(model):
-            trainer.model_wrapped = model
-            trainer.model = model
-            _ = trainer.train(agent)
-            return trainer.model
-
-        def eval_func(model):
-            trainer.model = model
-            metrics = trainer.evaluate()
-            return metrics["eval_accuracy"]
-
-        config_path = os.path.dirname(os.path.abspath(__file__))
-        q8_config = IncQuantizationConfig.from_pretrained(config_path)
-        q8_config.set_config("quantization.approach", IncQuantizationMode.AWARE_TRAINING.value)
-        q8_config.set_config("tuning.accuracy_criterion.relative", 0.2)
-        q8_config.set_config("model.framework", "pytorch_fx")
-        quantizer = IncQuantizer(q8_config, eval_func=eval_func, train_func=train_func)
-        distillation_config = IncDistillationConfig.from_pretrained(config_path)
-        distiller = IncDistiller(
-            teacher_model=teacher_model,
-            config=distillation_config,
-            eval_func=eval_func,
-            train_func=train_func,
-        )
-        optimizer = IncOptimizer(
-            model,
-            quantizer=quantizer,
-            distiller=distiller,
-            one_shot_optimization=True,
-            eval_func=eval_func,
-            train_func=train_func,
-        )
-        agent = optimizer.get_agent()
-
         with tempfile.TemporaryDirectory() as tmp_dir:
             training_args = TrainingArguments(tmp_dir, num_train_epochs=1.0)
             trainer = IncTrainer(
@@ -410,6 +379,43 @@ class IncOptimizerTest(unittest.TestCase):
                 tokenizer=tokenizer,
                 data_collator=default_data_collator,
             )
+
+            def train_func(model):
+                trainer.model_wrapped = model
+                trainer.model = model
+                _ = trainer.train(agent)
+                return trainer.model
+
+            def eval_func(model):
+                trainer.model = model
+                metrics = trainer.evaluate()
+                return metrics["eval_accuracy"]
+
+            config_path = os.path.dirname(os.path.abspath(__file__))
+            q8_config = IncQuantizationConfig.from_pretrained(config_path)
+            q8_config.set_config("quantization.approach", IncQuantizationMode.AWARE_TRAINING.value)
+            q8_config.set_config("tuning.accuracy_criterion.relative", 0.2)
+            q8_config.set_config("model.framework", "pytorch_fx")
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, calib_dataloader=trainer.get_eval_dataloader(), train_func=train_func
+            )
+            distillation_config = IncDistillationConfig.from_pretrained(config_path)
+            distiller = IncDistiller(
+                teacher_model=teacher_model,
+                config=distillation_config,
+                eval_func=eval_func,
+                train_func=train_func,
+            )
+            optimizer = IncOptimizer(
+                model,
+                quantizer=quantizer,
+                distiller=distiller,
+                one_shot_optimization=True,
+                eval_func=eval_func,
+                train_func=train_func,
+            )
+            agent = optimizer.get_agent()
+
             model_result = eval_func(model)
             optimized_model = optimizer.fit()
             optimized_model_result = eval_func(optimized_model)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- <!-- Remove if not applicable -->

This PR will supported PyTorch 1.13.0 and above version quantization. In PyTorch 1.13.0, there is a parameter: [example_input](https://github.com/pytorch/pytorch/blob/dc00bb51b8d370bf3891f0edb2c6e0c2914e329a/torch/ao/quantization/quantize_fx.py#L271) in prepare_fx function. So we should specify the dataloader to optimum for static quantization and quantization-aware training.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

