### PR TITLE
Enable overflow_fix in JPQD examples

### DIFF
--- a/examples/openvino/question-answering/configs/bert-base-jpqd.json
+++ b/examples/openvino/question-answering/configs/bert-base-jpqd.json
@@ -10,14 +10,14 @@
         "sparse_structure_by_scopes": [
             {"mode": "block", "sparse_factors": [32, 32], "target_scopes": "{re}.*BertAttention.*"},
             {"mode": "per_dim", "axis": 0, "target_scopes": "{re}.*BertIntermediate.*"},
-            {"mode": "per_dim", "axis": 1, "target_scopes": "{re}.*BertOutput.*"},
+            {"mode": "per_dim", "axis": 1, "target_scopes": "{re}.*BertOutput.*"}
         ],
         "ignored_scopes": ["{re}.*NNCFEmbedding.*", "{re}.*qa_outputs.*", "{re}.*LayerNorm.*"]
     },
     {
         "algorithm": "quantization",
         "preset": "mixed",
-        "overflow_fix": "disable",
+        "overflow_fix": "enable",
         "initializer": {
             "range": {
                 "num_init_samples": 32,
@@ -37,7 +37,7 @@
             "{re}.*__add___[0-1]",
             "{re}.*layer_norm_0",
             "{re}.*matmul_1",
-            "{re}.*__truediv__*",
-        ],
+            "{re}.*__truediv__*"
+        ]
     }
 ]

--- a/examples/openvino/text-classification/configs/bert-base-jpqd.json
+++ b/examples/openvino/text-classification/configs/bert-base-jpqd.json
@@ -5,12 +5,12 @@
             "warmup_start_epoch": 1,
             "warmup_end_epoch": 2,
             "importance_regularization_factor": 0.05,
-            "enable_structured_masking": true,
+            "enable_structured_masking": true
         },
         "sparse_structure_by_scopes": [
             {"mode": "block", "sparse_factors": [32, 32], "target_scopes": "{re}.*BertAttention.*"},
             {"mode": "per_dim", "axis": 0, "target_scopes": "{re}.*BertIntermediate.*"},
-            {"mode": "per_dim", "axis": 1, "target_scopes": "{re}.*BertOutput.*"},
+            {"mode": "per_dim", "axis": 1, "target_scopes": "{re}.*BertOutput.*"}
         ],
         "ignored_scopes": [
             "{re}.*NNCFEmbedding.*",
@@ -21,7 +21,7 @@
     {
         "algorithm": "quantization",
         "preset": "mixed",
-        "overflow_fix": "disable",
+        "overflow_fix": "enable",
         "initializer": {
             "range": {
                 "num_init_samples": 32,
@@ -41,7 +41,7 @@
             "{re}.*__add___[0-1]",
             "{re}.*layer_norm_0",
             "{re}.*matmul_1",
-            "{re}.*__truediv__*",
-        ],
+            "{re}.*__truediv__*"
+        ]
     }
 ]


### PR DESCRIPTION
Enable overflow_fix for JPQD examples to restore accuracy on computers without VNNI.
With overflow_fix disabled, accuracy on non-VNNI machines is terrible, model outputs are almost random. 
Enabling overflow_fix has no disadvantages: accuracy is now as expected on both VNNI and non-VNNI machines.

Also removed some comma's from the config file to make it valid JSON.

cc @vuiseng9 