### PR TITLE
Fix collecting duplicate tensors in quantization calibration dataset

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -88,7 +88,10 @@ class InferRequestWrapper:
         self.data_cache = data_cache
 
     def __call__(self, *args, **kwargs):
-        self.data_cache.append(copy.deepcopy(args))
+        # If __call__ is invoked then self.request must be an instance of CompiledModel
+        signature = inspect.signature(self.request)
+        bound_args = signature.bind(*args, **kwargs).arguments
+        self.data_cache.append(copy.deepcopy(bound_args["inputs"]))
         return self.request(*args, **kwargs)
 
     def infer(self, inputs: Any = None, share_inputs: bool = False):

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -88,11 +88,11 @@ class InferRequestWrapper:
         self.data_cache = data_cache
 
     def __call__(self, *args, **kwargs):
-        self.data_cache.append(*args)
+        self.data_cache.append(copy.deepcopy(args))
         return self.request(*args, **kwargs)
 
     def infer(self, inputs: Any = None, share_inputs: bool = False):
-        self.data_cache.append(inputs)
+        self.data_cache.append(copy.deepcopy(inputs))
         return self.request.infer(inputs, share_inputs)
 
     def start_async(

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+import copy
 import inspect
 import logging
 import os
@@ -102,7 +103,7 @@ class InferRequestWrapper:
         *,
         shared_memory: Any = None,
     ):
-        self.data_cache.append(inputs)
+        self.data_cache.append(copy.deepcopy(inputs))
         self.request.infer(inputs, share_inputs, share_outputs=True)
 
     def wait(self):

--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,6 @@ TESTS_REQUIRE = [
     "timm",
     "invisible-watermark>=0.2.0",
     "auto-gptq",
-    "librosa",
-    "soundfile",
 ]
 
 QUALITY_REQUIRE = ["black~=23.1", "ruff>=0.0.241"]

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ TESTS_REQUIRE = [
     "timm",
     "invisible-watermark>=0.2.0",
     "auto-gptq",
-    "soundfile"
+    "librosa",
+    "soundfile",
 ]
 
 QUALITY_REQUIRE = ["black~=23.1", "ruff>=0.0.241"]

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ TESTS_REQUIRE = [
     "timm",
     "invisible-watermark>=0.2.0",
     "auto-gptq",
+    "soundfile"
 ]
 
 QUALITY_REQUIRE = ["black~=23.1", "ruff>=0.0.241"]

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -628,5 +628,5 @@ class InferRequestWrapperTest(unittest.TestCase):
                 x = (v.numpy() if isinstance(v, torch.Tensor) else v).copy()
                 data_hashes_per_key[k].append(hash(x.tobytes()))
         for k, data_hashes in data_hashes_per_key.items():
-            # All hashes must not be equal because calibration dataset contains at least 2 different samples
-            assert any(data_hashes[0] != it for it in data_hashes), f"Collected samples are all equal for input {k}"
+            # All hashes can not be equal because calibration dataset contains at least 2 different samples
+            assert any(data_hashes[0] != it for it in data_hashes), f"Collected tensors are all equal for input {k}"

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -628,4 +628,4 @@ class InferRequestWrapperTest(unittest.TestCase):
                 data_hashes_per_key[k].append(hash(x.tobytes()))
         for k, data_hashes in data_hashes_per_key.items():
             # All hashes can not be equal because calibration dataset contains at least 2 different samples
-            assert any(data_hashes[0] != it for it in data_hashes), f"Collected tensors are all equal for input {k}"
+            self.assertTrue(any(data_hashes[0] != it for it in data_hashes))


### PR DESCRIPTION
# What does this PR do?

There appear to be duplicates data tensors in collected calibration data for quantization.

For example, when collecting calibration data for whisper decoder on a dataset of audio samples, all tensors for input `encoder_hidden_states` point to the same memory view (the last one encountered). 

I suspect sharing of inputs/outputs to be the reason. However, setting `share_inputs=False, share_outputs=False` for all request calls inside `InferRequestWrapper` class did not help. So I added deepcopying of inputs as a fix.

Added a test covering the fixed issue.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

