### PR TITLE
Update runner image github actions workflows

### DIFF
--- a/.github/workflows/check_code_quality.yml
+++ b/.github/workflows/check_code_quality.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8]
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_inc.yml
+++ b/.github/workflows/test_inc.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [3.8, 3.9]
-        os: [ubuntu-18.04]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Migrate to `ubuntu-22.04` as `ubuntu-18.04` is deprecated