### PR TITLE
enable torch dtype on TSModelForCausalLM

### DIFF
--- a/optimum/intel/generation/modeling.py
+++ b/optimum/intel/generation/modeling.py
@@ -204,6 +204,7 @@ class TSModelForCausalLM(OptimizedModel, GenerationMixin):
             "subfolder": subfolder,
             "local_files_only": local_files_only,
             "force_download": force_download,
+            "torch_dtype": kwargs.get("torch_dtype", None),
         }
 
         model = TasksManager.get_model_from_task(task, model_id, **model_kwargs)


### PR DESCRIPTION
Hi @echarlaix,  there is an important parameter `torch_dtype` missed on `from_pretrain` function. I added this parameter so the users can specify the `torch_dtype` of models. Would you please review it? Thanks!

