### PR TITLE
Added Support for Timm models

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -290,7 +290,7 @@ class OVBaseModel(PreTrainedModel):
             "subfolder": subfolder,
             "local_files_only": local_files_only,
             "force_download": force_download,
-            "trust_remote_code": trust_remote_code
+            "trust_remote_code": trust_remote_code,
         }
 
         if model_id.startswith("timm/"):

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -261,6 +261,8 @@ class OVBaseModel(PreTrainedModel):
         local_files_only: bool = False,
         task: Optional[str] = None,
         trust_remote_code: bool = False,
+        use_safetensors: bool = None,
+        num_lables: int = None,
         **kwargs,
     ):
         """
@@ -291,8 +293,12 @@ class OVBaseModel(PreTrainedModel):
             "local_files_only": local_files_only,
             "force_download": force_download,
             "trust_remote_code": trust_remote_code,
+            "use_safetensors": use_safetensors
         }
 
+        if num_lables:
+            model_kwargs["num_lables"] = num_lables
+            
         model = TasksManager.get_model_from_task(task, model_id, **model_kwargs)
         model_type = model.config.model_type.replace("_", "-")
 

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -263,12 +263,10 @@ class OVBaseModel(PreTrainedModel):
             "force_download": force_download,
             "trust_remote_code": trust_remote_code,
         }
-
         # Fix the mismatch between timm_config and huggingface_config
         if not os.path.isdir(model_id) and model_info(model_id).library_name == "timm":
             model_kwargs["use_safetensors"] = False
             model_kwargs["num_labels"] = config.num_classes
-            
         model = TasksManager.get_model_from_task(task, model_id, **model_kwargs)
         model_type = model.config.model_type.replace("_", "-")
 

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -19,7 +19,7 @@ from tempfile import TemporaryDirectory
 from typing import Dict, Optional, Union
 
 import openvino
-from huggingface_hub import hf_hub_download
+from huggingface_hub import hf_hub_download, model_info
 from openvino._offline_transformations import apply_moc_transformations, compress_model_transformation
 from openvino.runtime import Core
 from transformers import PretrainedConfig
@@ -264,7 +264,8 @@ class OVBaseModel(PreTrainedModel):
             "trust_remote_code": trust_remote_code,
         }
 
-        if model_id.startswith("timm/"):
+        # Fix the mismatch between timm_config and huggingface_config
+        if not os.path.isdir(model_id) and model_info(model_id).library_name == "timm":
             model_kwargs["use_safetensors"] = False
             model_kwargs["num_labels"] = config.num_classes
             

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -261,8 +261,6 @@ class OVBaseModel(PreTrainedModel):
         local_files_only: bool = False,
         task: Optional[str] = None,
         trust_remote_code: bool = False,
-        use_safetensors: bool = None,
-        num_lables: int = None,
         **kwargs,
     ):
         """
@@ -292,12 +290,12 @@ class OVBaseModel(PreTrainedModel):
             "subfolder": subfolder,
             "local_files_only": local_files_only,
             "force_download": force_download,
-            "trust_remote_code": trust_remote_code,
-            "use_safetensors": use_safetensors
+            "trust_remote_code": trust_remote_code
         }
 
-        if num_lables:
-            model_kwargs["num_lables"] = num_lables
+        if model_id.startswith("timm/"):
+            model_kwargs["use_safetensors"] = False
+            model_kwargs["num_labels"] = config.num_classes
             
         model = TasksManager.get_model_from_task(task, model_id, **model_kwargs)
         model_type = model.config.model_type.replace("_", "-")


### PR DESCRIPTION
# What does this PR do?
This PR modifies the `_from_transformers` method of `OVBaseModel` class using `use_safetensors` and `num_labels`, two parameters that are supported by original `AutoModelForImageClassification.from_pretrained ` method from Huggngface.

This enables loading the Timm models through 'from_pretrained' method on `OVBaseModel` models.

This PR is part of an ongoing GSOC project for seamless integration of TIMM library to intel-optimum, and these parameters are necessary to have enough control to load timm modelsusing existing classes.

Example Usage:
```
import torch
from transformers import AutoConfig
from optimum.intel import OVModelForImageClassification

model_id = "timm/vit_tiny_patch16_224.augreg_in21k"

hf_model = OVModelForImageClassification.from_pretrained(model_id, export=True)
out = hf_model(pixel_values = torch.zeros((5, 3, 224, 224)))
print(out.logits.shape)
```
Test the PR in this [Colab Notebook](https://colab.research.google.com/drive/1CT3d7UKxRfaBS4UmPlHh5lV2GeqaYuqG?usp=sharing)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

