### PR TITLE
Remove GPU dynamic shapes restriction

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -85,11 +85,6 @@ class OVBaseModel(OptimizedModel):
         self.preprocessors = kwargs.get("preprocessors", [])
         enable_compilation = kwargs.get("compile", True)
 
-        if "GPU" in self._device and self.is_dynamic:
-            raise ValueError(
-                "Support of dynamic shapes for GPU devices is not yet available. Set `dynamic_shapes` to `False` to continue."
-            )
-
         if self.is_dynamic:
             height = -1 if self.export_feature == "image-classification" else None
             width = -1 if self.export_feature == "image-classification" else None
@@ -363,7 +358,7 @@ class OVBaseModel(OptimizedModel):
 
     def half(self):
         """
-        Converts all the model weights to FP16 for more efficient inference on GPU.
+        Converts all the model weights to FP16
         """
         apply_moc_transformations(self.model, cf=False)
         compress_model_transformation(self.model)


### PR DESCRIPTION
- Remove message about GPU dynamic shapes. Dynamic shapes on GPU work in the current OpenVINO prerelease, though there are still some known issues. We currently only show this message when a user loads a model though, not when moving a model `.to("gpu")`.
- Change comment for `.half()`. It's not necessary anymore to explicitly convert the model to  FP16 for increased performance on GPU; OpenVINO will do this automatically. It's still a useful method to save the model weights with half the size. 

We should discuss how to support setting explicit inference hints https://docs.openvino.ai/latest/openvino_docs_OV_UG_supported_plugins_CPU.html