### PR TITLE
Add upgrade strategy installation instruction in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@ To install the latest release of 🤗 Optimum Intel with the corresponding requi
 
 | Accelerator                                                                                                      | Installation                                                         |
 |:-----------------------------------------------------------------------------------------------------------------|:---------------------------------------------------------------------|
-| [Intel Neural Compressor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install "optimum[neural-compressor]"`                 |
-| [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install "optimum[openvino,nncf]"`                     |
+| [Intel Neural Compressor](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `pip install --upgrade-strategy eager "optimum[neural-compressor]"`  |
+| [OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `pip install --upgrade-strategy eager "optimum[openvino,nncf]"`      |
+
+The `--upgrade-strategy eager` option is needed to ensure `optimum-intel` is upgraded to the latest version.
 
 We recommend creating a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) and upgrading
 pip with `python -m pip install --upgrade pip`.

--- a/docs/source/installation.mdx
+++ b/docs/source/installation.mdx
@@ -18,13 +18,17 @@ limitations under the License.
 
 To install the latest release of 🤗 Optimum Intel with the corresponding required dependencies, you can do respectively:
 
-| Accelerator                                                                                                            | Installation                                        |
-|:-----------------------------------------------------------------------------------------------------------------------|:----------------------------------------------------|
-| [Intel Neural Compressor (INC)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `python -m pip install "optimum[neural-compressor]"`|
-| [Intel OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `python -m pip install "optimum[openvino,nncf]"`    |
+| Accelerator                                                                                                            | Installation                                                       |
+|:-----------------------------------------------------------------------------------------------------------------------|:-------------------------------------------------------------------|
+| [Intel Neural Compressor (INC)](https://www.intel.com/content/www/us/en/developer/tools/oneapi/neural-compressor.html) | `pip install --upgrade-strategy eager "optimum[neural-compressor]"`|
+| [Intel OpenVINO](https://docs.openvino.ai/latest/index.html)                                                           | `pip install --upgrade-strategy eager "optimum[openvino,nncf]"`    |
 
-We recommend creating a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) and upgrading
-pip with `python -m pip install --upgrade pip`.
+The `--upgrade-strategy eager` option is needed to ensure `optimum-intel` is upgraded to the latest version.
+
+We recommend creating a [virtual environment](https://packaging.python.org/en/latest/guides/installing-using-pip-and-virtual-environments/#creating-a-virtual-environment) and upgrading pip with :
+```bash
+python -m pip install --upgrade pip
+```
 
 Optimum Intel is a fast-moving project, and you may want to install from source with the following command:
 


### PR DESCRIPTION
adding `--upgrade-strategy eager` so that the latest version of `optimum-intel` is installed. With `pip install --upgrade optimum[intel]`  the latest `optimum` version will be downloaded but not the latest version of `optimum-intel`