### PR TITLE
Add try for get_property

### DIFF
--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -135,13 +135,13 @@ def _print_compiled_model_properties(compiled_model):
     for k in keys:
         try:
             value = compiled_model.get_property(k)
+            if k == properties.device.properties():
+                for device_key in value.keys():
+                    logger.info(f"  {device_key}:")
+                    for k2, value2 in value.get(device_key).items():
+                        if k2 not in skip_keys:
+                            logger.info(f"    {k2}: {value2}")
+            else:
+                logger.info(f"  {k}: {value}")
         except Exception:
             logger.error(f"[error] Get property of '{k}' failed")
-        if k == properties.device.properties():
-            for device_key in value.keys():
-                logger.info(f"  {device_key}:")
-                for k2, value2 in value.get(device_key).items():
-                    if k2 not in skip_keys:
-                        logger.info(f"    {k2}: {value2}")
-        else:
-            logger.info(f"  {k}: {value}")

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -133,7 +133,10 @@ def _print_compiled_model_properties(compiled_model):
     skip_keys = {"SUPPORTED_METRICS", "SUPPORTED_CONFIG_KEYS", supported_properties}
     keys = set(compiled_model.get_property(supported_properties)) - skip_keys
     for k in keys:
-        value = compiled_model.get_property(k)
+        try:
+            value = compiled_model.get_property(k)
+        except Exception:
+            logger.error(f"[error] Get property of '{k}' failed")
         if k == properties.device.properties():
             for device_key in value.keys():
                 logger.info(f"  {device_key}:")


### PR DESCRIPTION
Add try to get_property to avoid throwing exceptions.
Running OV 2024.0.0-13874-eadb9cea806-refs/pull/21980/head will throw exception to get the property of GPU's 'CACHE_MODE' through compiled_model.get_property().

After adding try, the GPU properties are printed as follows:
GPU SUPPORTED_PROPERTIES:
  OPTIMAL_NUMBER_OF_INFER_REQUESTS: 1
  PERF_COUNT: False
  PERFORMANCE_HINT: LATENCY
  GPU_QUEUE_THROTTLE: Priority.MEDIUM
  ENABLE_CPU_PINNING: False
  MODEL_PRIORITY: Priority.MEDIUM
[error] Get property of 'CACHE_MODE' failed
  CACHE_DIR: 
  NETWORK_NAME: main_graph
  PERFORMANCE_HINT_NUM_REQUESTS: 0
  EXECUTION_DEVICES: ['OCL_GPU.0']
  COMPILATION_NUM_THREADS: 32
  GPU_ENABLE_LOOP_UNROLLING: True
  GPU_QUEUE_PRIORITY: Priority.MEDIUM
  GPU_HOST_TASK_PRIORITY: Priority.MEDIUM
  NUM_STREAMS: 1
  GPU_DISABLE_WINOGRAD_CONVOLUTION: False
  EXECUTION_MODE_HINT: ExecutionMode.PERFORMANCE
  DEVICE_ID: 0
  INFERENCE_PRECISION_HINT: <Type: 'float16'>
