### PR TITLE
Fix openvino/test_training.py

### DIFF
--- a/tests/openvino/test_training.py
+++ b/tests/openvino/test_training.py
@@ -276,7 +276,7 @@ class OVTrainerBaseTrainingTest(unittest.TestCase, ABC):
         shutil.rmtree(self.output_dir)
 
 
-CUSTOMIZED_QUANTIZATION_CONFIG = {
+TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG = {
     "algorithm": "quantization",
     "overflow_fix": "disable",
     "initializer": {
@@ -288,7 +288,11 @@ CUSTOMIZED_QUANTIZATION_CONFIG = {
         "batchnorm_adaptation": {"num_bn_adaptation_samples": 4},
     },
     "scope_overrides": {"activations": {"{re}.*matmul_0": {"mode": "asymmetric"}}},
-    "ignored_scopes": [],
+    "ignored_scopes": [
+        "BertForSequenceClassification/BertModel[bert]/__rsub___0",
+        "BertForSequenceClassification/BertModel[bert]/__mul___0",
+        "{re}BertLayer\\[[0-9]+\\]/BertAttention\\[attention\\]/BertSelfAttention\\[self\\]/__add___0",
+    ],
 }
 
 STRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT = {
@@ -335,16 +339,16 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
     ),
     "customized_quantization": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
-        nncf_compression_config=CUSTOMIZED_QUANTIZATION_CONFIG,
-        expected_fake_quantize=69,
+        nncf_compression_config=TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+        expected_fake_quantize=64,
         expected_int8=35,
         compression_metrics=["compression_loss"],
     ),
     "distillation,customized_quantization": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
         teacher_model_id="hf-internal-testing/tiny-random-bert",
-        nncf_compression_config=CUSTOMIZED_QUANTIZATION_CONFIG,
-        expected_fake_quantize=69,
+        nncf_compression_config=TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+        expected_fake_quantize=64,
         expected_int8=35,
         compression_metrics=["compression_loss", "distillation_loss", "task_loss"],
     ),
@@ -371,8 +375,11 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
     ),
     "customized_quantization,structured_movement_sparsity": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
-        nncf_compression_config=[CUSTOMIZED_QUANTIZATION_CONFIG, STRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT],
-        expected_fake_quantize=69,
+        nncf_compression_config=[
+            TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+            STRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT,
+        ],
+        expected_fake_quantize=64,
         expected_int8=35,
         expected_binary_masks=60,
         compression_metrics=["compression_loss"],
@@ -389,8 +396,11 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
     "distillation,customized_quantization,structured_movement_sparsity": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
         teacher_model_id="hf-internal-testing/tiny-random-bert",
-        nncf_compression_config=[CUSTOMIZED_QUANTIZATION_CONFIG, STRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT],
-        expected_fake_quantize=69,
+        nncf_compression_config=[
+            TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+            STRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT,
+        ],
+        expected_fake_quantize=64,
         expected_int8=35,
         expected_binary_masks=60,
         compression_metrics=["compression_loss", "distillation_loss", "task_loss"],
@@ -418,8 +428,11 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
     ),
     "customized_quantization,unstructured_movement_sparsity": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
-        nncf_compression_config=[CUSTOMIZED_QUANTIZATION_CONFIG, UNSTRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT],
-        expected_fake_quantize=69,
+        nncf_compression_config=[
+            TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+            UNSTRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT,
+        ],
+        expected_fake_quantize=64,
         expected_int8=35,
         expected_binary_masks=60,
         compression_metrics=["compression_loss"],
@@ -436,8 +449,11 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
     "distillation,customized_quantization,unstructured_movement_sparsity": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
         teacher_model_id="hf-internal-testing/tiny-random-bert",
-        nncf_compression_config=[CUSTOMIZED_QUANTIZATION_CONFIG, UNSTRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT],
-        expected_fake_quantize=69,
+        nncf_compression_config=[
+            TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+            UNSTRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT,
+        ],
+        expected_fake_quantize=64,
         expected_int8=35,
         expected_binary_masks=60,
         compression_metrics=["compression_loss", "distillation_loss", "task_loss"],

--- a/tests/openvino/test_training.py
+++ b/tests/openvino/test_training.py
@@ -276,24 +276,21 @@ class OVTrainerBaseTrainingTest(unittest.TestCase, ABC):
         shutil.rmtree(self.output_dir)
 
 
-TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG = {
-    "algorithm": "quantization",
-    "overflow_fix": "disable",
-    "initializer": {
-        "range": {
-            "num_init_samples": 16,
-            "type": "percentile",
-            "params": {"min_percentile": 0.01, "max_percentile": 99.99},
+CUSTOMIZED_QUANTIZATION_CONFIG = deepcopy(DEFAULT_QUANTIZATION_CONFIG)
+CUSTOMIZED_QUANTIZATION_CONFIG.update(
+    {
+        "overflow_fix": "disable",
+        "initializer": {
+            "range": {
+                "num_init_samples": 16,
+                "type": "percentile",
+                "params": {"min_percentile": 0.01, "max_percentile": 99.99},
+            },
+            "batchnorm_adaptation": {"num_bn_adaptation_samples": 4},
         },
-        "batchnorm_adaptation": {"num_bn_adaptation_samples": 4},
-    },
-    "scope_overrides": {"activations": {"{re}.*matmul_0": {"mode": "asymmetric"}}},
-    "ignored_scopes": [
-        "BertForSequenceClassification/BertModel[bert]/__rsub___0",
-        "BertForSequenceClassification/BertModel[bert]/__mul___0",
-        "{re}BertLayer\\[[0-9]+\\]/BertAttention\\[attention\\]/BertSelfAttention\\[self\\]/__add___0",
-    ],
-}
+        "scope_overrides": {"activations": {"{re}.*matmul_0": {"mode": "asymmetric"}}},
+    }
+)
 
 STRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT = {
     "algorithm": "movement_sparsity",
@@ -339,17 +336,17 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
     ),
     "customized_quantization": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
-        nncf_compression_config=TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
-        expected_fake_quantize=64,
-        expected_int8=35,
+        nncf_compression_config=CUSTOMIZED_QUANTIZATION_CONFIG,
+        expected_fake_quantize=44,
+        expected_int8=32,
         compression_metrics=["compression_loss"],
     ),
     "distillation,customized_quantization": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
         teacher_model_id="hf-internal-testing/tiny-random-bert",
-        nncf_compression_config=TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
-        expected_fake_quantize=64,
-        expected_int8=35,
+        nncf_compression_config=CUSTOMIZED_QUANTIZATION_CONFIG,
+        expected_fake_quantize=44,
+        expected_int8=32,
         compression_metrics=["compression_loss", "distillation_loss", "task_loss"],
     ),
     "structured_movement_sparsity": OVTrainerTestDescriptor(
@@ -376,11 +373,11 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
     "customized_quantization,structured_movement_sparsity": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
         nncf_compression_config=[
-            TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+            CUSTOMIZED_QUANTIZATION_CONFIG,
             STRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT,
         ],
-        expected_fake_quantize=64,
-        expected_int8=35,
+        expected_fake_quantize=44,
+        expected_int8=32,
         expected_binary_masks=60,
         compression_metrics=["compression_loss"],
     ),
@@ -397,11 +394,11 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
         model_id="hf-internal-testing/tiny-random-bert",
         teacher_model_id="hf-internal-testing/tiny-random-bert",
         nncf_compression_config=[
-            TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+            CUSTOMIZED_QUANTIZATION_CONFIG,
             STRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT,
         ],
-        expected_fake_quantize=64,
-        expected_int8=35,
+        expected_fake_quantize=44,
+        expected_int8=32,
         expected_binary_masks=60,
         compression_metrics=["compression_loss", "distillation_loss", "task_loss"],
     ),
@@ -429,11 +426,11 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
     "customized_quantization,unstructured_movement_sparsity": OVTrainerTestDescriptor(
         model_id="hf-internal-testing/tiny-random-bert",
         nncf_compression_config=[
-            TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+            CUSTOMIZED_QUANTIZATION_CONFIG,
             UNSTRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT,
         ],
-        expected_fake_quantize=64,
-        expected_int8=35,
+        expected_fake_quantize=44,
+        expected_int8=32,
         expected_binary_masks=60,
         compression_metrics=["compression_loss"],
     ),
@@ -450,11 +447,11 @@ OVTRAINER_TEXT_CLASSIFICATION_TEST_DESCRIPTORS = {
         model_id="hf-internal-testing/tiny-random-bert",
         teacher_model_id="hf-internal-testing/tiny-random-bert",
         nncf_compression_config=[
-            TINY_RANDOM_BERT_CUSTOMIZED_QUANTIZATION_CONFIG,
+            CUSTOMIZED_QUANTIZATION_CONFIG,
             UNSTRUCTURED_MOVEMENT_SPARSITY_CONFIG_FOR_BERT,
         ],
-        expected_fake_quantize=64,
-        expected_int8=35,
+        expected_fake_quantize=44,
+        expected_int8=32,
         expected_binary_masks=60,
         compression_metrics=["compression_loss", "distillation_loss", "task_loss"],
     ),


### PR DESCRIPTION
# What does this PR do?

* Ignored scope is updated for `CUSTOMIZED_QUANTIZATION_CONFIG`
* Number of expected quantizers is decreased for the impacted cases.

### Reasons:

After nncf update (2.7.0 -> 2.8.0), NNCFGraph was fixed for the Bert model: now head masks path is visible for the quantization algorithm:
![Screenshot 2024-02-01 121631](https://github.com/huggingface/optimum-intel/assets/74656388/55668959-58bc-437c-b501-a0034eaea3a3)
This led to head masks path quantization: 
![Screenshot 2024-02-01 115618](https://github.com/huggingface/optimum-intel/assets/74656388/5c791e26-c5ab-47f0-b17e-44c8afe7e454)
I've updated Ignored scope with IS from the default config, and now amount of quantizers was decreased.

CC: @AlexKoff88 
