### PR TITLE
Tiny test updates

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -30,6 +30,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
+        # install PyTorch CPU version to avoid installing CUDA packages on GitHub runner without GPU
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
         pip install .[openvino,nncf,tests,diffusers]
     - name: Test with Pytest
       run: |

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -422,7 +422,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "pegasus",
     )
     GENERATION_LENGTH = 100
-    SPEEDUP_CACHE = 1.2
+    SPEEDUP_CACHE = 1.1
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):


### PR DESCRIPTION
- Install PyTorch CPU version in modeling test to speed up requirements installation time.
- Decrease pkv speedup minimum to 1.1: inference without pkv has been improved with OpenVINO 2023.1 prerelease, and now the comparison of with_and_without_pkv is sometimes small (this difference is smaller on the GitHub actions runner than locally).