### PR TITLE
Removed pkv history from quantization statistics of Decoders

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -298,7 +298,7 @@ class OVQuantizer(OptimumQuantizer):
 
         self.model.request = InferRequestWrapper(self.model.request)
         for _, data in enumerate(calibration_dataloader):
-            self.model.generate(**data, max_new_tokens=10)
+            self.model.generate(**data, max_new_tokens=1)
             if len(data_cache) >= subset_size:
                 break
         self.model.request = self.model.request.request


### PR DESCRIPTION
It turns out that accuracy results are significantly better if not consider PKV history during quantization, so removing it from Decoders quantization.