### PR TITLE
Added int4 config for Mixtral-8x7B weight compression

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -96,6 +96,7 @@ _DEFAULT_4BIT_CONFIGS = {
     "openlm-research/open_llama_3b": {"bits": 4, "sym": True, "group_size": 64, "all_layers": True},
     "tiiuae/falcon-7b": {"bits": 4, "sym": True, "group_size": 64, "all_layers": True},
     "psmathur/orca_mini_3b": {"bits": 4, "sym": True, "group_size": 64, "all_layers": True},
+    "mistralai/Mixtral-8x7B-v0.1": {"bits": 4, "sym": True, "group_size": 128, "ratio": 0.8},
 }
 
 


### PR DESCRIPTION
# What does this PR do?

Evaluated word perplexity of Mixtral-8x7B on wikitext and found int4 config for weight compression that has a neglible increase (0.4) in the perplexity from original model.
 
Mixtral 8x7B  | word_ppl on wikitext
-- | --
Torch CPU | 5.17
OV CPU | 5.17
sym_g128_r100 (default) | 5.98
sym_g128_r90 | 5.60
sym_g128_r80 (added) | 5.55


