### PR TITLE
Update README to fix issue with transformers 4.24/OpenVINO

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ pip install git+https://github.com/huggingface/optimum-intel.git
 
 To install the latest release of this package with the corresponding required dependencies, you can do respectively:
 
-| Accelerator                                                                                                      | Installation                                      |
-|:-----------------------------------------------------------------------------------------------------------------|:--------------------------------------------------|
-| [Intel Neural Compressor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install optimum[neural-compressor]`|
-| [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install optimum[openvino,nncf]`    |
+| Accelerator                                                                                                      | Installation                                                        |
+|:-----------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------|
+| [Intel Neural Compressor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install optimum[neural-compressor]`                  |
+| [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install optimum[openvino,nncf] transformers==4.23.*` |
 
 ## Running the examples
 


### PR DESCRIPTION
# What does this PR do?

Add `transformers==4.23.*` to the `pip install` command for OpenVINO to workaround an issue with transformers 4.24. 
`pip install optimum[openvino]` installs the latest transformers version by default, which results in the issue that is fixed in https://github.com/huggingface/optimum-intel/pull/94 (but this is not yet part of the release). 
I tried to install with `pip install git+...` but with transformers 4.24, inference on MBart gave an empty result. While we look into this, the best option seems to be to tell the users to install a specific known good version of transformers.