### PR TITLE
Pin npm version for doc building

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y \
 RUN apt-get update && apt-get install -y \
     software-properties-common \
     npm
-RUN npm install npm@latest -g && \
+RUN npm install npm@9.8.1 -g && \
     npm install n -g && \
     n latest
 


### PR DESCRIPTION
cc @echarlaix, npm 10.0.0 [released 7 days ago](https://www.npmjs.com/package/npm?activeTab=versions) apparently breaks this step:
```
 ERR! code EBADENGINE
1.096 npm ERR! engine Unsupported engine
1.096 npm ERR! engine Not compatible with your version of node/npm: npm@10.0.0
1.097 npm ERR! notsup Not compatible with your version of node/npm: npm@10.0.0
1.097 npm ERR! notsup Required: {"node":"^18.17.0 || >=20.5.0"}
1.097 npm ERR! notsup Actual:   {"npm":"9.2.0"}
1.099 
1.099 npm ERR! A complete log of this run can be found in:
1.099 npm ERR!     /root/.npm/_logs/2023-09-07T08_57_22_510Z-debug-0.log
```