### PR TITLE
Support num_key_value_heads

### DIFF
--- a/optimum/intel/generation/modeling.py
+++ b/optimum/intel/generation/modeling.py
@@ -273,7 +273,9 @@ class BaseModelForCausalLM(PreTrainedModel, GenerationMixin):
                 nb_pkv = 2
                 num_layers = self.normalized_config.num_layers
                 num_attention_heads = self.normalized_config.num_attention_heads
-                num_key_value_heads = self.normalized_config.num_key_value_heads or num_attention_heads
+                num_key_value_heads = num_attention_heads
+                if hasattr(self.normalized_config, "num_key_value_heads"):
+                    num_key_value_heads = self.normalized_config.num_key_value_heads
                 hidden_size = self.normalized_config.hidden_size
                 d_k = hidden_size // num_attention_heads
                 if self.config.model_type == "gpt_bigcode":

--- a/optimum/intel/generation/modeling.py
+++ b/optimum/intel/generation/modeling.py
@@ -273,6 +273,7 @@ class BaseModelForCausalLM(PreTrainedModel, GenerationMixin):
                 nb_pkv = 2
                 num_layers = self.normalized_config.num_layers
                 num_attention_heads = self.normalized_config.num_attention_heads
+                num_key_value_heads = self.normalized_config.num_key_value_heads or num_attention_heads
                 hidden_size = self.normalized_config.hidden_size
                 d_k = hidden_size // num_attention_heads
                 if self.config.model_type == "gpt_bigcode":
@@ -282,7 +283,7 @@ class BaseModelForCausalLM(PreTrainedModel, GenerationMixin):
                         empty_tensor = empty_tensor.to(self.model_dtype)
                     past_key_values = tuple([empty_tensor] * num_layers)
                 elif self.config.model_type != "bloom":
-                    new_shape = [input_ids.shape[0], num_attention_heads, 0, d_k]
+                    new_shape = [input_ids.shape[0], num_key_value_heads, 0, d_k]
                     empty_tensor = torch.empty(size=new_shape)
                     if self.model_dtype is not None:
                         empty_tensor = empty_tensor.to(self.model_dtype)
@@ -291,9 +292,9 @@ class BaseModelForCausalLM(PreTrainedModel, GenerationMixin):
                     pkv = ()
                     for nb_pkv in range(nb_pkv):
                         if nb_pkv % 2 == 0:
-                            new_shape = [input_ids.shape[0] * num_attention_heads, d_k, 0]
+                            new_shape = [input_ids.shape[0] * num_key_value_heads, d_k, 0]
                         else:
-                            new_shape = [input_ids.shape[0] * num_attention_heads, 0, d_k]
+                            new_shape = [input_ids.shape[0] * num_key_value_heads, 0, d_k]
                         empty_tensor = torch.empty(size=new_shape)
                         if self.model_dtype is not None:
                             empty_tensor = empty_tensor.to(self.model_dtype)


### PR DESCRIPTION
Hi @echarlaix .

This PR enables models with `num_key_value_heads` like [mistral](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.1) to generate the correct shape of `past_key_values`. Could you please help review it after [1440](https://github.com/huggingface/optimum/pull/1440) merged? Thx!