### PR TITLE
fix bug of cli <recipe>

### DIFF
--- a/examples/neural_compressor/language-modeling/run_clm.py
+++ b/examples/neural_compressor/language-modeling/run_clm.py
@@ -598,6 +598,8 @@ def main():
         else:
             if optim_args.smooth_quant:
                 recipes = {"smooth_quant": True, "smooth_quant_args": {"alpha": optim_args.smooth_quant_alpha}}
+            else:
+                recipes = {}
             quantization_config = PostTrainingQuantConfig(approach=optim_args.quantization_approach, recipes=recipes)
 
     if optim_args.apply_pruning:


### PR DESCRIPTION
# What does this PR do?

This PR fixed the bug with CLI parameter <recipes>. <recipes> has to be defaulted to empty {} if not provided in command line. 


