### PR TITLE
Add upgrade pip instructions to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,22 @@ To install the latest release of 🤗 Optimum Intel with the corresponding requi
 | [Intel Neural Compressor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install optimum[neural-compressor]`                  |
 | [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install optimum[openvino,nncf]`                      |
 
+We recommend creating a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) and upgrading
+pip with `python -m pip install --upgrade pip`.
 
-Optimum Intel is a fast-moving project, and you may want to install from source.
+Optimum Intel is a fast-moving project, and you may want to install from source with the following command:
 
 ```bash
-pip install git+https://github.com/huggingface/optimum-intel.git
+python -m pip install git+https://github.com/huggingface/optimum-intel.git
 ```
+
+or to install from source including dependencies:
+
+```bash
+python -m pip install git+https://github.com/huggingface/optimum-intel.git#egg=optimum-intel[extras]
+```
+
+where `extras` can be one or more of `neural-compressor`, `openvino`, `nncf`.
 
 # Quick tour
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ You can find more examples in the [documentation](https://huggingface.co/docs/op
 
 ## Running the examples
 
-Check out the [`examples`](https://github.com/huggingface/optimum-intel/tree/main/examples) directory to see how 🤗 Optimum Intel can be used to accelerate inference.
+Check out the [`examples`](https://github.com/huggingface/optimum-intel/tree/main/examples) directory to see how 🤗 Optimum Intel can be used to optimize models and accelerate inference.
 
 Do not forget to install requirements for every example:
 

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -32,9 +32,19 @@ To install the latest release of 🤗 Optimum Intel with the corresponding requi
 | [Intel Neural Compressor (INC)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install optimum[neural-compressor]`|
 | [Intel OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install optimum[openvino,nncf]`    |
 
-Optimum Intel is a fast-moving project, you can install it from source with the following command:
+We recommend creating a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) and upgrading
+pip with `python -m pip install --upgrade pip`.
+
+Optimum Intel is a fast-moving project, and you may want to install from source with the following command:
 
 ```bash
 python -m pip install git+https://github.com/huggingface/optimum-intel.git
 ```
 
+or to install from source including dependencies:
+
+```bash
+python -m pip install git+https://github.com/huggingface/optimum-intel.git#egg=optimum-intel[extras]
+```
+
+where `extras` can be one or more of `neural-compressor`, `openvino`, `nncf`.


### PR DESCRIPTION
- With an out-of-date pip you run into errors. For example: `pip install optimum-intel[openvino]` did not install the onnx dependency with an outdated pip.
- We recommend to install from source, and then it's nice to have the command for how to install the extras with it. It's not obvious that for the OpenVINO integration to work, you would need to install onnx manually for example.

[EDIT] also slightly changed sentence that refers to examples to clarify that these are examples that optimize models. 