### PR TITLE
Enable overflow_fix in ovtrainer tests on machines without VNNI support

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -22,7 +22,7 @@ from optimum.configuration_utils import BaseConfig
 DEFAULT_QUANTIZATION_CONFIG = {
     "algorithm": "quantization",
     "preset": "mixed",
-    "overflow_fix": "disable",
+    "overflow_fix": "enable",
     "initializer": {
         "range": {"num_init_samples": 300, "type": "mean_min_max"},
         "batchnorm_adaptation": {"num_bn_adaptation_samples": 0},

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -22,7 +22,7 @@ from optimum.configuration_utils import BaseConfig
 DEFAULT_QUANTIZATION_CONFIG = {
     "algorithm": "quantization",
     "preset": "mixed",
-    "overflow_fix": "enable",
+    "overflow_fix": "disable",
     "initializer": {
         "range": {"num_init_samples": 300, "type": "mean_min_max"},
         "batchnorm_adaptation": {"num_bn_adaptation_samples": 0},

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ INSTALL_REQUIRE = [
     "scipy",
 ]
 
-TESTS_REQUIRE = ["pytest", "parameterized", "Pillow", "evaluate", "diffusers"]
+TESTS_REQUIRE = ["pytest", "parameterized", "Pillow", "evaluate", "diffusers", "py-cpuinfo"]
 
 QUALITY_REQUIRE = ["black==22.3", "isort>=5.5.4"]
 

--- a/tests/openvino/test_training.py
+++ b/tests/openvino/test_training.py
@@ -367,7 +367,7 @@ class OVTrainerTrainingTest(unittest.TestCase):
                     torch.allclose(
                         torch.softmax(ovmodel_logits, dim=-1),
                         torch.softmax(torch_logits, dim=-1),
-                        rtol=0.2,
+                        rtol=0.01,
                     )
                 )
 

--- a/tests/openvino/test_training.py
+++ b/tests/openvino/test_training.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import re
 import tempfile
 import unittest
 from copy import deepcopy
@@ -100,9 +101,8 @@ def initialize_movement_sparsifier_parameters_by_sparsity(
                 operand.bias_importance.copy_(bias_init_tensor)
 
 
-def is_avx512_vnni_supported() -> bool:
-    flags = [flag.lower() for flag in cpuinfo.get_cpu_info()["flags"]]
-    return "avx512_vnni" in flags or "avx512vnni" in flags or "avx_vnni" in flags
+def is_avx_vnni_supported() -> bool:
+    return any(re.search("avx.*vnni", flag.lower()) is not None for flag in cpuinfo.get_cpu_info()["flags"])
 
 
 @dataclass
@@ -324,7 +324,7 @@ class OVTrainerTrainingTest(unittest.TestCase):
         torch.manual_seed(42)
         self.ov_config = OVConfig()
         nncf_compression_config = desc.nncf_compression_config
-        if not is_avx512_vnni_supported():
+        if not is_avx_vnni_supported():
             # should enable "overflow_fix" in quantization otherwise accuracy degradation may be seen
             nncf_compression_config = self.get_nncf_config_with_overflow_fix_override(
                 nncf_compression_config, "enable"

--- a/tests/openvino/test_training.py
+++ b/tests/openvino/test_training.py
@@ -40,6 +40,7 @@ from parameterized import parameterized
 
 CUSTOMIZED_QUANTIZATION_CONFIG = {
     "algorithm": "quantization",
+    "overflow_fix": "enable",
     "initializer": {
         "range": {
             "num_init_samples": 16,

--- a/tests/openvino/test_training.py
+++ b/tests/openvino/test_training.py
@@ -102,7 +102,7 @@ def initialize_movement_sparsifier_parameters_by_sparsity(
 
 def is_avx512_vnni_supported() -> bool:
     flags = [flag.lower() for flag in cpuinfo.get_cpu_info()["flags"]]
-    return "avx512_vnni" in flags or "avx512vnni" in flags
+    return "avx512_vnni" in flags or "avx512vnni" in flags or "avx_vnni" in flags
 
 
 @dataclass

--- a/tests/openvino/test_training.py
+++ b/tests/openvino/test_training.py
@@ -368,7 +368,7 @@ class OVTrainerTrainingTest(unittest.TestCase):
                     torch.allclose(
                         torch.softmax(ovmodel_logits, dim=-1),
                         torch.softmax(torch_logits, dim=-1),
-                        rtol=0.01,
+                        rtol=0.001,
                     )
                 )
 

--- a/tests/openvino/test_training.py
+++ b/tests/openvino/test_training.py
@@ -398,7 +398,7 @@ class OVTrainerTrainingTest(unittest.TestCase):
                     torch.allclose(
                         torch.softmax(ovmodel_logits, dim=-1),
                         torch.softmax(torch_logits, dim=-1),
-                        rtol=0.001,
+                        rtol=0.0001,
                     )
                 )
 


### PR DESCRIPTION
This PR addresses the tests on checking torch outputs and IR outputs:

(1) sets a reasonable relative error tolerance value (rtol)  as 0.01% when checking IR and torch outputs;

(2) when doing `test_training` on a machine without VNNI support (e.g., this CI system), will first modify the test config with "overflow_fix" enabled, and then do the following checking. Otherwise the CI computer cannot pass the tests with rtol=0.01%, see https://github.com/openvinotoolkit/nncf/issues/1498#issuecomment-1446052227 

(3) to detect if VNNI is supported, we added a new test requirement: [py-cpuinfo](https://github.com/workhorsy/py-cpuinfo), which is MIT license. 