### PR TITLE
Allow openvino-nightly

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -36,3 +36,9 @@ jobs:
     - name: Test with Pytest
       run: |
         pytest tests/openvino/ --ignore test_modeling_basic
+    - name: Test openvino-nightly import
+      run: |
+        pip uninstall -y openvino
+        pip install openvino-nightly
+        python -c "from optimum.intel import OVModelForCausalLM; OVModelForCausalLM.from_pretrained('hf-internal-testing/tiny-random-gpt2', export=True, compile=False)"
+

--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -71,7 +71,10 @@ if _openvino_available:
     try:
         _openvino_version = importlib_metadata.version("openvino")
     except importlib_metadata.PackageNotFoundError:
-        _openvino_available = False
+        try:
+            _openvino_version = importlib_metadata.version("openvino-nightly")
+        except importlib_metadata.PackageNotFoundError:
+            _openvino_available = False
 
 
 _nncf_available = importlib.util.find_spec("nncf") is not None


### PR DESCRIPTION
OpenVINO recently added nightly releases: https://pypi.org/project/openvino-nightly/
This currently doesn't work well with optimum-intel, because import_utils expects a package named "openvino". This PR fixes that.

```
$ python -c "from optimum.intel import OVModelForCausalLM; OVModelForCausalLM.from_pretrained('hf-internal-testing/tiny-random-gpt2', export=True, compile=False)"
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/optimum/intel/utils/dummy_openvino_objects.py", line 70, in from_pretrained
    requires_backends(cls, ["openvino"])
  File "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/optimum/intel/utils/import_utils.py", line 264, in requires_backends
    raise ImportError("".join(failed))
ImportError: 
OVModelForCausalLM requires the openvino library but it was not found in your environment. You can install it with pip:
`pip install openvino`. Please note that you may need to restart your runtime after installation.
```

Note that there is no guaruantee that openvino-nightly works well; it is prerelease software for testing only (see the note on the PyPI page). The only thing that this PR does is make sure that we can use openvino-nightly for testing optimum-intel.