### PR TITLE
change llama test model to cover MQA

### DIFF
--- a/tests/generation/test_modeling.py
+++ b/tests/generation/test_modeling.py
@@ -30,7 +30,8 @@ MODEL_NAMES = {
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",
     "mistral": "echarlaix/tiny-random-mistral",
-    "llama": "Jiqing/tiny_random_llama2",
+    "llama": "fxmarty/tiny-llama-fast-tokenizer",
+    "llama2": "Jiqing/tiny_random_llama2",
     "gpt_bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",
 }
 
@@ -54,6 +55,7 @@ class ModelingIntegrationTest(unittest.TestCase):
         "gpt_neo",
         "mistral",
         "llama",
+        "llama2",
         # "gpt_bigcode",
     )
 

--- a/tests/generation/test_modeling.py
+++ b/tests/generation/test_modeling.py
@@ -30,7 +30,7 @@ MODEL_NAMES = {
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",
     "mistral": "echarlaix/tiny-random-mistral",
-    "llama": "fxmarty/tiny-llama-fast-tokenizer",
+    "llama": "Jiqing/tiny_random_llama2",
     "gpt_bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",
 }
 

--- a/tests/ipex/test_inference.py
+++ b/tests/ipex/test_inference.py
@@ -41,7 +41,7 @@ MODEL_NAMES = {
     "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",
     "gpt_neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
     "gpt_bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",
-    "llama": "fxmarty/tiny-llama-fast-tokenizer",
+    "llama": "Jiqing/tiny_random_llama2",
     "opt": "hf-internal-testing/tiny-random-OPTModel",
     "mpt": "hf-internal-testing/tiny-random-MptForCausalLM",
 }

--- a/tests/ipex/test_inference.py
+++ b/tests/ipex/test_inference.py
@@ -41,7 +41,8 @@ MODEL_NAMES = {
     "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",
     "gpt_neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
     "gpt_bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",
-    "llama": "Jiqing/tiny_random_llama2",
+    "llama": "fxmarty/tiny-llama-fast-tokenizer",
+    "llama2": "Jiqing/tiny_random_llama2",
     "opt": "hf-internal-testing/tiny-random-OPTModel",
     "mpt": "hf-internal-testing/tiny-random-MptForCausalLM",
 }
@@ -66,6 +67,7 @@ class IPEXIntegrationTest(unittest.TestCase):
         "gpt_neo",
         # "gpt_bigcode",
         "llama",
+        "llama2",
         "opt",
         "mpt",
     )

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -66,7 +66,7 @@ MODEL_NAMES = {
     "gpt_neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
     "gptj": "hf-internal-testing/tiny-random-GPTJModel",
     "levit": "hf-internal-testing/tiny-random-LevitModel",
-    "llama": "fxmarty/tiny-llama-fast-tokenizer",
+    "llama": "Jiqing/tiny_random_llama2",
     "marian": "sshleifer/tiny-marian-en-de",
     "mbart": "hf-internal-testing/tiny-random-mbart",
     "mistral": "echarlaix/tiny-random-mistral",

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -228,7 +228,9 @@ class IPEXModelForCausalLMTest(unittest.TestCase):
         self.assertTrue(ipex_model.use_cache)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         tokens = tokenizer(
-            "This is a sample", return_tensors="pt", return_token_type_ids=False if model_arch in ("llama", "llama2") else None
+            "This is a sample",
+            return_tensors="pt",
+            return_token_type_ids=False if model_arch in ("llama", "llama2") else None,
         )
         position_ids = None
         if model_arch.replace("_", "-") in MODEL_TYPES_REQUIRING_POSITION_IDS:

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -66,7 +66,8 @@ MODEL_NAMES = {
     "gpt_neox": "hf-internal-testing/tiny-random-GPTNeoXForCausalLM",
     "gptj": "hf-internal-testing/tiny-random-GPTJModel",
     "levit": "hf-internal-testing/tiny-random-LevitModel",
-    "llama": "Jiqing/tiny_random_llama2",
+    "llama": "fxmarty/tiny-llama-fast-tokenizer",
+    "llama2": "Jiqing/tiny_random_llama2",
     "marian": "sshleifer/tiny-marian-en-de",
     "mbart": "hf-internal-testing/tiny-random-mbart",
     "mistral": "echarlaix/tiny-random-mistral",
@@ -209,6 +210,7 @@ class IPEXModelForCausalLMTest(unittest.TestCase):
         "gpt_neo",
         "gpt_neox",
         "llama",
+        "llama2",
         "mistral",
         # "phi",
         "mpt",
@@ -226,7 +228,7 @@ class IPEXModelForCausalLMTest(unittest.TestCase):
         self.assertTrue(ipex_model.use_cache)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         tokens = tokenizer(
-            "This is a sample", return_tensors="pt", return_token_type_ids=False if model_arch == "llama" else None
+            "This is a sample", return_tensors="pt", return_token_type_ids=False if model_arch in ("llama", "llama2") else None
         )
         position_ids = None
         if model_arch.replace("_", "-") in MODEL_TYPES_REQUIRING_POSITION_IDS:


### PR DESCRIPTION
Hi @echarlaix  . This PR changed the llama test model to align with llama2 (llama2 and llama share the same model arch but have little difference in config, we would like to change to llama2 as most people use llama2 now.). The new llama test model is quite small and also covers the MQA which met failed issues before. Would you please review it? Thx.

New llama test model link: [Jiqing/tiny_random_llama2](https://huggingface.co/Jiqing/tiny_random_llama2). It is more similar to llama2-(7b, 13b, 70b)


(Might need to re-run CI)