### PR TITLE
Set CPU as default device in INC training examples

### DIFF
--- a/examples/neural_compressor/multiple-choice/run_swag.py
+++ b/examples/neural_compressor/multiple-choice/run_swag.py
@@ -48,7 +48,8 @@ from transformers.utils.versions import require_version
 from neural_compressor import DistillationConfig, QuantizationAwareTrainingConfig, WeightPruningConfig
 from optimum.intel.neural_compressor import INCModelForMultipleChoice, INCTrainer
 
-# Will be removed when neural-compressor next release is out 
+
+# Will be removed when neural-compressor next release is out
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 

--- a/examples/neural_compressor/multiple-choice/run_swag.py
+++ b/examples/neural_compressor/multiple-choice/run_swag.py
@@ -48,6 +48,9 @@ from transformers.utils.versions import require_version
 from neural_compressor import DistillationConfig, QuantizationAwareTrainingConfig, WeightPruningConfig
 from optimum.intel.neural_compressor import INCModelForMultipleChoice, INCTrainer
 
+# Will be removed when neural-compressor next release is out 
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
 
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.20.0")

--- a/examples/neural_compressor/question-answering/run_qa.py
+++ b/examples/neural_compressor/question-answering/run_qa.py
@@ -56,6 +56,10 @@ from trainer_qa import QuestionAnsweringINCTrainer
 from utils_qa import postprocess_qa_predictions
 
 
+# Will be removed when neural-compressor next release is out 
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.20.0")
 

--- a/examples/neural_compressor/question-answering/run_qa.py
+++ b/examples/neural_compressor/question-answering/run_qa.py
@@ -56,7 +56,7 @@ from trainer_qa import QuestionAnsweringINCTrainer
 from utils_qa import postprocess_qa_predictions
 
 
-# Will be removed when neural-compressor next release is out 
+# Will be removed when neural-compressor next release is out
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 

--- a/examples/neural_compressor/summarization/run_summarization.py
+++ b/examples/neural_compressor/summarization/run_summarization.py
@@ -54,6 +54,10 @@ from neural_compressor import QuantizationAwareTrainingConfig, WeightPruningConf
 from optimum.intel.neural_compressor import INCModelForSeq2SeqLM, INCSeq2SeqTrainer
 
 
+# Will be removed when neural-compressor next release is out 
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.20.0")
 

--- a/examples/neural_compressor/summarization/run_summarization.py
+++ b/examples/neural_compressor/summarization/run_summarization.py
@@ -54,7 +54,7 @@ from neural_compressor import QuantizationAwareTrainingConfig, WeightPruningConf
 from optimum.intel.neural_compressor import INCModelForSeq2SeqLM, INCSeq2SeqTrainer
 
 
-# Will be removed when neural-compressor next release is out 
+# Will be removed when neural-compressor next release is out
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 

--- a/examples/neural_compressor/text-classification/run_glue.py
+++ b/examples/neural_compressor/text-classification/run_glue.py
@@ -51,6 +51,10 @@ from neural_compressor import DistillationConfig, QuantizationAwareTrainingConfi
 from optimum.intel.neural_compressor import INCModelForSequenceClassification, INCTrainer
 
 
+# Will be removed when neural-compressor next release is out 
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.20.0")
 

--- a/examples/neural_compressor/text-classification/run_glue.py
+++ b/examples/neural_compressor/text-classification/run_glue.py
@@ -51,7 +51,7 @@ from neural_compressor import DistillationConfig, QuantizationAwareTrainingConfi
 from optimum.intel.neural_compressor import INCModelForSequenceClassification, INCTrainer
 
 
-# Will be removed when neural-compressor next release is out 
+# Will be removed when neural-compressor next release is out
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 

--- a/examples/neural_compressor/token-classification/run_ner.py
+++ b/examples/neural_compressor/token-classification/run_ner.py
@@ -50,7 +50,7 @@ from neural_compressor import DistillationConfig, QuantizationAwareTrainingConfi
 from optimum.intel.neural_compressor import INCModelForTokenClassification, INCQuantizer, INCTrainer
 
 
-# Will be removed when neural-compressor next release is out 
+# Will be removed when neural-compressor next release is out
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 

--- a/examples/neural_compressor/token-classification/run_ner.py
+++ b/examples/neural_compressor/token-classification/run_ner.py
@@ -50,6 +50,10 @@ from neural_compressor import DistillationConfig, QuantizationAwareTrainingConfi
 from optimum.intel.neural_compressor import INCModelForTokenClassification, INCQuantizer, INCTrainer
 
 
+# Will be removed when neural-compressor next release is out 
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.20.0")
 

--- a/examples/neural_compressor/translation/run_translation.py
+++ b/examples/neural_compressor/translation/run_translation.py
@@ -54,6 +54,10 @@ from neural_compressor import QuantizationAwareTrainingConfig, WeightPruningConf
 from optimum.intel.neural_compressor import INCModelForSeq2SeqLM, INCSeq2SeqTrainer
 
 
+# Will be removed when neural-compressor next release is out 
+os.environ["CUDA_VISIBLE_DEVICES"] = ""
+
+
 # Will error if the minimal version of Transformers is not installed. Remove at your own risks.
 check_min_version("4.20.0")
 

--- a/examples/neural_compressor/translation/run_translation.py
+++ b/examples/neural_compressor/translation/run_translation.py
@@ -54,7 +54,7 @@ from neural_compressor import QuantizationAwareTrainingConfig, WeightPruningConf
 from optimum.intel.neural_compressor import INCModelForSeq2SeqLM, INCSeq2SeqTrainer
 
 
-# Will be removed when neural-compressor next release is out 
+# Will be removed when neural-compressor next release is out
 os.environ["CUDA_VISIBLE_DEVICES"] = ""
 
 


### PR DESCRIPTION
Set temporarily CPU as default device in INC training examples, this will be removed when `neural-compressor` `v2.0.1` is out 