### PR TITLE
fix: self.config -> self.model.config else throws up error during evaluation in INCSeq2SeqTrainer.

### DIFF
--- a/optimum/intel/neural_compressor/trainer_seq2seq.py
+++ b/optimum/intel/neural_compressor/trainer_seq2seq.py
@@ -157,8 +157,8 @@ class INCSeq2SeqTrainer(INCTrainer):
 
         # XXX: adapt synced_gpus for fairscale as well
         gen_kwargs = {
-            "max_length": self._max_length if self._max_length is not None else self.config.max_length,
-            "num_beams": self._num_beams if self._num_beams is not None else self.config.num_beams,
+            "max_length": self._max_length if self._max_length is not None else self.model.config.max_length,
+            "num_beams": self._num_beams if self._num_beams is not None else self.model.config.num_beams,
             "synced_gpus": True if is_deepspeed_zero3_enabled() else False,
         }
 


### PR DESCRIPTION
# What does this PR do?

- The predictions during evaluation are converted into ids. model.config was missing so the prediction was not converted to a token because of the missing hyperparameter in the model config.
