### PR TITLE
Deprecate compression options

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ from optimum.intel import OVQuantizer, OVModelForSequenceClassification
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
-model = AutoModelForSequenceClassification.from_pretrained(model_id)
+model = OVModelForSequenceClassification.from_pretrained(model_id, export=True)
 tokenizer = AutoTokenizer.from_pretrained(model_id)
 def preprocess_fn(examples, tokenizer):
     return tokenizer(

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -116,16 +116,20 @@ model = OVModelForCausalLM.from_pretrained(model_id, load_in_8bit=True)
 
 There are also alternative compression options for a different performance-accuracy trade-off:
 
-| Option                                                              | Description       |
-|---------------------------------------------------------------------|-------------------|
-| `fp16`                                                              | Float16 weights   |
-| `int8`                                                              | INT8 weights      |
-| `int4_sym_g128`, `int4_asym_g128`, `int4_sym_g64`, `int4_asym_g64`* | INT4 weights      |
+| Option  | Description       |
+|---------|-------------------|
+| `fp16`  | Float16 weights   |
+| `int8`  | INT8 weights      |
+| `int4`  | INT4 weights      |
 
-*`sym` and `asym` stand for symmetric and asymmetric quantization, `g128` and `g64` means the group size `128` and `64` respectively. 
+The `--sym` parameter stands for symmetric quantization, asymmetric quantization will be applied by default if not provided.
 
-`--ratio` CLI parameter controls the ratio between 4-bit and 8-bit quantized layers and can also change performance-accuracy trade-off for the optimized model. It is valid only for INT4 quantization options.
+For INT4 quantization :
+* The `--group-size` parameter will define the group size to use for quantization, the rcommended value is 128 and -1 will results in per-column quantization.
+* The `--ratio` CLI parameter controls the ratio between 4-bit and 8-bit quantized layers and can also change performance-accuracy trade-off for the optimized model. It is valid only for INT4 quantization options.
 
+
+controls the ratio between 4-bit and 8-bit quantized layers and can also change performance-accuracy trade-off for the optimized model. It is valid only for INT4 quantization options.
 
 To apply quantization on both weights and activations, you can use the `OVQuantizer`, more information in the [documentation](https://huggingface.co/docs/optimum/main/en/intel/optimization_ov#optimization).
 

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -47,6 +47,8 @@ Here we set the `task` to `text-generation-with-past`, with the `-with-past` suf
 optimum-cli export openvino --model local_path --task text-generation-with-past ov_model
 ```
 
+To export your model in fp16, you can add `--weight-format fp16` when exporting your model.
+
 Once the model is exported, you can load the OpenVINO model using :
 
 ```python
@@ -96,7 +98,7 @@ tokenizer.save_pretrained(save_directory)
 
 ### Weight-only quantization
 
-You can also apply 8-bit or 4-bit weight quantization when exporting your model with the CLI:
+You can also apply 8-bit or 4-bit weight quantization when exporting your model with the CLI by setting the `weight-format` argument to respectively `int8` or `int4`:
 
 ```bash
 optimum-cli export openvino --model gpt2 --weight-format int8 ov_model
@@ -104,7 +106,15 @@ optimum-cli export openvino --model gpt2 --weight-format int8 ov_model
 
 This will result in the exported model linear and embedding layers to be quantized to INT8 or INT4, the activations will be kept in floating point precision. This type of optimization allows reducing the footprint and latency of LLMs.
 
-This can also be done when loading your model by setting the `load_in_8bit` argument when calling the `from_pretrained()` method.
+By default the quantization scheme will be [assymmetric](https://github.com/openvinotoolkit/nncf/blob/develop/docs/compression_algorithms/Quantization.md#asymmetric-quantization), to make it [symmetric](https://github.com/openvinotoolkit/nncf/blob/develop/docs/compression_algorithms/Quantization.md#symmetric-quantization) you can add `--sym`.
+
+For INT4 quantization you can also specify the following arguments :
+* The `--group-size` parameter will define the group size to use for quantization, `-1` it will results in per-column quantization.
+* The `--ratio` CLI parameter controls the ratio between 4-bit and 8-bit quantization. If set to 0.9, it means that 90% of the layers will be quantized to `int4` while 10% will be quantized to `int8`.
+
+Smaller `group_size` and `ratio` of usually improve accuracy at the sacrifice of the model size and inference latency.
+
+You can also apply apply 8-bit quantization on your model's weight when loading your model by setting the `load_in_8bit=True` argument when calling the `from_pretrained()` method.
 
 ```python
 from optimum.intel import OVModelForCausalLM
@@ -114,22 +124,6 @@ model = OVModelForCausalLM.from_pretrained(model_id, load_in_8bit=True)
 
 > **NOTE:** `load_in_8bit` is enabled by default for the models larger than 1 billion parameters.
 
-There are also alternative compression options for a different performance-accuracy trade-off:
-
-| Option  | Description       |
-|---------|-------------------|
-| `fp16`  | Float16 weights   |
-| `int8`  | INT8 weights      |
-| `int4`  | INT4 weights      |
-
-The `--sym` parameter stands for symmetric quantization, asymmetric quantization will be applied by default if not provided.
-
-For INT4 quantization :
-* The `--group-size` parameter will define the group size to use for quantization, the rcommended value is 128 and -1 will results in per-column quantization.
-* The `--ratio` CLI parameter controls the ratio between 4-bit and 8-bit quantized layers and can also change performance-accuracy trade-off for the optimized model. It is valid only for INT4 quantization options.
-
-
-controls the ratio between 4-bit and 8-bit quantized layers and can also change performance-accuracy trade-off for the optimized model. It is valid only for INT4 quantization options.
 
 To apply quantization on both weights and activations, you can use the `OVQuantizer`, more information in the [documentation](https://huggingface.co/docs/optimum/main/en/intel/optimization_ov#optimization).
 

--- a/docs/source/inference.mdx
+++ b/docs/source/inference.mdx
@@ -114,7 +114,7 @@ For INT4 quantization you can also specify the following arguments :
 
 Smaller `group_size` and `ratio` of usually improve accuracy at the sacrifice of the model size and inference latency.
 
-You can also apply apply 8-bit quantization on your model's weight when loading your model by setting the `load_in_8bit=True` argument when calling the `from_pretrained()` method.
+You can also apply 8-bit quantization on your model's weight when loading your model by setting the `load_in_8bit=True` argument when calling the `from_pretrained()` method.
 
 ```python
 from optimum.intel import OVModelForCausalLM

--- a/docs/source/optimization_ov.mdx
+++ b/docs/source/optimization_ov.mdx
@@ -26,11 +26,11 @@ Here is how to apply static quantization on a fine-tuned DistilBERT:
 
 ```python
 from functools import partial
-from transformers import AutoModelForSequenceClassification, AutoTokenizer
-from optimum.intel import OVConfig, OVQuantizer
+from transformers import  AutoTokenizer
+from optimum.intel import OVConfig, OVQuantizer, OVModelForSequenceClassification,
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
-model = AutoModelForSequenceClassification.from_pretrained(model_id)
+model = OVModelForSequenceClassification.from_pretrained(model_id, export=True)
 tokenizer = AutoTokenizer.from_pretrained(model_id)
 # The directory where the quantized model will be saved
 save_dir = "ptq_model"

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -157,11 +157,13 @@ class OVExportCommand(BaseOptimumCLICommand):
             )
             self.args.weight_format = "int8"
 
+        weight_format = self.args.weight_format or "fp32"
+
         ov_config = None
-        if self.args.weight_format in {"fp16", "fp32"}:
-            ov_config = OVConfig(dtype=self.args.weight_format)
+        if weight_format in {"fp16", "fp32"}:
+            ov_config = OVConfig(dtype=weight_format)
         else:
-            is_int8 = self.args.weight_format == "int8"
+            is_int8 = weight_format == "int8"
 
             # For int4 quantization if not parameter is provided, then use the default config if exist
             if (
@@ -180,12 +182,12 @@ class OVExportCommand(BaseOptimumCLICommand):
                     "group_size": -1 if is_int8 else self.args.group_size,
                 }
 
-            if self.args.weight_format in {"int4_sym_g128", "int4_asym_g128", "int4_sym_g64", "int4_asym_g64"}:
+            if weight_format in {"int4_sym_g128", "int4_asym_g128", "int4_sym_g64", "int4_asym_g64"}:
                 logger.warning(
-                    f"--weight-format {self.args.weight_format} is deprecated, possible choices are fp32, fp16, int8, int4"
+                    f"--weight-format {weight_format} is deprecated, possible choices are fp32, fp16, int8, int4"
                 )
-                quantization_config["sym"] = "asym" not in self.args.weight_format
-                quantization_config["group_size"] = 128 if "128" in self.args.weight_format else 64
+                quantization_config["sym"] = "asym" not in weight_format
+                quantization_config["group_size"] = 128 if "128" in weight_format else 64
             ov_config = OVConfig(quantization_config=quantization_config)
 
         # TODO : add input shapes

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -94,11 +94,10 @@ def parse_args_openvino(parser: "ArgumentParser"):
     )
     optional_group.add_argument(
         "--sym",
-        type=bool,
+        action="store_true",
         default=None,
         help=("Whether to apply symmetric quantization"),
     )
-
     optional_group.add_argument(
         "--group-size",
         type=int,

--- a/optimum/exporters/openvino/__init__.py
+++ b/optimum/exporters/openvino/__init__.py
@@ -1,3 +1,17 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .__main__ import main_export
 from .convert import export, export_from_model, export_models, export_pytorch_via_onnx
 from .stateful import ensure_stateful_is_available, patch_stateful

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -161,7 +161,6 @@ def main_export(
             "Please, pass a `OVWeightQuantizationConfig(ratio=compression_ratio)` object in `quantization_config` argument instead."
         )
 
-
     # default_config = _check_default_4bit_configs(config)
 
     if ov_config is None and compression_option is not None:

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -21,8 +21,6 @@ from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
 
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig
-
-
 from optimum.utils.save_utils import maybe_load_preprocessors
 
 from ...intel.utils.import_utils import (
@@ -165,7 +163,6 @@ def main_export(
     # default_config = _check_default_4bit_configs(config)
 
     if ov_config is None and compression_option is not None:
-
         from ...intel.openvino.configuration import OVConfig
 
         if compression_option == "fp16":

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -21,7 +21,8 @@ from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
 
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig
-from optimum.intel.openvino.configuration import OVConfig
+
+
 from optimum.utils.save_utils import maybe_load_preprocessors
 
 from ...intel.utils.import_utils import (
@@ -152,18 +153,21 @@ def main_export(
     if compression_option is not None:
         logger.warning(
             "The `compression_option` argument is deprecated and will be removed in optimum-intel v1.17.0. "
-            "Please, pass a `OVWeightQuantizationConfig` object in `quantization_config` argument instead."
+            "Please, pass an `ov_config` argument instead `OVConfig(..., quantization_config=quantization_config)`."
         )
 
     if compression_ratio is not None:
         logger.warning(
             "The `compression_ratio` argument is deprecated and will be removed in optimum-intel v1.17.0. "
-            "Please, pass a `OVWeightQuantizationConfig(ratio=compression_ratio)` object in `quantization_config` argument instead."
+            "Please, pass an `ov_config` argument instead `OVConfig(quantization_config={ratio=compression_ratio})`."
         )
 
     # default_config = _check_default_4bit_configs(config)
 
     if ov_config is None and compression_option is not None:
+
+        from ...intel.openvino.configuration import OVConfig
+
         if compression_option == "fp16":
             ov_config = OVConfig(dtype="fp16")
         elif compression_option != "fp32":

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -14,7 +14,7 @@
 
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
@@ -40,6 +40,9 @@ else:
         "whisper",
     ]
 
+
+if TYPE_CHECKING:
+    from optimum.intel.openvino.configuration import OVConfig
 
 _COMPRESSION_OPTIONS = {
     "int8": {"bits": 8},

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -163,8 +163,6 @@ def main_export(
             "Please, pass an `ov_config` argument instead `OVConfig(quantization_config={ratio=compression_ratio})`."
         )
 
-    # default_config = _check_default_4bit_configs(config)
-
     if ov_config is None and compression_option is not None:
         from ...intel.openvino.configuration import OVConfig
 

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -172,7 +172,7 @@ def main_export(
             ov_config = OVConfig(dtype="fp16")
         elif compression_option != "fp32":
             q_config = _COMPRESSION_OPTIONS[compression_option] if compression_option in _COMPRESSION_OPTIONS else {}
-            q_config["ratio"] = compression_ratio
+            q_config["ratio"] = compression_ratio or 1.0
             ov_config = OVConfig(quantization_config=q_config)
 
     original_task = task

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -85,7 +85,7 @@ def _save_model(model, path: str, ov_config: Optional["OVConfig"] = None):
 
             _weight_only_quantization(model, ov_config.quantization_config)
 
-        compress_to_fp16 = ov_config.dtype == "fp16":
+        compress_to_fp16 = ov_config.dtype == "fp16"
 
     save_model(model, path, compress_to_fp16)
 

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -32,7 +32,6 @@ from optimum.exporters.onnx.base import OnnxConfig
 from optimum.exporters.onnx.convert import check_dummy_inputs_are_allowed
 from optimum.exporters.onnx.convert import export_pytorch as export_pytorch_to_onnx
 from optimum.exporters.onnx.convert import export_tensorflow as export_tensorflow_onnx
-
 from optimum.utils import DEFAULT_DUMMY_SHAPES, is_diffusers_available
 from optimum.utils.save_utils import maybe_save_preprocessors
 
@@ -47,6 +46,7 @@ from .utils import (
     get_input_shapes,
     remove_none_from_dummy_inputs,
 )
+
 
 if is_optimum_version(">=", "1.16.99"):
     from optimum.exporters.onnx.utils import _get_submodels_and_onnx_configs
@@ -598,7 +598,6 @@ def export_from_model(
 
         if num_parameters >= _MAX_UNCOMPRESSED_SIZE:
             if is_nncf_available():
-
                 from ...intel.openvino.configuration import OVConfig
 
                 ov_config = OVConfig(quantization_config={"bits": 8})

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -32,7 +32,7 @@ from optimum.exporters.onnx.base import OnnxConfig
 from optimum.exporters.onnx.convert import check_dummy_inputs_are_allowed
 from optimum.exporters.onnx.convert import export_pytorch as export_pytorch_to_onnx
 from optimum.exporters.onnx.convert import export_tensorflow as export_tensorflow_onnx
-from optimum.intel.openvino.configuration import OVConfig
+
 from optimum.utils import DEFAULT_DUMMY_SHAPES, is_diffusers_available
 from optimum.utils.save_utils import maybe_save_preprocessors
 
@@ -47,7 +47,6 @@ from .utils import (
     get_input_shapes,
     remove_none_from_dummy_inputs,
 )
-
 
 if is_optimum_version(">=", "1.16.99"):
     from optimum.exporters.onnx.utils import _get_submodels_and_onnx_configs
@@ -599,6 +598,9 @@ def export_from_model(
 
         if num_parameters >= _MAX_UNCOMPRESSED_SIZE:
             if is_nncf_available():
+
+                from ...intel.openvino.configuration import OVConfig
+
                 ov_config = OVConfig(quantization_config={"bits": 8})
 
                 logger.info("The model weights will be quantized to int8.")

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -18,7 +18,7 @@ import inspect
 import logging
 import os
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from transformers import T5Tokenizer, T5TokenizerFast
 from transformers.utils import is_tf_available, is_torch_available
@@ -69,6 +69,10 @@ if is_diffusers_available():
 
 if is_tf_available():
     from transformers.modeling_tf_utils import TFPreTrainedModel
+
+
+if TYPE_CHECKING:
+    from optimum.intel.openvino.configuration import OVConfig
 
 
 def _save_model(model, path: str, ov_config: Optional["OVConfig"] = None):

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -120,11 +120,8 @@ def export(
         device (`str`, *optional*, defaults to `cpu`):
             The device on which the model will be exported. Either `cpu` or `cuda`. Only PyTorch is supported for
             export on CUDA devices.
-        compression_option (`Optional[str]`, defaults to `None`):
-            The weight compression option, e.g. `f16` stands for float16 weights, `i8` - INT8 weights, `int4_sym_g128` - INT4 symmetric weights w/ group size 128, `int4_asym_g128` - as previous but asymmetric w/ zero-point,
-            `int4_sym_g64` - INT4 symmetric weights w/ group size 64, "int4_asym_g64" - as previous but asymmetric w/ zero-point.
-        compression_ratio (`Optional[float]`, defaults to `None`):
-            Compression ratio between primary and backup precision (only relevant to INT4).
+        ov_config (`OVConfig`, *optional*):
+            The configuration containing the parameters related to quantization.
         input_shapes (`Optional[Dict]`, defaults to `None`):
             If specified, allows to use specific shapes for the example input provided to the exporter.
         stateful (`bool`, defaults to `True`):
@@ -233,11 +230,8 @@ def export_pytorch_via_onnx(
             If specified, allows to use specific shapes for the example input provided to the exporter.
         model_kwargs (optional[Dict[str, Any]], defaults to `None`):
             Additional kwargs for model export.
-        compression_option (`Optional[str]`, defaults to `None`):
-            The weight compression option, e.g. `f16` stands for float16 weights, `i8` - INT8 weights, `int4_sym_g128` - INT4 symmetric weights w/ group size 128, `int4_asym_g128` - as previous but asymmetric w/ zero-point,
-            `int4_sym_g64` - INT4 symmetric weights w/ group size 64, "int4_asym_g64" - as previous but asymmetric w/ zero-point.
-        compression_ratio (`Optional[float]`, defaults to `None`):
-            Compression ratio between primary and backup precision (only relevant to INT4).
+        ov_config (`OVConfig`, *optional*):
+            The configuration containing the parameters related to quantization.
 
     Returns:
         `Tuple[List[str], List[str], bool]`: A tuple with an ordered list of the model's inputs, and the named inputs from
@@ -290,11 +284,8 @@ def export_pytorch(
             If specified, allows to use specific shapes for the example input provided to the exporter.
         model_kwargs (optional[Dict[str, Any]], defaults to `None`):
             Additional kwargs for model export
-        compression_option (`Optional[str]`, defaults to `None`):
-            The weight compression option, e.g. `f16` stands for float16 weights, `i8` - INT8 weights, `int4_sym_g128` - INT4 symmetric weights w/ group size 128, `int4_asym_g128` - as previous but asymmetric w/ zero-point,
-            `int4_sym_g64` - INT4 symmetric weights w/ group size 64, "int4_asym_g64" - as previous but asymmetric w/ zero-point.
-        compression_ratio (`Optional[float]`, defaults to `None`):
-            Compression ratio between primary and backup precision (only relevant to INT4).
+        ov_config (`OVConfig`, *optional*):
+            The configuration containing the parameters related to quantization.
         stateful (`bool`, defaults to `False`):
             Produce stateful model where all kv-cache inputs and outputs are hidden in the model and are not exposed as model inputs and outputs. Applicable only for decoder models.
 
@@ -452,11 +443,8 @@ def export_models(
             export on CUDA devices.
         input_shapes (Optional[Dict], optional, Defaults to None):
             If specified, allows to use specific shapes for the example input provided to the exporter.
-        compression_option (`Optional[str]`, defaults to `None`):
-            The weight compression option, e.g. `f16` stands for float16 weights, `i8` - INT8 weights, `int4_sym_g128` - INT4 symmetric weights w/ group size 128, `int4_asym_g128` - as previous but asymmetric w/ zero-point,
-            `int4_sym_g64` - INT4 symmetric weights w/ group size 64, "int4_asym_g64" - as previous but asymmetric w/ zero-point.
-        compression_ratio (`Optional[int]`, defaults to `None`):
-            Compression ratio between primary and backup precision (only relevant to INT4).
+        ov_config (`OVConfig`, *optional*):
+            The configuration containing the parameters related to quantization.
         model_kwargs (Optional[Dict[str, Any]], optional):
             Additional kwargs for model export.
         stateful (`bool`, defaults to `True`)

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -32,6 +32,7 @@ from optimum.exporters.onnx.base import OnnxConfig
 from optimum.exporters.onnx.convert import check_dummy_inputs_are_allowed
 from optimum.exporters.onnx.convert import export_pytorch as export_pytorch_to_onnx
 from optimum.exporters.onnx.convert import export_tensorflow as export_tensorflow_onnx
+from optimum.intel.openvino.configuration import OVConfig
 from optimum.utils import DEFAULT_DUMMY_SHAPES, is_diffusers_available
 from optimum.utils.save_utils import maybe_save_preprocessors
 
@@ -71,42 +72,21 @@ if is_tf_available():
     from transformers.modeling_tf_utils import TFPreTrainedModel
 
 
-def _save_model(model, path: str, compression_option: Optional[str] = None, compression_ratio: Optional[float] = None):
-    if compression_option is not None and compression_option != "fp16" and compression_option != "fp32":
-        if not is_nncf_available():
-            raise ImportError(
-                "Quantization of the weights to int8 requires nncf, please install it with `pip install nncf`"
-            )
+def _save_model(model, path: str, ov_config: Optional["OVConfig"] = None):
+    compress_to_fp16 = False
+    if ov_config is not None:
+        if ov_config.quantization_config is not None:
+            if not is_nncf_available():
+                raise ImportError(
+                    "Quantization of the weights to int8 requires nncf, please install it with `pip install nncf`"
+                )
 
-        import nncf
+            from optimum.intel.openvino.quantization import _weight_only_quantization
 
-        COMPRESSION_OPTIONS = {
-            "int8": {"mode": nncf.CompressWeightsMode.INT8},
-            "int4_sym_g128": {
-                "mode": nncf.CompressWeightsMode.INT4_SYM,
-                "group_size": 128,
-                "ratio": compression_ratio,
-            },
-            "int4_asym_g128": {
-                "mode": nncf.CompressWeightsMode.INT4_ASYM,
-                "group_size": 128,
-                "ratio": compression_ratio,
-            },
-            "int4_sym_g64": {
-                "mode": nncf.CompressWeightsMode.INT4_SYM,
-                "group_size": 64,
-                "ratio": compression_ratio,
-            },
-            "int4_asym_g64": {
-                "mode": nncf.CompressWeightsMode.INT4_ASYM,
-                "group_size": 64,
-                "ratio": compression_ratio,
-            },
-        }
+            _weight_only_quantization(model, ov_config.quantization_config)
 
-        model = nncf.compress_weights(model, **COMPRESSION_OPTIONS[compression_option])
+        compress_to_fp16 = ov_config.dtype == "fp16":
 
-    compress_to_fp16 = compression_option == "fp16"
     save_model(model, path, compress_to_fp16)
 
 
@@ -118,8 +98,7 @@ def export(
     device: str = "cpu",
     input_shapes: Optional[Dict] = None,
     model_kwargs: Optional[Dict[str, Any]] = None,
-    compression_option: Optional[str] = None,
-    compression_ratio: Optional[float] = None,
+    ov_config: Optional["OVConfig"] = None,
     stateful: bool = True,
 ) -> Tuple[List[str], List[str]]:
     """
@@ -172,8 +151,7 @@ def export(
             output,
             device=device,
             input_shapes=input_shapes,
-            compression_option=compression_option,
-            compression_ratio=compression_ratio,
+            ov_config=ov_config,
             model_kwargs=model_kwargs,
             stateful=stateful,
         )
@@ -186,9 +164,7 @@ def export(
             raise RuntimeError("`tf2onnx` does not support export on CUDA device.")
         if input_shapes is not None:
             logger.info("`input_shapes` argument is not supported by the Tensorflow ONNX export and will be ignored.")
-        return export_tensorflow(
-            model, config, opset, output, compression_option=compression_option, compression_ratio=compression_ratio
-        )
+        return export_tensorflow(model, config, opset, output, ov_config=ov_config)
 
     else:
         raise RuntimeError(
@@ -201,8 +177,7 @@ def export_tensorflow(
     config: OnnxConfig,
     opset: int,
     output: Path,
-    compression_option: Optional[str] = None,
-    compression_ratio: Optional[float] = None,
+    ov_config: Optional["OVConfig"] = None,
 ):
     """
     Export the TensorFlow model to OpenVINO format.
@@ -221,9 +196,7 @@ def export_tensorflow(
     onnx_path = Path(output).with_suffix(".onnx")
     input_names, output_names = export_tensorflow_onnx(model, config, opset, onnx_path)
     ov_model = convert_model(str(onnx_path))
-    _save_model(
-        ov_model, output.parent / output, compression_option=compression_option, compression_ratio=compression_ratio
-    )
+    _save_model(ov_model, output.parent / output, ov_config=ov_config)
     return input_names, output_names, True
 
 
@@ -235,8 +208,7 @@ def export_pytorch_via_onnx(
     device: str = "cpu",
     input_shapes: Optional[Dict] = None,
     model_kwargs: Optional[Dict[str, Any]] = None,
-    compression_option: Optional[str] = None,
-    compression_ratio: Optional[float] = None,
+    ov_config: Optional["OVConfig"] = None,
 ):
     """
     Exports a PyTorch model to an OpenVINO Intermediate Representation via ONNX export.
@@ -280,12 +252,7 @@ def export_pytorch_via_onnx(
     )
     torch.onnx.export = orig_torch_onnx_export
     ov_model = convert_model(str(onnx_output))
-    _save_model(
-        ov_model,
-        output.parent / OV_XML_FILE_NAME if output.suffix != ".xml" else output,
-        compression_option=compression_option,
-        compression_ratio=compression_ratio,
-    )
+    _save_model(ov_model, output.parent / OV_XML_FILE_NAME if output.suffix != ".xml" else output, ov_config=ov_config)
     return input_names, output_names, True
 
 
@@ -297,8 +264,7 @@ def export_pytorch(
     device: str = "cpu",
     input_shapes: Optional[Dict] = None,
     model_kwargs: Optional[Dict[str, Any]] = None,
-    compression_option: Optional[str] = None,
-    compression_ratio: Optional[float] = None,
+    ov_config: Optional["OVConfig"] = None,
     stateful: bool = False,
 ) -> Tuple[List[str], List[str]]:
     """
@@ -422,8 +388,7 @@ def export_pytorch(
                 device,
                 input_shapes,
                 model_kwargs,
-                compression_option=compression_option,
-                compression_ratio=compression_ratio,
+                ov_config=ov_config,
             )
 
         sig = inspect.signature(model.forward) if hasattr(model, "forward") else inspect.signature(model.call)
@@ -450,7 +415,7 @@ def export_pytorch(
         if stateful:
             patch_stateful(model.config, ov_model)
 
-        _save_model(ov_model, output, compression_option=compression_option, compression_ratio=compression_ratio)
+        _save_model(ov_model, output, ov_config=ov_config)
         clear_class_registry()
         del model
         gc.collect()
@@ -467,8 +432,7 @@ def export_models(
     device: str = "cpu",
     input_shapes: Optional[Dict] = None,
     model_kwargs: Optional[Dict[str, Any]] = None,
-    compression_option: Optional[str] = None,
-    compression_ratio: Optional[int] = None,
+    ov_config: Optional["OVConfig"] = None,
     stateful: bool = True,
 ) -> Tuple[List[List[str]], List[List[str]]]:
     """
@@ -501,7 +465,6 @@ def export_models(
         list of input_names and output_names from ONNX configuration
     """
 
-    # TODO : modify compression_option to quantization_config
     outputs = []
 
     if output_names is not None and len(output_names) != len(models_and_onnx_configs):
@@ -523,8 +486,7 @@ def export_models(
                 device=device,
                 input_shapes=input_shapes,
                 model_kwargs=model_kwargs,
-                compression_option=compression_option,
-                compression_ratio=compression_ratio,
+                ov_config=ov_config,
                 stateful=stateful,
             )
         )
@@ -537,8 +499,7 @@ def export_from_model(
     model: Union["PreTrainedModel", "TFPreTrainedModel"],
     output: Union[str, Path],
     task: Optional[str] = None,
-    compression_option: Optional[str] = None,
-    compression_ratio: Optional[float] = None,
+    ov_config: Optional["OVConfig"] = None,
     stateful: bool = True,
     opset: Optional[int] = None,
     model_kwargs: Optional[Dict[str, Any]] = None,
@@ -548,14 +509,9 @@ def export_from_model(
     device: str = "cpu",
     **kwargs_shapes,
 ):
-    if (
-        compression_option is not None
-        and compression_option != "fp16"
-        and compression_option != "fp32"
-        and not is_nncf_available()
-    ):
+    if ov_config is not None and ov_config.quantization_config and not is_nncf_available():
         raise ImportError(
-            f"Compression of the weights to {compression_option} requires nncf, please install it with `pip install nncf`"
+            f"Compression of the weights to {ov_config.quantization_config} requires nncf, please install it with `pip install nncf`"
         )
 
     model_kwargs = model_kwargs or {}
@@ -635,7 +591,7 @@ def export_from_model(
         legacy=False,
     )
 
-    if compression_option is None:
+    if ov_config is None:
         if library_name == "diffusers":
             num_parameters = model.unet.num_parameters()
         else:
@@ -643,7 +599,8 @@ def export_from_model(
 
         if num_parameters >= _MAX_UNCOMPRESSED_SIZE:
             if is_nncf_available():
-                compression_option = "int8"
+                ov_config = OVConfig(quantization_config={"bits": 8})
+
                 logger.info("The model weights will be quantized to int8.")
             else:
                 logger.warning(
@@ -697,8 +654,7 @@ def export_from_model(
         output_names=files_subpaths,
         input_shapes=input_shapes,
         device=device,
-        compression_option=compression_option,
-        compression_ratio=compression_ratio,
+        ov_config=ov_config,
         stateful=stateful,
         opset=opset,
         model_kwargs=model_kwargs,

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -77,8 +77,9 @@ if TYPE_CHECKING:
 
 def _save_model(model, path: str, ov_config: Optional["OVConfig"] = None):
     compress_to_fp16 = False
+
     if ov_config is not None:
-        if ov_config.quantization_config is not None:
+        if ov_config.quantization_config:
             if not is_nncf_available():
                 raise ImportError(
                     "Quantization of the weights to int8 requires nncf, please install it with `pip install nncf`"

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -58,16 +58,12 @@ try:
         raise OptionalDependencyNotAvailable()
 except OptionalDependencyNotAvailable:
     _import_structure["utils.dummy_openvino_and_nncf_objects"] = [
-        "OVConfig",
         "OVQuantizer",
         "OVTrainer",
         "OVTrainingArguments",
-        "OVWeightQuantizationConfig",
     ]
 else:
-    _import_structure["openvino"].extend(
-        ["OVConfig", "OVQuantizer", "OVTrainer", "OVTrainingArguments", "OVWeightQuantizationConfig"]
-    )
+    _import_structure["openvino"].extend(["OVQuantizer", "OVTrainer", "OVTrainingArguments"])
 
 try:
     if not (is_openvino_available() and is_diffusers_available()):
@@ -119,6 +115,8 @@ else:
             "OVModelForSpeechSeq2Seq",
             "OVModelForSequenceClassification",
             "OVModelForTokenClassification",
+            "OVWeightQuantizationConfig",
+            "OVConfig",
         ]
     )
 
@@ -180,14 +178,12 @@ if TYPE_CHECKING:
             raise OptionalDependencyNotAvailable()
     except OptionalDependencyNotAvailable:
         from .utils.dummy_openvino_and_nncf_objects import (
-            OVConfig,
             OVQuantizer,
             OVTrainer,
             OVTrainingArguments,
-            OVWeightQuantizationConfig,
         )
     else:
-        from .openvino import OVConfig, OVQuantizer, OVTrainer, OVTrainingArguments, OVWeightQuantizationConfig
+        from .openvino import OVQuantizer, OVTrainer, OVTrainingArguments
 
     try:
         if not (is_openvino_available() and is_diffusers_available()):
@@ -218,6 +214,7 @@ if TYPE_CHECKING:
         from .utils.dummy_openvino_objects import *
     else:
         from .openvino import (
+            OVConfig,
             OVModelForAudioClassification,
             OVModelForAudioFrameClassification,
             OVModelForAudioXVector,
@@ -231,6 +228,7 @@ if TYPE_CHECKING:
             OVModelForSequenceClassification,
             OVModelForSpeechSeq2Seq,
             OVModelForTokenClassification,
+            OVWeightQuantizationConfig,
         )
 
     try:

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -36,11 +36,12 @@ if is_nncf_available():
 
     patch_torch_operators()
 
-    from .configuration import OVConfig, OVWeightQuantizationConfig
     from .quantization import OVQuantizer
     from .trainer import OVTrainer
     from .training_args import OVTrainingArguments
 
+
+from .configuration import OVConfig, OVWeightQuantizationConfig
 from .modeling import (
     OVModelForAudioClassification,
     OVModelForAudioFrameClassification,

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -118,14 +118,12 @@ class OVConfig(BaseConfig):
         self.save_onnx_model = save_onnx_model
         self._enable_standard_onnx_export_option()
         self.optimum_version = kwargs.pop("optimum_version", None)
-        self.quantization_config = quantization_config
+        self.quantization_config = quantization_config or {}
 
-        bits = None
-        if isinstance(quantization_config, dict):
-            bits = quantization_config.get("bits", None)
-        elif isinstance(quantization_config, QuantizationConfigMixin):
-            bits = quantization_config.bits
-
+        if isinstance(quantization_config, QuantizationConfigMixin):
+            bits = self.quantization_config.bits
+        else:
+            bits = self.quantization_config.get("bits", None)
         self.dtype = "int" + str(bits) if isinstance(bits, int) else dtype
 
     def add_input_info(self, model_inputs: Dict, force_batch_one: bool = False):

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -77,7 +77,7 @@ INT8_WEIGHT_COMPRESSION_CONFIG = {
 }
 
 
-DEFAULT_4BIT_CONFIGS = {
+_DEFAULT_4BIT_CONFIGS = {
     "databricks/dolly-v2-3b": {"bits": 4, "sym": False, "group_size": 32, "ratio": 0.5},
     "EleutherAI/gpt-j-6b": {"bits": 4, "sym": False, "group_size": 64},
     "facebook/opt-6.7b": {"bits": 4, "sym": False, "group_size": 64, "ratio": 0.8},
@@ -241,4 +241,4 @@ class OVWeightQuantizationConfig(QuantizationConfigMixin):
 
 
 def _check_default_4bit_configs(config: PretrainedConfig):
-    return DEFAULT_4BIT_CONFIGS.get(config.name_or_path, None)
+    return _DEFAULT_4BIT_CONFIGS.get(config.name_or_path, None)

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -226,7 +226,7 @@ class OVWeightQuantizationConfig(QuantizationConfigMixin):
         Safety checker that arguments are correct
         """
         if self.ratio is not None and not (0 <= self.ratio <= 1):
-            raise ValueError("`damp_percent` must between 0 and 1.")
+            raise ValueError("`ratio` must between 0 and 1.")
         if self.group_size is not None and self.group_size != -1 and self.group_size <= 0:
             raise ValueError("`group_size` must be greater than 0 or equal to -1")
         if self.dataset is not None and isinstance(self.dataset, str):

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -34,7 +34,7 @@ from ...exporters.openvino import ensure_stateful_is_available, main_export, pat
 from ...exporters.openvino.stateful import model_has_state
 from ..utils.import_utils import is_nncf_available
 from ..utils.modeling_utils import MULTI_QUERY_ATTN_MODELS
-from .configuration import OVConfig, OVWeightQuantizationConfig, _check_default_4bit_configs
+from .configuration import _DEFAULT_4BIT_CONFIGS, OVConfig, OVWeightQuantizationConfig, _check_default_4bit_configs
 from .modeling import _TOKENIZER_FOR_DOC, INPUTS_DOCSTRING, MODEL_START_DOCSTRING, OVModel
 from .utils import ONNX_WEIGHTS_NAME, OV_XML_FILE_NAME, STR_TO_OV_TYPE
 
@@ -581,6 +581,9 @@ class OVModelForCausalLM(OVBaseDecoderModel, GenerationMixin):
             quantization_config = quantization_config or {"bits": 8}
 
         if isinstance(quantization_config, dict):
+            if quantization_config == {"bits": 4} and config.name_or_path in _DEFAULT_4BIT_CONFIGS:
+                quantization_config = _DEFAULT_4BIT_CONFIGS[config.name_or_path]
+
             quantization_config = OVWeightQuantizationConfig.from_dict(quantization_config)
 
         load_in_4bit = quantization_config.bits == 4 if quantization_config else False

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -231,6 +231,9 @@ class OVQuantizer(OptimumQuantizer):
             )
         ov_config = ov_config or quantization_config
 
+        if ov_config is not None and not isinstance(ov_config, OVConfig):
+            raise TypeError(f"`ov_config` should be an `OVConfig`, but got: {type(ov_config)} instead.")
+
         if isinstance(self.model, OVBaseModel):
             self._quantize_ovbasemodel(
                 calibration_dataset,
@@ -272,11 +275,10 @@ class OVQuantizer(OptimumQuantizer):
         save_directory.mkdir(parents=True, exist_ok=True)
 
         if weights_only:
+            q_config = getattr(ov_config, "quantization_config", None)
             # Use default 8-bit compression if not provided
-            q_config = (
-                OVWeightQuantizationConfig(bits=8, sym=True) if ov_config is None else ov_config.quantization_config
-            )
-            _weight_only_quantization(self.model, q_config)
+            q_config = q_config or OVWeightQuantizationConfig(bits=8, sym=True)
+            _weight_only_quantization(self.model.model, q_config)
 
             self.model.save_pretrained(save_directory)
             return
@@ -529,9 +531,9 @@ class OVQuantizer(OptimumQuantizer):
         return dataset.remove_columns(ignored_columns)
 
 
-def _weight_only_quantization(model: OVBaseModel, quantization_config: Union[OVWeightQuantizationConfig, Dict]):
-    ov_model = model.model
-
+def _weight_only_quantization(
+    model: openvino.runtime.Model, quantization_config: Union[OVWeightQuantizationConfig, Dict]
+):
     config = quantization_config
     if isinstance(config, dict):
         config = OVWeightQuantizationConfig.from_dict(quantization_config)
@@ -540,16 +542,13 @@ def _weight_only_quantization(model: OVBaseModel, quantization_config: Union[OVW
 
     if config.dataset is not None and isinstance(config.dataset, str):
         tokenizer = config.tokenizer
-        if tokenizer is None:
-            tokenizer = AutoTokenizer.from_pretrained(model.config.name_or_path)
-        elif isinstance(tokenizer, str):
+        if isinstance(tokenizer, str):
             tokenizer = AutoTokenizer.from_pretrained(tokenizer)
 
         from optimum.gptq.data import get_dataset, prepare_dataset
 
         dataset = get_dataset(config.dataset, tokenizer, seqlen=32)
         dataset = prepare_dataset(dataset)
-        dataset = nncf.Dataset(dataset, lambda x: model.prepare_inputs(**x))
 
     sensitivity_metric = None
     if isinstance(config.sensitivity_metric, str):
@@ -564,8 +563,8 @@ def _weight_only_quantization(model: OVBaseModel, quantization_config: Union[OVW
     else:
         mode = CompressWeightsMode.INT4_SYM if config.sym else CompressWeightsMode.INT4_ASYM
 
-    model.model = nncf.compress_weights(
-        ov_model,
+    return nncf.compress_weights(
+        model,
         mode=mode,
         ratio=config.ratio,
         group_size=config.group_size,

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -247,6 +247,10 @@ class OVQuantizer(OptimumQuantizer):
             )
 
         elif isinstance(self.model, torch.nn.Module):
+            logger.warning(
+                "The support of `torch.nn.Module` will be deprecated in a future release of optimum-intel, please use the corresponding `OVModelForXxx` class to load you model."
+                "To convert a PyTorch model to OpenVINO, you can set `export=True` when loading your model as `OVModelForXxx.from_pretrained(..., export=True)`"
+            )
             self._quantize_torchmodel(
                 calibration_dataset,
                 save_directory,

--- a/optimum/intel/utils/dummy_openvino_and_nncf_objects.py
+++ b/optimum/intel/utils/dummy_openvino_and_nncf_objects.py
@@ -46,25 +46,3 @@ class OVQuantizer(metaclass=DummyObject):
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["openvino", "nncf"])
-
-
-class OVConfig(metaclass=DummyObject):
-    _backends = ["openvino", "nncf"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["openvino", "nncf"])
-
-    @classmethod
-    def from_pretrained(cls, *args, **kwargs):
-        requires_backends(cls, ["openvino", "nncf"])
-
-
-class OVWeightQuantizationConfig(metaclass=DummyObject):
-    _backends = ["openvino", "nncf"]
-
-    def __init__(self, *args, **kwargs):
-        requires_backends(self, ["openvino", "nncf"])
-
-    @classmethod
-    def from_pretrained(cls, *args, **kwargs):
-        requires_backends(cls, ["openvino", "nncf"])

--- a/optimum/intel/utils/dummy_openvino_objects.py
+++ b/optimum/intel/utils/dummy_openvino_objects.py
@@ -167,3 +167,25 @@ class OVModelForTokenClassification(metaclass=DummyObject):
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
         requires_backends(cls, ["openvino"])
+
+
+class OVConfig(metaclass=DummyObject):
+    _backends = ["openvino"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["openvino"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(self, ["openvino"])
+
+
+class OVWeightQuantizationConfig(metaclass=DummyObject):
+    _backends = ["openvino"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["openvino"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(self, ["openvino"])

--- a/optimum/intel/utils/dummy_openvino_objects.py
+++ b/optimum/intel/utils/dummy_openvino_objects.py
@@ -177,7 +177,7 @@ class OVConfig(metaclass=DummyObject):
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
-        requires_backends(self, ["openvino"])
+        requires_backends(cls, ["openvino"])
 
 
 class OVWeightQuantizationConfig(metaclass=DummyObject):
@@ -188,4 +188,4 @@ class OVWeightQuantizationConfig(metaclass=DummyObject):
 
     @classmethod
     def from_pretrained(cls, *args, **kwargs):
-        requires_backends(self, ["openvino"])
+        requires_backends(cls, ["openvino"])


### PR DESCRIPTION
 In this PR we deprecate `compression_option` and `compression_ratio` during export, in favor of `ov_config` which will handle all quantization parameters (`group_size`, `ratio`, sym, ...) through `quantization_config` and `dtype` (for fp16 export)

Also add an `quantization_config` argument for all `OVModels` to enable 8bit and 4bit quantization
```python
model = OVModelForXxx.from_pretrained(model_id, quantization_config={"bits" : 4})
```