### PR TITLE
Suppress torch version mismatch warning with NNCF

### DIFF
--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -11,13 +11,20 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
+import logging
 
 from ..utils.import_utils import is_diffusers_available, is_nncf_available
 from .utils import OV_DECODER_NAME, OV_DECODER_WITH_PAST_NAME, OV_ENCODER_NAME, OV_XML_FILE_NAME
 
 
 if is_nncf_available():
+    import nncf
+
+    # Suppress version mismatch logging
+    nncf.set_log_level(logging.ERROR)
     from nncf.torch import patch_torch_operators
+
+    nncf.set_log_level(logging.INFO)
 
     patch_torch_operators()
 


### PR DESCRIPTION
# What does this PR do?
Removes the `WARNING:nncf:NNCF provides best results with torch==1.13.1, while current torch version is 1.13.0+cu117. If you encounter issues, consider switching to torch==1.13.1` line from the logs when using `optimum-intel`. 

NNCF does this at `nncf.torch` import-time once, and it seems that NNCF is being imported in `optimum-intel` regardless of being used in such situations.

