### PR TITLE
fix causallm weights compression via quantizaer

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -260,7 +260,8 @@ class OVQuantizer(OptimumQuantizer):
         save_directory.mkdir(parents=True, exist_ok=True)
 
         if weights_only:
-            self.model.model = nncf.compress_weights(self.model.model)
+            model = nncf.compress_weights(self.model._original_model)
+            self.model.model = model
             self.model.save_pretrained(save_directory)
             return
 


### PR DESCRIPTION
# What does this PR do?

this PR prevent issue with NotImplementedError: NNCF is not yet supported OpenVINO data type: bf16 on some platforms. 
bf16 injected using preprocessing for modifying past key values precision based on inference precision hint applied before model compilation
