### PR TITLE
Add small tests for optimum/transformer update testing

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -33,4 +33,4 @@ jobs:
         pip install .[openvino,nncf,tests]
     - name: Test with Pytest
       run: |
-        pytest tests/openvino/
+        pytest tests/openvino/ --ignore test_modeling_basic

--- a/.github/workflows/test_openvino_basic.yml
+++ b/.github/workflows/test_openvino_basic.yml
@@ -22,6 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Testing lower and upper bound of supported Python versions
+        # This also ensures that the test fails if dependencies break for Python 3.7
         python-version: ["3.7", "3.10"]
         transformers: ['transformers', 'git+https://github.com/huggingface/transformers.git']
         optimum: ['optimum', 'git+https://github.com/huggingface/optimum.git']

--- a/.github/workflows/test_openvino_basic.yml
+++ b/.github/workflows/test_openvino_basic.yml
@@ -4,6 +4,14 @@ on:
   workflow_dispatch:
   schedule:
     - cron:  '41 1 * * *'  # run every day at 1:41
+  push:
+    paths:
+    - 'tests/openvino/test_modeling_basic.py'
+    - '.github/workflows/test_openvino_basic.yml'
+  pull_request:
+    paths:
+    - 'tests/openvino/test_modeling_basic.py'
+    - '.github/workflows/test_openvino_basic.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -26,7 +34,7 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install dependencies
       run: |
         # Install openvino manually to prevent dependency conflicts when .[openvino] pins

--- a/.github/workflows/test_openvino_basic.yml
+++ b/.github/workflows/test_openvino_basic.yml
@@ -1,0 +1,41 @@
+name: OpenVINO - Basic Test
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '41 1 * * *'  # run every day at 1:41
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.10"]
+        transformers: ['transformers', 'git+https://github.com/huggingface/transformers.git']
+        optimum: ['optimum', 'git+https://github.com/huggingface/optimum.git']
+
+    runs-on: ubuntu-20.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    
+    - name: Install dependencies
+      run: |
+        # Install openvino manually to prevent dependency conflicts when .[openvino] pins
+        # optimum or transformers to a specific version
+        # Install PyTorch CPU to prevent unnecessary downloading/installing of CUDA packages
+        pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install .[tests] openvino onnx ${{ matrix.optimum}} ${{ matrix.transformers }}
+        
+    - name: Test with Pytest
+      run: |
+        pytest tests/openvino/test_modeling_basic.py
+

--- a/.github/workflows/test_openvino_basic.yml
+++ b/.github/workflows/test_openvino_basic.yml
@@ -42,7 +42,10 @@ jobs:
         # Install PyTorch CPU to prevent unnecessary downloading/installing of CUDA packages
         pip install torch --extra-index-url https://download.pytorch.org/whl/cpu
         pip install .[tests] openvino onnx ${{ matrix.optimum}} ${{ matrix.transformers }}
-        
+
+    - name: Pip freeze        
+      run: pip freeze
+
     - name: Test with Pytest
       run: |
         pytest tests/openvino/test_modeling_basic.py

--- a/tests/openvino/test_modeling_basic.py
+++ b/tests/openvino/test_modeling_basic.py
@@ -55,7 +55,7 @@ class OVModelBasicIntegrationTest(unittest.TestCase):
         if model_class_str == "OVModelForQuestionAnswering":
             input_text *= 2
         elif model_class_str == "OVModelForMaskedLM":
-            input_text[0] = f"{input_text} {tokenizer.mask_token}"
+            input_text[0] = f"{input_text[0]} {tokenizer.mask_token}"
 
         if model_class_str in TASKS:
             task = TASKS[model_class_str]

--- a/tests/openvino/test_modeling_basic.py
+++ b/tests/openvino/test_modeling_basic.py
@@ -34,7 +34,7 @@ TASKS = {
     "OVModelForSequenceClassification": "text-classification",
     "OVModelForQuestionAnswering": "question-answering",
     "OVModelForCausalLM": "text-generation",
-    "OVModelForSeq2SeqLM": "text-generation",
+    "OVModelForSeq2SeqLM": "text2text-generation",
 }
 
 

--- a/tests/openvino/test_modeling_basic.py
+++ b/tests/openvino/test_modeling_basic.py
@@ -1,0 +1,85 @@
+"""
+The goal of the test in this file is to test that basic functionality of optimum[openvino] works:
+- Load the model with `from_transformers=True`
+- Do inference with appropriate pipeline
+- Save the model to disk
+
+This test is meant to run quickly with tiny test models. More extensive tests are in 
+test_modeling.py.
+"""
+
+import gc
+import unittest
+
+from transformers import AutoTokenizer, pipeline
+
+from huggingface_hub import HfApi
+from optimum.intel.openvino import *
+from parameterized import parameterized
+
+
+# Make sure that common architectures are used in combination with common tasks
+MODEL_NAMES = {
+    "hf-internal-testing/tiny-random-bert": "OVModelForMaskedLM",
+    "hf-internal-testing/tiny-random-distilbert": "OVModelForSequenceClassification",
+    "hf-internal-testing/tiny-random-mbart": "OVModelForSeq2SeqLM",
+    "hf-internal-testing/tiny-random-roberta": "OVModelForQuestionAnswering",
+    "hf-internal-testing/tiny-random-gpt2": "OVModelForCausalLM",
+    "hf-internal-testing/tiny-random-t5": "OVModelForSeq2SeqLM",
+    "hf-internal-testing/tiny-random-bart": "OVModelForSeq2SeqLM",
+}
+
+TASKS = {
+    "OVModelForMaskedLM": "fill-mask",
+    "OVModelForSequenceClassification": "text-classification",
+    "OVModelForQuestionAnswering": "question-answering",
+    "OVModelForCausalLM": "text-generation",
+    "OVModelForSeq2SeqLM": "text-generation",
+}
+
+
+class OVModelBasicIntegrationTest(unittest.TestCase):
+    @parameterized.expand(MODEL_NAMES.keys())
+    def test_pipeline(self, model_id):
+        """
+        Test that loading, inference and saving works for all models in MODEL_NAMES
+        """
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        model_class_str = MODEL_NAMES[model_id]
+        model_class = eval(model_class_str)
+        model = model_class.from_pretrained(model_id, from_transformers=True)
+        model.save_pretrained(f"{model_id}_ov")
+        model = model_class.from_pretrained(f"{model_id}_ov")
+
+        input_text = ["hello world"]
+        if model_class_str == "OVModelForQuestionAnswering":
+            input_text *= 2
+        elif model_class_str == "OVModelForMaskedLM":
+            input_text[0] = f"{input_text} {tokenizer.mask_token}"
+
+        if model_class_str in TASKS:
+            task = TASKS[model_class_str]
+            pipe = pipeline(task, model=model, tokenizer=tokenizer)
+            pipe(*input_text)
+        gc.collect()
+
+    def test_openvino_methods(self):
+        """
+        Sanity check for .reshape() .to() and .half()
+        """
+        model_id = "hf-internal-testing/tiny-random-distilbert"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        model = OVModelForSequenceClassification.from_pretrained(model_id, from_transformers=True)
+        model.reshape(1, 16)
+        model.half()
+        model.to("CPU")
+        pipe = pipeline(
+            "text-classification",
+            model=model,
+            tokenizer=tokenizer,
+            max_length=16,
+            padding="max_length",
+            truncation=True,
+        )
+        pipe("hello world")
+        gc.collect()


### PR DESCRIPTION
Add basic functionality check for optimum[openvino] integration with released and source versions of optimum and transformers. This will allow us to find issues with updated dependencies earlier. 
The test only checks if no exceptions occur on loading, saving and doing inference (with pipeline) on the most common model types. 
The test is configured to run daily. With initial testing I saw some differences depending on Python version, so the test checks with both Python 3.7 and 3.10. 
The test is excluded from tests that are run on PR (except for PRs that modify the test itself) because this test overlaps with them.

TODO (in later PR): Add ViT model type.