### PR TITLE
Add new _export method

### DIFF
--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -124,12 +124,12 @@ class OVModel(OVBaseModel):
         self.auto_model_class.register(AutoConfig, self.__class__)
         self.device = torch.device("cpu")
 
-    def to(self, device: str):
+    def to(self, device: Union["torch.device", str]):
         """
         Use the specified `device` for inference. For example: "cpu" or "gpu". `device` can
         be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
         """
-        self._device = device.upper()
+        self._device = str(device).upper()
         self.request = None
         return self
 

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -22,8 +22,9 @@ import openvino
 from huggingface_hub import hf_hub_download
 from openvino import Core, convert_model
 from openvino._offline_transformations import apply_moc_transformations, compress_model_transformation
-from transformers import PretrainedConfig, GenerationConfig
+from transformers import GenerationConfig, PretrainedConfig
 from transformers.file_utils import add_start_docstrings
+from transformers.generation import GenerationMixin
 
 from optimum.exporters.onnx import OnnxConfig
 from optimum.modeling_base import OptimizedModel
@@ -31,7 +32,7 @@ from optimum.modeling_base import OptimizedModel
 from ...exporters.openvino import export, main_export
 from ..utils.import_utils import is_nncf_available
 from .utils import ONNX_WEIGHTS_NAME, OV_XML_FILE_NAME, _print_compiled_model_properties
-from transformers.generation import GenerationMixin
+
 
 core = Core()
 

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -21,7 +21,7 @@ from typing import Dict, Optional, Union
 import openvino
 from huggingface_hub import hf_hub_download
 from openvino._offline_transformations import apply_moc_transformations, compress_model_transformation
-from transformers import PretrainedConfig, GenerationConfig
+from transformers import GenerationConfig, PretrainedConfig
 from transformers.file_utils import add_start_docstrings
 
 from ...exporters.openvino import main_export

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -21,11 +21,10 @@ from typing import Dict, Optional, Union
 import openvino
 from huggingface_hub import hf_hub_download
 from openvino._offline_transformations import apply_moc_transformations, compress_model_transformation
-from transformers import PretrainedConfig
+from transformers import PretrainedConfig, GenerationConfig
 from transformers.file_utils import add_start_docstrings
 
 from ...exporters.openvino import main_export
-from ..utils.import_utils import is_transformers_version
 from .modeling_base import OVBaseModel
 from .utils import (
     ONNX_DECODER_NAME,
@@ -75,13 +74,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         self.encoder_model = encoder
         self.decoder_model = decoder
         self.decoder_with_past_model = decoder_with_past
-
-        if is_transformers_version("<=", "4.25.1"):
-            self.generation_config = None
-        else:
-            from transformers import GenerationConfig
-
-            self.generation_config = GenerationConfig.from_model_config(config) if self.can_generate() else None
+        self.generation_config = GenerationConfig.from_model_config(config) if self.can_generate() else None
 
     def _save_pretrained(self, save_directory: Union[str, Path]):
         """

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -32,7 +32,6 @@ from optimum.utils import NormalizedConfigManager
 
 from ...exporters.openvino import ensure_stateful_is_available, main_export, patch_stateful
 from ...exporters.openvino.stateful import model_has_state
-from ..utils.import_utils import is_transformers_version
 from ..utils.modeling_utils import MULTI_QUERY_ATTN_MODELS
 from .modeling import _TOKENIZER_FOR_DOC, INPUTS_DOCSTRING, MODEL_START_DOCSTRING, OVModel
 from .utils import ONNX_WEIGHTS_NAME, OV_XML_FILE_NAME, STR_TO_OV_TYPE

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -25,6 +25,7 @@ from openvino.preprocess import PrePostProcessor
 from openvino.runtime import Core, Tensor, Type
 from transformers import AutoModelForCausalLM, PretrainedConfig
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
+from transformers.generation import GenerationMixin
 from transformers.modeling_outputs import CausalLMOutputWithPast
 
 from optimum.utils import NormalizedConfigManager
@@ -33,7 +34,6 @@ from ...exporters.openvino import main_export
 from ..utils.modeling_utils import MULTI_QUERY_ATTN_MODELS
 from .modeling import _TOKENIZER_FOR_DOC, INPUTS_DOCSTRING, MODEL_START_DOCSTRING, OVModel
 from .utils import ONNX_WEIGHTS_NAME, OV_XML_FILE_NAME, STR_TO_OV_TYPE
-from transformers.generation import GenerationMixin
 
 
 logger = logging.getLogger(__name__)

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -30,16 +30,10 @@ from transformers.modeling_outputs import CausalLMOutputWithPast
 from optimum.utils import NormalizedConfigManager
 
 from ...exporters.openvino import main_export
-from ..utils.import_utils import is_transformers_version
 from ..utils.modeling_utils import MULTI_QUERY_ATTN_MODELS
 from .modeling import _TOKENIZER_FOR_DOC, INPUTS_DOCSTRING, MODEL_START_DOCSTRING, OVModel
 from .utils import ONNX_WEIGHTS_NAME, OV_XML_FILE_NAME, STR_TO_OV_TYPE
-
-
-if is_transformers_version("<", "4.25.0"):
-    from transformers.generation_utils import GenerationMixin
-else:
-    from transformers.generation import GenerationMixin
+from transformers.generation import GenerationMixin
 
 
 logger = logging.getLogger(__name__)

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -329,8 +329,8 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
             **kwargs,
         )
 
-    def to(self, device: str):
-        self._device = device.upper()
+    def to(self, device: Union["torch.device", str]):
+        self._device = str(device).upper()
         self.clear_requests()
         return self
 

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -36,15 +36,10 @@ from transformers.generation.logits_process import WhisperTimeStampLogitsProcess
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 from transformers.models.whisper.tokenization_whisper import TASK_IDS, TO_LANGUAGE_CODE
 
-from ..utils.import_utils import is_transformers_version
 from .modeling_base_seq2seq import OVBaseModelForSeq2SeqLM
 from .utils import _print_compiled_model_properties
+from transformers.generation import GenerationMixin
 
-
-if is_transformers_version("<", "4.25.0"):
-    from transformers.generation_utils import GenerationMixin
-else:
-    from transformers.generation import GenerationMixin
 
 if TYPE_CHECKING:
     from transformers import PretrainedConfig

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -750,7 +750,7 @@ class _OVModelForWhisper(OVModelForSpeechSeq2Seq):
     auto_model_class = WhisperForConditionalGeneration
 
     @classmethod
-    def _from_pretrained(cls, model_id: Union[str, Path], config: "PretrainedConfig",  **kwargs):
+    def _from_pretrained(cls, model_id: Union[str, Path], config: "PretrainedConfig", **kwargs):
         return super(OVModelForSpeechSeq2Seq, cls)._from_pretrained(model_id, config, **kwargs)
 
     # Adapted from transformers.models.whisper.modeling_whisper

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -32,13 +32,13 @@ from transformers import (
     WhisperForConditionalGeneration,
 )
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
+from transformers.generation import GenerationMixin
 from transformers.generation.logits_process import WhisperTimeStampLogitsProcessor
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 from transformers.models.whisper.tokenization_whisper import TASK_IDS, TO_LANGUAGE_CODE
 
 from .modeling_base_seq2seq import OVBaseModelForSeq2SeqLM
 from .utils import _print_compiled_model_properties
-from transformers.generation import GenerationMixin
 
 
 if TYPE_CHECKING:

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -299,8 +299,8 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
         except AttributeError:
             pass
 
-    def to(self, device: str):
-        self._device = device.upper()
+    def to(self, device: Union["torch.device", str]):
+        self._device = str(device).upper()
         self.encoder._device = self._device
         self.decoder._device = self._device
         if self.use_cache:
@@ -750,12 +750,7 @@ class _OVModelForWhisper(OVModelForSpeechSeq2Seq):
     auto_model_class = WhisperForConditionalGeneration
 
     @classmethod
-    def _from_pretrained(
-        cls,
-        model_id: Union[str, Path],
-        config: "PretrainedConfig",
-        **kwargs,
-    ):
+    def _from_pretrained(cls, model_id: Union[str, Path], config: "PretrainedConfig",  **kwargs):
         return super(OVModelForSpeechSeq2Seq, cls)._from_pretrained(model_id, config, **kwargs)
 
     # Adapted from transformers.models.whisper.modeling_whisper

--- a/tests/openvino/test_modeling_basic.py
+++ b/tests/openvino/test_modeling_basic.py
@@ -1,6 +1,6 @@
 """
 The goal of the test in this file is to test that basic functionality of optimum[openvino] works:
-- Load the model with `from_transformers=True`
+- Load the model with `export=True`
 - Do inference with appropriate pipeline
 - Save the model to disk
 
@@ -58,7 +58,7 @@ class OVModelBasicIntegrationTest(unittest.TestCase):
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         model_class_str = MODEL_NAMES[model_id]
         model_class = eval(model_class_str)
-        model = model_class.from_pretrained(model_id, from_transformers=True)
+        model = model_class.from_pretrained(model_id, export=True)
         model.save_pretrained(f"{model_id}_ov")
         model = model_class.from_pretrained(f"{model_id}_ov")
 
@@ -80,7 +80,7 @@ class OVModelBasicIntegrationTest(unittest.TestCase):
         """
         model_id = "hf-internal-testing/tiny-random-distilbert"
         tokenizer = AutoTokenizer.from_pretrained(model_id)
-        model = OVModelForSequenceClassification.from_pretrained(model_id, from_transformers=True)
+        model = OVModelForSequenceClassification.from_pretrained(model_id, export=True)
         model.reshape(1, 16)
         model.half()
         model.to("cpu")


### PR DESCRIPTION
Add new `_export` method introduced in https://github.com/huggingface/optimum/pull/1578/, will add a warning for soon to be deprecated `_from_transformers` (once [`from_pretrained_method`](https://github.com/huggingface/optimum/blob/8c6b6b602e8a458a67372a175dd027a4546c2fa0/optimum/modeling_base.py#L398) is updated accordingly)

Fixes https://github.com/huggingface/optimum-intel/actions/runs/7455656880