### PR TITLE
Move PyTorch install to [extras]

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -3,10 +3,12 @@
 name: OpenVINO - Test
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ INSTALL_REQUIRES = [
     "optimum",
     "transformers>=4.20.0",
     "datasets",
-    "torch",
     "sentencepiece",
     "scipy",
 ]
@@ -29,9 +28,9 @@ QUALITY_REQUIRES = [
 ]
 
 EXTRAS_REQUIRE = {
-    "neural-compressor": "neural-compressor>=1.13.0",
+    "neural-compressor": ["neural-compressor>=1.13.0", "torch"],
     "openvino": ["openvino>=2022.2.0"],
-    "nncf": ["nncf"],
+    "nncf": ["nncf", "torch<=1.13.*"],
     "quality": QUALITY_REQUIRES,
     "tests": TESTS_REQUIRE,
 }


### PR DESCRIPTION
This PR removes PyTorch from the default installed packages, and moves it to the extras "neural_compressor" and "nncf". The reason for this change is that PyTorch is a pretty large framework which from the latest release by default also installs several CUDA related packages. This takes up more than 3GB of space, and takes quite a long time to download if you're on a slowish internet connection. These packages are unnecessary for users who just want to do inference on an OpenVINO model and it is useful to have a more minimal package for these users. 

The GitHub Actions tests passed in my fork, but they may not catch everything so I made this a draft PR for now so we can discuss/review if there are edge-cases that need to be resolved.

Also made a minor change to the test_openvino.yml file to allow running the test manually without having to make a PR. 