### PR TITLE
Create infer request per inference to enable concurrency

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -17,6 +17,7 @@ import os
 from pathlib import Path
 from tempfile import TemporaryDirectory, gettempdir
 from typing import Dict, Optional, Union
+import queue
 
 import openvino
 from huggingface_hub import hf_hub_download
@@ -88,7 +89,8 @@ class OVBaseModel(OptimizedModel):
         self.output_names = output_names
 
         self.model = model
-        self.request = None
+        self.compiled_model = None
+        
         if enable_compilation:
             self.compile()
 
@@ -337,7 +339,7 @@ class OVBaseModel(OptimizedModel):
         )
 
     def compile(self):
-        if self.request is None:
+        if self.compiled_model is None:
             logger.info(f"Compiling the model to {self._device} ...")
             ov_config = {**self.ov_config}
             if "CACHE_DIR" not in self.ov_config.keys() and not str(self.model_save_dir).startswith(gettempdir()):
@@ -345,7 +347,7 @@ class OVBaseModel(OptimizedModel):
                 cache_dir = Path(self.model_save_dir).joinpath("model_cache")
                 ov_config["CACHE_DIR"] = str(cache_dir)
                 logger.info(f"Setting OpenVINO CACHE_DIR to {str(cache_dir)}")
-            self.request = core.compile_model(self.model, self._device, ov_config)
+            self.compiled_model = core.compile_model(self.model, self._device, ov_config)
 
     def _reshape(
         self,
@@ -383,7 +385,8 @@ class OVBaseModel(OptimizedModel):
         """
         self.is_dynamic = True if batch_size == -1 and sequence_length == -1 else False
         self.model = self._reshape(self.model, batch_size, sequence_length, height, width)
-        self.request = None
+        self.compiled_model = None
+        
         return self
 
     def half(self):
@@ -392,7 +395,8 @@ class OVBaseModel(OptimizedModel):
         """
         apply_moc_transformations(self.model, cf=False)
         compress_model_transformation(self.model)
-        self.request = None
+        self.compiled_model = None
+        
         return self
 
     def forward(self, *args, **kwargs):

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -287,7 +287,6 @@ class OVBaseDecoderModel(OVModel):
     def compile(self):
         if self.compiled_model is None:
             super().compile()
-            self.compiled_model = core.compile_model(self.model, self.device, self.ov_config)
 
 
 @add_start_docstrings(

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -19,7 +19,7 @@ import shutil
 from pathlib import Path
 from tempfile import TemporaryDirectory, gettempdir
 from typing import Any, Dict, List, Optional, Union
-import queue
+import copy
 
 import numpy as np
 import openvino
@@ -564,11 +564,11 @@ class OVModelTextEncoder(OVModelPart):
         inputs = {
             "input_ids": input_ids,
         }
+
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs, shared_memory=True)
         infer_request.wait()
-        outputs = infer_request.outputs
-        
+        outputs = [output.data for output in infer_request.outputs]
         return outputs
 
 
@@ -605,7 +605,7 @@ class OVModelUnet(OVModelPart):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs, shared_memory=True)
         infer_request.wait()
-        outputs = infer_request.outputs
+        outputs = [output.data for output in infer_request.outputs]
         
         return outputs
 
@@ -625,7 +625,7 @@ class OVModelVaeDecoder(OVModelPart):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs, shared_memory=True)
         infer_request.wait()
-        outputs = infer_request.outputs
+        outputs = [output.data for output in infer_request.outputs]
         
         return outputs
 
@@ -650,7 +650,7 @@ class OVModelVaeEncoder(OVModelPart):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs, shared_memory=True)
         infer_request.wait()
-        outputs = infer_request.outputs
+        outputs = [output.data for output in infer_request.outputs]
         
         return outputs
 


### PR DESCRIPTION
### This is just a draft PR for now to start a discussion.

It modifies `forward` calls to create inference request every time instead of reusing only one, created along with the model. This way multiple inferences can be run at the same time allowing higher overall throughput. 


