### PR TITLE
Fix openvino decoder model without cache

### DIFF
--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -133,6 +133,7 @@ class OVBaseDecoderModel(OVModel):
         self.key_value_input_names = [key for key in self.input_names if "key_values" in key]
         self.key_value_output_names = [key for key in self.output_names if "present" in key]
         self._original_model = self.model.clone()  # keep original model for serialization
+        self._pkv_precision = Type.f32
         self.update_pkv_precision()
         if self.is_dynamic:
             self.model = self._reshape(self.model, -1, -1)

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -123,9 +123,10 @@ class OVModelIntegrationTest(unittest.TestCase):
 
     @parameterized.expand((True, False))
     def test_load_from_hub_and_save_decoder_model(self, use_cache):
-        tokenizer = AutoTokenizer.from_pretrained(self.OV_DECODER_MODEL_ID)
+        model_id = "vuiseng9/ov-gpt2-fp32-kv-cache" if use_cache else "vuiseng9/ov-gpt2-fp32-no-cache"
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
         tokens = tokenizer("This is a sample input", return_tensors="pt")
-        loaded_model = OVModelForCausalLM.from_pretrained(self.OV_DECODER_MODEL_ID, use_cache=use_cache)
+        loaded_model = OVModelForCausalLM.from_pretrained(model_id, use_cache=use_cache)
         self.assertIsInstance(loaded_model.config, PretrainedConfig)
         loaded_model_outputs = loaded_model(**tokens)
 

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -121,10 +121,11 @@ class OVModelIntegrationTest(unittest.TestCase):
         del model
         gc.collect()
 
-    def test_load_from_hub_and_save_decoder_model(self):
+    @parameterized.expand((True, False))
+    def test_load_from_hub_and_save_decoder_model(self, use_cache):
         tokenizer = AutoTokenizer.from_pretrained(self.OV_DECODER_MODEL_ID)
         tokens = tokenizer("This is a sample input", return_tensors="pt")
-        loaded_model = OVModelForCausalLM.from_pretrained(self.OV_DECODER_MODEL_ID, use_cache=True)
+        loaded_model = OVModelForCausalLM.from_pretrained(self.OV_DECODER_MODEL_ID, use_cache=use_cache)
         self.assertIsInstance(loaded_model.config, PretrainedConfig)
         loaded_model_outputs = loaded_model(**tokens)
 
@@ -133,7 +134,8 @@ class OVModelIntegrationTest(unittest.TestCase):
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(OV_XML_FILE_NAME in folder_contents)
             self.assertTrue(OV_XML_FILE_NAME.replace(".xml", ".bin") in folder_contents)
-            model = OVModelForCausalLM.from_pretrained(tmpdirname, use_cache=True)
+            model = OVModelForCausalLM.from_pretrained(tmpdirname, use_cache=use_cache)
+            self.assertEqual(model.use_cache, use_cache)
 
         outputs = model(**tokens)
         self.assertTrue(torch.equal(loaded_model_outputs.logits, outputs.logits))

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -542,7 +542,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
             )
 
         model_without_pkv = OVModelForCausalLM.from_pretrained(model_id, export=True, use_cache=False)
-        
+
         # Warmup
         _ = model_without_pkv.generate(**tokens)
         with Timer() as without_pkv_timer:

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -540,6 +540,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
             )
 
         model_without_pkv = OVModelForCausalLM.from_pretrained(model_id, export=True, use_cache=False)
+        
         # Warmup
         _ = model_without_pkv.generate(**tokens)
         with Timer() as without_pkv_timer:
@@ -710,12 +711,8 @@ class OVModelForImageClassificationIntegrationTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdirname:
             model_save_path = os.path.join(tmpdirname, "timm_ov_model")
             ov_model.save_pretrained(model_save_path)
-            new_ov_model = OVModelForImageClassification.from_pretrained(
-                model_save_path,
-            )
-            new_ov_model(
-                pixel_values=torch.zeros((5, 3, new_ov_model.config.image_size, new_ov_model.config.image_size))
-            )
+            model = OVModelForImageClassification.from_pretrained(model_save_path)
+            model(pixel_values=torch.zeros((5, 3, model.config.image_size, model.config.image_size)))
         gc.collect()
 
 


### PR DESCRIPTION
Set `_pkv_precision` attribute to `Type.f32` by default, attrribute which is currently doesn't exist for model if `use_cache=False` because of https://github.com/huggingface/optimum-intel/blob/v1.11.0/optimum/intel/openvino/modeling_decoder.py#L152, resulting in an error when the model needs to be saved https://github.com/huggingface/optimum-intel/blob/v1.11.0/optimum/intel/openvino/modeling_decoder.py#L191