### PR TITLE
Support IPEX backend

### DIFF
--- a/examples/neural_compressor/question-answering/README.md
+++ b/examples/neural_compressor/question-answering/README.md
@@ -55,6 +55,8 @@ python run_qa.py \
     --output_dir /tmp/squad_output
 ```
 
+The flag `--use_ipex` can be passed along to use INC IPEX backend. Default backend is `pytorch_fx` if value not specified. INC IPEX only supports static quantization for now.
+
 The distillation process can be accelerated by the flag `--generate_teacher_logits`, which will add an additional step where the teacher outputs will be computed and saved in the training dataset, removing the need to compute the teacher outputs at every training step.
 
 The following example fine-tunes DistilBERT on the SQuAD1.0 dataset while applying magnitude pruning and then applies 

--- a/examples/neural_compressor/question-answering/README.md
+++ b/examples/neural_compressor/question-answering/README.md
@@ -55,7 +55,7 @@ python run_qa.py \
     --output_dir /tmp/squad_output
 ```
 
-The flag `--use_ipex` can be passed along to use INC IPEX backend. Default backend is `pytorch_fx` if value not specified. INC IPEX only supports static quantization for now.
+The flag `--use_ipex` can be passed along to use INC IPEX backend. Default backend is `pytorch_fx` if value not specified. INC IPEX (Intel Extension for PyTorch) extends PyTorch with up-to-date features optimizations for an extra performance boost on Intel hardware. INC IPEX only supports static quantization for now.
 
 The distillation process can be accelerated by the flag `--generate_teacher_logits`, which will add an additional step where the teacher outputs will be computed and saved in the training dataset, removing the need to compute the teacher outputs at every training step.
 

--- a/examples/neural_compressor/question-answering/run_qa.py
+++ b/examples/neural_compressor/question-answering/run_qa.py
@@ -811,7 +811,10 @@ def main():
             if not training_args.do_train:
                 raise ValueError("do_train must be set to True for quantization aware training.")
 
-            q8_config.set_config("model.framework", "pytorch_fx")
+            if training_args.use_ipex:
+                q8_config.set_config("model.framework", "pytorch_ipex")
+            else:
+                q8_config.set_config("model.framework", "pytorch_fx")
 
         calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(

--- a/examples/neural_compressor/test_examples.py
+++ b/examples/neural_compressor/test_examples.py
@@ -118,6 +118,39 @@ class TestExamples(unittest.TestCase):
                 self.assertGreaterEqual(results["eval_f1"], 70)
                 self.assertGreaterEqual(results["eval_exact_match"], 70)
 
+    def test_run_qa_ipex(self):
+        quantization_approach = "static"
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            test_args = f"""
+                run_qa.py
+                --model_name_or_path bert-large-uncased-whole-word-masking-finetuned-squad
+                --dataset_name squad
+                --apply_quantization
+                --quantization_approach {quantization_approach}
+                --metric eval_f1
+                --tolerance_criterion 0.1
+                --apply_pruning
+                --target_sparsity 0.02
+                --do_eval
+                --do_train
+                --per_device_eval_batch_size 1
+                --per_device_train_batch_size 1
+                --max_eval_samples 50
+                --max_train_samples 4
+                --num_train_epoch 2
+                --learning_rate 1e-10
+                --verify_loading
+                --output_dir {tmp_dir}
+                --use_ipex
+                """.split()
+
+            with patch.object(sys, "argv", test_args):
+                run_qa.main()
+                results = get_results(tmp_dir)
+                self.assertGreaterEqual(results["eval_f1"], 70)
+                self.assertGreaterEqual(results["eval_exact_match"], 70)
+
     def test_run_ner(self):
         quantization_approach = "static"
 

--- a/optimum/intel/neural_compressor/optimization.py
+++ b/optimum/intel/neural_compressor/optimization.py
@@ -147,6 +147,9 @@ class IncOptimizer:
         os.makedirs(save_directory, exist_ok=True)
         if isinstance(self.config, PretrainedConfig):
             self.config.save_pretrained(save_directory)
+        if isinstance(self._model.model, torch.jit._script.RecursiveScriptModule):
+            self._model.model.save(os.path.join(save_directory, WEIGHTS_NAME))
+            return
         state_dict = self._model.model.state_dict()
         if hasattr(self._model, "q_config"):
             state_dict["best_configure"] = self._model.q_config

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -115,6 +115,8 @@ class IncQuantizer:
         if self.approach == IncQuantizationMode.AWARE_TRAINING:
             if self.train_func is None:
                 raise ValueError("train_func must be provided for quantization aware training.")
+            if self.config.usr_cfg.model.framework == "pytorch_ipex":
+                raise ValueError("INC IPEX only supports static quantization for now.")
             self.quantization.q_func = self.train_func
             if not is_torch_less_than_1_13:
                 if self.calib_dataloader is None:
@@ -278,8 +280,8 @@ class IncQuantizedModel:
             model_class._keys_to_ignore_on_load_missing.extend(missing_keys_to_ignore_on_load)
 
         model = model_class.from_pretrained(model_name_or_path, **kwargs)
-
-        dummy_inputs = list(model.dummy_inputs.keys())
+        
+        dummy_inputs = list(model.dummy_inputs.values())
 
         model_class._keys_to_ignore_on_load_unexpected = keys_to_ignore_on_load_unexpected
         model_class._keys_to_ignore_on_load_missing = keys_to_ignore_on_load_missing

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -280,7 +280,7 @@ class IncQuantizedModel:
             model_class._keys_to_ignore_on_load_missing.extend(missing_keys_to_ignore_on_load)
 
         model = model_class.from_pretrained(model_name_or_path, **kwargs)
-        
+
         dummy_inputs = list(model.dummy_inputs.values())
 
         model_class._keys_to_ignore_on_load_unexpected = keys_to_ignore_on_load_unexpected

--- a/optimum/intel/neural_compressor/trainer.py
+++ b/optimum/intel/neural_compressor/trainer.py
@@ -90,6 +90,7 @@ class IncTrainer(Trainer):
                 Additional keyword arguments used to hide deprecated arguments
         """
         self.agent = agent
+        self.args.use_ipex = False
 
         return super().train(resume_from_checkpoint, trial, ignore_keys_for_eval)
 
@@ -619,6 +620,7 @@ class IncTrainer(Trainer):
         ignore_keys: Optional[List[str]] = None,
         metric_key_prefix: str = "eval",
     ) -> Dict[str, float]:
+        self.args.use_ipex = False
         if hasattr(self.model, "config") and getattr(self.model.config, "torch_dtype", None) == "int8":
             if self.model.config.framework in ["pytorch", "pytorch_fx"] and self.use_cpu_amp:
                 logger.warn(


### PR DESCRIPTION
# What does this PR do?
This PR is used to support INC IPEX features and add QA example.

**examples/neural_compressor/question-answering/run_qa.py**
- Change `calib_dataloader`  from `get_train_dataloader()` to `get_eval_dataloader()` when using INC IPEX backend, in order to keep the form of `example_inputs` identical.

**optimum/intel/neural_compressor/optimization.py**
- Load `pytorch_model.bin` when using INC IPEX backend.

**optimum/intel/neural_compressor/quantization.py**
- Use `torch.jit.load` to recover the int8 model quantized by INC IPEX backend, instead of `torch.load`.

**examples/neural_compressor/question-answering/README.md**
- Add INC IPEX backend example explanation

**examples/neural_compressor/test_examples.py**
- Add a unit test for `run_qa.py` using INC IPEX backend

**Example**:
The following example applies INC IPEX backend:
python run_qa.py \
    --model_name_or_path bert-large-uncased-whole-word-masking-finetuned-squad \
    --dataset_name squad \
    --apply_quantization \
    --quantization_approach static \
    --do_train \
    --do_eval \
    --verify_loading \
    --output_dir /tmp/squad_output \
    --backend ipex

**Environment for this PR:**
Python 3.8.13
transformers 4.24.0
datasets 2.6.1
intel-extension-for-pytorch 1.12.300
torch 1.12.0

