### PR TITLE
fix model dtype

### DIFF
--- a/optimum/intel/generation/modeling.py
+++ b/optimum/intel/generation/modeling.py
@@ -428,5 +428,6 @@ class TSModelForCausalLM(BaseModelForCausalLM):
             force_download=force_download,
             cache_dir=cache_dir,
             local_files_only=local_files_only,
+            model_dtype=torch_dtype,
             **kwargs,
         )


### PR DESCRIPTION
Hi @echarlaix . The `model_dtype` in `TSModelForCausalLM` should be the same as the loaded dtype `torch_dtype` . Otherwise, it will cause data type error if I loaded model with bf16 or fp16 by `TSModelForCausalLM`.

Would you please help to review it? Thx!