### PR TITLE
OVModelForCausalLM pastkv uses bf16 precision

### DIFF
--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -74,7 +74,7 @@ else:
         [
             "OVModelForAudioClassification",
             "OVModelForCausalLM",
-            "OVModelForCausalLMDisablePastKVOpt",
+            "OVModelForCausalLMDisablePKVOpt",
             "OVModelForFeatureExtraction",
             "OVModelForImageClassification",
             "OVModelForMaskedLM",
@@ -152,7 +152,7 @@ if TYPE_CHECKING:
         from .openvino import (
             OVModelForAudioClassification,
             OVModelForCausalLM,
-            OVModelForCausalLMDisablePastKVOpt,
+            OVModelForCausalLMDisablePKVOpt,
             OVModelForFeatureExtraction,
             OVModelForImageClassification,
             OVModelForMaskedLM,

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -74,6 +74,7 @@ else:
         [
             "OVModelForAudioClassification",
             "OVModelForCausalLM",
+            "OVModelForCausalLMDisablePastKVOpt",
             "OVModelForFeatureExtraction",
             "OVModelForImageClassification",
             "OVModelForMaskedLM",
@@ -151,6 +152,7 @@ if TYPE_CHECKING:
         from .openvino import (
             OVModelForAudioClassification,
             OVModelForCausalLM,
+            OVModelForCausalLMDisablePastKVOpt,
             OVModelForFeatureExtraction,
             OVModelForImageClassification,
             OVModelForMaskedLM,

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -42,7 +42,7 @@ from .modeling import (
     OVModelForSequenceClassification,
     OVModelForTokenClassification,
 )
-from .modeling_decoder import OVModelForCausalLM
+from .modeling_decoder import OVModelForCausalLM, OVModelForCausalLMDisablePastKVOpt
 from .modeling_seq2seq import OVModelForSeq2SeqLM
 
 

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -42,7 +42,7 @@ from .modeling import (
     OVModelForSequenceClassification,
     OVModelForTokenClassification,
 )
-from .modeling_decoder import OVModelForCausalLM, OVModelForCausalLMDisablePastKVOpt
+from .modeling_decoder import OVModelForCausalLM, OVModelForCausalLMDisablePKVOpt
 from .modeling_seq2seq import OVModelForSeq2SeqLM
 
 

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -14,6 +14,7 @@
 
 
 import numpy as np
+from openvino.runtime import Type
 from transformers.onnx.utils import ParameterFormat, compute_serialized_parameters_size
 
 
@@ -47,6 +48,23 @@ OV_TO_NP_TYPE = {
     "f16": np.float16,
     "f32": np.float32,
     "f64": np.float64,
+}
+
+
+STR_TO_OV_TYPE = {
+    "boolean": Type.boolean,
+    "f16": Type.f16,
+    "f32": Type.f32,
+    "f64": Type.f64,
+    "i8": Type.i8,
+    "i16": Type.i16,
+    "i32": Type.i32,
+    "i64": Type.i64,
+    "u8": Type.u8,
+    "u16": Type.u16,
+    "u32": Type.u32,
+    "u64": Type.u64,
+    "bf16": Type.bf16,
 }
 
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -36,7 +36,7 @@ from optimum.intel import (
     OVConfig,
     OVModelForQuestionAnswering,
     OVModelForSequenceClassification,
-    OVModelForCausalLM,
+    OVModelForCausalLMDisablePastKVOpt,
     OVModelForTokenClassification,
     OVQuantizer,
     OVTrainer,
@@ -65,7 +65,7 @@ class OVQuantizerTest(unittest.TestCase):
     # TODO : add models
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (
         (OVModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 42, 32),
-        (OVModelForCausalLM, "hf-internal-testing/tiny-random-gpt2", 41, 21),
+        (OVModelForCausalLMDisablePastKVOpt, "hf-internal-testing/tiny-random-gpt2", 41, 21),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS)
@@ -147,7 +147,7 @@ class OVWeightCompressionTest(unittest.TestCase):
     # TODO : add models
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS = (
         (OVModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 39),
-        (OVModelForCausalLM, "hf-internal-testing/tiny-random-gpt2", 5),
+        (OVModelForCausalLMDisablePastKVOpt, "hf-internal-testing/tiny-random-gpt2", 5),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS)

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -36,7 +36,7 @@ from optimum.intel import (
     OVConfig,
     OVModelForQuestionAnswering,
     OVModelForSequenceClassification,
-    OVModelForCausalLMDisablePastKVOpt,
+    OVModelForCausalLMDisablePKVOpt,
     OVModelForTokenClassification,
     OVQuantizer,
     OVTrainer,
@@ -65,7 +65,7 @@ class OVQuantizerTest(unittest.TestCase):
     # TODO : add models
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (
         (OVModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 42, 32),
-        (OVModelForCausalLMDisablePastKVOpt, "hf-internal-testing/tiny-random-gpt2", 41, 21),
+        (OVModelForCausalLMDisablePKVOpt, "hf-internal-testing/tiny-random-gpt2", 41, 21),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS)
@@ -147,7 +147,7 @@ class OVWeightCompressionTest(unittest.TestCase):
     # TODO : add models
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS = (
         (OVModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 39),
-        (OVModelForCausalLMDisablePastKVOpt, "hf-internal-testing/tiny-random-gpt2", 5),
+        (OVModelForCausalLMDisablePKVOpt, "hf-internal-testing/tiny-random-gpt2", 5),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS)


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

When openvino is using bf16 in SPR the pastkv inside the inference is already bf16. Because the input/output parameter format is fp32, there must use reorder to convert fp32 to bf16 in input and bf16 to fp32 in output, furthermore from bf16 to fp32 the memory bandwidth will enlarge 1 time. This PR will use preprocess to modify the input/output precision to bf16 when:
1, `INFERENCE_PRECISION_HINT` in ov_config sets to `bf16`, or
2, `INFERENCE_PRECISION_HINT` in environment variable sets to `bf16`, this will help batch testing in SPR.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

