### PR TITLE
Update README to workaround issue with optimum 1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To install the latest release of this package with the corresponding required de
 | Accelerator                                                                                                      | Installation                                                        |
 |:-----------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------|
 | [Intel Neural Compressor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install optimum[neural-compressor]`                  |
-| [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install optimum[openvino,nncf] transformers==4.23.*` |
+| [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install optimum[openvino,nncf] optimum==1.4.1` |
 
 ## Running the examples
 


### PR DESCRIPTION
optimum 1.5 results in this error. This PR updates the installation instructions in the README to install optimum 1.4.1 to give users a workaround for now.

```
  File "/home/ubuntu/venvs/optimum_env/lib/python3.8/site-packages/optimum/intel/openvino/modeling_base.py", line 150, in _from_pretrained
    config = PretrainedConfig.from_dict(config_dict)
  File "/home/ubuntu/venvs/optimum_env/lib/python3.8/site-packages/transformers/configuration_utils.py", line 676, in from_dict
    config = cls(**config_dict)
TypeError: type object argument after ** must be a mapping, not BertConfig
```