### PR TITLE
Fix compatibility causallm models export with optimum 1.15

### DIFF
--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -29,6 +29,7 @@ else:
 
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
 
+_optimum_version = importlib_metadata.version("optimum")
 
 _transformers_available = importlib.util.find_spec("transformers") is not None
 _transformers_version = "N/A"
@@ -173,6 +174,10 @@ def is_transformers_version(operation: str, version: str):
     if not _transformers_available:
         return False
     return compare_versions(parse(_transformers_version), operation, version)
+
+
+def is_optimum_version(operation: str, version: str):
+    return compare_versions(parse(_optimum_version), operation, version)
 
 
 def is_neural_compressor_version(operation: str, version: str):


### PR DESCRIPTION
Fix export CausalLM models with new optimum version applying workaround from https://github.com/huggingface/optimum-intel/pull/477 only for 1.14


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

