### PR TITLE
Return the original forward in PyTorch model after exporting to OpenVINO.

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -428,6 +428,9 @@ def export_pytorch(
                 compression_option=compression_option,
                 compression_ratio=compression_ratio,
             )
+        # return original forward
+        if patch_model_forward:
+            model.forward = orig_forward
         ordered_dummy_inputs = {param: dummy_inputs[param] for param in sig.parameters if param in dummy_inputs}
         ordered_input_names = list(inputs)
         flatten_inputs = flattenize_inputs(ordered_dummy_inputs.values())


### PR DESCRIPTION
# What does this PR do?
`export_pytorch` can patch forward function of the input Pytorch model for correct exporting to OpenVINO, but does not return the original forward. It leads to undefined behavior if user uses PyTorch model after export. For example to the following error:
```
'tuple' object has no attribute 'values'.
```

This PR corrects it.
