### PR TITLE
Add `.to()` to OVBaseModel

### DIFF
--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -105,11 +105,6 @@ class OVModel(OVBaseModel):
         self.auto_model_class.register(AutoConfig, self.__class__)
         self.device = torch.device("cpu")
 
-    def to(self, device: str):
-        self._device = device.upper()
-        self.request = None
-        return self
-
     def forward(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -105,6 +105,15 @@ class OVModel(OVBaseModel):
         self.auto_model_class.register(AutoConfig, self.__class__)
         self.device = torch.device("cpu")
 
+    def to(self, device: str):
+        """
+        Use the specified `device` for inference. For example: "cpu" or "gpu". `device` can
+        be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
+        """
+        self._device = device.upper()
+        self.request = None
+        return self
+
     def forward(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -382,12 +382,3 @@ class OVBaseModel(OptimizedModel):
         if isinstance(self, GenerationMixin):
             return True
         return False
-
-    def to(self, device: str):
-        """
-        Use the specified `device` for inference. For example: "cpu" or "gpu". `device` can
-        be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
-        """
-        self._device = device.upper()
-        self.request = None
-        return self

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -382,3 +382,12 @@ class OVBaseModel(OptimizedModel):
         if isinstance(self, GenerationMixin):
             return True
         return False
+
+    def to(self, device: str):
+        """
+        Use the specified `device` for inference. For example: "cpu" or "gpu". `device` can
+        be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
+        """
+        self._device = device.upper()
+        self.request = None
+        return self

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -215,7 +215,7 @@ class OVBaseDecoderModel(OVBaseModel):
         """
         self._device = device.upper()
         self.decoder._device = device.upper()
-        self.request = None
+        self.decoder.request = None
         return self
 
     def forward(self, *args, **kwargs):

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -208,6 +208,16 @@ class OVBaseDecoderModel(OVBaseModel):
         logger.warning("Static shapes are not supported for causal language model.")
         return self
 
+    def to(self, device: str):
+        """
+        Use the specified `device` for inference. For example: "cpu" or "gpu". `device` can
+        be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
+        """
+        self._device = device.upper()
+        self.decoder._device = device.upper()
+        self.request = None
+        return self
+
     def forward(self, *args, **kwargs):
         raise NotImplementedError
 

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -444,6 +444,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
     def test_pipeline(self, model_arch):
         model_id = MODEL_NAMES[model_arch]
         model = OVModelForCausalLM.from_pretrained(model_id, from_transformers=True, use_cache=False)
+        model.to("cpu")
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         pipe = pipeline("text-generation", model=model, tokenizer=tokenizer)
         outputs = pipe("This is a sample", max_length=10)

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -465,6 +465,13 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         self.assertIsInstance(outputs, torch.Tensor)
         self.assertEqual(outputs.shape[0], 3)
 
+    def test_model_and_decoder_same_device(self):
+        model_id = MODEL_NAMES["gpt2"]
+        model = OVModelForCausalLM.from_pretrained(model_id, export=True)
+        model.to("TEST")
+        self.assertEqual(model._device, model.decoder._device)
+        self.assertEqual(model.decoder._device, "TEST")
+
     def test_compare_with_and_without_past_key_values(self):
         model_id = MODEL_NAMES["gpt2"]
         tokenizer = AutoTokenizer.from_pretrained(model_id)


### PR DESCRIPTION
Fixes `.to()` not working for OVModelForCausalLM
