### PR TITLE
Remove INC deprecated classes

### DIFF
--- a/examples/neural_compressor/question-answering/trainer_qa.py
+++ b/examples/neural_compressor/question-answering/trainer_qa.py
@@ -13,7 +13,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 """
-A subclass of `IncTrainer` specific to Question-Answering tasks
+A subclass of `INCTrainer` specific to Question-Answering tasks
 """
 import math
 import time

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -650,4 +650,3 @@ class IncQuantizedModelForXLNetLM(IncQuantizedModel):
 
 class IncQuantizedModelForVision2Seq(IncQuantizedModel):
     TRANSFORMERS_AUTO_CLASS = AutoModelForVision2Seq
-

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -651,10 +651,3 @@ class IncQuantizedModelForXLNetLM(IncQuantizedModel):
 class IncQuantizedModelForVision2Seq(IncQuantizedModel):
     TRANSFORMERS_AUTO_CLASS = AutoModelForVision2Seq
 
-
-class IncQuantizer(INCQuantizer):
-    # Warning at import time
-    warnings.warn(
-        "The class `IncQuantizer` has been depreciated and will be removed in optimum-intel v1.7, please use "
-        "`INCQuantizer` instead.",
-    )

--- a/optimum/intel/neural_compressor/trainer.py
+++ b/optimum/intel/neural_compressor/trainer.py
@@ -17,7 +17,6 @@ import math
 import os
 import sys
 import time
-import warnings
 from collections.abc import Mapping
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
@@ -810,4 +809,3 @@ class INCTrainer(Trainer):
         if self._compression_manager is not None:
             sparsity = self._compression_manager.model.report_sparsity()[-1]
         return sparsity
-

--- a/optimum/intel/neural_compressor/trainer.py
+++ b/optimum/intel/neural_compressor/trainer.py
@@ -811,10 +811,3 @@ class INCTrainer(Trainer):
             sparsity = self._compression_manager.model.report_sparsity()[-1]
         return sparsity
 
-
-class IncTrainer(INCTrainer):
-    # Warning at import time
-    warnings.warn(
-        "The class `IncTrainer` has been depreciated and will be removed in optimum-intel v1.7, please use "
-        "`INCTrainer` instead.",
-    )


### PR DESCRIPTION
the `IncQuantizedModel` class should be deprecated as well, but we need to update the model cards from https://huggingface.co/Intel before doing so