### PR TITLE
Fix compatibility with diffusers 0.25.0

### DIFF
--- a/optimum/intel/openvino/loaders.py
+++ b/optimum/intel/openvino/loaders.py
@@ -16,11 +16,7 @@ import logging
 from typing import Dict, List, Optional, Union
 
 import torch
-from diffusers.utils import (
-    DIFFUSERS_CACHE,
-    HF_HUB_OFFLINE,
-    _get_model_file,
-)
+from diffusers.utils import _get_model_file
 
 from ..utils.import_utils import is_safetensors_available
 
@@ -29,12 +25,19 @@ if is_safetensors_available():
     import safetensors
 
 import openvino
+from huggingface_hub.constants import HF_HUB_OFFLINE
 from openvino.runtime import Type
 from openvino.runtime import opset11 as ops
 from openvino.runtime.passes import Manager, Matcher, MatcherPass, WrapType
 from transformers import PreTrainedTokenizer
 
 from .utils import TEXTUAL_INVERSION_EMBEDDING_KEY, TEXTUAL_INVERSION_NAME, TEXTUAL_INVERSION_NAME_SAFE
+
+
+try:
+    from diffusers.utils import DIFFUSERS_CACHE
+except ImportError:
+    DIFFUSERS_CACHE = None
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
# What does this PR do?
fix import error after diffusers 0.25.0 release:
ImportError: cannot import name 'DIFFUSERS_CACHE' from 'diffusers.utils