### PR TITLE
support for concurrency in llm models

### DIFF
--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -201,7 +201,11 @@ class OVModelForSequenceClassification(OVModel):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs)
         infer_request.wait()
-        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
+        logits = (
+            torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("logits").data
+        )
         return SequenceClassifierOutput(logits=logits)
 
 
@@ -270,10 +274,14 @@ class OVModelForQuestionAnswering(OVModel):
         infer_request.start_async(inputs)
         infer_request.wait()
         start_logits = (
-            torch.from_numpy(infer_request.get_tensor("start_logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("start_logits").data
+            torch.from_numpy(infer_request.get_tensor("start_logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("start_logits").data
         )
         end_logits = (
-            torch.from_numpy(infer_request.get_tensor("end_logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("end_logits").data
+            torch.from_numpy(infer_request.get_tensor("end_logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("end_logits").data
         )
         return QuestionAnsweringModelOutput(start_logits=start_logits, end_logits=end_logits)
 
@@ -341,7 +349,11 @@ class OVModelForTokenClassification(OVModel):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs)
         infer_request.wait()
-        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
+        logits = (
+            torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("logits").data
+        )
         return TokenClassifierOutput(logits=logits)
 
 
@@ -480,7 +492,11 @@ class OVModelForMaskedLM(OVModel):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs)
         infer_request.wait()
-        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
+        logits = (
+            torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("logits").data
+        )
         return MaskedLMOutput(logits=logits)
 
 
@@ -609,7 +625,11 @@ class OVModelForImageClassification(OVModel):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs)
         infer_request.wait()
-        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
+        logits = (
+            torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("logits").data
+        )
         return ImageClassifierOutput(logits=logits)
 
 
@@ -676,7 +696,11 @@ class OVModelForAudioClassification(OVModel):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs)
         infer_request.wait()
-        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
+        logits = (
+            torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("logits").data
+        )
         return SequenceClassifierOutput(logits=logits)
 
 
@@ -750,7 +774,11 @@ class OVModelForCTC(OVModel):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs)
         infer_request.wait()
-        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
+        logits = (
+            torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("logits").data
+        )
         return CausalLMOutput(logits=logits)
 
 
@@ -833,9 +861,15 @@ class OVModelForAudioXVector(OVModel):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs)
         infer_request.wait()
-        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
+        logits = (
+            torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("logits").data
+        )
         embeddings = (
-            torch.from_numpy(infer_request.get_tensor("embeddings").data).to(self.device) if not np_inputs else infer_request.get_tensor("embeddings").data
+            torch.from_numpy(infer_request.get_tensor("embeddings").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("embeddings").data
         )
         return XVectorOutput(logits=logits, embeddings=embeddings)
 
@@ -911,6 +945,10 @@ class OVModelForAudioFrameClassification(OVModel):
         infer_request = self.compiled_model.create_infer_request()
         infer_request.start_async(inputs)
         infer_request.wait()
-        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
+        logits = (
+            torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device)
+            if not np_inputs
+            else infer_request.get_tensor("logits").data
+        )
 
         return TokenClassifierOutput(logits=logits)

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -130,6 +130,7 @@ class OVModel(OVBaseModel):
         be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
         """
         self._device = device.upper()
+        self.compiled_model = None
         self.request = None
         return self
 
@@ -197,8 +198,10 @@ class OVModelForSequenceClassification(OVModel):
             inputs["token_type_ids"] = token_type_ids
 
         # Run inference
-        outputs = self.request(inputs)
-        logits = torch.from_numpy(outputs["logits"]).to(self.device) if not np_inputs else outputs["logits"]
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
+        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
         return SequenceClassifierOutput(logits=logits)
 
 
@@ -263,12 +266,14 @@ class OVModelForQuestionAnswering(OVModel):
             inputs["token_type_ids"] = token_type_ids
 
         # Run inference
-        outputs = self.request(inputs)
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
         start_logits = (
-            torch.from_numpy(outputs["start_logits"]).to(self.device) if not np_inputs else outputs["start_logits"]
+            torch.from_numpy(infer_request.get_tensor("start_logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("start_logits").data
         )
         end_logits = (
-            torch.from_numpy(outputs["end_logits"]).to(self.device) if not np_inputs else outputs["end_logits"]
+            torch.from_numpy(infer_request.get_tensor("end_logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("end_logits").data
         )
         return QuestionAnsweringModelOutput(start_logits=start_logits, end_logits=end_logits)
 
@@ -333,8 +338,10 @@ class OVModelForTokenClassification(OVModel):
             inputs["token_type_ids"] = token_type_ids
 
         # Run inference
-        outputs = self.request(inputs)
-        logits = torch.from_numpy(outputs["logits"]).to(self.device) if not np_inputs else outputs["logits"]
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
+        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
         return TokenClassifierOutput(logits=logits)
 
 
@@ -398,11 +405,13 @@ class OVModelForFeatureExtraction(OVModel):
             inputs["token_type_ids"] = token_type_ids
 
         # Run inference
-        outputs = self.request(inputs)
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
         last_hidden_state = (
-            torch.from_numpy(outputs["last_hidden_state"]).to(self.device)
+            torch.from_numpy(infer_request.get_tensor("last_hidden_state").data).to(self.device)
             if not np_inputs
-            else outputs["last_hidden_state"]
+            else infer_request.get_tensor("last_hidden_state").data
         )
         return BaseModelOutput(last_hidden_state=last_hidden_state)
 
@@ -468,8 +477,10 @@ class OVModelForMaskedLM(OVModel):
             inputs["token_type_ids"] = token_type_ids
 
         # Run inference
-        outputs = self.request(inputs)
-        logits = torch.from_numpy(outputs["logits"]).to(self.device) if not np_inputs else outputs["logits"]
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
+        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
         return MaskedLMOutput(logits=logits)
 
 
@@ -595,8 +606,10 @@ class OVModelForImageClassification(OVModel):
         }
 
         # Run inference
-        outputs = self.request(inputs)
-        logits = torch.from_numpy(outputs["logits"]).to(self.device) if not np_inputs else outputs["logits"]
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
+        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
         return ImageClassifierOutput(logits=logits)
 
 
@@ -660,8 +673,10 @@ class OVModelForAudioClassification(OVModel):
             inputs["attention_mask"] = attention_mask
 
         # Run inference
-        outputs = self.request(inputs)
-        logits = torch.from_numpy(outputs["logits"]).to(self.device) if not np_inputs else outputs["logits"]
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
+        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
         return SequenceClassifierOutput(logits=logits)
 
 
@@ -732,8 +747,10 @@ class OVModelForCTC(OVModel):
             inputs["attention_mask"] = attention_mask
 
         # Run inference
-        outputs = self.request(inputs)
-        logits = torch.from_numpy(outputs["logits"]).to(self.device) if not np_inputs else outputs["logits"]
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
+        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
         return CausalLMOutput(logits=logits)
 
 
@@ -813,12 +830,13 @@ class OVModelForAudioXVector(OVModel):
             inputs["attention_mask"] = attention_mask
 
         # Run inference
-        outputs = self.request(inputs)
-        logits = torch.from_numpy(outputs["logits"]).to(self.device) if not np_inputs else outputs["logits"]
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
+        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
         embeddings = (
-            torch.from_numpy(outputs["embeddings"]).to(self.device) if not np_inputs else outputs["embeddings"]
+            torch.from_numpy(infer_request.get_tensor("embeddings").data).to(self.device) if not np_inputs else infer_request.get_tensor("embeddings").data
         )
-
         return XVectorOutput(logits=logits, embeddings=embeddings)
 
 
@@ -890,7 +908,9 @@ class OVModelForAudioFrameClassification(OVModel):
             inputs["attention_mask"] = attention_mask
 
         # Run inference
-        outputs = self.request(inputs)
-        logits = torch.from_numpy(outputs["logits"]).to(self.device) if not np_inputs else outputs["logits"]
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs)
+        infer_request.wait()
+        logits = torch.from_numpy(infer_request.get_tensor("logits").data).to(self.device) if not np_inputs else infer_request.get_tensor("logits").data
 
         return TokenClassifierOutput(logits=logits)

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -89,6 +89,7 @@ class OVBaseModel(OptimizedModel):
 
         self.model = model
         self.request = None
+        self.compiled_model = None
         if enable_compilation:
             self.compile()
 
@@ -343,7 +344,7 @@ class OVBaseModel(OptimizedModel):
         )
 
     def compile(self):
-        if self.request is None:
+        if self.compiled_model is None:
             logger.info(f"Compiling the model to {self._device} ...")
             ov_config = {**self.ov_config}
             if "CACHE_DIR" not in self.ov_config.keys() and not str(self.model_save_dir).startswith(gettempdir()):
@@ -351,7 +352,7 @@ class OVBaseModel(OptimizedModel):
                 cache_dir = Path(self.model_save_dir).joinpath("model_cache")
                 ov_config["CACHE_DIR"] = str(cache_dir)
                 logger.info(f"Setting OpenVINO CACHE_DIR to {str(cache_dir)}")
-            self.request = core.compile_model(self.model, self._device, ov_config)
+            self.compiled_model = core.compile_model(self.model, self._device, ov_config)
             # OPENVINO_LOG_LEVEL can be found in https://docs.openvino.ai/2023.2/openvino_docs_OV_UG_supported_plugins_AUTO_debugging.html
             if "OPENVINO_LOG_LEVEL" in os.environ and int(os.environ["OPENVINO_LOG_LEVEL"]) > 2:
                 logger.info(f"{self._device} SUPPORTED_PROPERTIES:")
@@ -403,6 +404,7 @@ class OVBaseModel(OptimizedModel):
         apply_moc_transformations(self.model, cf=False)
         compress_model_transformation(self.model)
         self.request = None
+        self.compiled_model = None
         return self
 
     def forward(self, *args, **kwargs):

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -111,7 +111,6 @@ class OVBaseDecoderModel(OVModel):
                 "`dynamic_shapes` was set to `False` but static shapes are not supported for causal language model. Please set `dynamic_shapes=True`."
             )
 
-        enable_compilation = kwargs.get("compile", True)
         kwargs["compile"] = False  # avoid extra compilation in the base class
 
         super().__init__(
@@ -333,6 +332,7 @@ class OVBaseDecoderModel(OVModel):
             self.compile()
         if self.request is None:
             self.request = self.compiled_model.create_infer_request()
+
 
 @add_start_docstrings(
     """
@@ -572,6 +572,7 @@ class OVModelForCausalLM(OVBaseDecoderModel, GenerationMixin):
         model_instance._pkv_precision = self._pkv_precision
         model_instance.request = None
         return model_instance
+
 
 class OVBloomForCausalLM(OVModelForCausalLM):
     # Adapted from transformers.models.bloom.modeling_bloom.BloomForCausalLM.prepare_inputs_for_generation

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -532,7 +532,7 @@ class OVModelPart:
             for inputs in self.model.inputs
         }
         self.ov_config = ov_config or {**self.parent_model.ov_config}
-        self.request = None
+        self.compiled_model = None
         self._model_name = model_name
         self._model_dir = Path(model_dir or parent_model._model_save_dir)
         config_path = self._model_dir / model_name / self.CONFIG_NAME
@@ -541,13 +541,13 @@ class OVModelPart:
             self.ov_config["CACHE_DIR"] = os.path.join(self._model_dir, self._model_name, "model_cache")
 
     def _compile(self):
-        if self.request is None:
+        if self.compiled_model is None:
             logger.info(f"Compiling the {self._model_name} to {self.device} ...")
-            self.request = core.compile_model(self.model, self.device, self.ov_config)
+            self.compiled_model = core.compile_model(self.model, self.device, self.ov_config)
             # OPENVINO_LOG_LEVEL can be found in https://docs.openvino.ai/2023.2/openvino_docs_OV_UG_supported_plugins_AUTO_debugging.html
             if "OPENVINO_LOG_LEVEL" in os.environ and int(os.environ["OPENVINO_LOG_LEVEL"]) > 2:
                 logger.info(f"{self.device} SUPPORTED_PROPERTIES:")
-                _print_compiled_model_properties(self.request)
+                _print_compiled_model_properties(self.compiled_model)
 
     @property
     def device(self):
@@ -570,8 +570,11 @@ class OVModelTextEncoder(OVModelPart):
         inputs = {
             "input_ids": input_ids,
         }
-        outputs = self.request(inputs, share_inputs=True)
-        return list(outputs.values())
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs, share_inputs=True)
+        infer_request.wait()
+        outputs = [infer_request.get_tensor(output).data for output in infer_request.results]
+        return outputs
 
 
 class OVModelUnet(OVModelPart):
@@ -604,8 +607,11 @@ class OVModelUnet(OVModelPart):
         if timestep_cond is not None:
             inputs["timestep_cond"] = timestep_cond
 
-        outputs = self.request(inputs, share_inputs=True)
-        return list(outputs.values())
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs, share_inputs=True)
+        infer_request.wait()
+        outputs = [infer_request.get_tensor(output).data for output in infer_request.results]
+        return outputs
 
 
 class OVModelVaeDecoder(OVModelPart):
@@ -620,8 +626,11 @@ class OVModelVaeDecoder(OVModelPart):
         inputs = {
             "latent_sample": latent_sample,
         }
-        outputs = self.request(inputs, share_inputs=True)
-        return list(outputs.values())
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs, share_inputs=True)
+        infer_request.wait()
+        outputs = [infer_request.results[output].data for output in infer_request.results]
+        return outputs
 
     def _compile(self):
         if "GPU" in self.device:
@@ -641,8 +650,11 @@ class OVModelVaeEncoder(OVModelPart):
         inputs = {
             "sample": sample,
         }
-        outputs = self.request(inputs, share_inputs=True)
-        return list(outputs.values())
+        infer_request = self.compiled_model.create_infer_request()
+        infer_request.start_async(inputs, share_inputs=True)
+        infer_request.wait()
+        outputs = [infer_request.get_tensor(output).data for output in infer_request.results]
+        return outputs
 
     def _compile(self):
         if "GPU" in self.device:

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -294,6 +294,8 @@ class OVQuantizer(OptimumQuantizer):
         # Prefeth past_key_values
         self.model.update_pkv_precision(True)
         self.model.compile()
+        self.model.create_infer_request()
+
         subset_size = kwargs.get("subset_size", 300)
         data_cache = []
 

--- a/tests/openvino/gen_batch.py
+++ b/tests/openvino/gen_batch.py
@@ -52,8 +52,8 @@ def gen_thread(prompt, results, i):
         "do_sample": True,
         "top_p": 1.0,
         "top_k": 50,
-        "num_beams" :5,
-        "repetition_penalty": 1.1
+        "num_beams": 5,
+        "repetition_penalty": 1.1,
     }
     start = datetime.now()
     model_exec = model.clone()

--- a/tests/openvino/gen_batch.py
+++ b/tests/openvino/gen_batch.py
@@ -1,0 +1,72 @@
+from optimum.intel import OVModelForCausalLM
+from transformers import AutoTokenizer, AutoConfig, set_seed
+import threading
+from datetime import datetime 
+
+set_seed(10)
+model_path = "/home/devuser/openvino.genai/llm_bench/python/llama-2-7b-chat-hf-stateful/pytorch/dldt/compressed_weights/OV_FP16-INT8/"
+#model_path = "/home/devuser/openvino.genai/llm_bench/python/llama-2-7b-chat-hf/pytorch/dldt/compressed_weights/OV_FP16-INT8/"
+tokenizer = AutoTokenizer.from_pretrained(model_path)
+tokenizer.pad_token = "[PAD]"
+tokenizer.padding_side = "left"
+
+prompt1 = [" The weather is "]
+prompt2 = [" Openvino is a " , " What the the relativity theory "]
+prompt3 = [" Are cats smarter that dogs ", " How big is an elephant ", " the water in the ocean is much hotter than before  "]
+prompts = [prompt1, prompt2, prompt3]
+OV_CONFIG = {'PERFORMANCE_HINT': 'LATENCY', 'CACHE_DIR': '','NUM_STREAMS': '1'}
+model = OVModelForCausalLM.from_pretrained(model_path, config=AutoConfig.from_pretrained(model_path, trust_remote_code=True),ov_config=OV_CONFIG, compile=True)
+
+NUM_THREADS = 3
+
+threads = [None]* NUM_THREADS
+results = [None]* NUM_THREADS
+
+def print_response(t,p,r):
+    print("THREAD", t)
+    print("PROMPT:", p)
+    for answer in r:
+        print("Answer:")
+        print(tokenizer.decode(answer, skip_special_tokens=True))
+
+def gen_thread(prompt, results, i):
+    inputs = tokenizer(prompt, return_tensors="pt", padding=True)
+    generate_kwargs = dict(
+            input_ids=inputs.input_ids,
+            max_new_tokens=500,
+            temperature=1.0,
+            do_sample=True,
+            top_p=1.0,
+            top_k=50,
+            num_beams=5,
+            repetition_penalty=1.1
+             )
+    start = datetime.now()
+    model_exec = model.clone()
+    end = datetime.now()
+    print("cloning model duration", (end - start).total_seconds()*1000000, "us")
+    outputs = model_exec.generate(**generate_kwargs)
+    num_tok = 0
+    for i in range(len(prompt)):
+        num_tok += outputs[i].numel() - inputs.get("input_ids")[i].numel()
+    results[i] = outputs, num_tok
+
+start = datetime.now()
+for i in range(len(threads)):
+    threads[i] = threading.Thread(target=gen_thread, args=(prompts[i],results, i))
+    threads[i].start()
+
+total_tok = 0
+for i in range(len(threads)):
+    threads[i].join()
+    total_tok += results[i][1]
+end = datetime.now()
+
+for i in range(len(threads)):
+    print_response(i,prompts[i],results[i][0])
+
+print("Generation time [s]", ((end-start).total_seconds()), "tokens:", total_tok)
+print("Throughput:", total_tok * 60 / ((end-start).total_seconds()), "tokens/min" )
+
+
+

--- a/tests/openvino/gen_batch.py
+++ b/tests/openvino/gen_batch.py
@@ -1,59 +1,74 @@
-from optimum.intel import OVModelForCausalLM
-from transformers import AutoTokenizer, AutoConfig, set_seed
 import threading
-from datetime import datetime 
+from datetime import datetime
+
+from transformers import AutoConfig, AutoTokenizer, set_seed
+
+from optimum.intel import OVModelForCausalLM
+
 
 set_seed(10)
 model_path = "/home/devuser/openvino.genai/llm_bench/python/llama-2-7b-chat-hf-stateful/pytorch/dldt/compressed_weights/OV_FP16-INT8/"
-#model_path = "/home/devuser/openvino.genai/llm_bench/python/llama-2-7b-chat-hf/pytorch/dldt/compressed_weights/OV_FP16-INT8/"
+# model_path = "/home/devuser/openvino.genai/llm_bench/python/llama-2-7b-chat-hf/pytorch/dldt/compressed_weights/OV_FP16-INT8/"
 tokenizer = AutoTokenizer.from_pretrained(model_path)
 tokenizer.pad_token = "[PAD]"
 tokenizer.padding_side = "left"
 
 prompt1 = [" The weather is "]
-prompt2 = [" Openvino is a " , " What the the relativity theory "]
-prompt3 = [" Are cats smarter that dogs ", " How big is an elephant ", " the water in the ocean is much hotter than before  "]
+prompt2 = [" Openvino is a ", " What the the relativity theory "]
+prompt3 = [
+    " Are cats smarter that dogs ",
+    " How big is an elephant ",
+    " the water in the ocean is much hotter than before  ",
+]
 prompts = [prompt1, prompt2, prompt3]
-OV_CONFIG = {'PERFORMANCE_HINT': 'LATENCY', 'CACHE_DIR': '','NUM_STREAMS': '1'}
-model = OVModelForCausalLM.from_pretrained(model_path, config=AutoConfig.from_pretrained(model_path, trust_remote_code=True),ov_config=OV_CONFIG, compile=True)
+OV_CONFIG = {"PERFORMANCE_HINT": "LATENCY", "CACHE_DIR": "", "NUM_STREAMS": "1"}
+model = OVModelForCausalLM.from_pretrained(
+    model_path,
+    config=AutoConfig.from_pretrained(model_path, trust_remote_code=True),
+    ov_config=OV_CONFIG,
+    compile=True,
+)
 
 NUM_THREADS = 3
 
-threads = [None]* NUM_THREADS
-results = [None]* NUM_THREADS
+threads = [None] * NUM_THREADS
+results = [None] * NUM_THREADS
 
-def print_response(t,p,r):
+
+def print_response(t, p, r):
     print("THREAD", t)
     print("PROMPT:", p)
     for answer in r:
         print("Answer:")
         print(tokenizer.decode(answer, skip_special_tokens=True))
 
+
 def gen_thread(prompt, results, i):
     inputs = tokenizer(prompt, return_tensors="pt", padding=True)
-    generate_kwargs = dict(
-            input_ids=inputs.input_ids,
-            max_new_tokens=500,
-            temperature=1.0,
-            do_sample=True,
-            top_p=1.0,
-            top_k=50,
-            num_beams=5,
-            repetition_penalty=1.1
-             )
+    generate_kwargs = {
+        "input_ids": inputs.input_ids,
+        "max_new_tokens": 200,
+        "temperature": 1.0,
+        "do_sample": True,
+        "top_p": 1.0,
+        "top_k": 50,
+        "num_beams" :5,
+        "repetition_penalty": 1.1
+    }
     start = datetime.now()
     model_exec = model.clone()
     end = datetime.now()
-    print("cloning model duration", (end - start).total_seconds()*1000000, "us")
+    print("cloning model duration", (end - start).total_seconds() * 1000000, "us")
     outputs = model_exec.generate(**generate_kwargs)
     num_tok = 0
     for i in range(len(prompt)):
         num_tok += outputs[i].numel() - inputs.get("input_ids")[i].numel()
     results[i] = outputs, num_tok
 
+
 start = datetime.now()
 for i in range(len(threads)):
-    threads[i] = threading.Thread(target=gen_thread, args=(prompts[i],results, i))
+    threads[i] = threading.Thread(target=gen_thread, args=(prompts[i], results, i))
     threads[i].start()
 
 total_tok = 0
@@ -63,10 +78,7 @@ for i in range(len(threads)):
 end = datetime.now()
 
 for i in range(len(threads)):
-    print_response(i,prompts[i],results[i][0])
+    print_response(i, prompts[i], results[i][0])
 
-print("Generation time [s]", ((end-start).total_seconds()), "tokens:", total_tok)
-print("Throughput:", total_tok * 60 / ((end-start).total_seconds()), "tokens/min" )
-
-
-
+print("Generation time [s]", ((end - start).total_seconds()), "tokens:", total_tok)
+print("Throughput:", total_tok * 60 / ((end - start).total_seconds()), "tokens/min")

--- a/tests/openvino/gen_img.py
+++ b/tests/openvino/gen_img.py
@@ -1,0 +1,59 @@
+import datetime
+import threading
+
+from diffusers import DDIMScheduler
+
+from optimum.intel.openvino import OVStableDiffusionPipeline
+
+
+MODEL_PATH = "/home/devuser/model_server/demos/python_demos/stable_diffusion/model"
+OV_CONFIG = {"PERFORMANCE_HINT": "LATENCY", "NUM_STREAMS": "1"}
+
+
+pipe = OVStableDiffusionPipeline.from_pretrained(MODEL_PATH, device="CPU", ov_config=OV_CONFIG)
+pipe.scheduler = DDIMScheduler.from_config(pipe.scheduler.config)
+
+
+# set_seed(10)
+
+
+prompt1 = [" Zebras in space "]
+prompt2 = [" The statue of liberty in New York", " Big Ben in London "]
+prompt3 = [" pigs on the grass field", "beach in the storm", "sail yacht on the ocean"]
+prompts = [prompt1, prompt2, prompt3]
+
+NUM_THREADS = 3
+
+threads = [None] * NUM_THREADS
+results = [None] * NUM_THREADS
+
+
+def save_response(t, p, r):
+    print("THREAD", t)
+    print("PROMPT:", p)
+    for i in range(len(r)):
+        print("IMG:", i)
+        r[i].save("img_" + str(t) + "_" + str(i) + ".png", format="PNG")
+
+
+def gen_thread(prompt, results, i):
+    text = prompt
+    images = pipe(text).images
+    results[i] = images
+
+
+start = datetime.datetime.now()
+for i in range(len(threads)):
+    threads[i] = threading.Thread(target=gen_thread, args=(prompts[i], results, i))
+    threads[i].start()
+nu_img = 0
+for i in range(len(threads)):
+    threads[i].join()
+    nu_img += len(results[i])
+end = datetime.datetime.now()
+
+for i in range(len(threads)):
+    save_response(i, prompts[i], results[i])
+
+print("Generation time [s]", ((end - start).total_seconds()), "images:", nu_img)
+print("Throughput:", nu_img * 60 / ((end - start).total_seconds()), "images/min")

--- a/tests/openvino/gen_seq2seq.py
+++ b/tests/openvino/gen_seq2seq.py
@@ -1,0 +1,51 @@
+import datetime
+import threading
+
+from transformers import AutoTokenizer, pipeline
+
+from optimum.intel import OVModelForSeq2SeqLM
+
+
+model_id = "echarlaix/t5-small-openvino"
+model = OVModelForSeq2SeqLM.from_pretrained(model_id)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+pipe = pipeline("translation_en_to_fr", model=model, tokenizer=tokenizer)
+
+prompt1 = ["I live in Europe"]
+prompt2 = ["What is your name?", "The dog is very happy"]
+prompt3 = ["It's a beautiful weather today", "Yes", "Good morning"]
+prompts = [prompt1, prompt2, prompt3]
+
+NUM_THREADS = 3
+
+threads = [None] * NUM_THREADS
+results = [None] * NUM_THREADS
+
+
+def print_response(t, p, r):
+    print("THREAD", t)
+    print("PROMPT:", p)
+    for i in range(len(r)):
+        print("TRANSLATION", i, ":", r[i]["translation_text"])
+
+
+def gen_thread(prompt, results, i):
+    translations = pipe(prompt)
+    results[i] = translations
+
+
+start = datetime.datetime.now()
+for i in range(len(threads)):
+    threads[i] = threading.Thread(target=gen_thread, args=(prompts[i], results, i))
+    threads[i].start()
+nu_trans = 0
+for i in range(len(threads)):
+    threads[i].join()
+    nu_trans += len(results[i])
+end = datetime.datetime.now()
+
+for i in range(len(threads)):
+    print_response(i, prompts[i], results[i])
+
+print("Generation time [s]", ((end - start).total_seconds()), "translations:", nu_trans)
+print("Throughput:", nu_trans / ((end - start).total_seconds()), "translations/s")

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -886,21 +886,25 @@ class OVModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         text = "This is a sample input"
         tokens = tokenizer(text, return_tensors="pt")
 
-        model_with_pkv = OVModelForSeq2SeqLM.from_pretrained(model_id, export=True, use_cache=True, ov_config=F32_CONFIG)
+        model_with_pkv = OVModelForSeq2SeqLM.from_pretrained(
+            model_id, export=True, use_cache=True, ov_config=F32_CONFIG
+        )
         _ = model_with_pkv.generate(**tokens)  # warmup
         with Timer() as with_pkv_timer:
             outputs_model_with_pkv = model_with_pkv.generate(
                 **tokens, min_length=self.GENERATION_LENGTH, max_length=self.GENERATION_LENGTH, num_beams=1
             )
 
-        model_without_pkv = OVModelForSeq2SeqLM.from_pretrained(model_id, export=True, use_cache=False, ov_config=F32_CONFIG)
+        model_without_pkv = OVModelForSeq2SeqLM.from_pretrained(
+            model_id, export=True, use_cache=False, ov_config=F32_CONFIG
+        )
         _ = model_without_pkv.generate(**tokens)  # warmup
         with Timer() as without_pkv_timer:
             outputs_model_without_pkv = model_without_pkv.generate(
                 **tokens, min_length=self.GENERATION_LENGTH, max_length=self.GENERATION_LENGTH, num_beams=1
             )
         print(outputs_model_with_pkv)
-        print(outputs_model_without_pkv)    
+        print(outputs_model_without_pkv)
         self.assertTrue(torch.equal(outputs_model_with_pkv, outputs_model_without_pkv))
         self.assertEqual(outputs_model_with_pkv.shape[1], self.GENERATION_LENGTH)
         self.assertEqual(outputs_model_without_pkv.shape[1], self.GENERATION_LENGTH)
@@ -1202,14 +1206,18 @@ class OVModelForPix2StructIntegrationTest(unittest.TestCase):
         question = "Who am I?"
         inputs = preprocessor(images=self.IMAGE, text=question, return_tensors="pt")
 
-        model_with_pkv = OVModelForPix2Struct.from_pretrained(model_id, export=True, use_cache=True, ov_config=F32_CONFIG)
+        model_with_pkv = OVModelForPix2Struct.from_pretrained(
+            model_id, export=True, use_cache=True, ov_config=F32_CONFIG
+        )
         _ = model_with_pkv.generate(**inputs)  # warmup
         with Timer() as with_pkv_timer:
             outputs_model_with_pkv = model_with_pkv.generate(
                 **inputs, min_length=self.GENERATION_LENGTH, max_length=self.GENERATION_LENGTH, num_beams=1
             )
 
-        model_without_pkv = OVModelForPix2Struct.from_pretrained(model_id, export=True, use_cache=False, ov_config=F32_CONFIG)
+        model_without_pkv = OVModelForPix2Struct.from_pretrained(
+            model_id, export=True, use_cache=False, ov_config=F32_CONFIG
+        )
         _ = model_without_pkv.generate(**inputs)  # warmup
         with Timer() as without_pkv_timer:
             outputs_model_without_pkv = model_without_pkv.generate(


### PR DESCRIPTION
# Allows running llm generate operations in multithreaded application 

Support in parallel execution for stateful LLM models is implemented using a cloned model object but with shared OV model and compiled model to avoid duplicating memory consumption. Each cloned model object is using a single OpenVINO `inference_request` object which keeps the execution context and state.
```
model = OVModelForCausalLM.from_pretrained(model_path,compile=True) # done once
model_exec = model.clone() # done in every new thread
outputs = model_exec.generate(**generate_kwargs)
```

For stable diffusion and seq2seq pipelines which are without stateful models, no changes are needed for multi threaded execution.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

