### PR TITLE
Added 8-bit weight compression for OVModel

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -167,10 +167,6 @@ class OVQuantizer(OptimumQuantizer):
             raise ValueError("`save_directory` needs to be specified")
 
         if weights_only:
-            if isinstance(self.model, OVBaseModel):
-                raise ValueError(
-                    "`weights_only` currently not supported for `OVModels`, only available for torch.nn.Module."
-                )
             if calibration_dataset is not None:
                 logger.warning(
                     "`calibration_dataset` was provided but will not be used as `weights_only` is set to `True`."
@@ -189,6 +185,7 @@ class OVQuantizer(OptimumQuantizer):
                 batch_size,
                 data_collator,
                 remove_unused_columns,
+                weights_only,
                 **kwargs,
             )
         elif isinstance(self.model, OVBaseModel):
@@ -198,6 +195,7 @@ class OVQuantizer(OptimumQuantizer):
                 batch_size,
                 data_collator,
                 remove_unused_columns,
+                weights_only,
                 **kwargs,
             )
         elif isinstance(self.model, torch.nn.Module):
@@ -221,10 +219,16 @@ class OVQuantizer(OptimumQuantizer):
         batch_size: int = 1,
         data_collator: Optional[DataCollator] = None,
         remove_unused_columns: bool = True,
+        weights_only: bool = False,
         **kwargs,
     ):
         save_directory = Path(save_directory)
         save_directory.mkdir(parents=True, exist_ok=True)
+
+        if weights_only:
+            self.model.model = nncf.compress_weights(self.model.model)
+            self.model.save_pretrained(save_directory)
+            return
 
         calibration_dataloader = self._get_calibration_dataloader(
             calibration_dataset=calibration_dataset,
@@ -251,10 +255,16 @@ class OVQuantizer(OptimumQuantizer):
         batch_size: int = 1,
         data_collator: Optional[DataCollator] = None,
         remove_unused_columns: bool = True,
+        weights_only: bool = False,
         **kwargs,
     ):
         save_directory = Path(save_directory)
         save_directory.mkdir(parents=True, exist_ok=True)
+
+        if weights_only:
+            self.model.model = nncf.compress_weights(self.model.model)
+            self.model.save_pretrained(save_directory)
+            return
 
         calibration_dataloader = self._get_calibration_dataloader(
             calibration_dataset=calibration_dataset,

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -146,12 +146,12 @@ class OVQuantizerTest(unittest.TestCase):
 class OVWeightCompressionTest(unittest.TestCase):
     # TODO : add models
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS = (
-        (OVModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 70),
-        (OVModelForCausalLM, "hf-internal-testing/tiny-random-gpt2", 45),
+        (OVModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 70, 35),
+        (OVModelForCausalLM, "hf-internal-testing/tiny-random-gpt2", 45, 23),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS)
-    def test_automodel_weight_compression(self, model_cls, model_name, expected_int8):
+    def test_automodel_weight_compression(self, model_cls, model_name, expected_pt_int8, expected_ov_int8):
         task = model_cls.export_feature
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -166,7 +166,7 @@ class OVWeightCompressionTest(unittest.TestCase):
 
             # TODO: uncomment once move to a newer version of NNCF which has some fixes
             _, num_int8 = get_num_quantized_nodes(model)
-            self.assertEqual(expected_int8, num_int8)
+            self.assertEqual(expected_pt_int8, num_int8)
 
             tokens = tokenizer("This is a sample input", return_tensors="pt")
             outputs = model(**tokens)
@@ -175,6 +175,27 @@ class OVWeightCompressionTest(unittest.TestCase):
             # Verify that that the configuration is correctly saved and loaded
             loaded_config = OVConfig.from_pretrained(tmp_dir)
             self.assertIsNotNone(loaded_config)
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS)
+    def test_ovmodel_weight_compression(self, model_cls, model_name, expected_pt_int8, expected_ov_int8):
+        task = model_cls.export_feature
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            transformers_model = model_cls.from_pretrained(model_name, export=True)
+            tokenizer = AutoTokenizer.from_pretrained(model_name)
+            if tokenizer.pad_token is None:
+                tokenizer.pad_token = tokenizer.eos_token
+
+            quantizer = OVQuantizer.from_pretrained(transformers_model, task=task)
+            quantizer.quantize(save_directory=tmp_dir, weights_only=True)
+            model = model_cls.from_pretrained(tmp_dir)
+
+            _, num_int8 = get_num_quantized_nodes(model)
+            self.assertEqual(expected_ov_int8, num_int8)
+
+            tokens = tokenizer("This is a sample input", return_tensors="pt")
+            outputs = model(**tokens)
+            self.assertTrue("logits" in outputs)
 
 
 class OVQuantizerQATest(unittest.TestCase):

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -147,7 +147,7 @@ class OVWeightCompressionTest(unittest.TestCase):
     # TODO : add models
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS = (
         (OVModelForSequenceClassification, "hf-internal-testing/tiny-random-bert", 70, 35),
-        (OVModelForCausalLM, "hf-internal-testing/tiny-random-gpt2", 45, 23),
+        (OVModelForCausalLM, "hf-internal-testing/tiny-random-gpt2", 45, 22),
     )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_COMPRESSED_MATMULS)


### PR DESCRIPTION
# What does this PR do?

Introduced data-free weight compression to 8 bits for `OVBaseModel` and `OVBaseDecoderModel`
PR to nncf https://github.com/openvinotoolkit/nncf/pull/2059 was merged

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

