### PR TITLE
Do not automatically cache models in temp dirs

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -339,7 +339,7 @@ class OVBaseModel(PreTrainedModel):
         if self.request is None:
             logger.info(f"Compiling the model to {self._device} ...")
             ov_config = {**self.ov_config}
-            if "CACHE_DIR" not in self.ov_config.keys() and not self.model_save_dir.is_relative_to(gettempdir()):
+            if "CACHE_DIR" not in self.ov_config.keys() and not str(self.model_save_dir).startswith(gettempdir()):
                 # Set default CACHE_DIR only if it is not set, and if the model is not in a temporary directory
                 cache_dir = Path(self.model_save_dir).joinpath("model_cache")
                 ov_config["CACHE_DIR"] = str(cache_dir)

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -15,7 +15,7 @@
 import logging
 import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, gettempdir
 from typing import Dict, Optional, Union
 
 import openvino
@@ -339,11 +339,11 @@ class OVBaseModel(PreTrainedModel):
         if self.request is None:
             logger.info(f"Compiling the model to {self._device} ...")
             ov_config = {**self.ov_config}
-            if "CACHE_DIR" not in self.ov_config.keys():
-                # Set default CACHE_DIR only if it is not set.
+            if "CACHE_DIR" not in self.ov_config.keys() and not self.model_save_dir.is_relative_to(gettempdir()):
+                # Set default CACHE_DIR only if it is not set, and if the model is not in a temporary directory
                 cache_dir = Path(self.model_save_dir).joinpath("model_cache")
                 ov_config["CACHE_DIR"] = str(cache_dir)
-                logger.info(f"Set CACHE_DIR to {str(cache_dir)}")
+                logger.info(f"Setting OpenVINO CACHE_DIR to {str(cache_dir)}")
             self.request = core.compile_model(self.model, self._device, ov_config)
 
     def _reshape(

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -539,7 +539,7 @@ class OVModelPart:
         self._model_dir = Path(model_dir or parent_model._model_save_dir)
         config_path = self._model_dir / model_name / self.CONFIG_NAME
         self.config = self.parent_model._dict_from_json_file(config_path) if config_path.is_file() else {}
-        if "CACHE_DIR" not in self.ov_config.keys() and not self._model_dir.is_relative_to(gettempdir()):
+        if "CACHE_DIR" not in self.ov_config.keys() and not str(self._model_dir).startswith(gettempdir()):
             self.ov_config["CACHE_DIR"] = os.path.join(self._model_dir, self._model_name, "model_cache")
 
     def _compile(self):

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -17,7 +17,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from tempfile import TemporaryDirectory, gettempdir
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
@@ -539,10 +539,8 @@ class OVModelPart:
         self._model_dir = Path(model_dir or parent_model._model_save_dir)
         config_path = self._model_dir / model_name / self.CONFIG_NAME
         self.config = self.parent_model._dict_from_json_file(config_path) if config_path.is_file() else {}
-
-        # TODO : disable if self._model_dir tmp directory
-        if "CACHE_DIR" not in self.ov_config:
-            self.ov_config["CACHE_DIR"] = os.path.join(self._model_dir, self._model_name)
+        if "CACHE_DIR" not in self.ov_config.keys() and not self._model_dir.is_relative_to(gettempdir()):
+            self.ov_config["CACHE_DIR"] = os.path.join(self._model_dir, self._model_name, "model_cache")
 
     def _compile(self):
         if self.request is None:

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -14,6 +14,7 @@
 
 import logging
 from pathlib import Path
+from tempfile import gettempdir
 from typing import Dict, Optional, Tuple
 
 import numpy as np
@@ -202,31 +203,32 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
         self.decoder_with_past = None
         enable_compilation = kwargs.get("compile", True)
         encoder_cache_dir = Path(self.model_save_dir).joinpath("encoder_cache")
-        encoder_cache_dir.mkdir(parents=True, exist_ok=True)
-        ov_encoder_config = (
-            {**self.ov_config}
-            if "CACHE_DIR" in self.ov_config.keys()
-            else {**self.ov_config, "CACHE_DIR": str(encoder_cache_dir)}
-        )
+        ov_encoder_config = self.ov_config
+
+        if "CACHE_DIR" not in ov_encoder_config.keys() and not self.model_save_dir.is_relative_to(gettempdir()):
+            ov_encoder_config["CACHE_DIR"] = str(encoder_cache_dir)
+
         self.encoder = OVEncoder(
             self.encoder_model, self._device, ov_encoder_config, main_input_name=self.main_input_name
         )
+
         decoder_cache_dir = Path(self.model_save_dir).joinpath("decoder_cache")
-        decoder_cache_dir.mkdir(parents=True, exist_ok=True)
-        ov_decoder_config = (
-            {**self.ov_config}
-            if "CACHE_DIR" in self.ov_config.keys()
-            else {**self.ov_config, "CACHE_DIR": str(decoder_cache_dir)}
-        )
+        ov_decoder_config = self.ov_config
+
+        if "CACHE_DIR" not in ov_decoder_config.keys() and not self.model_save_dir.is_relative_to(gettempdir()):
+            ov_decoder_config["CACHE_DIR"] = str(decoder_cache_dir)
+
         self.decoder = OVDecoder(self.decoder_model, self._device, ov_decoder_config)
+
         if self.use_cache:
             decoder_past_cache_dir = Path(self.model_save_dir).joinpath("decoder_past_cache")
-            decoder_past_cache_dir.mkdir(parents=True, exist_ok=True)
-            ov_decoder_past_config = (
-                {**self.ov_config}
-                if "CACHE_DIR" in self.ov_config.keys()
-                else {**self.ov_config, "CACHE_DIR": str(decoder_past_cache_dir)}
-            )
+            ov_decoder_past_config = self.ov_config
+
+            if "CACHE_DIR" not in ov_decoder_past_config.keys() and not self.model_save_dir.is_relative_to(
+                gettempdir()
+            ):
+                ov_decoder_past_config["CACHE_DIR"] = str(decoder_past_cache_dir)
+
             self.decoder_with_past = OVDecoder(self.decoder_with_past_model, self._device, ov_decoder_past_config)
         if enable_compilation:
             self.compile()

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -203,7 +203,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
         self.decoder_with_past = None
         enable_compilation = kwargs.get("compile", True)
         encoder_cache_dir = Path(self.model_save_dir).joinpath("encoder_cache")
-        ov_encoder_config = self.ov_config
+        ov_encoder_config = {**self.ov_config}
 
         if "CACHE_DIR" not in ov_encoder_config.keys() and not str(self.model_save_dir).startswith(gettempdir()):
             ov_encoder_config["CACHE_DIR"] = str(encoder_cache_dir)
@@ -213,7 +213,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
         )
 
         decoder_cache_dir = Path(self.model_save_dir).joinpath("decoder_cache")
-        ov_decoder_config = self.ov_config
+        ov_decoder_config = {**self.ov_config}
 
         if "CACHE_DIR" not in ov_decoder_config.keys() and not str(self.model_save_dir).startswith(gettempdir()):
             ov_decoder_config["CACHE_DIR"] = str(decoder_cache_dir)
@@ -222,7 +222,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
 
         if self.use_cache:
             decoder_past_cache_dir = Path(self.model_save_dir).joinpath("decoder_past_cache")
-            ov_decoder_past_config = self.ov_config
+            ov_decoder_past_config = {**self.ov_config}
 
             if "CACHE_DIR" not in ov_decoder_past_config.keys() and not str(self.model_save_dir).startswith(
                 gettempdir()

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -205,7 +205,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
         encoder_cache_dir = Path(self.model_save_dir).joinpath("encoder_cache")
         ov_encoder_config = self.ov_config
 
-        if "CACHE_DIR" not in ov_encoder_config.keys() and not self.model_save_dir.is_relative_to(gettempdir()):
+        if "CACHE_DIR" not in ov_encoder_config.keys() and not str(self.model_save_dir).startswith(gettempdir()):
             ov_encoder_config["CACHE_DIR"] = str(encoder_cache_dir)
 
         self.encoder = OVEncoder(
@@ -215,7 +215,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
         decoder_cache_dir = Path(self.model_save_dir).joinpath("decoder_cache")
         ov_decoder_config = self.ov_config
 
-        if "CACHE_DIR" not in ov_decoder_config.keys() and not self.model_save_dir.is_relative_to(gettempdir()):
+        if "CACHE_DIR" not in ov_decoder_config.keys() and not str(self.model_save_dir).startswith(gettempdir()):
             ov_decoder_config["CACHE_DIR"] = str(decoder_cache_dir)
 
         self.decoder = OVDecoder(self.decoder_model, self._device, ov_decoder_config)
@@ -224,7 +224,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
             decoder_past_cache_dir = Path(self.model_save_dir).joinpath("decoder_past_cache")
             ov_decoder_past_config = self.ov_config
 
-            if "CACHE_DIR" not in ov_decoder_past_config.keys() and not self.model_save_dir.is_relative_to(
+            if "CACHE_DIR" not in ov_decoder_past_config.keys() and not str(self.model_save_dir).startswith(
                 gettempdir()
             ):
                 ov_decoder_past_config["CACHE_DIR"] = str(decoder_past_cache_dir)


### PR DESCRIPTION
Currently, CACHE_DIR for exported models is set to a temporary directory unique to the model export. This is not useful, the cache will never be used. It also can cause issues with large exported models on GPU (model loading crashes).

This PR disables automatic model caching if the model save directory is a temporary directory. That doesn't just affect exported models, automatic model caching is now also disabled if users manually save models in /tmp (or Windows equivalent) - but I do not think that that is an issue. Users can always enable model caching manually by setting CACHE_DIR. 

I also aligned the cache dir for diffusion models with other models, so now all cache dirs are in a specific _cache directory (previously for stable diffusion the cache dir was the model dir). 