### PR TITLE
Fix typos, broken documentation links, and clarify instructions for building docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,14 +22,17 @@ To generate the documentation for 🤗 Optimum Intel, simply run the following
 command from the root of the `optimum-intel` repository:
 
 ```bash
-make doc BUILD_DIR=intel-doc-build
+make doc BUILD_DIR=intel-doc-build VERSION=main
 ```
 
 This command will generate the HTML files that will be rendered as the
 documentation on the [Hugging Face
 website](https://huggingface.co/docs/optimum/index). You can inspect them in
 your favorite browser. You can also adapt the `BUILD_DIR` argument to any
-temporary folder that you prefer.
+temporary folder that you prefer. By default, the comamnd builds a Docker container
+with the latest files from the main branch. To build documentation for a different
+commit or a fork, use the `DEFAULT_CLONE_URL` and `COMMIT_SHA_SUBPACKAGE`
+environment variables.
 
 ---
 **NOTE**

--- a/docs/source/optimization_inc.mdx
+++ b/docs/source/optimization_inc.mdx
@@ -61,7 +61,7 @@ quantizer.quantize(quantization_config=quantization_config, save_directory="dyna
 
 ### Static quantization
 
-In the same maneer we can apply static quantization, for which we also need to generate the calibration dataset in order to perform the calibration step.
+In the same manner we can apply static quantization, for which we also need to generate the calibration dataset in order to perform the calibration step.
 
 ```python
 from functools import partial
@@ -181,7 +181,7 @@ trainer.save_model()
 
 ### Pruning
 
-In the same maneer, pruning can be applied by specifiying the pruning configuration detailing the desired pruning process.
+In the same manner, pruning can be applied by specifying the pruning configuration detailing the desired pruning process.
 To know more about the different supported methodologies, you can refer to the Neural Compressor [documentation](https://github.com/intel/neural-compressor/tree/master/neural_compressor/compression/pruner#pruning-types).
 At the moment, pruning is applied on both the linear and the convolutional layers, and not on other layers such as the embeddings. It's important to mention that the pruning sparsity defined in the configuration will be applied on these layers, and thus will not results in the global model sparsity.
 
@@ -219,7 +219,7 @@ model = AutoModelForSequenceClassification.from_pretrained(save_dir)
 ```
 ### Knowledge distillation
 
-Knowledge distillation can also be applied in the same maneer.
+Knowledge distillation can also be applied in the same manner.
 To know more about the different supported methodologies, you can refer to the Neural Compressor [documentation](https://github.com/intel/neural-compressor/blob/master/docs/source/distillation.md)
 
 ```diff

--- a/docs/source/optimization_inc.mdx
+++ b/docs/source/optimization_inc.mdx
@@ -129,7 +129,7 @@ Please refer to INC [documentation](https://github.com/intel/neural-compressor/b
 
 ## During training optimization
 
-The [`INCTrainer`] class provides an API to train your model while combining different compression techniques such as knowledge distillation, pruning and quantization.
+The [`INCTrainer`](https://huggingface.co/docs/optimum/main/intel/reference_inc#optimum.intel.INCTrainer) class provides an API to train your model while combining different compression techniques such as knowledge distillation, pruning and quantization.
 The `INCTrainer` is very similar to the 🤗 Transformers [`Trainer`](https://huggingface.co/docs/transformers/main/en/main_classes/trainer#trainer), which can be replaced with minimal changes in your code.
 
 ### Quantization
@@ -182,7 +182,7 @@ trainer.save_model()
 ### Pruning
 
 In the same maneer, pruning can be applied by specifiying the pruning configuration detailing the desired pruning process.
-To know more about the different supported methodologies, you can refer to the Neural Compressor [documentation](https://github.com/intel/neural-compressor/tree/master/neural_compressor/pruner#pruning-types).
+To know more about the different supported methodologies, you can refer to the Neural Compressor [documentation](https://github.com/intel/neural-compressor/tree/master/neural_compressor/compression/pruner#pruning-types).
 At the moment, pruning is applied on both the linear and the convolutional layers, and not on other layers such as the embeddings. It's important to mention that the pruning sparsity defined in the configuration will be applied on these layers, and thus will not results in the global model sparsity.
 
 ```diff


### PR DESCRIPTION
There are a few of changes in this PR:
* Fixed a few typos
* Fixing 2 broken links in the [Optimization INC](https://huggingface.co/docs/optimum/intel/optimization_inc) documentation:
  * The `INCTrainer` link under the "During training optimization" doesn't work. It seems like URL for this link was intended to be autogenerated and point to the reference page, however that autogenerated URL doesn't work
  * Under the "Pruning" header there's a link to neural-compressor documentation that's going to a GitHub URL that no longer exists, so I fixed that
* After making the above changes, I tried to build the docs to locally test the links and ran into a couple of issues.
  * Specifying `VERSION` is required otherwise the make command gives a "VERSION is empty" error 
  * The README does not mention that command will clone a new copy of the repo in a docker container (versus using the local copy of the optimum-intel code). When I followed the instructions, I was confused why I wasn't seeing my local changes in the built html. Only after inspecting the Makefile and Dockerfile did I understand what was going on. I added a couple sentences to explain this, so that others don't run into the same issue.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

