### PR TITLE
Show device name in _print_compiled_model_properties

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -349,7 +349,7 @@ class OVBaseModel(OptimizedModel):
             if (
                 "CACHE_DIR" not in self.ov_config.keys()
                 and not str(self.model_save_dir).startswith(gettempdir())
-                and self._device.lower().split(":")[0] == "gpu"
+                and "gpu" in self._device.lower()
             ):
                 # Set default CACHE_DIR only if it is not set, if the model is not in a temporary directory, and device is GPU
                 cache_dir = Path(self.model_save_dir).joinpath("model_cache")

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -349,7 +349,7 @@ class OVBaseModel(OptimizedModel):
             if (
                 "CACHE_DIR" not in self.ov_config.keys()
                 and not str(self.model_save_dir).startswith(gettempdir())
-                and self._device.lower() == "gpu"
+                and self._device.lower().split(":")[0] == "gpu"
             ):
                 # Set default CACHE_DIR only if it is not set, if the model is not in a temporary directory, and device is GPU
                 cache_dir = Path(self.model_save_dir).joinpath("model_cache")

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -547,7 +547,7 @@ class OVModelPart:
             if (
                 "CACHE_DIR" not in self.ov_config.keys()
                 and not str(self._model_dir).startswith(gettempdir())
-                and self.device.lower() == "gpu"
+                and self.device.lower().split(":")[0] == "gpu"
             ):
                 self.ov_config["CACHE_DIR"] = os.path.join(self._model_dir, self._model_name, "model_cache")
 

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -568,7 +568,7 @@ class OVDecoder:
         if (
             "CACHE_DIR" not in ov_config.keys()
             and not str(self.parent_model.model_save_dir).startswith(gettempdir())
-            and self._device.lower().startswith("gpu")
+            and "gpu" in self._device.lower()
         ):
             cache_dir = Path(self.parent_model.model_save_dir).joinpath("model_cache")
             ov_config["CACHE_DIR"] = str(cache_dir)

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -456,7 +456,7 @@ class OVEncoder:
         if (
             "CACHE_DIR" not in ov_config.keys()
             and not str(self.parent_model.model_save_dir).startswith(gettempdir())
-            and self._device.lower() == "gpu"
+            and self._device.lower().split(":")[0] == "gpu"
         ):
             cache_dir = Path(self.parent_model.model_save_dir).joinpath("model_cache")
             ov_config["CACHE_DIR"] = str(cache_dir)
@@ -568,7 +568,7 @@ class OVDecoder:
         if (
             "CACHE_DIR" not in ov_config.keys()
             and not str(self.parent_model.model_save_dir).startswith(gettempdir())
-            and self._device.lower() == "gpu"
+            and self._device.lower().startswith("gpu")
         ):
             cache_dir = Path(self.parent_model.model_save_dir).joinpath("model_cache")
             ov_config["CACHE_DIR"] = str(cache_dir)

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -456,7 +456,7 @@ class OVEncoder:
         if (
             "CACHE_DIR" not in ov_config.keys()
             and not str(self.parent_model.model_save_dir).startswith(gettempdir())
-            and self._device.lower().split(":")[0] == "gpu"
+            and "gpu" in self._device.lower()
         ):
             cache_dir = Path(self.parent_model.model_save_dir).joinpath("model_cache")
             ov_config["CACHE_DIR"] = str(cache_dir)

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -20,7 +20,7 @@ from glob import glob
 
 import numpy as np
 from huggingface_hub import model_info
-from openvino.runtime import Type, properties
+from openvino.runtime import Core, Type, properties
 from transformers.onnx.utils import ParameterFormat, compute_serialized_parameters_size
 
 
@@ -145,3 +145,9 @@ def _print_compiled_model_properties(compiled_model):
                 logger.info(f"  {k}: {value}")
         except Exception:
             logger.error(f"[error] Get property of '{k}' failed")
+    try:
+        logger.info("EXECUTION_DEVICES:")
+        for device in compiled_model.get_property("EXECUTION_DEVICES"):
+            logger.info(f"  {device}: {Core().get_property(device, 'FULL_DEVICE_NAME')}")
+    except Exception:
+        logger.error("[error] Get FULL_DEVICE_NAME failed")


### PR DESCRIPTION
- Show device name in _print_compiled_model_properties
- Enable CACHE_DIR also for devices like "GPU:0"

It is useful to be able to quickly see the exact device name of the inference device. For example, when doing inference on a machine with several GPUs, to doublecheck whether iGPU or dGPU is used. This PR adds a line that shows the full name of the execution device in _print_compiled_model_properties. Works with CPU, GPU and AUTO. I also changed the logic for checking if CACHE_DIR should be enabled to also enable CACHE_DIR by default when device is specified as e.g. "GPU:0". 

```
EXECUTION_DEVICES:                                                                                                                                                                                                                    
  CPU: 11th Gen Intel(R) Core(TM) i9-11900KF @ 3.50GHz   
....
EXECUTION_DEVICES:
  OCL_GPU.0: Intel(R) Arc(TM) A770 Graphics (dGPU)
```