### PR TITLE
Disable INC IPEX

### DIFF
--- a/examples/neural_compressor/question-answering/README.md
+++ b/examples/neural_compressor/question-answering/README.md
@@ -55,8 +55,6 @@ python run_qa.py \
     --output_dir /tmp/squad_output
 ```
 
-The flag `--use_ipex` can be passed along to use INC IPEX backend. Default backend is `pytorch_fx` if value not specified. INC IPEX (Intel Extension for PyTorch) extends PyTorch with up-to-date features optimizations for an extra performance boost on Intel hardware. INC IPEX only supports static quantization for now.
-
 The distillation process can be accelerated by the flag `--generate_teacher_logits`, which will add an additional step where the teacher outputs will be computed and saved in the training dataset, removing the need to compute the teacher outputs at every training step.
 
 The following example fine-tunes DistilBERT on the SQuAD1.0 dataset while applying magnitude pruning and then applies 

--- a/examples/neural_compressor/question-answering/run_qa.py
+++ b/examples/neural_compressor/question-answering/run_qa.py
@@ -811,10 +811,7 @@ def main():
             if not training_args.do_train:
                 raise ValueError("do_train must be set to True for quantization aware training.")
 
-            if training_args.use_ipex:
-                q8_config.set_config("model.framework", "pytorch_ipex")
-            else:
-                q8_config.set_config("model.framework", "pytorch_fx")
+            q8_config.set_config("model.framework", "pytorch_fx")
 
         calib_dataloader = trainer.get_train_dataloader() if quant_approach != IncQuantizationMode.DYNAMIC else None
         quantizer = IncQuantizer(

--- a/examples/neural_compressor/test_examples.py
+++ b/examples/neural_compressor/test_examples.py
@@ -118,39 +118,6 @@ class TestExamples(unittest.TestCase):
                 self.assertGreaterEqual(results["eval_f1"], 70)
                 self.assertGreaterEqual(results["eval_exact_match"], 70)
 
-    def test_run_qa_ipex(self):
-        quantization_approach = "static"
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            test_args = f"""
-                run_qa.py
-                --model_name_or_path bert-large-uncased-whole-word-masking-finetuned-squad
-                --dataset_name squad
-                --apply_quantization
-                --quantization_approach {quantization_approach}
-                --metric eval_f1
-                --tolerance_criterion 0.1
-                --apply_pruning
-                --target_sparsity 0.02
-                --do_eval
-                --do_train
-                --per_device_eval_batch_size 1
-                --per_device_train_batch_size 1
-                --max_eval_samples 50
-                --max_train_samples 4
-                --num_train_epoch 2
-                --learning_rate 1e-10
-                --verify_loading
-                --output_dir {tmp_dir}
-                --use_ipex
-                """.split()
-
-            with patch.object(sys, "argv", test_args):
-                run_qa.main()
-                results = get_results(tmp_dir)
-                self.assertGreaterEqual(results["eval_f1"], 70)
-                self.assertGreaterEqual(results["eval_exact_match"], 70)
-
     def test_run_ner(self):
         quantization_approach = "static"
 

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -113,11 +113,12 @@ class IncQuantizer:
             if self.calib_dataloader is not None:
                 self.quantization._calib_dataloader = self.calib_dataloader
 
+        if self.config.usr_cfg.model.framework == "pytorch_ipex":
+            raise ValueError("INC IPEX only is not currently supported.")
+
         if self.approach == IncQuantizationMode.AWARE_TRAINING:
             if self.train_func is None:
                 raise ValueError("train_func must be provided for quantization aware training.")
-            if self.config.usr_cfg.model.framework == "pytorch_ipex":
-                raise ValueError("INC IPEX only supports static quantization for now.")
             self.quantization.q_func = self.train_func
             if not is_torch_less_than_1_13:
                 if self.calib_dataloader is None:
@@ -281,9 +282,6 @@ class IncQuantizedModel:
             model_class._keys_to_ignore_on_load_missing.extend(missing_keys_to_ignore_on_load)
 
         model = model_class.from_pretrained(model_name_or_path, **kwargs)
-
-        dummy_inputs = list(model.dummy_inputs.values())
-
         model_class._keys_to_ignore_on_load_unexpected = keys_to_ignore_on_load_unexpected
         model_class._keys_to_ignore_on_load_missing = keys_to_ignore_on_load_missing
 
@@ -330,16 +328,9 @@ class IncQuantizedModel:
                     raise EnvironmentError(msg)
 
             if config.framework == "pytorch_ipex":
-                state_dict = torch.jit.load(state_dict_path)
-                q_model = torch.jit.freeze(stat_dict.eval())
-                # After freezing, run 1 time to warm up the profiling graph executor to insert prim::profile
-                # At the 2nd run, the llga pass will be triggered and the model is turned int
-                # an int8 model: prim::profile will be removed and will have LlgaFusionGroup in the graph
-                q_model(*dummy_inputs)
-                q_model(*dummy_inputs)
-                return q_model
-            else:
-                state_dict = torch.load(state_dict_path)
+                raise ValueError("INC IPEX is currently not supported")
+
+            state_dict = torch.load(state_dict_path)
 
         if "best_configure" in state_dict:
             inc_config = state_dict.pop("best_configure")


### PR DESCRIPTION
Currently the loading of quantized model with INC IPEX is not working as the dummy inputs are not well generated. In this PR we disable the IPEX backend for INC quantization, which could be integrated later on