### PR TITLE
Add example_inputs for FX trace if PyTorch > 1.13

### DIFF
--- a/examples/neural_compressor/language-modeling/run_clm.py
+++ b/examples/neural_compressor/language-modeling/run_clm.py
@@ -613,9 +613,7 @@ def main():
 
         if quant_approach == IncQuantizationMode.STATIC:
             calib_dataloader = trainer.get_train_dataloader()
-            quantizer = IncQuantizer(
-                q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader
-            )
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader)
         else:
             example_inputs = next(iter(trainer.get_train_dataloader()))
             example_inputs = [example_inputs[key] for key in example_inputs]

--- a/examples/neural_compressor/language-modeling/run_clm.py
+++ b/examples/neural_compressor/language-modeling/run_clm.py
@@ -611,10 +611,17 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
-        quantizer = IncQuantizer(
-            q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
-        )
+        if quant_approach == IncQuantizationMode.STATIC:
+            calib_dataloader = trainer.get_train_dataloader()
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader
+            )
+        else:
+            example_inputs = next(iter(trainer.get_train_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
+            )
 
     if optim_args.apply_pruning:
 

--- a/examples/neural_compressor/language-modeling/run_mlm.py
+++ b/examples/neural_compressor/language-modeling/run_mlm.py
@@ -647,10 +647,15 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
-        quantizer = IncQuantizer(
-            q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
-        )
+        if quant_approach == IncQuantizationMode.STATIC:
+            calib_dataloader = trainer.get_train_dataloader()
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader)
+        else:
+            example_inputs = next(iter(trainer.get_train_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
+            )
 
     if optim_args.apply_pruning:
 

--- a/examples/neural_compressor/multiple-choice/run_swag.py
+++ b/examples/neural_compressor/multiple-choice/run_swag.py
@@ -559,10 +559,15 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
-        quantizer = IncQuantizer(
-            q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
-        )
+        if quant_approach == IncQuantizationMode.STATIC:
+            calib_dataloader = trainer.get_train_dataloader()
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader)
+        else:
+            example_inputs = next(iter(trainer.get_train_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
+            )
 
     if optim_args.apply_pruning:
 

--- a/examples/neural_compressor/optical-character-recognition/run_ocr.py
+++ b/examples/neural_compressor/optical-character-recognition/run_ocr.py
@@ -301,7 +301,14 @@ def main():
         if quant_approach == IncQuantizationMode.STATIC:
             q8_config.set_config("quantization.calibration.sampling_size", [data_args.max_calibration_samples])
         q8_config.set_config("tuning.accuracy_criterion.higher_is_better", False)
-        quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=test_dataloader)
+
+        if quant_approach == IncQuantizationMode.STATIC:
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=test_dataloader)
+        else:
+            example_inputs = next(iter(test_dataloader))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, example_inputs=example_inputs)
+
         optimizer = IncOptimizer(model, quantizer=quantizer)
         q_model = optimizer.fit()
         result_optimized_model = eval_func(q_model, 20)

--- a/examples/neural_compressor/question-answering/run_qa.py
+++ b/examples/neural_compressor/question-answering/run_qa.py
@@ -813,10 +813,15 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
-        quantizer = IncQuantizer(
-            q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
-        )
+        if quant_approach == IncQuantizationMode.STATIC:
+            calib_dataloader = trainer.get_train_dataloader()
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader)
+        else:
+            example_inputs = next(iter(trainer.get_train_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
+            )
 
     if optim_args.apply_pruning:
 

--- a/examples/neural_compressor/summarization/run_summarization.py
+++ b/examples/neural_compressor/summarization/run_summarization.py
@@ -791,10 +791,15 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
-        quantizer = IncQuantizer(
-            q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
-        )
+        if quant_approach == IncQuantizationMode.STATIC:
+            calib_dataloader = trainer.get_train_dataloader()
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader)
+        else:
+            example_inputs = next(iter(trainer.get_train_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
+            )
 
     if optim_args.apply_pruning:
 

--- a/examples/neural_compressor/text-classification/run_glue.py
+++ b/examples/neural_compressor/text-classification/run_glue.py
@@ -619,10 +619,15 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
-        quantizer = IncQuantizer(
-            q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
-        )
+        if quant_approach == IncQuantizationMode.STATIC:
+            calib_dataloader = trainer.get_train_dataloader()
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader)
+        else:
+            example_inputs = next(iter(trainer.get_train_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
+            )
 
     if optim_args.apply_pruning:
 

--- a/examples/neural_compressor/token-classification/run_ner.py
+++ b/examples/neural_compressor/token-classification/run_ner.py
@@ -658,10 +658,15 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
-        quantizer = IncQuantizer(
-            q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
-        )
+        if quant_approach == IncQuantizationMode.STATIC:
+            calib_dataloader = trainer.get_train_dataloader()
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader)
+        else:
+            example_inputs = next(iter(trainer.get_train_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
+            )
 
     if optim_args.apply_pruning:
 

--- a/examples/neural_compressor/translation/run_translation.py
+++ b/examples/neural_compressor/translation/run_translation.py
@@ -716,10 +716,15 @@ def main():
 
             q8_config.set_config("model.framework", "pytorch_fx")
 
-        calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
-        quantizer = IncQuantizer(
-            q8_config, eval_func=eval_func, train_func=train_func, calib_dataloader=calib_dataloader
-        )
+        if quant_approach == IncQuantizationMode.STATIC:
+            calib_dataloader = trainer.get_train_dataloader()
+            quantizer = IncQuantizer(q8_config, eval_func=eval_func, calib_dataloader=calib_dataloader)
+        else:
+            example_inputs = next(iter(trainer.get_train_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+            quantizer = IncQuantizer(
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
+            )
 
     if optim_args.apply_pruning:
 

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -270,7 +270,6 @@ class IncQuantizedModel:
         download_kwargs = {name: kwargs.get(name, default_value) for (name, default_value) in download_kwarg_default}
         state_dict = kwargs.get("state_dict", None)
 
-
         example_inputs = list(model.dummy_inputs.values())
 
         config = AutoConfig.from_pretrained(model_name_or_path)

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -256,8 +256,6 @@ class IncQuantizedModel:
             state_dict (`Dict[str, torch.Tensor]`, *optional*):
                 State dictionary of the quantized model, if not specified q_model_name will be used to load the
                 state dictionary.
-            example_inputs(List[torch.Tensor], *optional*):
-                List of input tensors for FX trace if PyTorch >= 1.13.
         Returns:
             q_model: Quantized model.
         """
@@ -269,8 +267,6 @@ class IncQuantizedModel:
         ]
         download_kwargs = {name: kwargs.get(name, default_value) for (name, default_value) in download_kwarg_default}
         state_dict = kwargs.get("state_dict", None)
-
-        example_inputs = list(model.dummy_inputs.values())
 
         config = AutoConfig.from_pretrained(model_name_or_path)
         model_class = _get_model_class(config, cls.TRANSFORMERS_AUTO_CLASS._model_mapping)
@@ -358,6 +354,8 @@ class IncQuantizedModel:
         else:
             config_path = inc_config if inc_config is not None else model_name_or_path
             inc_config = IncOptimizedConfig.from_pretrained(config_path, **download_kwargs).config
+
+        example_inputs = list(model.dummy_inputs.values())
 
         if "is_oneshot" in inc_config and inc_config["is_oneshot"]:
             return _load_int8_orchestration(

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -17,7 +17,7 @@ import logging
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Any, Callable, ClassVar, Dict, Optional, Union
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Union
 
 import torch
 from torch.quantization import add_observer_, convert
@@ -88,8 +88,8 @@ class IncQuantizer:
                 DataLoader for post-training quantization calibration.
             calib_func (`Callable`):
                 Calibration function for post training static quantization, If user specifies calib_func, calib_dataloader is also needed for PyTorch>1.12.
-            example_inputs (`Union[torch.Tensor, numpy array]`, *optional*):
-                Be used to FX trace for PyTorch>1.13, if calib_dataloader is not be specified,
+            example_inputs (`List`, *optional*):
+                List of the torch.Tensor which be used to FX trace for PyTorch>1.13, if calib_dataloader is not be specified,
                 then you must specify the example_inputs.
         """
 
@@ -135,7 +135,7 @@ class IncQuantizer:
 
 # Adapted from https://github.com/intel/neural-compressor/blob/master/neural_compressor/utils/pytorch.py#L96
 def apply_quantization_from_config(
-    q_config: Dict, model: torch.nn.Module, example_inputs: list[torch.Tensor] = None
+    q_config: Dict, model: torch.nn.Module, example_inputs: List = None
 ) -> torch.nn.Module:
     """
     Apply Intel Neural Compressor quantization steps on the given model.

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -269,7 +269,9 @@ class IncQuantizedModel:
         ]
         download_kwargs = {name: kwargs.get(name, default_value) for (name, default_value) in download_kwarg_default}
         state_dict = kwargs.get("state_dict", None)
-        example_inputs = kwargs.get("example_inputs", None)
+
+
+        example_inputs = list(model.dummy_inputs.values())
 
         config = AutoConfig.from_pretrained(model_name_or_path)
         model_class = _get_model_class(config, cls.TRANSFORMERS_AUTO_CLASS._model_mapping)

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -73,7 +73,7 @@ class IncQuantizer:
         train_func: Optional[Callable] = None,
         calib_dataloader: Optional[DataLoader] = None,
         calib_func: Optional[Callable] = None,
-        example_inputs: Optional[Any] = None
+        example_inputs: Optional[Any] = None,
     ):
         """
         Arguments:

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -48,7 +48,7 @@ from neural_compressor.experimental import Quantization
 from neural_compressor.utils.pytorch import _load_int8_orchestration
 
 from .configuration import IncOptimizedConfig, IncQuantizationConfig
-from .utils import WEIGHTS_NAME, IncDataLoader, _cfgs_to_fx_cfgs, is_torch_less_than_1_13, inputs_to_dataloader
+from .utils import WEIGHTS_NAME, IncDataLoader, _cfgs_to_fx_cfgs, inputs_to_dataloader, is_torch_less_than_1_13
 
 
 logger = logging.getLogger(__name__)
@@ -134,7 +134,9 @@ class IncQuantizer:
 
 
 # Adapted from https://github.com/intel/neural-compressor/blob/master/neural_compressor/utils/pytorch.py#L96
-def apply_quantization_from_config(q_config: Dict, model: torch.nn.Module, example_inputs: list[torch.Tensor]=None) -> torch.nn.Module:
+def apply_quantization_from_config(
+    q_config: Dict, model: torch.nn.Module, example_inputs: list[torch.Tensor] = None
+) -> torch.nn.Module:
     """
     Apply Intel Neural Compressor quantization steps on the given model.
 
@@ -357,10 +359,9 @@ class IncQuantizedModel:
             inc_config = IncOptimizedConfig.from_pretrained(config_path, **download_kwargs).config
 
         if "is_oneshot" in inc_config and inc_config["is_oneshot"]:
-            return _load_int8_orchestration(model,
-                                            inc_config,
-                                            state_dict,
-                                            dataloader=inputs_to_dataloader(example_inputs))
+            return _load_int8_orchestration(
+                model, inc_config, state_dict, dataloader=inputs_to_dataloader(example_inputs)
+            )
 
         q_model = apply_quantization_from_config(inc_config, model, example_inputs)
 

--- a/optimum/intel/neural_compressor/utils.py
+++ b/optimum/intel/neural_compressor/utils.py
@@ -15,7 +15,7 @@
 import logging
 import os
 from collections import UserDict
-from typing import Dict
+from typing import Dict, List, Tuple
 
 import torch
 from packaging import version
@@ -107,3 +107,20 @@ def load_quantized_model(checkpoint_dir_or_file: str, model: torch.nn.Module, **
         )
 
     return load(checkpoint_dir_or_file, model, **kwargs)
+
+
+def inputs_to_dataloader(example_inputs):
+    """Wrap a torch.Tensor or numpy ndarray to torch dataloader.
+    Args:
+        example_inputs (`Tuple[torch.Tensor]`):
+            Tuple of torch tensor to be wraped to torch dataloader.
+    Returns:
+        torch dataloader
+    """
+
+    import torch
+    if not isinstance(example_inputs, Tuple) and not isinstance(example_inputs, List):
+        raise ValueError("example_inputs should be a tuple.")
+
+    dataset = torch.utils.data.TensorDataset(*(example_inputs))
+    return torch.utils.data.DataLoader(dataset, batch_size=example_inputs[0].shape[0])

--- a/optimum/intel/neural_compressor/utils.py
+++ b/optimum/intel/neural_compressor/utils.py
@@ -119,6 +119,7 @@ def inputs_to_dataloader(example_inputs):
     """
 
     import torch
+
     if not isinstance(example_inputs, Tuple) and not isinstance(example_inputs, List):
         raise ValueError("example_inputs should be a tuple.")
 

--- a/optimum/intel/neural_compressor/utils.py
+++ b/optimum/intel/neural_compressor/utils.py
@@ -118,10 +118,9 @@ def inputs_to_dataloader(example_inputs):
         torch dataloader
     """
 
-    import torch
-
     if not isinstance(example_inputs, Tuple) and not isinstance(example_inputs, List):
-        raise ValueError("example_inputs should be a tuple.")
+        # raise ValueError("example_inputs should be a tuple.")
+        return None
 
     dataset = torch.utils.data.TensorDataset(*(example_inputs))
     return torch.utils.data.DataLoader(dataset, batch_size=example_inputs[0].shape[0])

--- a/tests/neural_compressor/test_optimization.py
+++ b/tests/neural_compressor/test_optimization.py
@@ -225,8 +225,12 @@ class IncQuantizationTest(unittest.TestCase):
                 data_collator=default_data_collator,
             )
 
+            # Need a example of tuple for FX trace if PyTorch version > 1.13.
+            example_inputs = next(iter(trainer.get_eval_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+
             quantizer = IncQuantizer(
-                q8_config, eval_func=eval_func, calib_dataloader=trainer.get_eval_dataloader(), train_func=train_func
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
             )
             optimizer = IncOptimizer(model, quantizer=quantizer)
 
@@ -431,8 +435,12 @@ class IncOptimizerTest(unittest.TestCase):
                 data_collator=default_data_collator,
             )
 
+            # Need a example of tuple for FX trace if PyTorch version > 1.13.
+            example_inputs = next(iter(trainer.get_eval_dataloader()))
+            example_inputs = [example_inputs[key] for key in example_inputs]
+
             quantizer = IncQuantizer(
-                q8_config, eval_func=eval_func, calib_dataloader=trainer.get_eval_dataloader(), train_func=train_func
+                q8_config, eval_func=eval_func, train_func=train_func, example_inputs=example_inputs
             )
             distiller = IncDistiller(
                 teacher_model=teacher_model,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

This PR is for adding example_input for FX trace, since PyTorch 1.13 and above version, prepare_fx has a example_inputs parameter.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

