### PR TITLE
Add stable diffusion OpenVINO pipeline

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -30,6 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        pip install git+https://github.com/huggingface/optimum
         pip install .[openvino,nncf,tests]
     - name: Test with Pytest
       run: |

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/huggingface/optimum@add-stable-diffusion-ort
         pip install .[openvino,nncf,tests]
     - name: Test with Pytest
       run: |

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install git+https://github.com/huggingface/optimum
+        pip install git+https://github.com/huggingface/optimum@add-stable-diffusion-ort
         pip install .[openvino,nncf,tests]
     - name: Test with Pytest
       run: |

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -14,7 +14,7 @@
 
 import importlib.util
 
-from ..utils.import_utils import is_nncf_available
+from ..utils.import_utils import is_diffusers_available, is_nncf_available
 from .utils import OV_DECODER_NAME, OV_DECODER_WITH_PAST_NAME, OV_ENCODER_NAME, OV_XML_FILE_NAME
 
 
@@ -39,3 +39,7 @@ from .modeling import (
     OVModelForTokenClassification,
 )
 from .modeling_seq2seq import OVModelForSeq2SeqLM
+
+
+if is_diffusers_available():
+    from .modeling_diffusion import OVStableDiffusionPipeline

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -104,17 +104,18 @@ class OVBaseModel(OptimizedModel):
             self.generation_config = GenerationConfig.from_model_config(config) if self.can_generate() else None
 
     @staticmethod
-    def load_model(file_name: Union[str, Path], bin_file_name: Optional[Union[str, Path]] = None):
+    def load_model(file_name: Union[str, Path]):
         """
         Loads the model.
 
         Arguments:
             file_name (`str` or `Path`):
                 The path of the model ONNX or XML file.
-            bin_file_name (`str` or `Path`, *optional*):
-                The path of the model binary file, for OpenVINO IR the weights file is expected to be in the same
-                directory as the .xml file if not provided.
         """
+        if isinstance(file_name, str):
+            file_name = Path(file_name)
+        bin_file_name = file_name.with_suffix(".bin") if file_name.suffix == ".xml" else None
+
         return core.read_model(file_name, bin_file_name)
 
     def _save_pretrained(self, save_directory: Union[str, Path], file_name: Optional[str] = None, **kwargs):
@@ -184,8 +185,7 @@ class OVBaseModel(OptimizedModel):
                     "The file names `ov_model.xml` and `ov_model.bin` will be soon deprecated."
                     "Make sure to rename your file to respectively `openvino_model.xml` and `openvino_model.bin`"
                 )
-            bin_file_name = file_name.replace(".xml", ".bin") if not from_onnx else None
-            model = cls.load_model(file_name, bin_file_name)
+            model = cls.load_model(file_name)
             model_save_dir = model_id
         # Download the model from the hub
         else:
@@ -225,8 +225,7 @@ class OVBaseModel(OptimizedModel):
                     "Make sure to rename your file to respectively `openvino_model.xml` and `openvino_model.bin`"
                 )
             model_save_dir = Path(model_cache_path).parent
-            bin_file_name = file_names[1] if not from_onnx else None
-            model = cls.load_model(file_names[0], bin_file_name=bin_file_name)
+            model = cls.load_model(file_names[0])
         return cls(model, config=config, model_save_dir=model_save_dir, **kwargs)
 
     @classmethod

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -193,7 +193,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
 
             encoder = cls.load_model(os.path.join(model_id, encoder_file_name))
             decoder = cls.load_model(os.path.join(model_id, decoder_file_name))
-            decoder_with_past = cls.load_model(os.path.join(model_id, decoder_with_past_file_name)) if use_cache else None
+            decoder_with_past = (
+                cls.load_model(os.path.join(model_id, decoder_with_past_file_name)) if use_cache else None
+            )
             model_save_dir = Path(model_id)
 
         # Load model from hub

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -190,23 +190,10 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                     "will be soon deprecated. Make sure to rename your file to respectively `openvino_encoder_model.xml`, "
                     "`openvino_decoder_model.xml` and `openvino_decoder_with_past_model.xml`"
                 )
-            encoder_bin_file_name = (
-                os.path.join(model_id, encoder_file_name.replace(".xml", ".bin")) if not from_onnx else None
-            )
-            decoder_bin_file_name = (
-                os.path.join(model_id, decoder_file_name.replace(".xml", ".bin")) if not from_onnx else None
-            )
-            decoder_with_past_bin_file_name = (
-                os.path.join(model_id, decoder_with_past_file_name.replace(".xml", ".bin")) if not from_onnx else None
-            )
 
-            encoder = cls.load_model(os.path.join(model_id, encoder_file_name), encoder_bin_file_name)
-            decoder = cls.load_model(os.path.join(model_id, decoder_file_name), decoder_bin_file_name)
-            decoder_with_past = (
-                cls.load_model(os.path.join(model_id, decoder_with_past_file_name), decoder_with_past_bin_file_name)
-                if use_cache
-                else None
-            )
+            encoder = cls.load_model(os.path.join(model_id, encoder_file_name))
+            decoder = cls.load_model(os.path.join(model_id, decoder_file_name))
+            decoder_with_past = cls.load_model(os.path.join(model_id, decoder_with_past_file_name)) if use_cache else None
             model_save_dir = Path(model_id)
 
         # Load model from hub
@@ -257,14 +244,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                 )
 
             model_save_dir = Path(model_cache_path).parent
-            encoder = cls.load_model(file_names["encoder"], bin_file_name=file_names.pop("encoder_bin", None))
-            decoder = cls.load_model(file_names["decoder"], bin_file_name=file_names.pop("decoder_bin", None))
-            if use_cache:
-                decoder_with_past = cls.load_model(
-                    file_names["decoder_with_past"], bin_file_name=file_names.pop("decoder_with_past_bin", None)
-                )
-            else:
-                decoder_with_past = None
+            encoder = cls.load_model(file_names["encoder"])
+            decoder = cls.load_model(file_names["decoder"])
+            decoder_with_past = cls.load_model(file_names["decoder_with_past"]) if use_cache else None
 
         return cls(
             encoder=encoder,

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -174,12 +174,14 @@ class OVStableDiffusionPipeline(OVBaseModel, StableDiffusionPipelineMixin):
 
         if not os.path.isdir(model_id):
             allow_patterns = [os.path.join(k, "*") for k in config.keys() if not k.startswith("_")]
-
             allow_patterns += list(
                 {
                     vae_decoder_file_name,
                     text_encoder_file_name,
                     unet_file_name,
+                    vae_decoder_file_name.replace(".xml", ".bin"),
+                    vae_decoder_file_name.replace(".xml", ".bin"),
+                    unet_file_name.replace(".xml", ".bin"),
                     SCHEDULER_CONFIG_NAME,
                     CONFIG_NAME,
                     cls.config_name,
@@ -193,7 +195,7 @@ class OVStableDiffusionPipeline(OVBaseModel, StableDiffusionPipelineMixin):
                 use_auth_token=use_auth_token,
                 revision=revision,
                 allow_patterns=allow_patterns,
-                ignore_patterns=["*.msgpack", "*.safetensors", "*.bin"],
+                ignore_patterns=["*.msgpack", "*.safetensors", "*pytorch_model.bin"],
             )
         new_model_save_dir = Path(model_id)
 

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -1,0 +1,395 @@
+#  Copyright 2022 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import importlib
+import logging
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Dict, Optional, Union
+
+import numpy as np
+from transformers import CLIPFeatureExtractor, CLIPTokenizer
+
+import openvino
+from diffusers import DDIMScheduler, LMSDiscreteScheduler, PNDMScheduler, StableDiffusionPipeline
+from diffusers.schedulers.scheduling_utils import SCHEDULER_CONFIG_NAME
+from diffusers.utils import CONFIG_NAME
+from huggingface_hub import snapshot_download
+from openvino._offline_transformations import compress_model_transformation
+from openvino.offline_transformations import compress_model_transformation
+from openvino.runtime import Core
+from optimum.exporters import TasksManager
+from optimum.exporters.onnx import export_models, get_stable_diffusion_models_for_export
+from optimum.pipelines.diffusers.pipeline_stable_diffusion import StableDiffusionPipelineMixin
+from optimum.utils import (
+    DIFFUSION_MODEL_TEXT_ENCODER_SUBFOLDER,
+    DIFFUSION_MODEL_UNET_SUBFOLDER,
+    DIFFUSION_MODEL_VAE_DECODER_SUBFOLDER,
+)
+from optimum.utils.constant import (
+    CONFIG_NAME,
+    DIFFUSION_MODEL_TEXT_ENCODER_SUBFOLDER,
+    DIFFUSION_MODEL_UNET_SUBFOLDER,
+    DIFFUSION_MODEL_VAE_DECODER_SUBFOLDER,
+    DIFFUSION_MODEL_VAE_ENCODER_SUBFOLDER,
+)
+
+from .modeling_base import OVBaseModel
+from .utils import ONNX_WEIGHTS_NAME, OV_TO_NP_TYPE, OV_XML_FILE_NAME
+
+
+core = Core()
+
+logger = logging.getLogger(__name__)
+
+
+class OVStableDiffusionPipeline(OVBaseModel, StableDiffusionPipelineMixin):
+
+    auto_model_class = StableDiffusionPipeline
+    config_name = "model_index.json"
+    export_feature = "stable-diffusion"
+
+    def __init__(
+        self,
+        vae_decoder: openvino.runtime.Model,
+        text_encoder: openvino.runtime.Model,
+        unet: openvino.runtime.Model,
+        config: Dict[str, Any],
+        tokenizer: "CLIPTokenizer",
+        scheduler: Union["DDIMScheduler", "PNDMScheduler", "LMSDiscreteScheduler"],
+        feature_extractor: Optional["CLIPFeatureExtractor"] = None,
+        device: str = "CPU",
+        dynamic_shapes: bool = True,
+        compile: bool = True,
+        **kwargs,
+    ):
+        self._internal_dict = config
+        self._device = device.upper()
+        self.is_dynamic = dynamic_shapes
+        self.ov_config = {}
+        self.vae_decoder = OVModelVaeDecoder(vae_decoder, self)
+        self.text_encoder = OVModelTextEncoder(text_encoder, self)
+        self.unet = OVModelUnet(unet, self)
+        self.tokenizer = tokenizer
+        self.scheduler = scheduler
+        self.feature_extractor = feature_extractor
+        self.vae_decoder_request = None
+        self.text_encoder_request = None
+        self.unet_request = None
+        self.safety_checker = None
+        self.preprocessors = kwargs.get("preprocessors", [])
+
+        if compile:
+            self.compile()
+
+        sub_models = {
+            DIFFUSION_MODEL_TEXT_ENCODER_SUBFOLDER: self.text_encoder,
+            DIFFUSION_MODEL_UNET_SUBFOLDER: self.unet,
+            DIFFUSION_MODEL_VAE_DECODER_SUBFOLDER: self.vae_decoder,
+        }
+        for name in sub_models.keys():
+            self._internal_dict[name] = ("optimum", sub_models[name].__class__.__name__)
+        self._internal_dict.pop("vae", None)
+
+    def _save_pretrained(
+        self,
+        save_directory: Union[str, Path],
+        vae_decoder_file_name: str = OV_XML_FILE_NAME,
+        text_encoder_file_name: str = OV_XML_FILE_NAME,
+        unet_file_name: str = OV_XML_FILE_NAME,
+        **kwargs,
+    ):
+        """
+        Saves the model to the OpenVINO IR format so that it can be re-loaded using the
+        [`~optimum.intel.openvino.modeling.OVModel.from_pretrained`] class method.
+
+        Arguments:
+            save_directory (`str` or `Path`):
+                The directory where to save the model files.
+            vae_decoder_file_name (`str`, defaults to `optimum.intel.utils.ONNX_WEIGHTS_NAME`):
+                The VAE decoder model file name. Overwrites the default file name and allows one to save the VAE decoder model
+                with a different name.
+            text_encoder_file_name (`str`, defaults to `optimum.onnxruntime.utils.ONNX_WEIGHTS_NAME`):
+                The text encoder model file name. Overwrites the default file name and allows one to save the text encoder model
+                with a different name.
+            unet_file_name (`str`, defaults to `optimum.onnxruntime.ONNX_WEIGHTS_NAME`):
+                The U-NET model file name. Overwrites the default file name and allows one to save the U-NET model
+                with a different name.
+        """
+        save_directory = Path(save_directory)
+        src_to_dst_file = {
+            self.vae_decoder.model: save_directory / DIFFUSION_MODEL_VAE_DECODER_SUBFOLDER / vae_decoder_file_name,
+            self.text_encoder.model: save_directory / DIFFUSION_MODEL_TEXT_ENCODER_SUBFOLDER / text_encoder_file_name,
+            self.unet.model: save_directory / DIFFUSION_MODEL_UNET_SUBFOLDER / unet_file_name,
+        }
+
+        for src_file, dst_path in src_to_dst_file.items():
+            dst_path.parent.mkdir(parents=True, exist_ok=True)
+            openvino.runtime.serialize(src_file, str(dst_path), str(dst_path.with_suffix(".bin")))
+
+        self.tokenizer.save_pretrained(save_directory.joinpath("tokenizer"))
+        self.scheduler.save_pretrained(save_directory.joinpath("scheduler"))
+        if self.feature_extractor is not None:
+            self.feature_extractor.save_pretrained(save_directory.joinpath("feature_extractor"))
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_id: Union[str, Path],
+        config: Dict[str, Any],
+        use_auth_token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        cache_dir: Optional[str] = None,
+        vae_decoder_file_name: Optional[str] = None,
+        text_encoder_file_name: Optional[str] = None,
+        unet_file_name: Optional[str] = None,
+        local_files_only: bool = False,
+        from_onnx: bool = False,
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        **kwargs,
+    ):
+        default_file_name = ONNX_WEIGHTS_NAME if from_onnx else OV_XML_FILE_NAME
+        vae_decoder_file_name = vae_decoder_file_name or default_file_name
+        text_encoder_file_name = text_encoder_file_name or default_file_name
+        unet_file_name = unet_file_name or default_file_name
+        model_id = str(model_id)
+        sub_models_to_load, _, _ = cls.extract_init_dict(config)
+        sub_models_names = set(sub_models_to_load.keys()).intersection({"feature_extractor", "tokenizer", "scheduler"})
+        sub_models = {}
+
+        if not os.path.isdir(model_id):
+            allow_patterns = [os.path.join(k, "*") for k in config.keys() if not k.startswith("_")]
+
+            allow_patterns += list(
+                {
+                    vae_decoder_file_name,
+                    text_encoder_file_name,
+                    unet_file_name,
+                    SCHEDULER_CONFIG_NAME,
+                    CONFIG_NAME,
+                    cls.config_name,
+                }
+            )
+            # Downloads all repo's files matching the allowed patterns
+            model_id = snapshot_download(
+                model_id,
+                cache_dir=cache_dir,
+                local_files_only=local_files_only,
+                use_auth_token=use_auth_token,
+                revision=revision,
+                allow_patterns=allow_patterns,
+                ignore_patterns=["*.msgpack", "*.safetensors", "*.bin"],
+            )
+        new_model_save_dir = Path(model_id)
+
+        for name in sub_models_names:
+            library_name, library_classes = sub_models_to_load[name]
+            if library_classes is not None:
+                library = importlib.import_module(library_name)
+                class_obj = getattr(library, library_classes)
+                load_method = getattr(class_obj, "from_pretrained")
+                # Check if the module is in a subdirectory
+                if (new_model_save_dir / name).is_dir():
+                    sub_models[name] = load_method(new_model_save_dir / name)
+                else:
+                    sub_models[name] = load_method(new_model_save_dir)
+
+        vae_decoder = cls.load_model(
+            new_model_save_dir / DIFFUSION_MODEL_VAE_DECODER_SUBFOLDER / vae_decoder_file_name
+        )
+        text_encoder = cls.load_model(
+            new_model_save_dir / DIFFUSION_MODEL_TEXT_ENCODER_SUBFOLDER / text_encoder_file_name
+        )
+        unet = cls.load_model(new_model_save_dir / DIFFUSION_MODEL_UNET_SUBFOLDER / unet_file_name)
+
+        if model_save_dir is None:
+            model_save_dir = new_model_save_dir
+
+        return cls(
+            vae_decoder=vae_decoder,
+            text_encoder=text_encoder,
+            unet=unet,
+            config=config,
+            tokenizer=sub_models["tokenizer"],
+            scheduler=sub_models["scheduler"],
+            feature_extractor=sub_models.pop("feature_extractor", None),
+            model_save_dir=model_save_dir,
+            **kwargs,
+        )
+
+    @classmethod
+    def _from_transformers(
+        cls,
+        model_id: str,
+        config: Dict[str, Any],
+        use_auth_token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        force_download: bool = False,
+        cache_dir: Optional[str] = None,
+        local_files_only: bool = False,
+        task: Optional[str] = None,
+        **kwargs,
+    ):
+        if task is None:
+            task = cls._auto_model_to_task(cls.auto_model_class)
+        save_dir = TemporaryDirectory()
+        save_dir_path = Path(save_dir.name)
+
+        model = TasksManager.get_model_from_task(
+            task,
+            model_id,
+            revision=revision,
+            cache_dir=cache_dir,
+            config=config,
+            use_auth_token=use_auth_token,
+            local_files_only=local_files_only,
+            force_download=force_download,
+        )
+
+        output_names = [
+            os.path.join(DIFFUSION_MODEL_TEXT_ENCODER_SUBFOLDER, ONNX_WEIGHTS_NAME),
+            os.path.join(DIFFUSION_MODEL_UNET_SUBFOLDER, ONNX_WEIGHTS_NAME),
+            os.path.join(DIFFUSION_MODEL_VAE_ENCODER_SUBFOLDER, ONNX_WEIGHTS_NAME),
+            os.path.join(DIFFUSION_MODEL_VAE_DECODER_SUBFOLDER, ONNX_WEIGHTS_NAME),
+        ]
+        models_and_onnx_configs = get_stable_diffusion_models_for_export(model)
+
+        model.save_config(save_dir_path)
+        model.tokenizer.save_pretrained(save_dir_path.joinpath("tokenizer"))
+        model.scheduler.save_pretrained(save_dir_path.joinpath("scheduler"))
+        if model.feature_extractor is not None:
+            model.feature_extractor.save_pretrained(save_dir_path.joinpath("feature_extractor"))
+
+        export_models(
+            models_and_onnx_configs=models_and_onnx_configs,
+            output_dir=save_dir_path,
+            output_names=output_names,
+        )
+
+        return cls._from_pretrained(
+            model_id=save_dir_path,
+            config=config,
+            from_onnx=True,
+            use_auth_token=use_auth_token,
+            revision=revision,
+            force_download=force_download,
+            cache_dir=cache_dir,
+            local_files_only=local_files_only,
+            model_save_dir=save_dir,  # important
+            **kwargs,
+        )
+
+    def to(self, device: str):
+        self._device = device.upper()
+        self.clear_requests()
+        return self
+
+    def reshape(self, *args, **kwargs):
+        logger.warning("Stable Diffusion models do not currently support reshaping.")
+        return self
+
+    def half(self):
+        """
+        Converts all the model weights to FP16 for more efficient inference on GPU.
+        """
+        compress_model_transformation(self.vae_decoder.model)
+        compress_model_transformation(self.text_encoder.model)
+        compress_model_transformation(self.unet.model)
+        self.clear_requests()
+        return self
+
+    def clear_requests(self):
+        self.text_encoder.request = None
+        self.vae_decoder.request = None
+        self.unet.request = None
+
+    def compile(self):
+        self.text_encoder._create_inference_request()
+        self.vae_decoder._create_inference_request()
+        self.unet._create_inference_request()
+
+    def __call__(self, *args, **kwargs):
+        return StableDiffusionPipelineMixin.__call__(self, *args, **kwargs)
+
+    @classmethod
+    def _load_config(cls, config_name_or_path: Union[str, os.PathLike], **kwargs):
+        return cls.load_config(config_name_or_path, **kwargs)
+
+    def _save_config(self, save_directory):
+        self.save_config(save_directory)
+
+
+class OVModelPart:
+    def __init__(self, model: openvino.runtime.Model, parent_model: "OVModel" = None):
+        self.model = model
+        self.parent_model = parent_model
+        self.input_names = {key.get_any_name(): idx for idx, key in enumerate(self.model.inputs)}
+        self.input_dtype = {
+            inputs.get_any_name(): OV_TO_NP_TYPE[inputs.get_element_type().get_type_name()]
+            for inputs in self.model.inputs
+        }
+        self.ov_config = self.parent_model.ov_config
+        self.request = None
+
+    def _create_inference_request(self):
+        if self.request is None:
+            logger.info("Compiling the encoder and creating the inference request ...")
+            compiled_model = core.compile_model(self.model, self.device, self.ov_config)
+            self.request = compiled_model.create_infer_request()
+
+    @property
+    def device(self):
+        return self.parent_model._device
+
+
+class OVModelTextEncoder(OVModelPart):
+    def __call__(self, input_ids: np.ndarray):
+
+        self._create_inference_request()
+
+        inputs = {
+            "input_ids": input_ids,
+        }
+        outputs = self.request.infer(inputs)
+        outputs = {key.get_any_name(): value for key, value in outputs.items()}
+        return outputs
+
+
+class OVModelUnet(OVModelPart):
+    def __call__(self, sample: np.ndarray, timestep: np.ndarray, encoder_hidden_states: np.ndarray):
+
+        self._create_inference_request()
+
+        inputs = {
+            "sample": sample,
+            "timestep": timestep,
+            "encoder_hidden_states": encoder_hidden_states,
+        }
+        outputs = self.request.infer(inputs)
+        outputs = {key.get_any_name(): value for key, value in outputs.items()}
+        return outputs
+
+
+class OVModelVaeDecoder(OVModelPart):
+    def __call__(self, latent_sample: np.ndarray):
+
+        self._create_inference_request()
+
+        inputs = {
+            "latent_sample": latent_sample,
+        }
+        outputs = self.request.infer(inputs)
+        outputs = {key.get_any_name(): value for key, value in outputs.items()}
+        return outputs

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 
+import numpy as np
 from transformers.onnx.utils import ParameterFormat, compute_serialized_parameters_size
 
 
@@ -31,6 +32,22 @@ MAX_ONNX_OPSET = 13
 MIN_ONNX_QDQ_OPSET = 13
 
 EXTERNAL_DATA_FORMAT_SIZE_LIMIT = 2 * 1024 * 1024 * 1024
+
+
+OV_TO_NP_TYPE = {
+    "boolean": np.bool_,
+    "i8": np.int8,
+    "u8": np.uint8,
+    "i16": np.int16,
+    "u16": np.uint16,
+    "i32": np.int32,
+    "u32": np.uint32,
+    "i64": np.int64,
+    "u64": np.uint64,
+    "f16": np.float16,
+    "f32": np.float32,
+    "f64": np.float64,
+}
 
 
 def use_external_data_format(num_parameters: int) -> bool:

--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -65,6 +65,15 @@ if _nncf_available:
         _nncf_available = False
 
 
+_diffusers_available = importlib.util.find_spec("diffusers") is not None
+_diffusers_version = "N/A"
+if _diffusers_available:
+    try:
+        _diffusers_version = importlib_metadata.version("diffusers")
+    except importlib_metadata.PackageNotFoundError:
+        _diffusers_available = False
+
+
 def is_transformers_available():
     return _transformers_available
 
@@ -79,6 +88,10 @@ def is_openvino_available():
 
 def is_nncf_available():
     return _nncf_available
+
+
+def is_diffusers_available():
+    return _diffusers_available
 
 
 # This function was copied from: https://github.com/huggingface/accelerate/blob/874c4967d94badd24f893064cc3bef45f57cadf7/src/accelerate/utils/versions.py#L319
@@ -127,3 +140,12 @@ def is_openvino_version(operation: str, version: str):
     if not _openvino_available:
         return False
     return compare_versions(parse(_openvino_version), operation, version)
+
+
+def is_diffusers_version(operation: str, version: str):
+    """
+    Compare the current diffusers version to a given reference with an operation.
+    """
+    if not _diffusers_available:
+        return False
+    return compare_versions(parse(_diffusers_version), operation, version)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRE = [
     "scipy",
 ]
 
-TESTS_REQUIRE = ["pytest", "parameterized", "Pillow", "evaluate"]
+TESTS_REQUIRE = ["pytest", "parameterized", "Pillow", "evaluate", "diffusers"]
 
 QUALITY_REQUIRE = ["black==22.3", "isort>=5.5.4"]
 

--- a/setup.py
+++ b/setup.py
@@ -27,10 +27,7 @@ QUALITY_REQUIRE = ["black==22.3", "isort>=5.5.4"]
 EXTRAS_REQUIRE = {
     "neural-compressor": ["neural-compressor>=2.0.0", "onnx", "onnxruntime"],
     "openvino": ["openvino>=2022.3.0", "onnx", "onnxruntime"],
-    "nncf": [
-        "nncf>=2.4.0",
-        "openvino-dev>=2022.3.0",
-    ],
+    "nncf": ["nncf>=2.4.0", "openvino-dev>=2022.3.0"],
     "ipex": ["intel_extension_for_pytorch"],
     "diffusers": ["diffusers"],
     "quality": QUALITY_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except Exception as error:
     assert False, "Error: Could not open '%s' due %s\n" % (filepath, error)
 
 INSTALL_REQUIRE = [
-    "optimum>=1.6.1",
+    "optimum>=1.7.0",
     "transformers>=4.20.0",
     "datasets>=1.4.0",
     "torch",

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -144,9 +144,11 @@ class OVModelIntegrationTest(unittest.TestCase):
     def test_load_from_hub_and_save_stable_diffusion_model(self):
         loaded_pipeline = OVStableDiffusionPipeline.from_pretrained(self.OV_STABLE_DIFFUSION_MODEL_ID, compile=False)
         self.assertIsInstance(loaded_pipeline.config, Dict)
-        # loaded_pipeline.to("cpu")
-        # prompt = "sailing ship in storm by Leonardo da Vinci"
-        # loaded_pipeline_outputs = loaded_pipeline(prompt, num_inference_steps=2, output_type="np").images
+        prompt = "sailing ship in storm by Leonardo da Vinci"
+        height = 16
+        width = 16
+        pipeline_outputs = loaded_pipeline(prompt, num_inference_steps=1, height=height, width=width, output_type="np")
+        self.assertEqual(pipeline_outputs.images.shape, (1, height, width, 3))
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             loaded_pipeline.save_pretrained(tmpdirname)
@@ -162,8 +164,8 @@ class OVModelIntegrationTest(unittest.TestCase):
                 self.assertIn(OV_XML_FILE_NAME.replace(".xml", ".bin"), folder_contents)
                 # pipeline = OVStableDiffusionPipeline.from_pretrained(tmpdirname)
 
-        # outputs = pipeline(prompt, num_inference_steps=2, output_type="np").images
-        # self.assertTrue(torch.equal(loaded_pipeline_outputs, outputs))
+        # outputs = pipeline(prompt, num_inference_steps=1, height=height, width=width, output_type="np").images
+        # self.assertTrue(torch.equal(pipeline_outputs.images, outputs))
 
 
 class OVModelForSequenceClassificationIntegrationTest(unittest.TestCase):

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -148,10 +148,12 @@ class OVModelIntegrationTest(unittest.TestCase):
         height = 16
         width = 16
         vae_scale_factor = 4  # needed for dummy stable diffusion model
+        np.random.seed(0)
         pipeline_outputs = loaded_pipeline(prompt, num_inference_steps=1, height=height, width=width, output_type="np")
         self.assertEqual(pipeline_outputs.images.shape, (1, height // vae_scale_factor, width // vae_scale_factor, 3))
         with tempfile.TemporaryDirectory() as tmpdirname:
             loaded_pipeline.save_pretrained(tmpdirname)
+            pipeline = OVStableDiffusionPipeline.from_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertIn(loaded_pipeline.config_name, folder_contents)
             for subfoler in {
@@ -162,10 +164,9 @@ class OVModelIntegrationTest(unittest.TestCase):
                 folder_contents = os.listdir(os.path.join(tmpdirname, subfoler))
                 self.assertIn(OV_XML_FILE_NAME, folder_contents)
                 self.assertIn(OV_XML_FILE_NAME.replace(".xml", ".bin"), folder_contents)
-                pipeline = OVStableDiffusionPipeline.from_pretrained(tmpdirname)
-
+        np.random.seed(0)
         outputs = pipeline(prompt, num_inference_steps=1, height=height, width=width, output_type="np").images
-        self.assertTrue(torch.equal(pipeline_outputs.images, outputs))
+        self.assertTrue(np.array_equal(pipeline_outputs.images, outputs))
 
 
 class OVModelForSequenceClassificationIntegrationTest(unittest.TestCase):

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -147,9 +147,9 @@ class OVModelIntegrationTest(unittest.TestCase):
         prompt = "sailing ship in storm by Leonardo da Vinci"
         height = 16
         width = 16
-        vae_scale_factor = 4 # needed for dummy stable diffusion model
+        vae_scale_factor = 4  # needed for dummy stable diffusion model
         pipeline_outputs = loaded_pipeline(prompt, num_inference_steps=1, height=height, width=width, output_type="np")
-        self.assertEqual(pipeline_outputs.images.shape, (1,  height // vae_scale_factor, width // vae_scale_factor, 3))
+        self.assertEqual(pipeline_outputs.images.shape, (1, height // vae_scale_factor, width // vae_scale_factor, 3))
         with tempfile.TemporaryDirectory() as tmpdirname:
             loaded_pipeline.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -56,13 +56,9 @@ from optimum.intel.openvino import (
     OVModelForSeq2SeqLM,
     OVModelForSequenceClassification,
     OVModelForTokenClassification,
-)
-from optimum.intel.openvino.modeling_diffusion import (
-    OVModelTextEncoder,
-    OVModelUnet,
-    OVModelVaeDecoder,
     OVStableDiffusionPipeline,
 )
+from optimum.intel.openvino.modeling_diffusion import OVModelTextEncoder, OVModelUnet, OVModelVaeDecoder
 from optimum.intel.openvino.modeling_seq2seq import OVDecoder, OVEncoder
 from optimum.utils import (
     CONFIG_NAME,


### PR DESCRIPTION
In this PR we add a stable diffusion pipeline enabling OpenVINO Runtime. To export the model to the OpenVINO IR `export` must be set to `True`. Needs https://github.com/huggingface/optimum/pull/786 to be merged.

```python
from optimum.intel.openvino import OVStableDiffusionPipeline

model_id = "runwayml/stable-diffusion-v1-5"
stable_diffusion = OVStableDiffusionPipeline.from_pretrained(model_id, export=True)
prompt = "sailing ship in storm by Leonardo da Vinci"
images = stable_diffusion(prompt).images
```
Closes https://github.com/huggingface/diffusers/issues/1760 and https://github.com/huggingface/diffusers/issues/2202
