### PR TITLE
Add inc config

### DIFF
--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -96,6 +96,7 @@ except OptionalDependencyNotAvailable:
     ]
 else:
     _import_structure["neural_compressor"] = [
+        "INCConfig",
         "INCModelForCausalLM",
         "INCModelForMaskedLM",
         "INCModelForMultipleChoice",
@@ -107,7 +108,6 @@ else:
         "INCQuantizer",
         "INCSeq2SeqTrainer",
         "INCTrainer",
-        "INCConfig",
     ]
 
 
@@ -161,6 +161,7 @@ if TYPE_CHECKING:
         from .utils.dummy_neural_compressor_objects import *
     else:
         from .neural_compressor import (
+            INCConfig,
             INCModel,
             INCModelForCausalLM,
             INCModelForMaskedLM,
@@ -173,7 +174,6 @@ if TYPE_CHECKING:
             INCQuantizer,
             INCSeq2SeqTrainer,
             INCTrainer,
-            INCConfig,
         )
 else:
     import sys

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -107,6 +107,7 @@ else:
         "INCQuantizer",
         "INCSeq2SeqTrainer",
         "INCTrainer",
+        "INCConfig",
     ]
 
 
@@ -172,6 +173,7 @@ if TYPE_CHECKING:
             INCQuantizer,
             INCSeq2SeqTrainer,
             INCTrainer,
+            INCConfig,
         )
 else:
     import sys

--- a/optimum/intel/neural_compressor/__init__.py
+++ b/optimum/intel/neural_compressor/__init__.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+from .configuration import INCConfig
 from .quantization import (
     INCModel,
     INCModelForCausalLM,
@@ -23,16 +24,6 @@ from .quantization import (
     INCModelForTokenClassification,
     INCModelForVision2Seq,
     INCQuantizationMode,
-    IncQuantizedModel,
-    IncQuantizedModelForCausalLM,
-    IncQuantizedModelForMaskedLM,
-    IncQuantizedModelForMultipleChoice,
-    IncQuantizedModelForQuestionAnswering,
-    IncQuantizedModelForSeq2SeqLM,
-    IncQuantizedModelForSequenceClassification,
-    IncQuantizedModelForTokenClassification,
-    IncQuantizedModelForVision2Seq,
-    IncQuantizedModelForXLNetLM,
     INCQuantizer,
 )
 from .trainer import INCTrainer

--- a/optimum/intel/neural_compressor/configuration.py
+++ b/optimum/intel/neural_compressor/configuration.py
@@ -67,13 +67,13 @@ class INCConfig(BaseConfig):
             weight_compression = config.weight_compression
             config = {
                 "approach": weight_compression.pruning_type,
-                "target_sparsity": weight_compression.target_sparsity,
                 "pattern": weight_compression.pattern,
-                "start_step": weight_compression.start_step,
-                "end_step": weight_compression.end_step,
-                "scope": weight_compression.pruning_scope,
+                "sparsity": weight_compression.target_sparsity,
+                # "operators": weight_compression.pruning_op_types,
+                # "start_step": weight_compression.start_step,
+                # "end_step": weight_compression.end_step,
+                # "scope": weight_compression.pruning_scope,
                 # "frequency": weight_compression.pruning_frequency,
-                "op_types": weight_compression.pruning_op_types,
             }
         return config
 
@@ -84,7 +84,7 @@ class INCConfig(BaseConfig):
             config = {
                 "teacher_model_name_or_path": config.teacher_model.config._name_or_path,
                 "temperature": criterion.temperature,
-                "loss_types": criterion.loss_types,
-                "loss_weights": criterion.loss_weights,
+                # "loss_types": criterion.loss_types,
+                # "loss_weights": criterion.loss_weights,
             }
         return config

--- a/optimum/intel/neural_compressor/configuration.py
+++ b/optimum/intel/neural_compressor/configuration.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional, Union
 
 import torch
 
-from neural_compressor.conf.pythonic_config import _BaseQuantizationConfig, WeightPruningConfig, WeightPruningConfig, DistillationConfig
+from neural_compressor.conf.pythonic_config import DistillationConfig, WeightPruningConfig, _BaseQuantizationConfig
 from optimum.configuration_utils import BaseConfig
 
 from ..utils.import_utils import _neural_compressor_version, _torch_version
@@ -83,8 +83,8 @@ class INCConfig(BaseConfig):
             criterion = next(iter(config.criterion.values()))
             config = {
                 "teacher_model_name_or_path": config.teacher_model.config._name_or_path,
-                "temperature" : criterion.temperature,
-                "loss_types" : criterion.loss_types,
-                "loss_weights" : criterion.loss_weights,
+                "temperature": criterion.temperature,
+                "loss_types": criterion.loss_types,
+                "loss_weights": criterion.loss_weights,
             }
         return config

--- a/optimum/intel/neural_compressor/configuration.py
+++ b/optimum/intel/neural_compressor/configuration.py
@@ -12,205 +12,79 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-import logging
-import os
-from functools import reduce
-from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Dict, List, Optional, Union
 
-from transformers.utils import TRANSFORMERS_CACHE, is_offline_mode
+import torch
 
-import yaml
-from huggingface_hub import hf_hub_download
-from neural_compressor.conf.config import Conf, Distillation_Conf, Pruning_Conf, Quantization_Conf
-from optimum.intel.neural_compressor.utils import CONFIG_NAME
+from neural_compressor.conf.pythonic_config import _BaseQuantizationConfig, WeightPruningConfig, WeightPruningConfig, DistillationConfig
+from optimum.configuration_utils import BaseConfig
+
+from ..utils.import_utils import _neural_compressor_version, _torch_version
 
 
-logger = logging.getLogger(__name__)
+_quantization_model = {
+    "post_training_dynamic_quant": "dynamic",
+    "post_training_static_quant": "static",
+    "quant_aware_training": "aware_training",
+}
 
 
-class IncConfig:
-    CONFIG_NAME = "best_configure.yml"
+class INCConfig(BaseConfig):
+    CONFIG_NAME = "inc_config.json"
+    FULL_CONFIGURATION_FILE = "inc_config.json"
 
-    def __init__(self, config_path: str):
-        """
-        Args:
-            config_path (`str`):
-                Path to the YAML configuration file used to control the tuning behavior.
-        Returns:
-            config: IncConfig object.
-        """
+    def __init__(
+        self,
+        quantization: Optional[Union[Dict, _BaseQuantizationConfig]] = None,
+        pruning: Optional[Union[Dict, _BaseQuantizationConfig]] = None,
+        distillation: Optional[Union[Dict, _BaseQuantizationConfig]] = None,
+        save_onnx_model: bool = False,
+        **kwargs,
+    ):
+        super().__init__()
+        self.torch_version = _torch_version
+        self.neural_compressor_version = _neural_compressor_version
+        self.quantization = self._create_quantization_config(quantization) or {}
+        self.pruning = self._create_pruning_config(pruning) or {}
+        self.distillation = self._create_distillation_config(distillation) or {}
+        self.save_onnx_model = save_onnx_model
 
-        self.path = config_path
-        self.config = Conf(config_path)
-        self.usr_cfg = self.config.usr_cfg
-
-    def get_config(self, keys: str):
-        return reduce(lambda d, key: d.get(key) if d else None, keys.split("."), self.usr_cfg)
-
-    def set_config(self, keys: str, value: Any):
-        d = self.usr_cfg
-        keys = keys.split(".")
-        for key in keys[:-1]:
-            d = d.setdefault(key, {})
-        d[keys[-1]] = value
-
-    def set_tolerance(self, tolerance_criterion: Union[int, float]):
-        if not isinstance(tolerance_criterion, (int, float)):
-            raise TypeError(
-                f"Supported type for performance tolerance are int and float, got {type(tolerance_criterion)}"
-            )
-        if "absolute" in self.get_config("tuning.accuracy_criterion"):
-            self.set_config("tuning.accuracy_criterion.absolute", tolerance_criterion)
-        else:
-            if not -1 < tolerance_criterion < 1:
-                raise ValueError("Relative performance tolerance must not be <=-1 or >=1.")
-            self.set_config("tuning.accuracy_criterion.relative", tolerance_criterion)
-
-    @classmethod
-    def from_pretrained(cls, config_name_or_path: str, config_file_name: Optional[str] = None, **kwargs):
-        """
-        Instantiate an IncConfig object from a configuration file which can either be hosted on
-        huggingface.co or from a local directory path.
-
-        Args:
-            config_name_or_path (`str`):
-                Repository name in the Hugging Face Hub or path to a local directory containing the configuration file.
-            config_file_name (`str`, *optional*):
-                Name of the configuration file.
-            cache_dir (`str`, *optional*):
-                Path to a directory in which a downloaded configuration should be cached if the standard cache should
-                not be used.
-            force_download (`bool`, *optional*, defaults to `False`):
-                Whether or not to force to (re-)download the configuration files and override the cached versions if
-                they exist.
-            resume_download (`bool`, *optional*, defaults to `False`):
-                Whether or not to delete incompletely received file. Attempts to resume the download if such a file
-                exists.
-            revision(`str`, *optional*):
-                The specific model version to use. It can be a branch name, a tag name, or a commit id, since we use a
-                git-based system for storing models and other artifacts on huggingface.co, so ``revision`` can be any
-                identifier allowed by git.
-        Returns:
-            config: IncConfig object.
-        """
-
-        cache_dir = kwargs.get("cache_dir", None)
-        force_download = kwargs.get("force_download", False)
-        resume_download = kwargs.get("resume_download", False)
-        revision = kwargs.get("revision", None)
-
-        config_file_name = config_file_name if config_file_name is not None else cls.CONFIG_NAME
-
-        if os.path.isdir(config_name_or_path):
-            config_file = os.path.join(config_name_or_path, config_file_name)
-        elif os.path.isfile(config_name_or_path):
-            config_file = config_name_or_path
-        else:
-            local_files_only = False
-            if is_offline_mode():
-                logger.info("Offline mode: forcing local_files_only=True")
-                local_files_only = True
-            if cache_dir is None:
-                cache_dir = TRANSFORMERS_CACHE
-            if isinstance(cache_dir, Path):
-                cache_dir = str(cache_dir)
-            try:
-                config_file = hf_hub_download(
-                    repo_id=config_name_or_path,
-                    filename=config_file_name,
-                    revision=revision,
-                    cache_dir=cache_dir,
-                    force_download=force_download,
-                    resume_download=resume_download,
-                    local_files_only=local_files_only,
-                )
-            except EnvironmentError as err:
-                logger.error(err)
-                msg = (
-                    f"Can't load config for '{config_name_or_path}'. Make sure that:\n\n"
-                    f"-'{config_name_or_path}' is a correct model identifier listed on 'https://huggingface.co/models'\n\n"
-                    f"-or '{config_name_or_path}' is a correct path to a directory containing a {config_file_name} file\n\n"
-                )
-
-                if revision is not None:
-                    msg += (
-                        f"- or '{revision}' is a valid git identifier (branch name, a tag name, or a commit id) that "
-                        f"exists for this model name as listed on its model page on 'https://huggingface.co/models'\n\n"
-                    )
-
-                raise EnvironmentError(msg)
-        config = cls(config_file)
-
+    @staticmethod
+    def _create_quantization_config(config: Union[Dict, _BaseQuantizationConfig]):
+        # TODO : add activations_dtype and weights_dtype
+        if isinstance(config, _BaseQuantizationConfig):
+            approach = _quantization_model[config.approach]
+            config = {
+                "is_static": approach != "dynamic",
+                "dataset_num_samples": config.calibration_sampling_size[0] if approach == "static" else None,
+                # "approach" : approach,
+            }
         return config
 
-
-class IncOptimizedConfig(IncConfig):
-    def __init__(self, config_path: str):
-        """
-        Args:
-            config_path (`str`):
-                Path to the YAML configuration file used to control the tuning behavior.
-        """
-
-        self.path = config_path
-        self.config = self._read_config()
-        self.usr_cfg = self.config
-
-    def _read_config(self):
-        with open(self.path, "r") as f:
-            try:
-                config = yaml.load(f, Loader=yaml.Loader)
-            except yaml.YAMLError as err:
-                logger.error(err)
-
+    @staticmethod
+    def _create_pruning_config(config: Union[Dict, WeightPruningConfig]):
+        if isinstance(config, WeightPruningConfig):
+            weight_compression = config.weight_compression
+            config = {
+                "approach": weight_compression.pruning_type,
+                "target_sparsity": weight_compression.target_sparsity,
+                "pattern": weight_compression.pattern,
+                "start_step": weight_compression.start_step,
+                "end_step": weight_compression.end_step,
+                "scope": weight_compression.pruning_scope,
+                # "frequency": weight_compression.pruning_frequency,
+                "op_types": weight_compression.pruning_op_types,
+            }
         return config
 
-
-class IncQuantizationConfig(IncConfig):
-    CONFIG_NAME = "quantization.yml"
-
-    def __init__(self, config_path: str):
-        """
-        The configuration describing the quantization process.
-
-        Args:
-            config_path (`str`):
-                Path to the YAML configuration file used to control the tuning behavior.
-        """
-
-        self.path = config_path
-        self.config = Quantization_Conf(config_path)
-        self.usr_cfg = self.config.usr_cfg
-
-
-class IncPruningConfig(IncConfig):
-    CONFIG_NAME = "prune.yml"
-
-    def __init__(self, config_path: str):
-        """
-        The configuration describing the pruning process.
-
-        Args:
-            config_path (`str`):
-                Path to the YAML configuration file used to control the tuning behavior.
-        """
-
-        self.path = config_path
-        self.config = Pruning_Conf(config_path)
-        self.usr_cfg = self.config.usr_cfg
-
-
-class IncDistillationConfig(IncConfig):
-    CONFIG_NAME = "distillation.yml"
-
-    def __init__(self, config_path: str):
-        """
-        Args:
-            config_path (:obj:`str`):
-                Path to the YAML configuration file used to control the tuning behavior.
-        """
-
-        self.path = config_path
-        self.config = Distillation_Conf(config_path)
-        self.usr_cfg = self.config.usr_cfg
+    @staticmethod
+    def _create_distillation_config(config: Union[Dict, DistillationConfig]):
+        if isinstance(config, DistillationConfig):
+            criterion = next(iter(config.criterion.values()))
+            config = {
+                "teacher_model_name_or_path": config.teacher_model.config._name_or_path,
+                "temperature" : criterion.temperature,
+                "loss_types" : criterion.loss_types,
+                "loss_weights" : criterion.loss_weights,
+            }
+        return config

--- a/optimum/intel/neural_compressor/trainer.py
+++ b/optimum/intel/neural_compressor/trainer.py
@@ -66,6 +66,7 @@ from neural_compressor.model.torch_model import PyTorchModel
 from optimum.exporters import TasksManager
 
 from ..utils.import_utils import is_neural_compressor_version
+from .configuration import INCConfig
 from .utils import MIN_QDQ_ONNX_OPSET, ONNX_WEIGHTS_NAME, TRAINING_ARGS_NAME
 
 
@@ -155,6 +156,13 @@ class INCTrainer(Trainer):
             if isinstance(callback, DistillationCallbacks):
                 self.distillation_callback = callback
                 break
+
+        self.inc_config = INCConfig(
+            quantization=self.quantization_config,
+            pruning=self.pruning_config,
+            distillation=self.distillation_config,
+            save_onnx_model=save_onnx_model,
+        )
 
     def _inner_training_loop(
         self, batch_size=None, args=None, resume_from_checkpoint=None, trial=None, ignore_keys_for_eval=None
@@ -600,6 +608,9 @@ class INCTrainer(Trainer):
 
             self.model.eval()
             self._onnx_export(self.model, onnx_config, output_onnx_path)
+
+        self.inc_config.save_onnx_model = save_onnx_model
+        self.inc_config.save_pretrained(output_dir)
 
         logger.info(f"Model weights saved in {output_model_file}")
 

--- a/optimum/intel/neural_compressor/trainer.py
+++ b/optimum/intel/neural_compressor/trainer.py
@@ -609,6 +609,8 @@ class INCTrainer(Trainer):
             self.model.eval()
             self._onnx_export(self.model, onnx_config, output_onnx_path)
 
+        if self.pruning_config is not None:
+            self.inc_config.pruning["sparsity"] = round(self.get_model_sparsity(), 2)
         self.inc_config.save_onnx_model = save_onnx_model
         self.inc_config.save_pretrained(output_dir)
 

--- a/optimum/intel/utils/dummy_neural_compressor_objects.py
+++ b/optimum/intel/utils/dummy_neural_compressor_objects.py
@@ -145,3 +145,14 @@ class INCTrainer(metaclass=DummyObject):
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["neural_compressor"])
+
+
+class INCConfig(metaclass=DummyObject):
+    _backends = ["neural_compressor"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["neural_compressor"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["neural_compressor"])

--- a/tests/neural_compressor/test_optimization.py
+++ b/tests/neural_compressor/test_optimization.py
@@ -197,7 +197,7 @@ class QuantizationTest(unittest.TestCase):
             "glue",
             dataset_config_name="sst2",
             preprocess_function=partial(preprocess_function, tokenizer=tokenizer),
-            num_samples=300,
+            num_samples=10,
             dataset_split="train",
         )
 
@@ -211,7 +211,7 @@ class QuantizationTest(unittest.TestCase):
             )
             transformers_model = INCModelForSequenceClassification.from_pretrained(tmp_dir)
             inc_config = INCConfig.from_pretrained(tmp_dir)
-            self.assertTrue(inc_config.save_onnx_model)
+            self.assertFalse(inc_config.save_onnx_model)
             self.assertTrue(inc_config.quantization["is_static"])
 
             with torch.no_grad():

--- a/tests/neural_compressor/test_optimization.py
+++ b/tests/neural_compressor/test_optimization.py
@@ -42,7 +42,13 @@ from neural_compressor.config import (
     WeightPruningConfig,
 )
 from onnx import load as onnx_load
-from optimum.intel import INCModelForQuestionAnswering, INCModelForSequenceClassification, INCQuantizer, INCTrainer
+from optimum.intel import (
+    INCConfig,
+    INCModelForQuestionAnswering,
+    INCModelForSequenceClassification,
+    INCQuantizer,
+    INCTrainer,
+)
 from optimum.onnxruntime import ORTModelForQuestionAnswering, ORTModelForSequenceClassification
 
 
@@ -69,6 +75,7 @@ class QuantizationTest(unittest.TestCase):
             loaded_model = INCModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_model = ORTModelForSequenceClassification.from_pretrained(tmp_dir)
             onnx_model = onnx_load(os.path.join(tmp_dir, "model.onnx"))
+            inc_config = INCConfig.from_pretrained(tmp_dir)
 
         num_quantized_matmul = 0
         for initializer in onnx_model.graph.initializer:
@@ -114,6 +121,8 @@ class QuantizationTest(unittest.TestCase):
                 save_onnx_model=True,
             )
             loaded_model = INCModelForQuestionAnswering.from_pretrained(tmp_dir)
+            inc_config = INCConfig.from_pretrained(tmp_dir)
+
         quantized_model_metric = eval_fn(loaded_model)
         # Verification accuracy loss is under 5%
         self.assertGreaterEqual(quantized_model_metric, original_model_metric * (1 - tolerance_criterion))
@@ -149,6 +158,7 @@ class QuantizationTest(unittest.TestCase):
             loaded_model = INCModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_model = ORTModelForSequenceClassification.from_pretrained(tmp_dir)
             onnx_model = onnx_load(os.path.join(tmp_dir, "model.onnx"))
+            inc_config = INCConfig.from_pretrained(tmp_dir)
 
         num_quantized_matmul = 0
         for initializer in onnx_model.graph.initializer:
@@ -192,6 +202,7 @@ class QuantizationTest(unittest.TestCase):
                 save_onnx_model=False,
             )
             transformers_model = INCModelForSequenceClassification.from_pretrained(tmp_dir)
+            inc_config = INCConfig.from_pretrained(tmp_dir)
 
             with torch.no_grad():
                 transformers_outputs = transformers_model(**tokens)
@@ -233,6 +244,7 @@ class QuantizationTest(unittest.TestCase):
             loaded_model = INCModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_model = ORTModelForSequenceClassification.from_pretrained(tmp_dir)
             onnx_model = onnx_load(os.path.join(tmp_dir, "model.onnx"))
+            inc_config = INCConfig.from_pretrained(tmp_dir)
 
         num_quantized_matmul = 0
         for initializer in onnx_model.graph.initializer:
@@ -290,6 +302,7 @@ class QuantizationTest(unittest.TestCase):
             metrics = trainer.evaluate()
             trainer.save_model(save_onnx_model=True)
 
+            inc_config = INCConfig.from_pretrained(tmp_dir)
             transformers_model = INCModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_model = ORTModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_outputs = ort_model(**tokens)
@@ -338,6 +351,8 @@ class PruningTest(unittest.TestCase):
             train_result = trainer.train()
             metrics = trainer.evaluate()
             trainer.save_model(save_onnx_model=True)
+
+            inc_config = INCConfig.from_pretrained(tmp_dir)
             transformers_model = INCModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_model = ORTModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_outputs = ort_model(**tokens)
@@ -380,6 +395,8 @@ class DistillationTest(unittest.TestCase):
             train_result = trainer.train()
             metrics = trainer.evaluate()
             trainer.save_model(save_onnx_model=True)
+
+            inc_config = INCConfig.from_pretrained(tmp_dir)
             transformers_model = INCModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_model = ORTModelForSequenceClassification.from_pretrained(tmp_dir)
             ort_outputs = ort_model(**tokens)


### PR DESCRIPTION
In this PR we add the `INCConfig` class, which allows to summarize the different compression techniques that were applied on a model and their characteristics, as well as `neural-compressor` and `torch` versions (useful when loading a quantized model). If present on the hub or local directory where a model is being loaded, the configuration will be loaded and the torch version will be checked for quantized model 