### PR TITLE
Fix error with optimum-cli export openvino --help

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -89,7 +89,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
         default=0.8,
         help=(
             "Compression ratio between primary and backup precision. In the case of INT4, NNCF evaluates layer sensitivity and keeps the most impactful layers in INT8"
-            "precision (by default 20% in INT8). This helps to achieve better accuracy after weight quantization."
+            "precision (by default 20%% in INT8). This helps to achieve better accuracy after weight compression."
         ),
     )
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -150,3 +150,10 @@ class OVCLIExportTestCase(unittest.TestCase):
             _, num_int8, num_int4 = get_num_quantized_nodes(model)
             self.assertEqual(expected_int8, num_int8)
             self.assertEqual(expected_int4, num_int4)
+
+    def test_exporters_cli_help(self):
+        subprocess.run(
+            "optimum-cli export openvino --help",
+            shell=True,
+            check=True,
+        )


### PR DESCRIPTION
The percentage sign in the help string caused an error. This PR fixes that and adds a test to catch this in the future.

Also made a tiny phrasing change for consistency: weight quantization to weight compression.

```
[...]
  File "/usr/lib/python3.10/argparse.py", line 226, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.10/argparse.py", line 226, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.10/argparse.py", line 226, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/usr/lib/python3.10/argparse.py", line 552, in _format_action
    help_text = self._expand_help(action)
  File "/usr/lib/python3.10/argparse.py", line 649, in _expand_help
    return self._get_help_string(action) % params
TypeError: %i format: a real number is required, not dict
```