### PR TITLE
Add stable diffusion XL OpenVINO export and inference

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -31,7 +31,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install git+https://github.com/huggingface/optimum.git
-        pip install .[openvino,nncf,tests, diffusers]
+        pip install .[openvino,nncf,tests,diffusers]
     - name: Test with Pytest
       run: |
         pytest tests/openvino/ --ignore test_modeling_basic

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -30,7 +30,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[openvino,nncf,tests]
+        python -m pip install git+https://github.com/huggingface/optimum.git
+        pip install .[openvino,nncf,tests, diffusers]
     - name: Test with Pytest
       run: |
         pytest tests/openvino/ --ignore test_modeling_basic

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -231,52 +231,6 @@ prompt = "Face of a yellow cat, high resolution, sitting on a park bench"
 image = pipeline(prompt=prompt, image=init_image, mask_image=mask_image).images[0]
 ```
 
-
-## Stable Diffusion XL
-
-Before using `OVtableDiffusionXLPipeline` make sure to have `diffusers` and `invisible_watermark` installed. You can install the libraries as follows:
-
-```bash
-pip install diffusers
-pip install invisible-watermark>=2.0
-```
-
-### Text-to-Image
-
-Here is an example of how you can load a PyTorch SD XL model, convert it to the adapted format on-the-fly and run inference with OpenVINO Runtime:
-
-```python
-from optimum.intel import OVtableDiffusionXLPipeline
-
-model_id = "stabilityai/stable-diffusion-xl-base-0.9"
-pipeline = OVtableDiffusionXLPipeline.from_pretrained(model_id, export=True)
-prompt = "sailing ship in storm by Leonardo da Vinci"
-image = pipeline(prompt).images[0]
-
-# Don't forget to save your OpenVINO model
-save_directory = "a_local_path"
-pipeline.save_pretrained(save_directory)
-
-```
-
-### Image-to-Image
-
-The image can be refined by making use of a model like [stabilityai/stable-diffusion-xl-refiner-0.9](https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-0.9). In this case, you only have to output the latents from the base model.
-
-
-```python
-from optimum.intel import OVStableDiffusionXLImg2ImgPipeline
-
-use_refiner = True
-model_id = "stabilityai/stable-diffusion-xl-refiner-0.9"
-refiner = OVStableDiffusionXLImg2ImgPipeline.from_pretrained(model_id, export=True)
-
-image = pipeline(prompt=prompt, output_type="latent" if use_refiner else "pil").images[0]
-image = refiner(prompt=prompt, image=image[None, :]).images[0]
-image.save("sailing_ship.png")
-```
-
-
 ## Supported tasks
 
 As shown in the table below, each task is associated with a class enabling to automatically load your model.
@@ -293,6 +247,8 @@ As shown in the table below, each task is associated with a class enabling to au
 | `fill-mask`                          | `OVModelForMaskedLM`                 |
 | `text-generation`                    | `OVModelForCausalLM`                 |
 | `text2text-generation`               | `OVModelForSeq2SeqLM`                |
-| `text-to-image`                      | `OVStableDiffusionPipeline`,        `OVStableDiffusionXLPipeline`|
-| `image-to-image`                     | `OVStableDiffusionImg2ImgPipeline`, `OVStableDiffusionXLImg2ImgPipeline`|
+| `text-to-image`                      | `OVStableDiffusionPipeline`          |
+| `text-to-image`                      | `OVStableDiffusionXLPipeline`        |
+| `image-to-image`                     | `OVStableDiffusionImg2ImgPipeline`   |
+| `image-to-image`                     | `OVStableDiffusionXLImg2ImgPipeline` |
 | `inpaint`                            | `OVStableDiffusionPipeline`          |

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -293,6 +293,6 @@ As shown in the table below, each task is associated with a class enabling to au
 | `fill-mask`                          | `OVModelForMaskedLM`                 |
 | `text-generation`                    | `OVModelForCausalLM`                 |
 | `text2text-generation`               | `OVModelForSeq2SeqLM`                |
-| `text-to-image`                      | `OVStableDiffusionPipeline`, `OVStableDiffusionXLPipeline`|
+| `text-to-image`                      | `OVStableDiffusionPipeline`,        `OVStableDiffusionXLPipeline`|
 | `image-to-image`                     | `OVStableDiffusionImg2ImgPipeline`, `OVStableDiffusionXLImg2ImgPipeline`|
 | `inpaint`                            | `OVStableDiffusionPipeline`          |

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -210,29 +210,6 @@ image.save("fantasy_landscape.png")
 ```
 
 
-### Inpaint
-
-```python
-import PIL
-import requests
-import torch
-from io import BytesIO
-from optimum.intel import OVStableDiffusionInpaintPipeline
-
-model_id = "runwayml/stable-diffusion-inpainting"
-pipeline = OVStableDiffusionInpaintPipeline.from_pretrained(model_id, export=True)
-
-def download_image(url):
-    response = requests.get(url)
-    return PIL.Image.open(BytesIO(response.content)).convert("RGB")
-
-img_url = "https://raw.githubusercontent.com/CompVis/latent-diffusion/main/data/inpainting_examples/overture-creations-5sI6fQgYIuo.png"
-mask_url = "https://raw.githubusercontent.com/CompVis/latent-diffusion/main/data/inpainting_examples/overture-creations-5sI6fQgYIuo_mask.png"
-init_image = download_image(img_url).resize((512, 512))
-mask_image = download_image(mask_url).resize((512, 512))
-prompt = "Face of a yellow cat, high resolution, sitting on a park bench"
-image = pipeline(prompt=prompt, image=init_image, mask_image=mask_image).images[0]
-```
 
 ## Supported tasks
 

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -211,6 +211,7 @@ image.save("fantasy_landscape.png")
 
 
 ### Inpaint
+
 ```python
 import PIL
 import requests
@@ -220,9 +221,11 @@ from optimum.intel import OVStableDiffusionInpaintPipeline
 
 model_id = "runwayml/stable-diffusion-inpainting"
 pipeline = OVStableDiffusionInpaintPipeline.from_pretrained(model_id, export=True)
+
 def download_image(url):
     response = requests.get(url)
     return PIL.Image.open(BytesIO(response.content)).convert("RGB")
+
 img_url = "https://raw.githubusercontent.com/CompVis/latent-diffusion/main/data/inpainting_examples/overture-creations-5sI6fQgYIuo.png"
 mask_url = "https://raw.githubusercontent.com/CompVis/latent-diffusion/main/data/inpainting_examples/overture-creations-5sI6fQgYIuo_mask.png"
 init_image = download_image(img_url).resize((512, 512))

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -11,7 +11,7 @@ specific language governing permissions and limitations under the License.
 
 Optimum Intel can be used to load optimized models from the [Hugging Face Hub](https://huggingface.co/models?library=openvino&sort=downloads) and create pipelines to run inference with OpenVINO Runtime without rewriting your APIs.
 
-## Switching from Transformers to Optimum Inference
+## Switching from Transformers to Optimum
 
 You can now easily perform inference with OpenVINO Runtime on a variety of Intel processors ([see](https://docs.openvino.ai/latest/openvino_docs_OV_UG_supported_plugins_Supported_Devices.html) the full list of supported devices). 
 For that, just replace the `AutoModelForXxx` class with the corresponding `OVModelForXxx` class.
@@ -102,7 +102,7 @@ model.half()
 model.compile()
 ```
 
-## Export and inference of sequence-to-sequence models
+## Sequence-to-sequence models
 
 Sequence-to-sequence (Seq2Seq) models, that generate a new sequence from an input, can also be used when running inference with OpenVINO. When Seq2Seq models are exported to the OpenVINO IR, they are decomposed into two parts : the encoder and the "decoder" (which actually consists of the decoder with the language modeling head), that are later combined during inference.
 To leverage the pre-computed key/values hidden-states to speed up sequential decoding, simply pass `use_cache=True` to the `from_pretrained()` method. An additional model component will be exported: the "decoder" with pre-computed key/values as one of its inputs.
@@ -128,7 +128,7 @@ tokenizer.save_pretrained(save_directory)
 [{'translation_text': "Il n'est jamais sorti sans un livre sous son bras, et il est souvent revenu avec deux."}]
 ```
 
-## Export and inference of Stable Diffusion models
+## Stable Diffusion
 
 Stable Diffusion models can also be used when running inference with OpenVINO. When Stable Diffusion models
 are exported to the OpenVINO format, they are decomposed into three components that are later combined during inference:
@@ -140,10 +140,11 @@ are exported to the OpenVINO format, they are decomposed into three components t
 Make sure you have 🤗 Diffusers installed.
 
 To install `diffusers`:
-```
-pip install diffusers
+```bash
+pip install optimum[diffusers]
 ```
 
+### Text-to-Image
 Here is an example of how you can load an OpenVINO Stable Diffusion model and run inference using OpenVINO Runtime:
 
 ```python
@@ -188,6 +189,94 @@ In case you want to change any parameters such as the outputs height or width, y
 ![img](https://huggingface.co/datasets/optimum/documentation-images/resolve/main/intel/openvino/stable_diffusion_v1_5_sail_boat_rembrandt.png)
 
 
+### Image-to-Image
+
+```python
+import requests
+import torch
+from PIL import Image
+from io import BytesIO
+from optimum.intel import OVStableDiffusionImg2ImgPipeline
+
+model_id = "runwayml/stable-diffusion-v1-5"
+pipeline = OVStableDiffusionImg2ImgPipeline.from_pretrained(model_id, export=True)
+url = "https://raw.githubusercontent.com/CompVis/stable-diffusion/main/assets/stable-samples/img2img/sketch-mountains-input.jpg"
+response = requests.get(url)
+init_image = Image.open(BytesIO(response.content)).convert("RGB")
+init_image = init_image.resize((768, 512))
+prompt = "A fantasy landscape, trending on artstation"
+image = pipeline(prompt=prompt, image=init_image, strength=0.75, guidance_scale=7.5).images[0]
+image.save("fantasy_landscape.png")
+```
+
+
+### Inpaint
+```python
+import PIL
+import requests
+import torch
+from io import BytesIO
+from optimum.intel import OVStableDiffusionInpaintPipeline
+
+model_id = "runwayml/stable-diffusion-inpainting"
+pipeline = OVStableDiffusionInpaintPipeline.from_pretrained(model_id, export=True)
+def download_image(url):
+    response = requests.get(url)
+    return PIL.Image.open(BytesIO(response.content)).convert("RGB")
+img_url = "https://raw.githubusercontent.com/CompVis/latent-diffusion/main/data/inpainting_examples/overture-creations-5sI6fQgYIuo.png"
+mask_url = "https://raw.githubusercontent.com/CompVis/latent-diffusion/main/data/inpainting_examples/overture-creations-5sI6fQgYIuo_mask.png"
+init_image = download_image(img_url).resize((512, 512))
+mask_image = download_image(mask_url).resize((512, 512))
+prompt = "Face of a yellow cat, high resolution, sitting on a park bench"
+image = pipeline(prompt=prompt, image=init_image, mask_image=mask_image).images[0]
+```
+
+
+## Stable Diffusion XL
+
+Before using `OVtableDiffusionXLPipeline` make sure to have `diffusers` and `invisible_watermark` installed. You can install the libraries as follows:
+
+```bash
+pip install diffusers
+pip install invisible-watermark>=2.0
+```
+
+### Text-to-Image
+
+Here is an example of how you can load a PyTorch SD XL model, convert it to the adapted format on-the-fly and run inference with OpenVINO Runtime:
+
+```python
+from optimum.intel import OVtableDiffusionXLPipeline
+
+model_id = "stabilityai/stable-diffusion-xl-base-0.9"
+pipeline = OVtableDiffusionXLPipeline.from_pretrained(model_id, export=True)
+prompt = "sailing ship in storm by Leonardo da Vinci"
+image = pipeline(prompt).images[0]
+
+# Don't forget to save your OpenVINO model
+save_directory = "a_local_path"
+pipeline.save_pretrained(save_directory)
+
+```
+
+### Image-to-Image
+
+The image can be refined by making use of a model like [stabilityai/stable-diffusion-xl-refiner-0.9](https://huggingface.co/stabilityai/stable-diffusion-xl-refiner-0.9). In this case, you only have to output the latents from the base model.
+
+
+```python
+from optimum.intel import OVStableDiffusionXLImg2ImgPipeline
+
+use_refiner = True
+model_id = "stabilityai/stable-diffusion-xl-refiner-0.9"
+refiner = OVStableDiffusionXLImg2ImgPipeline.from_pretrained(model_id, export=True)
+
+image = pipeline(prompt=prompt, output_type="latent" if use_refiner else "pil").images[0]
+image = refiner(prompt=prompt, image=image[None, :]).images[0]
+image.save("sailing_ship.png")
+```
+
+
 ## Supported tasks
 
 As shown in the table below, each task is associated with a class enabling to automatically load your model.
@@ -204,4 +293,6 @@ As shown in the table below, each task is associated with a class enabling to au
 | `fill-mask`                          | `OVModelForMaskedLM`                 |
 | `text-generation`                    | `OVModelForCausalLM`                 |
 | `text2text-generation`               | `OVModelForSeq2SeqLM`                |
-| `text-to-image`                      | `OVStableDiffusionPipeline`          |
+| `text-to-image`                      | `OVStableDiffusionPipeline`, `OVStableDiffusionXLPipeline`|
+| `image-to-image`                     | `OVStableDiffusionImg2ImgPipeline`, `OVStableDiffusionXLImg2ImgPipeline`|
+| `inpaint`                            | `OVStableDiffusionPipeline`          |

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -56,9 +56,23 @@ try:
     if not (is_openvino_available() and is_diffusers_available()):
         raise OptionalDependencyNotAvailable()
 except OptionalDependencyNotAvailable:
-    _import_structure["utils.dummy_openvino_and_diffusers_objects"] = ["OVStableDiffusionPipeline"]
+    _import_structure["utils.dummy_openvino_and_diffusers_objects"] = [
+        "OVStableDiffusionPipeline",
+        "OVStableDiffusionImg2ImgPipeline",
+        "OVStableDiffusionInpaintPipeline",
+        "OVStableDiffusionXLPipeline",
+        "OVStableDiffusionXLImg2ImgPipeline",
+    ]
 else:
-    _import_structure["openvino"].append("OVStableDiffusionPipeline")
+    _import_structure["openvino"].extend(
+        [
+            "OVStableDiffusionPipeline",
+            "OVStableDiffusionImg2ImgPipeline",
+            "OVStableDiffusionInpaintPipeline",
+            "OVStableDiffusionXLPipeline",
+            "OVStableDiffusionXLImg2ImgPipeline",
+        ]
+    )
 
 try:
     if not is_openvino_available():
@@ -138,9 +152,21 @@ if TYPE_CHECKING:
         if not (is_openvino_available() and is_diffusers_available()):
             raise OptionalDependencyNotAvailable()
     except OptionalDependencyNotAvailable:
-        from .utils.dummy_openvino_and_diffusers_objects import OVStableDiffusionPipeline
+        from .utils.dummy_openvino_and_diffusers_objects import (
+            OVStableDiffusionImg2ImgPipeline,
+            OVStableDiffusionInpaintPipeline,
+            OVStableDiffusionPipeline,
+            OVStableDiffusionXLImg2ImgPipeline,
+            OVStableDiffusionXLPipeline,
+        )
     else:
-        from .openvino import OVStableDiffusionPipeline
+        from .openvino import (
+            OVStableDiffusionImg2ImgPipeline,
+            OVStableDiffusionInpaintPipeline,
+            OVStableDiffusionPipeline,
+            OVStableDiffusionXLImg2ImgPipeline,
+            OVStableDiffusionXLPipeline,
+        )
 
     try:
         if not is_openvino_available():

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -47,4 +47,10 @@ from .modeling_seq2seq import OVModelForSeq2SeqLM
 
 
 if is_diffusers_available():
-    from .modeling_diffusion import OVStableDiffusionPipeline
+    from .modeling_diffusion import (
+        OVStableDiffusionImg2ImgPipeline,
+        OVStableDiffusionInpaintPipeline,
+        OVStableDiffusionPipeline,
+        OVStableDiffusionXLImg2ImgPipeline,
+        OVStableDiffusionXLPipeline,
+    )

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -25,8 +25,8 @@ from openvino.runtime import Core
 from transformers import PretrainedConfig
 from transformers.file_utils import add_start_docstrings
 
-from optimum.exporters import TasksManager
 from optimum.exporters.onnx import export
+from optimum.exporters.tasks import TasksManager
 from optimum.modeling_base import OptimizedModel
 
 from ..utils.import_utils import is_transformers_version

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -24,8 +24,8 @@ from openvino._offline_transformations import apply_moc_transformations, compres
 from transformers import PretrainedConfig
 from transformers.file_utils import add_start_docstrings
 
-from optimum.exporters import TasksManager
 from optimum.exporters.onnx import export_models, get_encoder_decoder_models_for_export
+from optimum.exporters.tasks import TasksManager
 
 from ..utils.import_utils import is_transformers_version
 from .modeling_base import OVBaseModel

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -25,8 +25,8 @@ from transformers import AutoModelForCausalLM, PretrainedConfig
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
-from optimum.exporters import TasksManager
 from optimum.exporters.onnx import export
+from optimum.exporters.tasks import TasksManager
 from optimum.utils import NormalizedConfigManager
 
 from ..utils.import_utils import is_transformers_version

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -156,12 +156,8 @@ class OVStableDiffusionPipelineBase(OVBaseModel):
                 dst_path = save_directory / dst_path / OV_XML_FILE_NAME
                 dst_path.parent.mkdir(parents=True, exist_ok=True)
                 openvino.runtime.serialize(ov_model.model, dst_path)
-                model_dir = Path(
-                    ov_model._model_dir / ov_model._model_name
-                    if ov_model._model_dir.is_dir()
-                    else ov_model.config.get("_name_or_path")
-                )
-                config_path = model_dir / ov_model.CONFIG_NAME
+                model_dir = ov_model.config.get("_name_or_path", None) or ov_model._model_dir / ov_model._model_name
+                config_path = Path(model_dir) / ov_model.CONFIG_NAME
                 if config_path.is_file():
                     shutil.copyfile(config_path, dst_path.parent / ov_model.CONFIG_NAME)
 

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -32,8 +32,8 @@ from openvino.runtime import Core, Tensor
 from torch.utils.data import DataLoader, RandomSampler, TensorDataset
 from transformers import DataCollator, PreTrainedModel, default_data_collator
 
-from optimum.exporters import TasksManager
 from optimum.exporters.onnx import export
+from optimum.exporters.tasks import TasksManager
 from optimum.quantization_base import OptimumQuantizer
 
 from ..utils.constant import _TASK_ALIASES

--- a/optimum/intel/openvino/trainer.py
+++ b/optimum/intel/openvino/trainer.py
@@ -78,8 +78,8 @@ from transformers.utils import (
     logging,
 )
 
-from optimum.exporters import TasksManager
 from optimum.exporters.onnx import OnnxConfig
+from optimum.exporters.tasks import TasksManager
 
 from ..utils.constant import _TASK_ALIASES
 from ..utils.import_utils import is_transformers_version

--- a/optimum/intel/utils/dummy_openvino_and_diffusers_objects.py
+++ b/optimum/intel/utils/dummy_openvino_and_diffusers_objects.py
@@ -24,3 +24,47 @@ class OVStableDiffusionPipeline(metaclass=DummyObject):
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["openvino", "diffusers"])
+
+
+class OVStableDiffusionImg2ImgPipeline(metaclass=DummyObject):
+    _backends = ["openvino", "diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["openvino", "diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["openvino", "diffusers"])
+
+
+class OVStableDiffusionInpaintPipeline(metaclass=DummyObject):
+    _backends = ["openvino", "diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["openvino", "diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["openvino", "diffusers"])
+
+
+class OVStableDiffusionXLPipeline(metaclass=DummyObject):
+    _backends = ["openvino", "diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["openvino", "diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["openvino", "diffusers"])
+
+
+class OVStableDiffusionXLImg2ImgPipeline(metaclass=DummyObject):
+    _backends = ["openvino", "diffusers"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["openvino", "diffusers"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["openvino", "diffusers"])

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ EXTRAS_REQUIRE = {
     "openvino": ["openvino>=2023.0.0", "onnx", "onnxruntime"],
     "nncf": ["nncf>=2.5.0", "openvino-dev>=2023.0.0"],
     "ipex": ["intel-extension-for-pytorch", "onnx"],
-    "diffusers": ["diffusers", "invisible-watermark>=2.0"],
+    "diffusers": ["diffusers", "invisible-watermark>=0.2.0"],
     "quality": QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,
 }

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ EXTRAS_REQUIRE = {
     "openvino": ["openvino>=2023.0.0", "onnx", "onnxruntime"],
     "nncf": ["nncf>=2.5.0", "openvino-dev>=2023.0.0"],
     "ipex": ["intel-extension-for-pytorch", "onnx"],
-    "diffusers": ["diffusers"],
+    "diffusers": ["diffusers", "invisible-watermark>=2.0"],
     "quality": QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,
 }

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -156,11 +156,11 @@ class OVModelIntegrationTest(unittest.TestCase):
         batch_size, height, width = 2, 16, 16
         np.random.seed(0)
         inputs = {
-        "prompt": ["sailing ship in storm by Leonardo da Vinci"] * batch_size,
-        "height": height,
-        "width": width,
-        "num_inference_steps": 2,
-        "output_type": "np",
+            "prompt": ["sailing ship in storm by Leonardo da Vinci"] * batch_size,
+            "height": height,
+            "width": width,
+            "num_inference_steps": 2,
+            "output_type": "np",
         }
         pipeline_outputs = loaded_pipeline(**inputs).images
         self.assertEqual(pipeline_outputs.shape, (batch_size, height, width, 3))

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -43,6 +43,7 @@ from transformers import (
     pipeline,
     set_seed,
 )
+from utils_tests import MODEL_NAMES
 
 from optimum.intel.openvino import (
     OV_DECODER_NAME,
@@ -60,12 +61,6 @@ from optimum.intel.openvino import (
     OVModelForTokenClassification,
     OVStableDiffusionPipeline,
 )
-from optimum.intel.openvino.modeling_diffusion import (
-    OVModelTextEncoder,
-    OVModelUnet,
-    OVModelVaeDecoder,
-    OVModelVaeEncoder,
-)
 from optimum.intel.openvino.modeling_seq2seq import OVDecoder, OVEncoder
 from optimum.utils import (
     DIFFUSION_MODEL_TEXT_ENCODER_SUBFOLDER,
@@ -74,72 +69,6 @@ from optimum.utils import (
     DIFFUSION_MODEL_VAE_ENCODER_SUBFOLDER,
 )
 from optimum.utils.testing_utils import require_diffusers
-
-
-MODEL_NAMES = {
-    "albert": "hf-internal-testing/tiny-random-albert",
-    "audio_spectrogram_transformer": "Ericwang/tiny-random-ast",
-    "beit": "hf-internal-testing/tiny-random-BeitForImageClassification",
-    "bert": "hf-internal-testing/tiny-random-bert",
-    "bart": "hf-internal-testing/tiny-random-bart",
-    "bigbird_pegasus": "hf-internal-testing/tiny-random-bigbird_pegasus",
-    "blenderbot-small": "hf-internal-testing/tiny-random-BlenderbotModel",
-    "blenderbot": "hf-internal-testing/tiny-random-blenderbot",
-    "bloom": "hf-internal-testing/tiny-random-BloomModel",
-    "camembert": "hf-internal-testing/tiny-random-camembert",
-    "convbert": "hf-internal-testing/tiny-random-ConvBertForSequenceClassification",
-    "codegen": "hf-internal-testing/tiny-random-CodeGenForCausalLM",
-    "data2vec_text": "hf-internal-testing/tiny-random-Data2VecTextModel",
-    "data2vec_vision": "hf-internal-testing/tiny-random-Data2VecVisionModel",
-    "data2vec_audio": "hf-internal-testing/tiny-random-Data2VecAudioModel",
-    "deberta": "hf-internal-testing/tiny-random-deberta",
-    "deberta_v2": "hf-internal-testing/tiny-random-DebertaV2Model",
-    "deit": "hf-internal-testing/tiny-random-deit",
-    "convnext": "hf-internal-testing/tiny-random-convnext",
-    "distilbert": "hf-internal-testing/tiny-random-distilbert",
-    "electra": "hf-internal-testing/tiny-random-electra",
-    "flaubert": "hf-internal-testing/tiny-random-flaubert",
-    # "gpt_bigcode": "bigcode/tiny_starcoder_py",
-    "gpt2": "hf-internal-testing/tiny-random-gpt2",
-    "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",
-    "gpt_neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
-    "gptj": "hf-internal-testing/tiny-random-GPTJModel",
-    "hubert": "hf-internal-testing/tiny-random-HubertModel",
-    "ibert": "hf-internal-testing/tiny-random-ibert",
-    "levit": "hf-internal-testing/tiny-random-LevitModel",
-    "longt5": "hf-internal-testing/tiny-random-longt5",
-    "llama": "fxmarty/tiny-llama-fast-tokenizer",
-    "m2m_100": "hf-internal-testing/tiny-random-m2m_100",
-    "opt": "hf-internal-testing/tiny-random-OPTModel",
-    "marian": "sshleifer/tiny-marian-en-de",  # hf-internal-testing ones are broken
-    "mbart": "hf-internal-testing/tiny-random-mbart",
-    "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
-    "mobilenet_v1": "google/mobilenet_v1_0.75_192",
-    "mobilenet_v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
-    "mobilevit": "hf-internal-testing/tiny-random-mobilevit",
-    "mt5": "stas/mt5-tiny-random",
-    "nystromformer": "hf-internal-testing/tiny-random-NystromformerModel",
-    "pegasus": "hf-internal-testing/tiny-random-pegasus",
-    "poolformer": "hf-internal-testing/tiny-random-PoolFormerModel",
-    "resnet": "hf-internal-testing/tiny-random-resnet",
-    "roberta": "hf-internal-testing/tiny-random-roberta",
-    "roformer": "hf-internal-testing/tiny-random-roformer",
-    "segformer": "hf-internal-testing/tiny-random-SegformerModel",
-    "squeezebert": "hf-internal-testing/tiny-random-squeezebert",
-    "stable-diffusion": "hf-internal-testing/tiny-stable-diffusion-torch",
-    "sew": "hf-internal-testing/tiny-random-SEWModel",
-    "sew_d": "hf-internal-testing/tiny-random-SEWDModel",
-    "swin": "hf-internal-testing/tiny-random-SwinModel",
-    "t5": "hf-internal-testing/tiny-random-t5",
-    "unispeech": "hf-internal-testing/tiny-random-unispeech",
-    "unispeech_sat": "hf-internal-testing/tiny-random-UnispeechSatModel",
-    "vit": "hf-internal-testing/tiny-random-vit",
-    "wavlm": "hf-internal-testing/tiny-random-WavlmModel",
-    "wav2vec2": "anton-l/wav2vec2-random-tiny-classifier",
-    "wav2vec2-conformer": "hf-internal-testing/tiny-random-wav2vec2-conformer",
-    "xlm": "hf-internal-testing/tiny-random-xlm",
-    "xlm_roberta": "hf-internal-testing/tiny-xlm-roberta",
-}
 
 
 TENSOR_ALIAS_TO_TYPE = {
@@ -864,137 +793,3 @@ class OVModelForAudioClassificationIntegrationTest(unittest.TestCase):
         outputs = pipe([np.random.random(16000)])
         self.assertEqual(pipe.device, model.device)
         self.assertTrue(all(item["score"] > 0.0 for item in outputs[0]))
-
-
-class OVStableDiffusionPipelineIntegrationTest(unittest.TestCase):
-    SUPPORTED_ARCHITECTURES = ("stable-diffusion",)
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
-    @require_diffusers
-    def test_compare_to_diffusers(self, model_arch: str):
-        model_id = MODEL_NAMES[model_arch]
-        ov_pipeline = OVStableDiffusionPipeline.from_pretrained(model_id, export=True, compile=False)
-        self.assertIsInstance(ov_pipeline.text_encoder, OVModelTextEncoder)
-        self.assertIsInstance(ov_pipeline.vae_encoder, OVModelVaeEncoder)
-        self.assertIsInstance(ov_pipeline.vae_decoder, OVModelVaeDecoder)
-        self.assertIsInstance(ov_pipeline.unet, OVModelUnet)
-        self.assertIsInstance(ov_pipeline.config, Dict)
-
-        from diffusers import StableDiffusionPipeline
-
-        diffusers_pipeline = StableDiffusionPipeline.from_pretrained(model_id)
-        diffusers_pipeline.safety_checker = None
-        num_images_per_prompt, height, width, scale_factor = 1, 512, 512, 8
-        latents_shape = (
-            num_images_per_prompt,
-            diffusers_pipeline.unet.in_channels,
-            height // scale_factor,
-            width // scale_factor,
-        )
-        latents = np.random.randn(*latents_shape).astype(np.float32)
-        kwargs = {
-            "prompt": "sailing ship in storm by Leonardo da Vinci",
-            "num_inference_steps": 1,
-            "output_type": "np",
-            "num_images_per_prompt": num_images_per_prompt,
-            "height": height,
-            "width": width,
-        }
-        ov_pipeline.to("cpu")
-        ov_pipeline.compile()
-        ov_outputs = ov_pipeline(latents=latents, **kwargs).images
-        self.assertIsInstance(ov_outputs, np.ndarray)
-        with torch.no_grad():
-            diffusers_outputs = diffusers_pipeline(latents=torch.from_numpy(latents), **kwargs).images
-        # Compare model outputs
-        self.assertTrue(np.allclose(ov_outputs, diffusers_outputs, atol=1e-4))
-        # Compare model devices
-        self.assertEqual(diffusers_pipeline.device.type, ov_pipeline.device)
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
-    @require_diffusers
-    def test_num_images_per_prompt(self, model_arch: str):
-        from diffusers import DPMSolverMultistepScheduler
-
-        model_id = MODEL_NAMES[model_arch]
-        scheduler = DPMSolverMultistepScheduler.from_pretrained(model_id, subfolder="scheduler")
-        pipeline = OVStableDiffusionPipeline.from_pretrained(model_id, export=True, scheduler=scheduler)
-        prompt = "sailing ship in storm by Leonardo da Vinci"
-
-        for batch_size in [1, 3]:
-            for num_images in [1, 2]:
-                outputs = pipeline(
-                    [prompt] * batch_size, num_inference_steps=2, num_images_per_prompt=num_images, output_type="np"
-                )
-                self.assertEqual(outputs.images.shape, (batch_size * num_images, 128, 128, 3))
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
-    @require_diffusers
-    def test_num_images_per_prompt_static_model(self, model_arch: str):
-        model_id = MODEL_NAMES[model_arch]
-        batch_size = 3
-        num_images_per_prompt = 4
-        height = 128
-        width = 64
-        vae_scale_factor = 4
-        prompt = "sailing ship in storm by Leonardo da Vinci"
-        pipeline = OVStableDiffusionPipeline.from_pretrained(model_id, export=True, compile=False)
-        pipeline.half()
-        pipeline.reshape(
-            batch_size=batch_size, height=height, width=width, num_images_per_prompt=num_images_per_prompt
-        )
-        self.assertFalse(pipeline.is_dynamic)
-        pipeline.compile()
-        # Verify output shapes requirements not matching the static model don't impact the final outputs
-        outputs = pipeline(
-            [prompt] * batch_size,
-            num_inference_steps=2,
-            num_images_per_prompt=num_images_per_prompt,
-            height=width,
-            width=width,
-            output_type="np",
-        ).images
-        self.assertEqual(
-            outputs.shape,
-            (batch_size * num_images_per_prompt, height // vae_scale_factor, width // vae_scale_factor, 3),
-        )
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
-    @require_diffusers
-    def test_image_reproducibility(self, model_arch: str):
-        model_id = MODEL_NAMES[model_arch]
-        pipeline = OVStableDiffusionPipeline.from_pretrained(model_id, export=True)
-
-        kwargs = {
-            "prompt": "sailing ship in storm by Leonardo da Vinci",
-            "output_type": "np",
-            "num_inference_steps": 2,
-        }
-        np.random.seed(0)
-        outputs_1 = pipeline(**kwargs)
-        np.random.seed(0)
-        outputs_2 = pipeline(**kwargs)
-        outputs_3 = pipeline(**kwargs)
-
-        # Compare model outputs
-        self.assertTrue(np.array_equal(outputs_1.images[0], outputs_2.images[0]))
-        self.assertFalse(np.array_equal(outputs_1.images[0], outputs_3.images[0]))
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
-    @require_diffusers
-    def test_height_width_properties(self, model_arch: str):
-        model_id = MODEL_NAMES[model_arch]
-        batch_size = 1
-        num_images_per_prompt = 4
-        height = 128
-        width = 64
-        pipeline = OVStableDiffusionPipeline.from_pretrained(model_id, export=True, compile=False, dynamic=True)
-        self.assertTrue(pipeline.is_dynamic)
-        self.assertEqual(pipeline.height, -1)
-        self.assertEqual(pipeline.width, -1)
-        pipeline.reshape(
-            batch_size=batch_size, height=height, width=width, num_images_per_prompt=num_images_per_prompt
-        )
-        self.assertFalse(pipeline.is_dynamic)
-        self.assertEqual(pipeline.height, height)
-        self.assertEqual(pipeline.width, width)

--- a/tests/openvino/test_stable_diffusion.py
+++ b/tests/openvino/test_stable_diffusion.py
@@ -80,13 +80,11 @@ class OVStableDiffusionPipelineBaseTest(unittest.TestCase):
         self.assertEqual(pipeline.vae_scale_factor, 2)
         self.assertEqual(pipeline.vae_decoder.config["latent_channels"], 4)
         self.assertEqual(pipeline.unet.config["in_channels"], 4)
-        height, width = 128, 128
-        inputs = self.generate_inputs(height=height, width=width)
-        prompt = inputs.pop("prompt")
-
-        for batch_size in [1, 2]:
+        batch_size, height = 2, 128
+        for width in [64, 128]:
+            inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
             for num_images in [1, 3]:
-                outputs = pipeline([prompt] * batch_size, num_images_per_prompt=num_images, **inputs).images
+                outputs = pipeline(**inputs, num_images_per_prompt=num_images).images
                 self.assertEqual(outputs.shape, (batch_size * num_images, height, width, 3))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)

--- a/tests/openvino/test_stable_diffusion.py
+++ b/tests/openvino/test_stable_diffusion.py
@@ -358,13 +358,13 @@ class OVtableDiffusionXLPipelineTest(unittest.TestCase):
 
         inputs = _generate_inputs(batch_size)
         np.random.seed(0)
-        ov_outputs_1 = pipeline(**inputs, height=height, width=width)
+        ov_outputs_1 = pipeline(**inputs, height=height, width=width, num_images_per_prompt=num_images_per_prompt)
         np.random.seed(0)
         with tempfile.TemporaryDirectory() as tmp_dir:
             pipeline.save_pretrained(tmp_dir)
             pipeline = self.MODEL_CLASS.from_pretrained(tmp_dir)
-        ov_outputs_2 = pipeline(**inputs, height=height, width=width)
-        ov_outputs_3 = pipeline(**inputs, height=height, width=width)
+        ov_outputs_2 = pipeline(**inputs, height=height, width=width, num_images_per_prompt=num_images_per_prompt)
+        ov_outputs_3 = pipeline(**inputs, height=height, width=width, num_images_per_prompt=num_images_per_prompt)
         self.assertTrue(np.array_equal(ov_outputs_1.images[0], ov_outputs_2.images[0]))
         self.assertFalse(np.array_equal(ov_outputs_1.images[0], ov_outputs_3.images[0]))
 

--- a/tests/openvino/test_stable_diffusion.py
+++ b/tests/openvino/test_stable_diffusion.py
@@ -1,0 +1,420 @@
+#  Copyright 2021 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import random
+import tempfile
+import unittest
+from typing import Dict
+
+import numpy as np
+import torch
+from diffusers import (
+    StableDiffusionPipeline,
+    StableDiffusionXLImg2ImgPipeline,
+    StableDiffusionXLPipeline,
+)
+from diffusers.utils import floats_tensor, load_image
+from parameterized import parameterized
+from utils_tests import MODEL_NAMES, SEED
+
+from optimum.intel import (
+    OVStableDiffusionImg2ImgPipeline,
+    OVStableDiffusionInpaintPipeline,
+    OVStableDiffusionPipeline,
+    OVStableDiffusionXLImg2ImgPipeline,
+    OVStableDiffusionXLPipeline,
+)
+from optimum.intel.openvino.modeling_diffusion import (
+    OVModelTextEncoder,
+    OVModelUnet,
+    OVModelVaeDecoder,
+    OVModelVaeEncoder,
+)
+from optimum.onnxruntime import (
+    ORTStableDiffusionImg2ImgPipeline,
+    ORTStableDiffusionInpaintPipeline,
+    ORTStableDiffusionXLImg2ImgPipeline,
+    ORTStableDiffusionXLPipeline,
+)
+
+
+def _generate_inputs(batch_size=1):
+    inputs = {
+        "prompt": ["sailing ship in storm by Leonardo da Vinci"] * batch_size,
+        "num_inference_steps": 3,
+        "guidance_scale": 7.5,
+        "output_type": "np",
+    }
+    return inputs
+
+
+def _create_image(height=128, width=128):
+    image = load_image(
+        "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main"
+        "/in_paint/overture-creations-5sI6fQgYIuo.png"
+    )
+    return image.resize((width, height))
+
+
+class OVStableDiffusionPipelineBaseTest(unittest.TestCase):
+    SUPPORTED_ARCHITECTURES = ("stable-diffusion",)
+    MODEL_CLASS = OVStableDiffusionPipeline
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_num_images_per_prompt(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True, compile=False)
+        pipeline.to("cpu")
+        pipeline.compile()
+        self.assertEqual(pipeline.vae_scale_factor, 2)
+        self.assertEqual(pipeline.vae_decoder.config["latent_channels"], 4)
+        self.assertEqual(pipeline.unet.config["in_channels"], 4)
+        height, width = 128, 128
+        inputs = self.generate_inputs(height=height, width=width)
+        prompt = inputs.pop("prompt")
+
+        for batch_size in [1, 2]:
+            for num_images in [1, 3]:
+                outputs = pipeline([prompt] * batch_size, num_images_per_prompt=num_images, **inputs).images
+                self.assertEqual(outputs.shape, (batch_size * num_images, height, width, 3))
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_callback(self, model_arch: str):
+        MODEL_NAMES[model_arch]
+
+        def callback_fn(step: int, timestep: int, latents: np.ndarray) -> None:
+            callback_fn.has_been_called = True
+            callback_fn.number_of_steps += 1
+
+        pipeline = self.MODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], export=True)
+        callback_fn.has_been_called = False
+        callback_fn.number_of_steps = 0
+        inputs = self.generate_inputs(height=64, width=64)
+        pipeline(**inputs, callback=callback_fn, callback_steps=1)
+        self.assertTrue(callback_fn.has_been_called)
+        self.assertEqual(callback_fn.number_of_steps, inputs["num_inference_steps"])
+
+    def generate_inputs(self, height=128, width=128, batch_size=1):
+        inputs = _generate_inputs(batch_size)
+        inputs["height"] = height
+        inputs["width"] = width
+        return inputs
+
+
+class OVStableDiffusionImg2ImgPipelineTest(OVStableDiffusionPipelineBaseTest):
+    SUPPORTED_ARCHITECTURES = ("stable-diffusion",)
+    MODEL_CLASS = OVStableDiffusionImg2ImgPipeline
+    ORT_MODEL_CLASS = ORTStableDiffusionImg2ImgPipeline
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_compare_diffusers_pipeline(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True)
+        inputs = self.generate_inputs()
+        inputs["prompt"] = "A painting of a squirrel eating a burger"
+
+        output = pipeline(**inputs, generator=np.random.RandomState(0)).images[0, -3:, -3:, -1]
+        # https://github.com/huggingface/diffusers/blob/v0.17.1/tests/pipelines/stable_diffusion/test_onnx_stable_diffusion_img2img.py#L71
+        expected_slice = np.array([0.69643, 0.58484, 0.50314, 0.58760, 0.55368, 0.59643, 0.51529, 0.41217, 0.49087])
+        self.assertTrue(np.allclose(output.flatten(), expected_slice, atol=1e-1))
+
+        ort_pipeline = self.ORT_MODEL_CLASS.from_pretrained(model_id, export=True)
+        ort_output = ort_pipeline(**inputs, generator=np.random.RandomState(0)).images[0, -3:, -3:, -1]
+        self.assertTrue(np.allclose(output, ort_output, atol=1e-1))
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_num_images_per_prompt_static_model(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True, compile=False, dynamic_shapes=False)
+        batch_size, num_images, height, width = 2, 3, 128, 64
+        pipeline.half()
+        inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
+        pipeline.reshape(batch_size=batch_size, height=height, width=width, num_images_per_prompt=num_images)
+        outputs = pipeline(**inputs, num_images_per_prompt=num_images, generator=np.random.RandomState(0)).images
+        self.assertEqual(outputs.shape, (batch_size * num_images, height, width, 3))
+
+    def generate_inputs(self, height=128, width=128, batch_size=1):
+        inputs = _generate_inputs(batch_size)
+        inputs["image"] = floats_tensor((batch_size, 3, height, width), rng=random.Random(SEED))
+        inputs["strength"] = 0.75
+        return inputs
+
+
+class OVStableDiffusionPipelineTest(unittest.TestCase):
+    SUPPORTED_ARCHITECTURES = ("stable-diffusion",)
+    MODEL_CLASS = OVStableDiffusionPipeline
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_compare_to_diffusers(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        ov_pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True)
+        self.assertIsInstance(ov_pipeline.text_encoder, OVModelTextEncoder)
+        self.assertIsInstance(ov_pipeline.vae_encoder, OVModelVaeEncoder)
+        self.assertIsInstance(ov_pipeline.vae_decoder, OVModelVaeDecoder)
+        self.assertIsInstance(ov_pipeline.unet, OVModelUnet)
+        self.assertIsInstance(ov_pipeline.config, Dict)
+
+        pipeline = StableDiffusionPipeline.from_pretrained(MODEL_NAMES[model_arch])
+        pipeline.safety_checker = None
+        batch_size, num_images_per_prompt, height, width = 1, 2, 64, 64
+
+        latents = ov_pipeline.prepare_latents(
+            batch_size * num_images_per_prompt,
+            ov_pipeline.unet.config["in_channels"],
+            height,
+            width,
+            dtype=np.float32,
+            generator=np.random.RandomState(0),
+        )
+
+        kwargs = {
+            "prompt": "sailing ship in storm by Leonardo da Vinci",
+            "num_inference_steps": 1,
+            "num_images_per_prompt": num_images_per_prompt,
+            "height": height,
+            "width": width,
+            "guidance_rescale": 0.1,
+        }
+
+        for output_type in ["latent", "np"]:
+            ov_outputs = ov_pipeline(latents=latents, output_type=output_type, **kwargs).images
+            self.assertIsInstance(ov_outputs, np.ndarray)
+            with torch.no_grad():
+                outputs = pipeline(latents=torch.from_numpy(latents), output_type=output_type, **kwargs).images
+            # Compare model outputs
+            self.assertTrue(np.allclose(ov_outputs, outputs, atol=1e-4))
+
+        # Compare model devices
+        self.assertEqual(pipeline.device.type, ov_pipeline.device)
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_image_reproducibility(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True)
+        inputs = _generate_inputs()
+        height, width = 64, 64
+        np.random.seed(0)
+        ov_outputs_1 = pipeline(**inputs, height=height, width=width)
+        np.random.seed(0)
+        ov_outputs_2 = pipeline(**inputs, height=height, width=width)
+        ov_outputs_3 = pipeline(**inputs, height=height, width=width)
+        # Compare model outputs
+        self.assertTrue(np.array_equal(ov_outputs_1.images[0], ov_outputs_2.images[0]))
+        self.assertFalse(np.array_equal(ov_outputs_1.images[0], ov_outputs_3.images[0]))
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_num_images_per_prompt_static_model(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True, compile=False)
+        batch_size, num_images, height, width = 3, 4, 128, 64
+        prompt = "sailing ship in storm by Leonardo da Vinci"
+        pipeline.half()
+        pipeline.reshape(batch_size=batch_size, height=height, width=width, num_images_per_prompt=num_images)
+        self.assertFalse(pipeline.is_dynamic)
+        pipeline.compile()
+        # Verify output shapes requirements not matching the static model don't impact the final outputs
+        outputs = pipeline(
+            [prompt] * batch_size,
+            num_inference_steps=2,
+            num_images_per_prompt=num_images,
+            height=height + 8,
+            width=width,
+            output_type="np",
+        ).images
+        self.assertEqual(outputs.shape, (batch_size * num_images, height, width, 3))
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_height_width_properties(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        batch_size, num_images, height, width = 2, 4, 128, 64
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True, compile=False, dynamic_shapes=True)
+        self.assertTrue(pipeline.is_dynamic)
+        self.assertEqual(pipeline.height, -1)
+        self.assertEqual(pipeline.width, -1)
+        pipeline.reshape(batch_size=batch_size, height=height, width=width, num_images_per_prompt=num_images)
+        self.assertFalse(pipeline.is_dynamic)
+        self.assertEqual(pipeline.height, height)
+        self.assertEqual(pipeline.width, width)
+
+
+class OVStableDiffusionInpaintPipelineTest(OVStableDiffusionPipelineBaseTest):
+    SUPPORTED_ARCHITECTURES = ("stable-diffusion",)
+    MODEL_CLASS = OVStableDiffusionInpaintPipeline
+    ORT_MODEL_CLASS = ORTStableDiffusionInpaintPipeline
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_compare_diffusers_pipeline(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True)
+        batch_size, num_images, height, width = 1, 1, 64, 64
+        latents = pipeline.prepare_latents(
+            batch_size * num_images,
+            pipeline.unet.config["in_channels"],
+            height,
+            width,
+            dtype=np.float32,
+            generator=np.random.RandomState(0),
+        )
+        inputs = self.generate_inputs(height=height, width=width)
+        outputs = pipeline(**inputs, latents=latents).images
+        self.assertEqual(outputs.shape, (batch_size * num_images, height, width, 3))
+
+        ort_pipeline = self.ORT_MODEL_CLASS.from_pretrained(model_id, export=True)
+        ort_outputs = ort_pipeline(**inputs, latents=latents).images
+        self.assertTrue(np.allclose(outputs, ort_outputs, atol=1e-1))
+
+        expected_slice = np.array([0.4692, 0.5260, 0.4005, 0.3609, 0.3259, 0.4676, 0.5593, 0.4728, 0.4411])
+        self.assertTrue(np.allclose(outputs[0, -3:, -3:, -1].flatten(), expected_slice, atol=1e-1))
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_num_images_per_prompt_static_model(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True, compile=False, dynamic_shapes=False)
+        batch_size, num_images, height, width = 1, 3, 128, 64
+        pipeline.half()
+        inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
+        pipeline.reshape(batch_size=batch_size, height=height, width=width, num_images_per_prompt=num_images)
+        outputs = pipeline(**inputs, num_images_per_prompt=num_images, generator=np.random.RandomState(0)).images
+        self.assertEqual(outputs.shape, (batch_size * num_images, height, width, 3))
+
+    def generate_inputs(self, height=128, width=128, batch_size=1):
+        inputs = super(OVStableDiffusionInpaintPipelineTest, self).generate_inputs(height, width, batch_size)
+        inputs["image"] = load_image(
+            "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main"
+            "/in_paint/overture-creations-5sI6fQgYIuo.png"
+        ).resize((width, height))
+
+        inputs["mask_image"] = load_image(
+            "https://huggingface.co/datasets/hf-internal-testing/diffusers-images/resolve/main"
+            "/in_paint/overture-creations-5sI6fQgYIuo_mask.png"
+        ).resize((width, height))
+
+        return inputs
+
+
+class OVtableDiffusionXLPipelineTest(unittest.TestCase):
+    SUPPORTED_ARCHITECTURES = ("stable-diffusion-xl",)
+    MODEL_CLASS = OVStableDiffusionXLPipeline
+    ORT_MODEL_CLASS = ORTStableDiffusionXLPipeline
+    PT_MODEL_CLASS = StableDiffusionXLPipeline
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_compare_to_diffusers(self, model_arch: str):
+        ov_pipeline = self.MODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], export=True)
+        self.assertIsInstance(ov_pipeline.text_encoder, OVModelTextEncoder)
+        self.assertIsInstance(ov_pipeline.text_encoder_2, OVModelTextEncoder)
+        self.assertIsInstance(ov_pipeline.vae_encoder, OVModelVaeEncoder)
+        self.assertIsInstance(ov_pipeline.vae_decoder, OVModelVaeDecoder)
+        self.assertIsInstance(ov_pipeline.unet, OVModelUnet)
+        self.assertIsInstance(ov_pipeline.config, Dict)
+
+        pipeline = self.PT_MODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch])
+        batch_size, num_images_per_prompt, height, width = 2, 3, 64, 128
+        latents = ov_pipeline.prepare_latents(
+            batch_size * num_images_per_prompt,
+            ov_pipeline.unet.config["in_channels"],
+            height,
+            width,
+            dtype=np.float32,
+            generator=np.random.RandomState(0),
+        )
+
+        kwargs = {
+            "prompt": ["sailing ship in storm by Leonardo da Vinci"] * batch_size,
+            "num_inference_steps": 1,
+            "num_images_per_prompt": num_images_per_prompt,
+            "height": height,
+            "width": width,
+            "guidance_rescale": 0.1,
+        }
+
+        for output_type in ["latent", "np"]:
+            ov_outputs = ov_pipeline(latents=latents, output_type=output_type, **kwargs).images
+
+            self.assertIsInstance(ov_outputs, np.ndarray)
+            with torch.no_grad():
+                outputs = pipeline(latents=torch.from_numpy(latents), output_type=output_type, **kwargs).images
+
+            # Compare model outputs
+            self.assertTrue(np.allclose(ov_outputs, outputs, atol=1e-4))
+        # Compare model devices
+        self.assertEqual(pipeline.device.type, ov_pipeline.device)
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_image_reproducibility(self, model_arch: str):
+        pipeline = self.MODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], export=True)
+        batch_size, num_images_per_prompt, height, width = 2, 3, 64, 128
+
+        inputs = _generate_inputs(batch_size)
+        np.random.seed(0)
+        ov_outputs_1 = pipeline(**inputs, height=height, width=width)
+        np.random.seed(0)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pipeline.save_pretrained(tmp_dir)
+            pipeline = self.MODEL_CLASS.from_pretrained(tmp_dir)
+        ov_outputs_2 = pipeline(**inputs, height=height, width=width)
+        ov_outputs_3 = pipeline(**inputs, height=height, width=width)
+        self.assertTrue(np.array_equal(ov_outputs_1.images[0], ov_outputs_2.images[0]))
+        self.assertFalse(np.array_equal(ov_outputs_1.images[0], ov_outputs_3.images[0]))
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_num_images_per_prompt_static_model(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True, compile=False)
+        batch_size, num_images, height, width = 3, 4, 128, 64
+        pipeline.half()
+        pipeline.reshape(batch_size=batch_size, height=height, width=width, num_images_per_prompt=num_images)
+        self.assertFalse(pipeline.is_dynamic)
+        pipeline.compile()
+        # Verify output shapes requirements not matching the static model don't impact the final outputs
+        inputs = _generate_inputs(batch_size)
+        outputs = pipeline(**inputs, num_images_per_prompt=num_images, height=height, width=width).images
+        self.assertEqual(outputs.shape, (batch_size * num_images, height, width, 3))
+
+
+class OVStableDiffusionXLImg2ImgPipelineTest(unittest.TestCase):
+    SUPPORTED_ARCHITECTURES = ("stable-diffusion-xl",)
+    MODEL_CLASS = OVStableDiffusionXLImg2ImgPipeline
+    ORT_MODEL_CLASS = ORTStableDiffusionXLImg2ImgPipeline
+    PT_MODEL_CLASS = StableDiffusionXLImg2ImgPipeline
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_inference(self, model_arch: str):
+        pipeline = self.MODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], export=True)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            pipeline.save_pretrained(tmp_dir)
+            pipeline = self.MODEL_CLASS.from_pretrained(tmp_dir)
+
+        inputs = self.generate_inputs()
+        output = pipeline(**inputs, generator=np.random.RandomState(0)).images[0, -3:, -3:, -1]
+        expected_slice = np.array([0.6515, 0.5405, 0.4858, 0.5632, 0.5174, 0.5681, 0.4948, 0.4253, 0.5080])
+        self.assertTrue(np.allclose(output.flatten(), expected_slice, atol=1e-1))
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    def test_num_images_per_prompt_static_model(self, model_arch: str):
+        model_id = MODEL_NAMES[model_arch]
+        pipeline = self.MODEL_CLASS.from_pretrained(model_id, export=True, compile=False, dynamic_shapes=False)
+        batch_size, num_images, height, width = 2, 3, 128, 64
+        pipeline.half()
+        inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
+        pipeline.reshape(batch_size=batch_size, height=height, width=width, num_images_per_prompt=num_images)
+        outputs = pipeline(**inputs, num_images_per_prompt=num_images, generator=np.random.RandomState(0)).images
+        self.assertEqual(outputs.shape, (batch_size * num_images, height, width, 3))
+
+    def generate_inputs(self, height=128, width=128, batch_size=1):
+        inputs = _generate_inputs(batch_size)
+        inputs["image"] = floats_tensor((batch_size, 3, height, width), rng=random.Random(SEED))
+        inputs["strength"] = 0.75
+        return inputs

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -1,0 +1,91 @@
+#  Copyright 2023 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import numpy as np
+import torch
+
+
+MODEL_NAMES = {
+    "albert": "hf-internal-testing/tiny-random-albert",
+    "audio_spectrogram_transformer": "Ericwang/tiny-random-ast",
+    "beit": "hf-internal-testing/tiny-random-BeitForImageClassification",
+    "bert": "hf-internal-testing/tiny-random-bert",
+    "bart": "hf-internal-testing/tiny-random-bart",
+    "bigbird_pegasus": "hf-internal-testing/tiny-random-bigbird_pegasus",
+    "blenderbot-small": "hf-internal-testing/tiny-random-BlenderbotModel",
+    "blenderbot": "hf-internal-testing/tiny-random-blenderbot",
+    "bloom": "hf-internal-testing/tiny-random-BloomModel",
+    "camembert": "hf-internal-testing/tiny-random-camembert",
+    "convbert": "hf-internal-testing/tiny-random-ConvBertForSequenceClassification",
+    "codegen": "hf-internal-testing/tiny-random-CodeGenForCausalLM",
+    "data2vec_text": "hf-internal-testing/tiny-random-Data2VecTextModel",
+    "data2vec_vision": "hf-internal-testing/tiny-random-Data2VecVisionModel",
+    "data2vec_audio": "hf-internal-testing/tiny-random-Data2VecAudioModel",
+    "deberta": "hf-internal-testing/tiny-random-deberta",
+    "deberta_v2": "hf-internal-testing/tiny-random-DebertaV2Model",
+    "deit": "hf-internal-testing/tiny-random-deit",
+    "convnext": "hf-internal-testing/tiny-random-convnext",
+    "distilbert": "hf-internal-testing/tiny-random-distilbert",
+    "electra": "hf-internal-testing/tiny-random-electra",
+    "flaubert": "hf-internal-testing/tiny-random-flaubert",
+    # "gpt_bigcode": "bigcode/tiny_starcoder_py",
+    "gpt2": "hf-internal-testing/tiny-random-gpt2",
+    "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",
+    "gpt_neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
+    "gptj": "hf-internal-testing/tiny-random-GPTJModel",
+    "hubert": "hf-internal-testing/tiny-random-HubertModel",
+    "ibert": "hf-internal-testing/tiny-random-ibert",
+    "levit": "hf-internal-testing/tiny-random-LevitModel",
+    "longt5": "hf-internal-testing/tiny-random-longt5",
+    "llama": "fxmarty/tiny-llama-fast-tokenizer",
+    "m2m_100": "hf-internal-testing/tiny-random-m2m_100",
+    "opt": "hf-internal-testing/tiny-random-OPTModel",
+    "marian": "sshleifer/tiny-marian-en-de",  # hf-internal-testing ones are broken
+    "mbart": "hf-internal-testing/tiny-random-mbart",
+    "mobilebert": "hf-internal-testing/tiny-random-MobileBertModel",
+    "mobilenet_v1": "google/mobilenet_v1_0.75_192",
+    "mobilenet_v2": "hf-internal-testing/tiny-random-MobileNetV2Model",
+    "mobilevit": "hf-internal-testing/tiny-random-mobilevit",
+    "mt5": "stas/mt5-tiny-random",
+    "nystromformer": "hf-internal-testing/tiny-random-NystromformerModel",
+    "pegasus": "hf-internal-testing/tiny-random-pegasus",
+    "poolformer": "hf-internal-testing/tiny-random-PoolFormerModel",
+    "resnet": "hf-internal-testing/tiny-random-resnet",
+    "roberta": "hf-internal-testing/tiny-random-roberta",
+    "roformer": "hf-internal-testing/tiny-random-roformer",
+    "segformer": "hf-internal-testing/tiny-random-SegformerModel",
+    "squeezebert": "hf-internal-testing/tiny-random-squeezebert",
+    "stable-diffusion": "hf-internal-testing/tiny-stable-diffusion-torch",
+    "stable-diffusion-xl": "echarlaix/tiny-random-stable-diffusion-xl",
+    "sew": "hf-internal-testing/tiny-random-SEWModel",
+    "sew_d": "hf-internal-testing/tiny-random-SEWDModel",
+    "swin": "hf-internal-testing/tiny-random-SwinModel",
+    "t5": "hf-internal-testing/tiny-random-t5",
+    "unispeech": "hf-internal-testing/tiny-random-unispeech",
+    "unispeech_sat": "hf-internal-testing/tiny-random-UnispeechSatModel",
+    "vit": "hf-internal-testing/tiny-random-vit",
+    "wavlm": "hf-internal-testing/tiny-random-WavlmModel",
+    "wav2vec2": "anton-l/wav2vec2-random-tiny-classifier",
+    "wav2vec2-conformer": "hf-internal-testing/tiny-random-wav2vec2-conformer",
+    "xlm": "hf-internal-testing/tiny-random-xlm",
+    "xlm_roberta": "hf-internal-testing/tiny-xlm-roberta",
+}
+
+
+TENSOR_ALIAS_TO_TYPE = {
+    "pt": torch.Tensor,
+    "np": np.ndarray,
+}
+
+SEED = 42


### PR DESCRIPTION
Enable Stable Diffusion XL OpenVINO export and inference for text-to-image and image-to-image. 
 
```python
from optimum.intel import OVStableDiffusionXLPipeline

model_id = "stabilityai/stable-diffusion-xl-base-0.9"
pipeline = OVStableDiffusionXLPipeline.from_pretrained(model_id, export=True)
```

Also enable image-to-image and  image inpainting tasks for SD models