### PR TITLE
Limit transformers to <4.29 in [openvino] extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,10 @@ EXTRAS_REQUIRE = {
         "onnxruntime",
         "torch<2.0.0",  # remove after neural-compressor next release
         "intel-extension-for-pytorch<2.0.0",
+        "accelerate"
     ],
     "openvino": ["openvino>=2023.0.0.dev20230217", "onnx", "onnxruntime", "transformers<4.29"],
-    "nncf": ["nncf>=2.4.0", "openvino-dev>=2023.0.0.dev20230217"],
+    "nncf": ["nncf>=2.4.0", "openvino-dev>=2023.0.0.dev20230217", "accelerate"],
     "ipex": ["intel-extension-for-pytorch", "onnx"],
     "diffusers": ["diffusers"],
     "quality": QUALITY_REQUIRE,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ EXTRAS_REQUIRE = {
         "torch<2.0.0",  # remove after neural-compressor next release
         "intel-extension-for-pytorch<2.0.0",
     ],
-    "openvino": ["openvino>=2023.0.0.dev20230217", "onnx", "onnxruntime"],
+    "openvino": ["openvino>=2023.0.0.dev20230217", "onnx", "onnxruntime", "transformers<4.29"],
     "nncf": ["nncf>=2.4.0", "openvino-dev>=2023.0.0.dev20230217"],
     "ipex": ["intel-extension-for-pytorch", "onnx"],
     "diffusers": ["diffusers"],


### PR DESCRIPTION
Transformers 4.29 raises this error in several places. @mfuntowicz can you help with this issue? If it is not easy to fix, this PR limits transformers to <4.29 for now. 

```
    def _get_default_group():
        """
        Getting the default process group created by init_process_group
        """
        if not is_initialized():
>           raise RuntimeError(
                "Default process group has not been initialized, "
                "please make sure to call init_process_group."
            )
E           RuntimeError: Default process group has not been initialized, please make sure to call init_process_group.
````

See for example here: https://github.com/helena-intel/openvino_tests/actions/runs/4970314799/jobs/8894108332#step:13:341 This is with 4.29.1

Also added accelerate to neural-compressor and nncf extras, since that is required for 4.29+ Trainer