### PR TITLE
Do not download onnx model in sd pipeline if from_onnx=False

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -217,6 +217,9 @@ class OVStableDiffusionPipelineBase(OVBaseModel):
                     cls.config_name,
                 }
             )
+            ignore_patterns = ["*.msgpack", "*.safetensors", "*pytorch_model.bin"]
+            if not from_onnx:
+                ignore_patterns.extend(["*.onnx", "*.onnx_data"])
             # Downloads all repo's files matching the allowed patterns
             model_id = snapshot_download(
                 model_id,
@@ -225,7 +228,7 @@ class OVStableDiffusionPipelineBase(OVBaseModel):
                 use_auth_token=use_auth_token,
                 revision=revision,
                 allow_patterns=allow_patterns,
-                ignore_patterns=["*.msgpack", "*.safetensors", "*pytorch_model.bin"],
+                ignore_patterns=ignore_patterns,
             )
         new_model_save_dir = Path(model_id)
 


### PR DESCRIPTION
# What does this PR do?

fixes downloading onnx model from hub if both openvino and onnx models are provided. Problem observed in stable diffusion pipeline (especially SDXL base)
![model_download](https://github.com/huggingface/optimum-intel/assets/29454499/15bf17d8-eb3c-4cb8-be2b-1a966c335f73)


Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

