### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,59 +28,6 @@ pip install git+https://github.com/huggingface/optimum-intel.git
 
 # Quick tour
 
-## Neural Compressor
-
-#### Dynamic quantization:
-
-Here is an example on how to apply dynamic quantization on a DistilBERT fine-tuned on the SQuAD1.0 dataset.
-Note that quantization is currently only supported for CPUs (only CPU backends are available), so we will not be utilizing GPUs / CUDA in this example.
-
-```python
-from datasets import load_dataset
-from transformers import AutoModelForQuestionAnswering, AutoTokenizer, pipeline
-from evaluate import evaluator
-from optimum.intel.neural_compressor import IncOptimizer, IncQuantizationConfig, IncQuantizer
-
-model_id = "distilbert-base-cased-distilled-squad"
-max_eval_samples = 100
-model = AutoModelForQuestionAnswering.from_pretrained(model_id)
-tokenizer = AutoTokenizer.from_pretrained(model_id)
-eval_dataset = load_dataset("squad", split="validation").select(range(max_eval_samples))
-eval = evaluator("question-answering")
-qa_pipeline = pipeline("question-answering", model=model, tokenizer=tokenizer)
-
-def eval_func(model):
-    qa_pipeline.model = model
-    metrics = eval.compute(model_or_pipeline=qa_pipeline, data=eval_dataset, metric="squad")
-    return metrics["f1"]
-
-# Load the quantization configuration detailing the quantization we wish to apply
-config_path = "echarlaix/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic"
-quantization_config = IncQuantizationConfig.from_pretrained(config_path)
-
-# Instantiate our IncQuantizer using the desired configuration and the evaluation function used
-# for the INC accuracy-driven tuning strategy
-quantizer = IncQuantizer(quantization_config, eval_func=eval_func)
-optimizer = IncOptimizer(model, quantizer=quantizer)
-
-# Apply dynamic quantization
-quantized_model = optimizer.fit()
-
-# Save the resulting model and its corresponding configuration in the given directory
-optimizer.save_pretrained("./quantized_model")
-```
-
-To load a quantized model hosted locally or on the 🤗 hub, you can do as follows :
-```python
-from optimum.intel.neural_compressor.quantization import IncQuantizedModelForSequenceClassification
-
-loaded_model_from_hub = IncQuantizedModelForSequenceClassification.from_pretrained(
-    "Intel/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic"
-)
-```
-
-You can load many more quantized models hosted on the hub under the Intel organization [`here`](https://huggingface.co/Intel).
-
 ## OpenVINO
 
 Below are the examples of how to use OpenVINO and its [NNCF](https://docs.openvino.ai/latest/tmo_introduction.html) framework to accelerate inference.
@@ -185,6 +132,59 @@ trainer.save_model()
 
 +optimized_model = OVModelForSequenceClassification.from_pretrained(save_dir)
 ```
+
+## Neural Compressor
+
+#### Dynamic quantization:
+
+Here is an example on how to apply dynamic quantization on a DistilBERT fine-tuned on the SQuAD1.0 dataset.
+Note that quantization is currently only supported for CPUs (only CPU backends are available), so we will not be utilizing GPUs / CUDA in this example.
+
+```python
+from datasets import load_dataset
+from transformers import AutoModelForQuestionAnswering, AutoTokenizer, pipeline
+from evaluate import evaluator
+from optimum.intel.neural_compressor import IncOptimizer, IncQuantizationConfig, IncQuantizer
+
+model_id = "distilbert-base-cased-distilled-squad"
+max_eval_samples = 100
+model = AutoModelForQuestionAnswering.from_pretrained(model_id)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+eval_dataset = load_dataset("squad", split="validation").select(range(max_eval_samples))
+eval = evaluator("question-answering")
+qa_pipeline = pipeline("question-answering", model=model, tokenizer=tokenizer)
+
+def eval_func(model):
+    qa_pipeline.model = model
+    metrics = eval.compute(model_or_pipeline=qa_pipeline, data=eval_dataset, metric="squad")
+    return metrics["f1"]
+
+# Load the quantization configuration detailing the quantization we wish to apply
+config_path = "echarlaix/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic"
+quantization_config = IncQuantizationConfig.from_pretrained(config_path)
+
+# Instantiate our IncQuantizer using the desired configuration and the evaluation function used
+# for the INC accuracy-driven tuning strategy
+quantizer = IncQuantizer(quantization_config, eval_func=eval_func)
+optimizer = IncOptimizer(model, quantizer=quantizer)
+
+# Apply dynamic quantization
+quantized_model = optimizer.fit()
+
+# Save the resulting model and its corresponding configuration in the given directory
+optimizer.save_pretrained("./quantized_model")
+```
+
+To load a quantized model hosted locally or on the 🤗 hub, you can do as follows :
+```python
+from optimum.intel.neural_compressor.quantization import IncQuantizedModelForSequenceClassification
+
+loaded_model_from_hub = IncQuantizedModelForSequenceClassification.from_pretrained(
+    "Intel/distilbert-base-uncased-finetuned-sst-2-english-int8-dynamic"
+)
+```
+
+You can load many more quantized models hosted on the hub under the Intel organization [`here`](https://huggingface.co/Intel).
 
 You can find more examples in the [documentation](https://huggingface.co/docs/optimum/intel/index).
 


### PR DESCRIPTION
In this PR, we change the order of the examples, putting the OpenVINO's example before the Intel Neural Compressor one. This choice was made because of the big refactorization coming with #118 in order to reduce visibility of the quantization API as it will change a lot.
I will open a PR to put it back after the next `neural-compressor` release and once #118 is merged 