### PR TITLE
Test training of examples with torchrun call

### DIFF
--- a/tests/openvino/test_training_examples.py
+++ b/tests/openvino/test_training_examples.py
@@ -149,7 +149,12 @@ class OVTrainingExampleTest(unittest.TestCase):
 
         self.env[CUDA_VISIBLE_DEVICES] = str(self.available_cuda_device_ids[0])
         with tempfile.TemporaryDirectory() as output_dir:
-            args = [sys.executable, desc.filename, *desc.get_args_with_output_dir(output_dir)]
+            args = [
+                "torchrun",
+                "--nproc_per_node=1",
+                desc.filename,
+                *desc.get_args_with_output_dir(output_dir)
+            ]
             proc = subprocess.Popen(
                 args=args,
                 cwd=desc.cwd,
@@ -184,9 +189,7 @@ class OVTrainingExampleTest(unittest.TestCase):
         self.env[CUDA_VISIBLE_DEVICES] = ",".join(map(str, self.available_cuda_device_ids[:2]))
         with tempfile.TemporaryDirectory() as output_dir:
             args = [
-                sys.executable,
-                "-m",
-                "torch.distributed.run",
+                "torchrun",
                 "--rdzv_backend=c10d",
                 "--rdzv_endpoint=localhost:0",
                 "--nnodes=1",


### PR DESCRIPTION
# What does this PR do?

Updated the example tests to be launched in the way it's recommended in the readme: https://github.com/huggingface/optimum-intel/pull/315
Previous way without setting CUDA_VISIBLE_DEVICES can lead to training in Data Parallel mode, which is slower and can even fail with error: https://github.com/openvinotoolkit/nncf/issues/1582

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->


