### PR TITLE
Update OpenVINO notebook requirements

### DIFF
--- a/notebooks/openvino/question_answering_quantization.ipynb
+++ b/notebooks/openvino/question_answering_quantization.ipynb
@@ -11,7 +11,17 @@
     "\n",
     "With quantization, we reduce the precision of the model's weights and activations from floating point (FP32) to integer (INT8). This results in a smaller model with faster inference times with OpenVINO Runtime. \n",
     "\n",
-    "The notebook demonstrates post-training quantization, which does not require specific hardware to execute. A laptop or desktop with a recent Intel Core processor is recommended for best results. To install the requirements for this notebook, please do `pip install -r requirements.txt`."
+    "The notebook demonstrates post-training quantization, which does not require specific hardware to execute. A laptop or desktop with a recent Intel Core processor is recommended for best results. To install the requirements for this notebook, please do `pip install -r requirements.txt` or uncomment the cell below to install the requirements in your current Python environment."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dffab375-a730-4015-8d17-360b76a0718d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %pip install \"optimum-intel[openvino, nncf]\" datasets evaluate[evaluator] ipywidgets"
    ]
   },
   {
@@ -926,7 +936,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -940,7 +950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.8.16"
   }
  },
  "nbformat": 4,

--- a/notebooks/openvino/requirements.txt
+++ b/notebooks/openvino/requirements.txt
@@ -1,6 +1,4 @@
-git+https://github.com/openvinotoolkit/nncf.git@develop
-git+https://github.com/huggingface/optimum-intel.git
-openvino>=2022.3.0.dev20221125
+optimum-intel[openvino, nncf]
 datasets
 evaluate[evaluator]
 ipywidgets


### PR DESCRIPTION
The notebook used to require source versions of optimum-intel and NNCF, but not anymore!
I also added a cell to the notebook to install the requirements directly in the notebook, to make it possible to run in cloud environments like colab. 