### PR TITLE
Fix past key values usage

### DIFF
--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -225,7 +225,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
     def prepare_inputs_for_generation(
         self,
         input_ids,
-        past=None,
+        past_key_values=None,
         attention_mask=None,
         head_mask=None,
         decoder_head_mask=None,
@@ -236,7 +236,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
     ) -> Dict:
         return {
             "decoder_input_ids": input_ids,
-            "past_key_values": past,
+            "past_key_values": past_key_values,
             "encoder_outputs": encoder_outputs,
             "attention_mask": attention_mask,
             "head_mask": head_mask,

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -236,7 +236,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
     ) -> Dict:
         return {
             "decoder_input_ids": input_ids,
-            "past_key_values": past_key_values,
+            "past_key_values": past_key_values or kwargs.get("past", None),
             "encoder_outputs": encoder_outputs,
             "attention_mask": attention_mask,
             "head_mask": head_mask,


### PR DESCRIPTION
transformers 4.26.0 broke the usage of past key and values in Optimum:

https://github.com/huggingface/transformers/blob/v4.25.1/src/transformers/models/t5/modeling_t5.py#L1703
vs
https://github.com/huggingface/transformers/blob/v4.26.0/src/transformers/models/t5/modeling_t5.py#L1715

This PR fixes the issue and adds the corresponding test.

Related: https://github.com/huggingface/optimum/pull/756 https://github.com/huggingface/optimum/issues/754