### PR TITLE
Fix  OpenVINO export of large models

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -108,7 +108,7 @@ Here is an example on how you can run inference for a translation task using an 
 from transformers import AutoTokenizer, pipeline
 from optimum.intel.openvino import OVModelForSeq2SeqLM
 
-model_id = "Helsinki-NLP/opus-mt-en-fr"
+model_id = "t5-small"
 model = OVModelForSeq2SeqLM.from_pretrained(model_id, from_transformers=True)
 tokenizer = AutoTokenizer.from_pretrained(model_id)
 translation_pipe = pipeline("translation_en_to_fr", model=model, tokenizer=tokenizer)

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -302,6 +302,10 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             kwargs (`Dict`, *optional*):
                 kwargs will be passed to the model during initialization
         """
+        encoder_file_name = os.path.join("encoder", ONNX_ENCODER_NAME)
+        decoder_file_name = os.path.join("decoder", ONNX_DECODER_NAME)
+        decoder_with_past_file_name = os.path.join("decoder_with_past", ONNX_DECODER_WITH_PAST_NAME)
+
         if task is None:
             task = cls._auto_model_to_task(cls.auto_model_class)
 
@@ -320,12 +324,13 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         )
 
         onnx_config_constructor = TasksManager.get_exporter_config_constructor(model=model, exporter="onnx", task=task)
-
         onnx_config = onnx_config_constructor(model.config, use_past=use_cache)
-        output_names = [ONNX_ENCODER_NAME, ONNX_DECODER_NAME]
-        if use_cache is True:
-            output_names.append(ONNX_DECODER_WITH_PAST_NAME)
         models_and_onnx_configs = get_encoder_decoder_models_for_export(model, onnx_config)
+
+        output_names = [encoder_file_name, decoder_file_name]
+        if use_cache is True:
+            output_names.append(decoder_with_past_file_name)
+
         export_models(
             models_and_onnx_configs=models_and_onnx_configs,
             opset=onnx_config.DEFAULT_ONNX_OPSET,
@@ -342,6 +347,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             revision=revision,
             force_download=force_download,
             cache_dir=cache_dir,
+            encoder_file_name=encoder_file_name,
+            decoder_file_name=decoder_file_name,
+            decoder_with_past_file_name=decoder_with_past_file_name,
             local_files_only=local_files_only,
             **kwargs,
         )

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -192,7 +192,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
         + TRANSLATION_EXAMPLE.format(
             processor_class=_TOKENIZER_FOR_DOC,
             model_class="OVModelForSeq2SeqLM",
-            checkpoint="Helsinki-NLP/opus-mt-en-fr",
+            checkpoint="t5-small",
         )
     )
     def forward(

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -60,6 +60,7 @@ MODEL_NAMES = {
     "distilbert": "hf-internal-testing/tiny-random-distilbert",
     "marian": "sshleifer/tiny-marian-en-de",
     "mbart": "hf-internal-testing/tiny-random-mbart",
+    "mbart_large": "facebook/mbart-large-50-many-to-many-mmt",
     "m2m_100": "valhalla/m2m100_tiny_random",
     "roberta": "hf-internal-testing/tiny-random-roberta",
     "t5": "hf-internal-testing/tiny-random-t5",
@@ -382,7 +383,11 @@ class OVModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         "t5",
     )
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    LARGE_ARCHITECTURES = (
+        "mbart_large",
+    )
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES + LARGE_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):
         model_id = MODEL_NAMES[model_arch]
         set_seed(SEED)

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -39,6 +39,9 @@ from transformers import (
 import requests
 from evaluate import evaluator
 from optimum.intel.openvino import (
+    OV_DECODER_NAME,
+    OV_DECODER_WITH_PAST_NAME,
+    OV_ENCODER_NAME,
     OV_XML_FILE_NAME,
     OVModelForCausalLM,
     OVModelForFeatureExtraction,
@@ -60,7 +63,6 @@ MODEL_NAMES = {
     "distilbert": "hf-internal-testing/tiny-random-distilbert",
     "marian": "sshleifer/tiny-marian-en-de",
     "mbart": "hf-internal-testing/tiny-random-mbart",
-    "mbart_large": "facebook/mbart-large-50-many-to-many-mmt",
     "m2m_100": "valhalla/m2m100_tiny_random",
     "roberta": "hf-internal-testing/tiny-random-roberta",
     "t5": "hf-internal-testing/tiny-random-t5",
@@ -75,15 +77,42 @@ class OVModelIntegrationTest(unittest.TestCase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.OV_MODEL_ID = "echarlaix/distilbert-base-uncased-finetuned-sst-2-english-openvino"
+        self.OV_SEQ2SEQ_MODEL_ID = "echarlaix/t5-small-openvino"
 
-    def test_load_model_from_hub(self):
+    def test_load_from_hub_and_save_model(self):
+        tokenizer = AutoTokenizer.from_pretrained(self.OV_MODEL_ID)
+        tokens = tokenizer("This is a sample input", return_tensors="pt")
+        loaded_model = OVModelForSequenceClassification.from_pretrained(self.OV_MODEL_ID)
+        self.assertIsInstance(loaded_model.config, PretrainedConfig)
+        loaded_model_outputs = loaded_model(**tokens)
+
         with tempfile.TemporaryDirectory() as tmpdirname:
-            model = OVModelForSequenceClassification.from_pretrained(self.OV_MODEL_ID)
-            self.assertIsInstance(model.config, PretrainedConfig)
-            model.save_pretrained(tmpdirname)
+            loaded_model.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(OV_XML_FILE_NAME in folder_contents)
             self.assertTrue(OV_XML_FILE_NAME.replace(".xml", ".bin") in folder_contents)
+            model = OVModelForSequenceClassification.from_pretrained(tmpdirname)
+
+        outputs = model(**tokens)
+        self.assertTrue(torch.equal(loaded_model_outputs.logits, outputs.logits))
+
+    def test_load_from_hub_and_save_seq2seq_model(self):
+        tokenizer = AutoTokenizer.from_pretrained(self.OV_MODEL_ID)
+        tokens = tokenizer("This is a sample input", return_tensors="pt")
+        loaded_model = OVModelForSeq2SeqLM.from_pretrained(self.OV_SEQ2SEQ_MODEL_ID)
+        self.assertIsInstance(loaded_model.config, PretrainedConfig)
+        loaded_model_outputs = loaded_model.generate(**tokens)
+
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            loaded_model.save_pretrained(tmpdirname)
+            folder_contents = os.listdir(tmpdirname)
+            self.assertTrue(OV_ENCODER_NAME in folder_contents)
+            self.assertTrue(OV_DECODER_NAME in folder_contents)
+            self.assertTrue(OV_DECODER_WITH_PAST_NAME in folder_contents)
+            model = OVModelForSeq2SeqLM.from_pretrained(tmpdirname)
+
+        outputs = model.generate(**tokens)
+        self.assertTrue(torch.equal(loaded_model_outputs, outputs))
 
 
 class OVModelForSequenceClassificationIntegrationTest(unittest.TestCase):
@@ -383,11 +412,7 @@ class OVModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         "t5",
     )
 
-    LARGE_ARCHITECTURES = (
-        "mbart_large",
-    )
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES + LARGE_ARCHITECTURES)
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):
         model_id = MODEL_NAMES[model_arch]
         set_seed(SEED)


### PR DESCRIPTION
In this PR we export the encoder-decoder model's component to different directories to avoid any possible collision during the ONNX export 