### PR TITLE
fix typos in SDXL inference docs

### DIFF
--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -217,7 +217,7 @@ Before using `OVtableDiffusionXLPipeline` make sure to have `diffusers` and `inv
 
 ```bash
 pip install diffusers
-pip install invisible-watermark>=2.0
+pip install invisible-watermark>=0.2.0
 ```
 
 ### Text-to-Image
@@ -225,10 +225,10 @@ pip install invisible-watermark>=2.0
 Here is an example of how you can load a PyTorch SDXL model, convert it to the adapted format on-the-fly and run inference with OpenVINO Runtime:
 
 ```python
-from optimum.intel import OVtableDiffusionXLPipeline
+from optimum.intel import OVStableDiffusionXLPipeline
 
 model_id = "stabilityai/stable-diffusion-xl-base-1.0"
-base = OVtableDiffusionXLPipeline.from_pretrained(model_id, export=True)
+base = OVStableDiffusionXLPipeline.from_pretrained(model_id, export=True)
 prompt = "train station by Caspar David Friedrich"
 image = base(prompt).images[0]
 


### PR DESCRIPTION
# What does this PR do?
fix small typos in stable diffusion xl instruction for openvino.
1. there is no invisible-watermark 2.0 on pypi - https://pypi.org/project/invisible-watermark/#history
2. fixed typo in class name in text2image example


## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

