### PR TITLE
Update  stable diffusion example requirements

### DIFF
--- a/examples/openvino/stable-diffusion/requirements.txt
+++ b/examples/openvino/stable-diffusion/requirements.txt
@@ -1,5 +1,6 @@
 accelerate
 diffusers
 torch~=1.13
-nncf @ git+https://github.com/openvinotoolkit/nncf.git
+torchvision~=0.14
+nncf
 tomesd @ git+https://github.com/AlexKoff88/tomesd.git@openvino


### PR DESCRIPTION
torchvision is needed for running the example. 
nncf from source was needed when this example was created, but  has had a new release since.