### PR TITLE
Prepare to NNCF v2.5 release

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -281,7 +281,7 @@ class OVQuantizer(OptimumQuantizer):
 
 
 def _onnx_export_nncf_model(model: NNCFNetwork, config: OnnxConfig, output: Union[str, io.BytesIO], opset: int = None):
-    signature = inspect.signature(model.get_nncf_wrapped_model().forward)
+    signature = inspect.signature(model.forward)
     signature = list(signature.parameters.keys())
     opset = opset or config.DEFAULT_ONNX_OPSET
     model_inputs = config.generate_dummy_inputs(framework="pt")
@@ -294,7 +294,7 @@ def _onnx_export_nncf_model(model: NNCFNetwork, config: OnnxConfig, output: Unio
             value = value.to(device)
         return value
 
-    with config.patch_model_for_export(model.get_nncf_wrapped_model()):
+    with config.patch_model_for_export(model):
         model_inputs = tree_map(remap, model_inputs)
         with torch.no_grad():
             model.eval()

--- a/optimum/intel/openvino/trainer.py
+++ b/optimum/intel/openvino/trainer.py
@@ -194,10 +194,7 @@ class OVTrainer(Trainer):
     def _set_signature_columns_if_needed(self):
         if self._signature_columns is None:
             # Inspect model forward signature to keep only the arguments it accepts.
-            if isinstance(self.model, NNCFNetwork):
-                signature = inspect.signature(self.model.get_nncf_wrapped_model().forward)
-            else:
-                signature = inspect.signature(self.model.forward)
+            signature = inspect.signature(self.model.forward)
             self._signature_columns = list(signature.parameters.keys())
             # Labels may be named label or label_ids, the default data collator handles that.
             self._signature_columns += list(set(["label", "label_ids"] + self.label_names))
@@ -655,8 +652,6 @@ class OVTrainer(Trainer):
 
         if not isinstance(self.model, PreTrainedModel):
             unwrapped_model = unwrap_model(self.model)
-            if isinstance(unwrapped_model, NNCFNetwork):
-                unwrapped_model = unwrapped_model.get_nncf_wrapped_model()
             is_pretrained_model = isinstance(unwrapped_model, PreTrainedModel)
             if state_dict is None:
                 state_dict = self.model.state_dict()

--- a/optimum/intel/openvino/trainer.py
+++ b/optimum/intel/openvino/trainer.py
@@ -36,7 +36,6 @@ from nncf.experimental.torch.sparsity.movement.scheduler import MovementSchedule
 from nncf.torch import create_compressed_model
 from nncf.torch.composite_compression import PTCompositeCompressionAlgorithmController
 from nncf.torch.compression_method_api import PTCompressionAlgorithmController
-from nncf.torch.nncf_network import NNCFNetwork
 from nncf.torch.quantization.algo import QuantizationController
 from openvino._offline_transformations import compress_quantize_weights_transformation
 from openvino.runtime import Core, PartialShape, serialize

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ EXTRAS_REQUIRE = {
         "intel-extension-for-pytorch<2.0.0",
     ],
     "openvino": ["openvino>=2023.0.0.dev20230217", "onnx", "onnxruntime"],
-    "nncf": ["nncf>=2.4.0", "openvino-dev>=2023.0.0.dev20230217"],
+    "nncf": ["nncf>=2.5.0", "openvino-dev>=2023.0.0.dev20230217"],
     "ipex": ["intel-extension-for-pytorch", "onnx"],
     "diffusers": ["diffusers"],
     "quality": QUALITY_REQUIRE,


### PR DESCRIPTION
# What does this PR do?

This PR updates deprecate NNCF API calls for switching to the upcoming NNCF 2.5.0 release.
The `.forward` on the NNCFNetwork function will always be an NNCF-wrapped forward version, no need to call `get_nncf_wrapped_model`

The API changes were introduced in the https://github.com/openvinotoolkit/nncf/pull/1584 

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


