### PR TITLE
OpenVINO device updates

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -43,17 +43,6 @@ core = Core()
 
 logger = logging.getLogger(__name__)
 
-_SUPPORTED_DEVICES = {
-    "CPU",
-    "GPU",
-    "AUTO",
-    "AUTO:CPU,GPU",
-    "AUTO:GPU,CPU",
-    "MULTI",
-    "MULTI:CPU,GPU",
-    "MULTI:GPU,CPU",
-}
-
 
 # workaround to enable compatibility between openvino models and transformers pipelines
 class PreTrainedModel(OptimizedModel):
@@ -325,7 +314,7 @@ class OVBaseModel(PreTrainedModel):
 
     def compile(self):
         if self.request is None:
-            logger.info("Compiling the model...")
+            logger.info(f"Compiling the model to {self._device} ...")
             ov_config = {**self.ov_config}
             if "CACHE_DIR" not in self.ov_config.keys():
                 # Set default CACHE_DIR only if it is not set.
@@ -381,11 +370,6 @@ class OVBaseModel(PreTrainedModel):
         compress_model_transformation(self.model)
         self.request = None
         return self
-
-    def _ensure_supported_device(self, device: str = None):
-        device = device if device is not None else self._device
-        if device not in _SUPPORTED_DEVICES:
-            raise ValueError(f"Unknown device: {device}. Expected one of {_SUPPORTED_DEVICES}.")
 
     def forward(self, *args, **kwargs):
         raise NotImplementedError

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -154,8 +154,12 @@ class OVBaseDecoderModel(OVModel):
         pkv_precision = Type.f32
         if not force_fp32:
             device = self._device.upper()
-            if "INFERENCE_PRECISION_HINT" in core.get_property(device, "SUPPORTED_PROPERTIES"):
-                pkv_precision = core.get_property(device, "INFERENCE_PRECISION_HINT")
+            try:
+                if "INFERENCE_PRECISION_HINT" in core.get_property(device, "SUPPORTED_PROPERTIES"):
+                    pkv_precision = core.get_property(device, "INFERENCE_PRECISION_HINT")
+            except RuntimeError:  # use default precision when get_property fails, e.g. when device is "AUTO:GPU"
+                pass
+
             # ov_config["INFERENCE_PRECISION_HINT"] may override the prefer precision
             if self.ov_config:
                 inference_precision_hint = self.ov_config.get("INFERENCE_PRECISION_HINT", "")

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -540,7 +540,7 @@ class OVModelPart:
 
     def _compile(self):
         if self.request is None:
-            logger.info(f"Compiling the {self._model_name}...")
+            logger.info(f"Compiling the {self._model_name} to {self.device} ...")
             self.request = core.compile_model(self.model, self.device, self.ov_config)
 
     @property

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -347,7 +347,7 @@ class OVEncoder:
 
     def _compile(self):
         if self.request is None:
-            logger.info("Compiling the encoder...")
+            logger.info(f"Compiling the encoder to {self._device} ...")
             self.request = core.compile_model(self.model, self._device, self.ov_config)
 
 
@@ -442,5 +442,5 @@ class OVDecoder:
 
     def _compile(self):
         if self.request is None:
-            logger.info("Compiling the decoder...")
+            logger.info(f"Compiling the decoder to {self._device} ...")
             self.request = core.compile_model(self.model, self._device, self.ov_config).create_infer_request()

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -560,11 +560,12 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
 
     def test_auto_device_loading(self):
         model_id = MODEL_NAMES["gpt2"]
-        model = OVModelForCausalLM.from_pretrained(model_id, export=True, use_cache=True, device="AUTO")
-        model.half()
-        self.assertEqual(model._device, "AUTO")
-        del model
-        gc.collect()
+        for device in ("AUTO", "AUTO:CPU"):
+            model = OVModelForCausalLM.from_pretrained(model_id, export=True, use_cache=True, device=device)
+            model.half()
+            self.assertEqual(model._device, device)
+            del model
+            gc.collect()
 
 
 class OVModelForMaskedLMIntegrationTest(unittest.TestCase):


### PR DESCRIPTION
- Fix error with `OVModelForCausalLM` when using a device like `AUTO:GPU` (which will automatically select a device, but only from available GPUs. For example if you want inference to run on either integrated or discrete GPU, but not on CPU).
- Remove `_SUPPORTED_DEVICES` and `_ensure_supported_device()` since they are not used
- Add device name to "Compiling the model" INFO messages