### PR TITLE
Add overflow_fix explanation to QA quantization notebook

### DIFF
--- a/notebooks/openvino/question_answering_quantization.ipynb
+++ b/notebooks/openvino/question_answering_quantization.ipynb
@@ -281,7 +281,19 @@
    "id": "eb0b0738-fdc9-4557-97bf-b4c6709280cc",
    "metadata": {},
    "source": [
-    "### Quantize the Model with Post Training Quantization"
+    "### Quantize the Model with Post Training Quantization\n",
+    "\n",
+    "**NOTE:** if you notice very low accuracy after post-training quantization, it is likely caused by an overflow issue which affects processors that do not contain VNNI (Vector Neural Network Instruction). NNCF has an `overflow_fix` option to address this. It will effectively use 7-bits for quantizing instead of 8-bits to prevent the overflow. To use this option, modify the code in the next cell to add an explicit quantization configuration, and set `overflow_fix` to `\"enable\"`:\n",
+    "\n",
+    "```\n",
+    "from optimum.intel.openvino import OVConfig\n",
+    "\n",
+    "ov_config = OVConfig()\n",
+    "ov_config.compression[\"overflow_fix\"] = \"enable\"\n",
+    "quantizer = OVQuantizer.from_pretrained(model, ov_config=ov_config)\n",
+    "```\n",
+    "\n",
+    "For more information, see [Lower Numerical Precision Deep Learning Inference and Training](https://www.intel.com/content/www/us/en/developer/articles/technical/lower-numerical-precision-deep-learning-inference-and-training.html)"
    ]
   },
   {
@@ -936,7 +948,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -950,7 +962,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.16"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
`overflow_fix` is disabled by default in our post-training quantization config because recent Intel processors have VNNI/DLBoost which makes this unnecessary, and with PTQ enabling overflow_fix can decrease accuracy (that's also the case in this notebook). But if you have a computer that does not have a processor with VNNI, accuracy of this notebook is not just lower, it is terrible and the model is unusable. See https://github.com/huggingface/optimum-intel/issues/258 . 

This PR adds an explanation in the notebook about enabling this overflow_fix if you see low accuracy. I'm happy with all suggestions for other phrasings.

I will also modify the docs, but this currently also applies to some QAT examples and that's a bit confusing to explain, so I will address that in a separate PR later (and check if we can switch all QAT to overflow_fix=enabled by default, because for QAT there may be no accuracy drop).

Q: Why don't we check the processor and enable this by default?
A: It would require an extra dependency (py-cpuinfo) to do this in a cross-platform way and (more importantly) people may quantize on one system but deploy on another.

Q: Will people know if their processor has VNNI? 
A: Probably not :-( But I do not know an easy cross-platform way to check this without installing anything.