### PR TITLE
move VAE to fp32 execution precision on GPU

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -606,6 +606,11 @@ class OVModelVaeDecoder(OVModelPart):
         outputs = self.request(inputs, shared_memory=True)
         return list(outputs.values())
 
+    def _compile(self):
+        if "GPU" in self.device:
+            self.ov_config.update({"INFERENCE_PRECISION_HINT": "f32"})
+        super()._compile()
+
 
 class OVModelVaeEncoder(OVModelPart):
     def __init__(
@@ -621,6 +626,11 @@ class OVModelVaeEncoder(OVModelPart):
         }
         outputs = self.request(inputs, shared_memory=True)
         return list(outputs.values())
+
+    def _compile(self):
+        if "GPU" in self.device:
+            self.ov_config.update({"INFERENCE_PRECISION_HINT": "f32"})
+        super()._compile()
 
 
 class OVStableDiffusionPipeline(OVStableDiffusionPipelineBase, StableDiffusionPipelineMixin):


### PR DESCRIPTION
Prevent fp16 overflow for inference OpenVINO on GPU for SDXL and SD2.1
