### PR TITLE
Make pip install instructions zsh compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Intel [Neural Compressor](https://www.intel.com/content/www/us/en/developer/tool
 
 To install the latest release of 🤗 Optimum Intel with the corresponding required dependencies, you can use `pip` as follows:
 
-| Accelerator                                                                                                      | Installation                                                        |
-|:-----------------------------------------------------------------------------------------------------------------|:--------------------------------------------------------------------|
-| [Intel Neural Compressor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install optimum[neural-compressor]`                  |
-| [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install optimum[openvino,nncf]`                      |
+| Accelerator                                                                                                      | Installation                                                         |
+|:-----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|
+| [Intel Neural Compressor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install "optimum[neural-compressor]"`                 |
+| [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install "optimum[openvino,nncf]"`                     |
 
 We recommend creating a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) and upgrading
 pip with `python -m pip install --upgrade pip`.
@@ -31,7 +31,7 @@ python -m pip install git+https://github.com/huggingface/optimum-intel.git
 or to install from source including dependencies:
 
 ```bash
-python -m pip install git+https://github.com/huggingface/optimum-intel.git#egg=optimum-intel[extras]
+python -m pip install "optimum-intel[extras]"@git+https://github.com/huggingface/optimum-intel.git
 ```
 
 where `extras` can be one or more of `neural-compressor`, `openvino`, `nncf`.

--- a/docs/source/index.mdx
+++ b/docs/source/index.mdx
@@ -27,10 +27,10 @@ limitations under the License.
 
 To install the latest release of 🤗 Optimum Intel with the corresponding required dependencies, you can do respectively:
 
-| Accelerator                                                                                                            | Installation                                      |
-|:-----------------------------------------------------------------------------------------------------------------------|:--------------------------------------------------|
-| [Intel Neural Compressor (INC)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install optimum[neural-compressor]`|
-| [Intel OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install optimum[openvino,nncf]`    |
+| Accelerator                                                                                                            | Installation                                        |
+|:-----------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------|
+| [Intel Neural Compressor (INC)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install "optimum[neural-compressor]"`|
+| [Intel OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install "optimum[openvino,nncf]"`    |
 
 We recommend creating a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) and upgrading
 pip with `python -m pip install --upgrade pip`.
@@ -44,7 +44,7 @@ python -m pip install git+https://github.com/huggingface/optimum-intel.git
 or to install from source including dependencies:
 
 ```bash
-python -m pip install git+https://github.com/huggingface/optimum-intel.git#egg=optimum-intel[extras]
+python -m pip install "optimum-intel[extras]"@git+https://github.com/huggingface/optimum-intel.git
 ```
 
 where `extras` can be one or more of `neural-compressor`, `openvino`, `nncf`.


### PR DESCRIPTION
The zsh shell requires quotes around `pip install packages[extras]`, this PR changes the pip install instructions in README and docs to add that. I tested the method with added quotes on Ubuntu and Windows and it worked fine there too. zsh is the default shell on macOS.

Also changed the `#egg=` method to the method now recommended by pip (the previous method now throws a deprecation warning).