### PR TITLE
fix load_in_int8 behaviour for large models

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -302,7 +302,7 @@ class OVBaseModel(OptimizedModel):
         )
 
         config.save_pretrained(save_dir_path)
-        return cls._from_pretrained(model_id=save_dir_path, config=config, load_in_8bit=load_in_8bit, **kwargs)
+        return cls._from_pretrained(model_id=save_dir_path, config=config, load_in_8bit=False, **kwargs)
 
     @classmethod
     def _to_load(

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -259,7 +259,7 @@ class OVBaseModel(OptimizedModel):
         local_files_only: bool = False,
         task: Optional[str] = None,
         trust_remote_code: bool = False,
-        load_in_8bit: bool = False,
+        load_in_8bit: Optional[bool] = None,
         **kwargs,
     ):
         """
@@ -283,6 +283,10 @@ class OVBaseModel(OptimizedModel):
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)
 
+        compression_option = None
+        if load_in_8bit is not None:
+            compression_option = "int8" if load_in_8bit else "fp32"
+
         main_export(
             model_name_or_path=model_id,
             output=save_dir_path,
@@ -294,7 +298,7 @@ class OVBaseModel(OptimizedModel):
             local_files_only=local_files_only,
             force_download=force_download,
             trust_remote_code=trust_remote_code,
-            int8=load_in_8bit,
+            compression_option=compression_option,
         )
 
         config.save_pretrained(save_dir_path)

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -270,7 +270,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
 
         config.save_pretrained(save_dir_path)
         return cls._from_pretrained(
-            model_id=save_dir_path, config=config, use_cache=use_cache, load_in_8bit=load_in_8bit, **kwargs
+            model_id=save_dir_path, config=config, use_cache=use_cache, load_in_8bit=False, **kwargs
         )
 
     def _reshape(self, model: openvino.runtime.Model, batch_size: int, sequence_length: int, is_decoder=True):

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -220,7 +220,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         task: Optional[str] = None,
         use_cache: bool = True,
         trust_remote_code: bool = False,
-        load_in_8bit: bool = False,
+        load_in_8bit: Optional[bool] = None,
         **kwargs,
     ):
         """
@@ -251,6 +251,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             if use_cache:
                 task = task + "-with-past"
 
+        compression_option = None
+        if load_in_8bit is not None:
+            compression_option = "int8" if load_in_8bit else "fp32"
         main_export(
             model_name_or_path=model_id,
             output=save_dir_path,
@@ -262,7 +265,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             local_files_only=local_files_only,
             force_download=force_download,
             trust_remote_code=trust_remote_code,
-            compression_option="int8" if load_in_8bit else None,
+            compression_option=compression_option,
         )
 
         config.save_pretrained(save_dir_path)

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -211,7 +211,7 @@ class OVBaseDecoderModel(OVModel):
         task: Optional[str] = None,
         use_cache: bool = True,
         trust_remote_code: bool = False,
-        load_in_8bit: bool = False,
+        load_in_8bit: Optional[bool] = None,
         **kwargs,
     ):
         if config.model_type.replace("_", "-") not in _SUPPORTED_ARCHITECTURES:
@@ -228,6 +228,9 @@ class OVBaseDecoderModel(OVModel):
             if use_cache:
                 task = task + "-with-past"
 
+        compression_option = None
+        if load_in_8bit is not None:
+            compression_option = "int8" if load_in_8bit else "fp32"
         main_export(
             model_name_or_path=model_id,
             output=save_dir_path,
@@ -239,7 +242,7 @@ class OVBaseDecoderModel(OVModel):
             local_files_only=local_files_only,
             force_download=force_download,
             trust_remote_code=trust_remote_code,
-            compression_option="int8" if load_in_8bit else None,
+            compression_option=compression_option,
         )
 
         config.is_decoder = True

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -249,7 +249,7 @@ class OVBaseDecoderModel(OVModel):
         config.is_encoder_decoder = False
         config.save_pretrained(save_dir_path)
         return cls._from_pretrained(
-            model_id=save_dir_path, config=config, use_cache=use_cache, load_in_8bit=load_in_8bit, **kwargs
+            model_id=save_dir_path, config=config, use_cache=use_cache, load_in_8bit=False, **kwargs
         )
 
     def _reshape(

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -286,12 +286,16 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
         tokenizer: Optional["CLIPTokenizer"] = None,
         scheduler: Union["DDIMScheduler", "PNDMScheduler", "LMSDiscreteScheduler"] = None,
         feature_extractor: Optional["CLIPFeatureExtractor"] = None,
-        load_in_8bit: bool = False,
+        load_in_8bit: Optional[bool] = None,
         tokenizer_2: Optional["CLIPTokenizer"] = None,
         **kwargs,
     ):
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)
+
+        compression_option = None
+        if load_in_8bit is not None:
+            compression_option = "int8" if load_in_8bit else "fp32"
 
         main_export(
             model_name_or_path=model_id,
@@ -304,7 +308,7 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
             use_auth_token=use_auth_token,
             local_files_only=local_files_only,
             force_download=force_download,
-            int8=load_in_8bit,
+            compression_option=compression_option,
         )
 
         return cls._from_pretrained(

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -325,7 +325,7 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
             tokenizer_2=tokenizer_2,
             scheduler=scheduler,
             feature_extractor=feature_extractor,
-            load_in_8bit=load_in_8bit,
+            load_in_8bit=False,
             **kwargs,
         )
 


### PR DESCRIPTION
# What does this PR do?

update load_in_int8 logic in from_pretrained for getting the following behavior:

if user specified explicitly load_in_int8=True - model weights will be compressed to int8 after conversion
if user specified explicitly load_in_int8=Flase - model weights will not be compressed
if user does not specify this argument, allow to decide based on model size 

This behavior is also aligned with optimum-cli export for openvino

Also changed providing load_in_8bit argument in _from_pretrained method after _from_transformers for avoiding double weights compression during model loading

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

