### PR TITLE
Add CACHE_DIR back for CPU

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -307,11 +307,8 @@ class OVBaseModel(OptimizedModel):
     def compile(self):
         if self.request is None:
             logger.info("Compiling the model and creating the inference request ...")
-            # Only enable CACHE_DIR for GPU because CACHE_DIR fails with some INT8 models on CPU with 2022.3
-            ov_config = self.ov_config.copy()
-            if self._device == "GPU":
-                cache_dir = Path(self.model_save_dir).joinpath("model_cache")
-                ov_config["CACHE_DIR"] = str(cache_dir)
+            cache_dir = Path(self.model_save_dir).joinpath("model_cache")
+            ov_config = {**self.ov_config, "CACHE_DIR": str(cache_dir)}
             compiled_model = core.compile_model(self.model, self._device, ov_config)
             self.request = compiled_model.create_infer_request()
 


### PR DESCRIPTION
CACHE_DIR on CPU was disabled in https://github.com/huggingface/optimum-intel/pull/164
I don't see the issue anymore in the 2023.0.0.dev20230217 prerelease, which is the current minimum OpenVINO version in setup.py, so we can enable CACHE_DIR for CPU again.