### PR TITLE
Remove pytorch v2.1.2 constraint for tests since ipex v2.2.0 release

### DIFF
--- a/.github/workflows/test_ipex.yml
+++ b/.github/workflows/test_ipex.yml
@@ -30,7 +30,6 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install torch==2.1.2 torchvision==0.16.2 torchaudio==2.1.2 --index-url https://download.pytorch.org/whl/cpu
         pip install .[ipex,tests]
     - name: Test with Pytest
       run: |


### PR DESCRIPTION
resulting from `intel-extension-for-pytorch` [v2.2.0](https://pypi.org/project/intel-extension-for-pytorch/2.2.0/) release