### PR TITLE
Fix OpenVINO notebooks

### DIFF
--- a/.github/workflows/test_openvino_notebooks.yml
+++ b/.github/workflows/test_openvino_notebooks.yml
@@ -49,5 +49,7 @@ jobs:
 
     - name: Test with Pytest
       run: |
+        sed -i 's/NUM_TRAIN_ITEMS = 600/NUM_TRAIN_ITEMS = 10/' notebooks/openvino/question_answering_quantization.ipynb
+        sed -i 's/# %pip install/%pip install/' notebooks/openvino/optimum_openvino_inference.ipynb
         python -m pytest --nbval-lax notebooks/openvino/optimum_openvino_inference.ipynb  notebooks/openvino/question_answering_quantization.ipynb
 

--- a/notebooks/openvino/optimum_openvino_inference.ipynb
+++ b/notebooks/openvino/optimum_openvino_inference.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "This notebook is a playground for running inference with OpenVINO on Transformers models with Optimum. The first part of this notebook explains the different ways to load a model, and some options specific to OpenVINO, like doing inference on an Intel GPU. The second part of this notebook consists of small examples for different supported tasks. \n",
     "\n",
-    "Do not forget to install the required dependencies before running this notebook with `pip install optimum[openvino] ipywidgets pillow torchaudio` or uncomment the cell below to install these requirements in your current Python environment. The audio classification example requires [ffmpeg](https://ffmpeg.org/download.html)."
+    "Do not forget to install the required dependencies before running this notebook by uncommenting the cell below to install these requirements in your current Python environment. The audio classification example requires [ffmpeg](https://ffmpeg.org/download.html)."
    ]
   },
   {
@@ -17,18 +17,11 @@
    "execution_count": 1,
    "id": "6a6774ad-912b-4053-b7f6-14dc020807ef",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:17.121564Z",
-     "iopub.status.busy": "2023-03-12T19:47:17.121264Z",
-     "iopub.status.idle": "2023-03-12T19:47:17.125098Z",
-     "shell.execute_reply": "2023-03-12T19:47:17.124669Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:17.121531Z"
-    },
     "tags": []
    },
    "outputs": [],
    "source": [
-    "# %pip install optimum[openvino] ipywidgets pillow torchaudio"
+    "# %pip install optimum[openvino] ipywidgets pillow torchaudio soundfile librosa"
    ]
   },
   {
@@ -52,13 +45,6 @@
    "execution_count": 2,
    "id": "0c89b2a2-ce31-4773-9454-3e0e57d1a231",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:17.127386Z",
-     "iopub.status.busy": "2023-03-12T19:47:17.127169Z",
-     "iopub.status.idle": "2023-03-12T19:47:24.576408Z",
-     "shell.execute_reply": "2023-03-12T19:47:24.575840Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:17.127372Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -66,15 +52,26 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/openvino/offline_transformations/__init__.py:10: FutureWarning: The module is private and following namespace `offline_transformations` will be removed in the future.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:nncf:NNCF initialized successfully. Supported frameworks detected: torch, onnx, openvino\n"
+      "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/transformers/utils/generic.py:441: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.\n",
+      "  _torch_pytree._register_pytree_node(\n",
+      "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/transformers/utils/generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.\n",
+      "  _torch_pytree._register_pytree_node(\n",
+      "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/transformers/utils/generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.\n",
+      "  _torch_pytree._register_pytree_node(\n",
+      "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/diffusers/utils/outputs.py:63: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.\n",
+      "  torch.utils._pytree._register_pytree_node(\n",
+      "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/diffusers/utils/outputs.py:63: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.\n",
+      "  torch.utils._pytree._register_pytree_node(\n",
+      "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/transformers/utils/generic.py:309: UserWarning: torch.utils._pytree._register_pytree_node is deprecated. Please use torch.utils._pytree.register_pytree_node instead.\n",
+      "  _torch_pytree._register_pytree_node(\n",
+      "Framework not specified. Using pt to export the model.\n",
+      "Using the export variant default. Available variants are:\n",
+      "    - default: The default ONNX variant.\n",
+      "Using framework PyTorch: 2.2.0+cpu\n",
+      "/home/helena/venvs/openvino_env/lib/python3.10/site-packages/transformers/models/distilbert/modeling_distilbert.py:246: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.\n",
+      "  mask, torch.tensor(torch.finfo(scores.dtype).min)\n",
+      "Compiling the model to CPU ...\n",
+      "Compiling the model to CPU ...\n"
      ]
     }
    ],
@@ -104,13 +101,6 @@
    "execution_count": 3,
    "id": "8053abe3-0e1f-445d-8397-630efac28269",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:24.577918Z",
-     "iopub.status.busy": "2023-03-12T19:47:24.577422Z",
-     "iopub.status.idle": "2023-03-12T19:47:25.276093Z",
-     "shell.execute_reply": "2023-03-12T19:47:25.275685Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:24.577895Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -154,13 +144,6 @@
    "execution_count": 4,
    "id": "dcf7a5c3-81ba-42cb-a7d9-d22c5bb00325",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:25.276779Z",
-     "iopub.status.busy": "2023-03-12T19:47:25.276603Z",
-     "iopub.status.idle": "2023-03-12T19:47:25.278703Z",
-     "shell.execute_reply": "2023-03-12T19:47:25.278355Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:25.276764Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -174,20 +157,20 @@
    "execution_count": 5,
    "id": "648a8eb1-1d50-4503-8094-c9a88098bee9",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:25.279302Z",
-     "iopub.status.busy": "2023-03-12T19:47:25.279139Z",
-     "iopub.status.idle": "2023-03-12T19:47:26.802333Z",
-     "shell.execute_reply": "2023-03-12T19:47:26.801969Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:25.279288Z"
-    },
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "{'score': 0.8515876531600952,\n",
+       "{'score': 0.8515874147415161,\n",
        " 'start': 12,\n",
        " 'end': 64,\n",
        " 'answer': 'a framework for deep learning inference optimization'}"
@@ -234,16 +217,16 @@
    "execution_count": 6,
    "id": "c5d8d4be-3449-4a78-aa92-56ef2b355572",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:26.802936Z",
-     "iopub.status.busy": "2023-03-12T19:47:26.802808Z",
-     "iopub.status.idle": "2023-03-12T19:47:27.259642Z",
-     "shell.execute_reply": "2023-03-12T19:47:27.259125Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:26.802923Z"
-    },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
@@ -285,10 +268,10 @@
     "### OpenVINO features\n",
     "\n",
     "- For improved performance, it is sometimes useful to reshape the model to use static input shapes\n",
-    "- Models can be compressed to FP16, which reduces model size by half, and improves performance on GPU (because GPUs contain optimizations for computations with FP16 data).\n",
+    "- On GPU, inference uses FP16 by default (GPUs contain optimizations for computations with FP16 data). On 4th generation and later Intel® Xeon® Scalable Processors, inference uses BF16 by default. \n",
     "- OpenVINO supports inference on Intel GPU, either an integrated GPU in your laptop or desktop, or an Intel discrete GPU, for example Intel Arc. \n",
     "\n",
-    "By default, when loading a model with `model = OVModelForXxx.from_pretrained(model_id)`, it is compiled on CPU. If you know you want to use GPU inference, static shapes, or FP16, you can set `compile=False` to the `.from_pretrained()` method, to skip the compilation step, as the model will have to be compiled again after steps such as reshaping, fp16 conversion or changing device. The model can then be compile with `model.compile()`. In the case the model was not compiled, it will be automatically done before the first inference, resulting in an increase of the first inference latency, since it will include the model compilation time."
+    "By default, when loading a model with `model = OVModelForXxx.from_pretrained(model_id)`, it is compiled on CPU. If you need to modify the model, for example to use static shapes, you can set `compile=False` to the `.from_pretrained()` method, to skip the compilation step, as the model will have to be compiled again after steps such as reshaping or changing device. The model can then be compile with `model.compile()`. In the case the model was not compiled, it will be automatically done before the first inference, resulting in an increase of the first inference latency, since it will include the model compilation time."
    ]
   },
   {
@@ -316,20 +299,20 @@
    "execution_count": 7,
    "id": "e0754efa-0beb-4060-8633-daecc5ebca31",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:27.261759Z",
-     "iopub.status.busy": "2023-03-12T19:47:27.261529Z",
-     "iopub.status.idle": "2023-03-12T19:47:31.027499Z",
-     "shell.execute_reply": "2023-03-12T19:47:31.027078Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:27.261738Z"
-    },
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "{'score': 0.7991431951522827,\n",
+       "{'score': 0.7991424798965454,\n",
        " 'start': 12,\n",
        " 'end': 62,\n",
        " 'answer': 'a toolkit for deep learning inference optimization'}"
@@ -366,12 +349,12 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a564882-dfd2-4f62-803b-f1e3485736c3",
+   "id": "8798b8d5-50ad-439f-a1d8-886d579a91fe",
    "metadata": {},
    "source": [
-    "#### Compressing model weights to FP16\n",
+    "#### Saving Model in FP16 format\n",
     "\n",
-    "Compressing model weights saves disk space, and speeds up inference on Intel GPU."
+    "`model.half()` converts the model weights to FP16 precision. This reduces the size of the model by half, with usually a negligible impact on accuracy."
    ]
   },
   {
@@ -379,13 +362,6 @@
    "execution_count": 8,
    "id": "09f443d5-ff58-416c-ab70-bee16e9f8235",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:31.028314Z",
-     "iopub.status.busy": "2023-03-12T19:47:31.028164Z",
-     "iopub.status.idle": "2023-03-12T19:47:32.026899Z",
-     "shell.execute_reply": "2023-03-12T19:47:32.026017Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:31.028301Z"
-    },
     "tags": []
    },
    "outputs": [],
@@ -401,7 +377,16 @@
    "source": [
     "#### Loading Model on GPU\n",
     "\n",
-    "For GPU inference, we recommend using FP16. OpenVINO support for dynamic shapes on GPU is in preview mode, so for now we recommend using static shapes.\n",
+    "A model can be loaded to GPU by using `model.to(\"GPU\")` or by passing `device` to `from_pretrained()`.\n",
+    "\n",
+    "GPU inference will automatically run with FP16 precision, regardless of the precision of the weights of the model. To override this, and force FP32 precision you can pass an `ov_config` argument to `.from_pretrained()`: \n",
+    "\n",
+    "```\n",
+    "model = OVModelForQuestionAnswering.from_pretrained(model_id,\n",
+    "    device_name=\"GPU\",\n",
+    "    ov_config={\"INFERENCE_PRECISION_HINT\": \"f32\"}\n",
+    ")\n",
+    "```\n",
     "\n",
     "OpenVINO's `Core().available_devices` property shows the supported devices on the system. "
    ]
@@ -411,13 +396,6 @@
    "execution_count": 9,
    "id": "09f13ef7-2321-47c6-a08f-5fbe61b32b43",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:32.029229Z",
-     "iopub.status.busy": "2023-03-12T19:47:32.028882Z",
-     "iopub.status.idle": "2023-03-12T19:47:32.061033Z",
-     "shell.execute_reply": "2023-03-12T19:47:32.060524Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:32.029205Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -426,7 +404,7 @@
      "output_type": "stream",
      "text": [
       "CPU 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz\n",
-      "GPU Intel(R) Iris(R) Xe Graphics [0x9a49] (iGPU)\n"
+      "GPU Intel(R) Iris(R) Xe Graphics (iGPU)\n"
      ]
     }
    ],
@@ -442,16 +420,17 @@
    "execution_count": 10,
    "id": "bf5194b5-5e80-4597-85d4-fab72fbed2fa",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:32.061881Z",
-     "iopub.status.busy": "2023-03-12T19:47:32.061689Z",
-     "iopub.status.idle": "2023-03-12T19:47:33.067283Z",
-     "shell.execute_reply": "2023-03-12T19:47:33.066928Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:32.061868Z"
-    },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to GPU ...\n",
+      "Setting OpenVINO CACHE_DIR to /home/helena/.cache/huggingface/hub/models--helenai--distilbert-base-uncased-distilled-squad-ov-fp32/snapshots/a9da64102a84c4b3f110c4d627937a110e56257f/model_cache\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -461,13 +440,33 @@
     }
    ],
    "source": [
-    "# Compile the model on GPU if a GPU is found\n",
+    "# Use `model.to()` to compile the model on GPU if a GPU is found\n",
     "if \"GPU\" in Core().available_devices:\n",
-    "    model.half()\n",
     "    model.reshape(1, 28)\n",
     "    model.to(\"gpu\")\n",
     "    model.compile()\n",
     "    print(ov_pipe.model._device)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "2538c02e-fa35-459f-90fb-e6667ef8747b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to GPU ...\n",
+      "Setting OpenVINO CACHE_DIR to distilbert-base-uncased-distilled-squad-ov-fp16/model_cache\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Set the device directly with `.from_pretrained()`\n",
+    "if \"GPU\" in Core().available_devices:\n",
+    "    model = OVModelForQuestionAnswering.from_pretrained(\"distilbert-base-uncased-distilled-squad-ov-fp16\", device=\"GPU\")"
    ]
   },
   {
@@ -507,23 +506,48 @@
    "source": [
     "Audio classification is the task of automatically categorizing audio data into classes or categories. See Hugging Face's [audio-classification](https://huggingface.co/tasks/audio-classificationhttps://huggingface.co/tasks/audio-classification) documentation for more information.\n",
     "\n",
-    "In this example, we use the [MIT/ast-finetuned-speech-commands-v2](https://huggingface.co/MIT/ast-finetuned-speech-commands-v2) model to do inference on an audio file from the [speech commands](https://huggingface.co/datasets/speech_commands/viewer/v0.01/test) dataset. You can try your own audio file too. To see the classes that this model was trained on, run `model.config.id2label`\n",
+    "In this example, we use the [MIT/ast-finetuned-speech-commands-v2](https://huggingface.co/MIT/ast-finetuned-speech-commands-v2) model to do inference on an audio file from the [speech commands](https://huggingface.co/datasets/speech_commands/viewer/v0.01/test) dataset. You can try your own audio file too. To do that, set `audio_sample = /path/to/audio_file`. To see the classes that this model was trained on, run `model.config.id2label`\n",
     "\n",
     "The model pipeline needs ffmpeg. On Ubuntu Linux: `sudo apt install ffmpeg`; see https://ffmpeg.org/download.html for other OSs"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "id": "570fd296-15a1-437d-97db-76b91407dc3c",
+   "execution_count": 12,
+   "id": "6b725d0a-e230-4b0e-b6b6-3d6d81eb984d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:33.068965Z",
-     "iopub.status.busy": "2023-03-12T19:47:33.068575Z",
-     "iopub.status.idle": "2023-03-12T19:47:38.120307Z",
-     "shell.execute_reply": "2023-03-12T19:47:38.119775Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:33.068947Z"
-    },
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    }
+   ],
+   "source": [
+    "from IPython.display import Audio\n",
+    "from optimum.intel.openvino import OVModelForAudioClassification\n",
+    "from transformers import AutoFeatureExtractor, pipeline\n",
+    "from datasets import load_dataset\n",
+    "\n",
+    "model_id = \"helenai/MIT-ast-finetuned-speech-commands-v2-ov\"\n",
+    "model = OVModelForAudioClassification.from_pretrained(model_id)\n",
+    "feature_extractor = AutoFeatureExtractor.from_pretrained(model_id)\n",
+    "ov_pipe = pipeline(\"audio-classification\", model=model, feature_extractor=feature_extractor)\n",
+    "\n",
+    "# streaming=true enables loading one item from the dataset without downloading the full dataset\n",
+    "dataset = load_dataset(\"speech_commands\", \"v0.02\", streaming=True)\n",
+    "audio_sample = next(iter(dataset[\"test\"]))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "d3012174-b58f-4efb-bb73-a88dbfb20392",
+   "metadata": {
     "tags": []
    },
    "outputs": [
@@ -532,7 +556,7 @@
       "text/html": [
        "\n",
        "                <audio  controls=\"controls\" >\n",
-       "                    <source src=\"data:audio/mpeg;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4LjQ1LjEwMAAAAAAAAAAAAAAA//NYwAAAAAAAAAAAAEluZm8AAAAPAAAAHgAADVwAFRUVHR0dJSUlLS0tLTU1NT09PUZGRkZOTk5WVlZeXl5eZmZmbm5udnZ2dn5+foaGho6Ojo6Wlpaenp6np6enr6+vt7e3v7+/v8fHx8/Pz9fX19ff39/n5+fv7+/v9/f3////AAAAAExhdmM1OC45MQAAAAAAAAAAAAAAACQCwAAAAAAAAA1ctMovWwAAAAAAAAAAAAAA//M4xAAROD4MFBsMAESlgAoIJAoWgMmTIECBAgQCAJwfB9584XeCYPicHz5zphc/QQggGcp5Ry35T8gT8l1hhQYy77/Lwfh+CE4XPxPOFDlK3iiQwMHwHQAarVtmmvs+60+KyXsaRr+KBows//M4xBoR2IoUCDMGECSrnC1IaQFVT56+KFQwFSNYVMjskMtctJK3tRW6e9bdKlOMJJHtjhle0e5x4tUEcreICBsVN91jRSWSsZtXaLI3cjHKaJFYW5vUj/a+LufJlHxuerw9Cnn2wsyzSxVl//M4xDEWchIg0jYGBCNskrb+o9XXzRP803v54PEw7CJzQWUAydYsJzhvVaIR8In3CAK2EwClAMViv44xy5wE1rGUJUJ15iy5vp2/bvrZo/Riuv4t3Nci3+KK7+qKp39GmlWYMgKIHPaCpRFK//M4xDYK0CpBl0gYAM7tiH2s4/+x0ByFpoIqAxsD1RJ01ounXDbDFMRvqSWkpM+w5hOClC+aWSVRvTdRfLBODgOldp21W6KVRms+fKI4xS6ae2rUzbpIkYQQbJEhOhaLxBBCT11b02Vtp2VG//M4xGkkW84oAZiQAMDjTz1qB40ZLs3qarV1t9TrmroIHCoWikOAZAT2JzEbv//////ydFxqz+pUlqaZjKhXMOXF5WtNe76Q5VEIzcgiYXzfp5bUba3aGsgvJECsGjx8rFy8/UfE12i3soht//M4xDYhAz6cAdhAATBkwKUggUIIdLNyuw0h3RinGj7HXCHCVxZwWQQaD9Cw1TnVqt++v//Svr+Ir/5itavSDT7pET46///2mmqTQ+FZXvookgRQ6LNFmGmD6vpqlZ4f7a7cB7F3motBEf2d//M4xBEY4Wcafl4SpjUEFevlLQFBklvdxWwBEnZoPg1HJrBsPn932RtO/nJOGXBAFF/4qEBafgqCYwrtKCAID+fYN7CEMQRWESgOAVYVKjQ/s/r+mMUUgEQBdJgfLziasAA/ANZ+jSO4N2b///M4xAwWYaLJkHpHKKnJNG+ZIwlltzxc3wW5kz2t8sOt2RYBxS15lCWeR6gYa2VEAaFLLuo59bYXHgyzlAwYpG0oatV+nKjr5v3sEOMEwOB7//FiKWEgGAckqtAwHAlaK4xhiJEFjv/lmbeu//M4xBEYqkLFpnrFLP4BCxSp/mQ4QlVtwcF0eOMTT4LSAIYGNSbV+mHuv1S501pl6ksUIAGV57HgQMPh2lbf6zIQiJVUv3T3ZaIX1v7dTr63bDlWYEVN/4b/65mtYM2x2vvWNSS7cVx4Z1KM//M4xA0Xsk8CXnsK6tXf1YcAoq/5GmOQDRSjJUTZ//CwCaAp39AdR7fbNOmZGsoo2FjzuqE6CATboJmvdvt6F9h/39Ht3q9E//+/V3Hyh4wHREJSU1/+guhegiTBhLVgCmBopU44K1+WxMrO//M4xA0UCQraVnrQ6v/pIVxWqP7IIB9GNFYskhd/qWLDjb5OE/rzV/EFJhUXZoXdDonleCnzyKc6lXWVcexw8JPd/0CWIg6Wb//+hXwEHAKqQAgDwiOQbCn3VYJ6UmPnmELTJXMgfQNzO/go//M4xBsU8VrGPnmFJIcVd5hNR3v9/J/BGHlM/SSGbKIB+85OkM6lbbZ/t6maoUKEN/sw0CwTOu+pYPETjP//+rRqHnakLuFAImbbcA1aG1GWQgHtNvel4m1cXoxA+0DPrB/m6PzGlEzoDMfz//M4xCYUmcrFvHpE6RoGzFq7xEOH8d3TDC8GQ6ig+oUJff5QIQjoYCIuqyN3+WVUccayt/7HM/jFdYJAs0oALGsfd5fCD9/f5wEjLLP184mSEInP+ltK24IlSJbnExrXKA6EoaJq1mcpUYmQ//M4xDIVEgK9dsHK6j3//ylGMrpdtrVEGkqeoiGC5CER0bw645FDrliJR7tsLrpV1ZD+2OXcD22MUeIoR06+VKqvrfc96eU1NT+CkXPLuzUBVnWGAjpaM1Wn7Z//M6BpyI9f6lYBK5HXpI5i//M4xDwUembZnmDE1pe9nKx1b//0Sxgo5BQLA0O9ahU25FSBV/7soH5ZUDR4+OsRa6fLZR3BIwNjmtmkpn7q7EpHPylPEpb+RxIIsU5kAEa7uuSlE8qjxVnednflYrSSkRbIZ1/m0mV/6cpn//M4xEkU0lq09sIKXi+ZREoCCrv4mSSqA/cbtkl/AH+usHoA5pOHa8enE+tEOACPc1hU+Qkp7dBRev9T1wz4zM24bW7L50KpLJr//JBgJ7DqIRV1qxWMZEKRFpZ/6OZE+n//7oo5ZRhNuK0E//M4xFQUqnLBvlmEuijTTlkl2AE1XCaDFEsPnT04XTnIluf2Oj+ozFT703AQeZ6GdS1uZWuLHWtaEcxht/mM6PQxSuGDg8LmMmpaukPR5uqIt3R8qp7/bT/4mwKAAl6VB0uSrfACURiQICzO//M4xGAU4lquXgMKHlCDumum+5rv71s8JgjlRm8xDBTWBAIkOMys93I92bkYiMHHIpXCCnSv9mLOJKDASsrf+ZWfWjDsxYXI50W3VFs9/+QKEHcHKhCgOgCJSSgiYRWuNBF0KVYpLLLU/O3Z//M4xGsUylKA/sMEUXzs5ZdlQ6dqoRw2iekoREz1Elp6rsVLvnp+RwTgxLAIlv/zKWoRwQGAiDCP84SUkJi1CCXG5RDTqPeBAx1IBlAIODySmuw+q3nXTkqgVQJy/LdDyK0oKO/1T++ZPb////M4xHYSKWZcEtpEyPz3BOUgRiBH35zdiv/+v+/1o6/odQovfvVA9QGMqCfgZglKETeTOOrJG2Z8bZyLLkIsV6NTXiSlha/8o8Mihhf/ydP/9Xba2v/T69FUy5A6bpNwMIGToTwmVU6mKyz4//M4xIwQmW5kPtMEUKkYga2A4IQCv3Pb6fAhMUbrhQSFhh008wPU+p6uF/Wi1f7/spT3f534Qf6F/bTGccG1TEFNRTMuMTAwVVVVVUAY5YLcMsKSHRRB3U6ZDNKUUKky2DxoRWl3s90YNBsH//M4xKgNeHpoNjYMBB6WKaR8/+v30O+iKSW8TnJbu99305bZ1jpbrSqmPUxBTUUzLjEwMFVVVVVVVVVVCVbkYvXEUAAgIKTYmNaLt6KHDECKBT6RtuIIg41pd27w0ZWISDdlCjrS7GIbbLOV//M4xNERIIpYFtpMTMTsYRBxk6AbSsWX0BFCBQsMbyYkcoISBysski+WNkxBTUUzLjEwMKqqDn/+CEY2DIHQDH9qRNjdl6faBl68BFxQMvtRY1c1dDSgVLA1vliombcuDagDj0rSLpSUoEgq//M4xN4PcIpYHsIETJoVCDCBAo4idSNUCJsJuJlCKxMIaNRjscxo+8WPVVyuM7oBwAvqAEzgy/BMVwTj41ZpbHc4C0lh6Ppfd+zxOXLntVOL20zVTrqjPLva2SSJLVBpgn5ThpasIqBGIP6s//M4xO4TeH5INnmEUJJfJvLKHKenSIznpYbHI2ZbNYV3ZkMiRYFVi4we4NKfAVsH9rc11HaLzfMP/Sozom6DghUCaOCY8iN04TvaDkeHXJCrI4MhAgAAWHPJzKE5mS+TrOWHwSGrHDFmFOIq//M4xPQUyJZANAvMAHPVsC+gisWNpEDXOU16ACSj8cypFJbxVg9yAm0WKnitRR71pcpyzZozKKxvGW0GhD9cLhMVaOj001m0ag6NS9aBAojhLg1I3JZ3InDqmkpkW+fCz40O/Nu+W5TSx0ys//M4xP8bimYgAMsGWT9HXzkMy1O5l5c2Z8jilkwJpsuRnMvfX80SukCK+T2Lb1F5Fmx//3Il/7fdS9gaMjKaGlxDiwlSGZLnLOWi4zouKcBJ4hMkTKJrqqATgTgKCj1JSDCgokRCYqMPBoNB//M4xO8WQNosCtPGKNBURE1jAqEgk/HDwk+SIki3kipE7ZbKlSwFAQ4f+dCh46e+ySEQlKlh4CN6awFsTEFNRTMuMTAwqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq//M4xPUZceooDMmGjaqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq//M4xO4XwKoEAsJGaKqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq\" type=\"audio/mpeg\" />\n",
+       "                    <source src=\"data:audio/wav;base64,UklGRiR9AABXQVZFZm10IBAAAAABAAEAgD4AAAB9AAACABAAZGF0YQB9AAAWABsAJQAjABwAHAAfABkAFAASABYAFQAUAAwACwALAAgADwALAAsADwAMAAcA/v8FAAQAAQAAAAAABAAFAAUABwAFAAoACgAHAP///v///wUABAACAAgACgAHABQADwABAPz//P8AAAEA/v/8/wUABwACAAgABAAHAAIA//8BAAAAAgAAAAEAAAAAAAEABAABAAUA+f/0//L/8f/1/+//9v/+//n/+f/2//X/+f/5//v/BwAKAAIA/v/5//b/8f/l/+r/8f/8/wIABAALAAIABwACAPz//P/5//j//P/7//b/8v/v//n/AAD8//T/9P/0/+//7P/u//b//P8BAAIADgAOAA4AFQAMAAgABQD+//z/7v/u//H/6P/s//T//v///wUABwALAAUAAQAIAAsAAgD///7/+/////v/9v/7/wIACgAIAAoABwAHAAAA9v/x//L/+P/4//H/6P/s/+//8v/y//L/5//l/+r/8f8AAAQA/v/4//7/AAAFAAEA//8BAAcABQD//wQA///4//b/7v/n/97/4f/k/+z/8f/x//7/BAAFAAIA/P/y/+7/6v/l/+X/7v/u/+v/5f/e/+D/8f/0//L/+f8BAAoACAD+//v/+f/+//7/+f/+/wIADAAMAA4ADAAbACMAKQAiABwAHwARAAsABAACAAgACAAMAAoACgAIAAIA/v/8//z/AAD///j/8v/l/+L/5P/n//H/9P/8/wEAAgAHAA4AFAAOAAwA///8//z/AAAKAA4AFQAbACUAIwAlACMAHAAVAA4AFQAVAB4AIAAeABkAFQASAA8ADAAHAAEABwALABQAGQAVABQAFAAPAAsADAASAA4ABQD2/+//7//s/+r/6v/q/+v/6P/v//X/+f/5//H/9f/5//z/AQD+//n/+//5/wEACAAHAAwAEQAZABgAFgAWABYAEQAHAAAAAAABAAIAAgABAP//+P/4//j/8f/v/+z/9P/v//L///8FAA4ADgAMAAgABQAFAP7/9f/0//L/8v/7/wAAAgAEAPz/+//5//7/BQAAAPn//P8KABUAFQALAAwAFAARABEAEQARAAwADgAOAA8ADwAVABUAGAAbABIAGAAPAAQA+//v/+//7v/u//T/+P////z////8//X/+//8//v/9v/4////CwAPAAsAEQAOAAIA+f/y/+//8f/7//z/AAAIAAcABAD7//b/+P8BAA4ACAAEAAIABwABAPj/+P/+/wAABAAEAAgACgAHAAgAAQAEAAAAAAACAAUABQD5//v//v/2//b/9v/5/wEAAAAAAAEAAAD4//X//P8AAP///v/8//v//P8CAAQABQAKAAgABAACAAIAAQACAAgACwAKAAEA+f/x//L/+f/8/wwAFQAUABQABQD8//b/8v/1/+//+f///wUABwACAAgABAAEAP7//P/5/wIACwAIAAoACwAIAAEA9v/n/+r/6//l/+v/6v/v//T/7v/s/+z/7//q/+H/5P/o/+v/+P/4//L/7//r/+j/6P/u/+v/9P/2//n//v/y//H/8f/y//j/9P/1//L/8v/v/+X/5//o/+j/8v/7/wgAFQAWABYAFAAWAA4AEQAMAAUA///+/wEA//8FAAEAAAD8/wIACAAIAAgABAABAAIAAgAAAPb/+P///wEA///8//b/9v////j/+//y/+7/6v/n/+j/7//1//v///8AAPz//v/+//z///8EAA8AEgAIAAIABwAMAA4AEQARABIAEgAWAB8AIgAjABYAFQASAA8ADAAPABEACwARABEADgAHAAUAAAD7//v/+P8CAA8ADAAVABYAGQARAAcABAAKABEADAAOAAwABwAEAAoADwAKAAUA+//7//n/AQAFAAUABQAEAAUAAgAEAAEABQAKAAcACwAMABEADgAIAAgABwAOABIADAAOAA4ACAASABQACgD5//L/7v/v//L/9P/5//7/AQD8//H/6//r/+z/7P/0//z///8BAAUABQALABEADAAKAAIA+P/+/wAAAQABAP//+//7//H/7v/k/+7/+P/x//H/+P/0/+r/6v/u//L/9f/u/+7/6//v//H/6v/u/+7/9v/5//v/+f/0/+z/4v/g/9v/1//e/+T/8f/7/wsAEQAIAAUA/v/8//b/+P/4//j/+f8BAAIA/v8HAAIABAAFAAUABwAAAPv/+/8AAA4AFAAUAAwABwAEAAsAFQAWABYADAACAAQA/////+//7P/v//H/9v/0//7/AAAAAPn//P/5//H/6v/d/9r/3v/h/+7/7v/o/+v/7//y//b/8f/r/+7/6//0//n///8OAAcADgALAAgACgAEAAAA+P8BAAAA9f/l/+D/5//o/+v/7v/5//z//P/5/wAA/P/2//n/7P/r/+j/6//0////AgABAAwADwAOABIADgAMAAgACAACAPn/+//4//z//v///woACwAYACMAKgAsACYAIwAgABQAFAAEAPv//////woACAALAA4ACwAPAAwAFQARABIADgAEAAIAAQAFAAoACgAOAA4ADAAHAAAA/P///wQABAAAAAAAAQAEAAQACgAOABEAGAAWABwAIgAtACYAGQAUAA4ADwAOABEABwAKAAwACwAZABIADAAAAPv//v/5////AQAFAAQABQAOAAQAAgACAAQADAACAAEA/v/+/wcAAAAAAAAABQAAAPj/+//+//z/+//8/wEAAQABAPn/7P/r/+L/3f/e/+H/6//4/wQADAAWABYAFQAVAAgABQD+//v/+P/y////+f8BAAcABwABAAEAAQD5//X/9P/+/wEACgAMAAwAFgAZAB4AGwAbABwAEQACAPb/+P/x/+7/6//u//b/9P/5//X//P8AAAUADAAMABQAEQAHAAQA+//7//j//P8BAPz/+f/5/wUABAAHAAcACwAMAPz/9v/x//X////8/wEABAALAA4ACwASAA8ADwAVABwAIAAZABgAGAAYABgAFQASAAsACwAEAAIABwACAAEA+f/u/+7/7P/5/wAACAASAA4AEgAHAAgA+f/s/+j/2P/e/9j/2v/i/+D/7v/y////AQAAAAAABwAPAA4ADgAAAPj/8f/h/+f/4f/k/+f/5P/v/+v/5f/u/+j/4v/d/9b/3f/i//H//v8BAAwAEgAPAA4ADgAFAAAA//8AAAUAAQD+//X/8v/x//X/9P/0//T/+/////z/AQAFAA4ADAARABkAHAAeABgAIAAcACkALQAgABwAGAAcABEABQAFAP///v/8//7/+f/7//b/8f/x/+v/7v/y//7/BQACAAgAFAAHAAEA+//2//j/7P/r/+//7v/u/+v/7//v//T/7//q/97/5f/u//H/+P/4//7/AgAIAAcACAAEAAUACwAPAAgACgAKABIAGwAYABYAFgAUABUABAAEAAgAFAAlACkAMwA3AEAAQQBKAFEAXQBfAFsAZQBrAHUAhgCIAJYAnQCdAJ8AoACrAKYAqwCtAK0ApwCfAJAAhQB4AGwAXgBNAD0AKAASAAEA8v/e/9H/v/+v/6v/of+R/4r/eP9s/1D/Qv8y/yL/Hv8T/xf/Cf8E/wn/Bv/3/ub+8/7z/vL++f4D/xD/Hf8u/0H/UP9q/4L/m/+v/87/7P8OADYAWwCCAKkAzgD0ABABNAFJAVkBdAGCAZ8BuQHQAegB9gH8AQICBQL7AfYB8QHuAfEB6AHnAeEB0wHKAbYBqAGZAY4BfwF4AWABQwEsAQ4B+gDRALAAgwBaADMACwDk/7r/lv9x/1L/Iv/2/sr+nf54/lH+MP4U/vb93P3F/bn9tP2l/Zj9lv2o/b791v3s/Qf+I/42/kf+V/5i/nv+oP7B/uv+KP9a/5j/1v8PAFcAnADzAEABhQHeATcCiALMAhYDdgPOAxQEWwSiBOsEJwVmBZkFvQXbBegF9wX+Bf4FAgb4BfIF3gXGBaQFdAVGBQUFwAR8BEAE+gOmA0gD6wKUAh4CogEkAZ0ABABS/5/+7f1E/Zr86fs1+4/64fk6+Y742/c294729fVf9dn0d/Qm9Pfz1fPM8+Pz/vMr9G30sfT99F31yfVO9s32YfcB+JX4O/nj+Zn6UPv8+678W/0F/r3+dP8cAMsAYAH5AZECGQOgAy4EyARQBdAFTga/BigHeAfKBw0IMghsCI8ItQi8CMQIxwivCJEIaghLCCII9gfOB48HUwceB+QGqwZhBhYGuAVvBRMFwARrBPkDngM3A8kCZQL/AZgBOwHjAIYAOgDr/4r/NP/e/oz+Pf7k/ZT9T/0V/db8mPxn/Dj8CfzL+5P7Vvsa+/D6rfpu+i36+Pm7+Wn5Nfn8+L74fvg8+BH45ffL98X3vvfC98/3+fc2+Hf4uvgM+W35xvk3+q36OfvS+2z8Bv2u/Vb+B/+1/14ABgGwAVMC8gKRAxwEuwRQBfEFkAYmB84HbAj0CI0JAQp7Ct8KOAuEC6gL0wvuCwYMEwwPDPwL1AuwC2sLFAuuCi8KqwkNCXcI5gdQB7IGCwZqBboEKQSTA+oCQgJ7AcIAEQBG/4X+tf3r/A38L/tY+n75ovi699f28vX29P3z//IW8i/xbPCy7xnvsu5n7j/uRe5p7qnu/u5f79TvaPAQ8cvxm/Jz8370lfWq9tb38fgZ+jn7TPxh/WH+Wf9JADsBMQIbA/QDwASIBUQG6QaDByAIpgg0Ca4JDwpTCpIKuwrICsEKnwqCCkQKFAraCZQJTwkCCbAIXQj5B4sHFAetBkMG3QV+BRAFvgRdBP4DrgNVA/oCrAJcAhACyAGBAS8B5QCTAEsABwCv/2T/If/b/p/+Wv4X/uf9vv2e/X/9Zf1N/Uf9J/0S/ff81/zN/J78efxM/DH8Hfzr+9D7mPtu+0L7CPvC+mL6CPqe+SH5tPhC+OL3efc59/720/bQ9rb2tvay9rj23PYC9z33ePfg91z43fh5+QL6uvp0+yD85/yN/UT+Bv/o/94AvAGrApwDlQSPBYYGdAdQCDUJ/Qm+Cn4LGgyoDCINjw3pDS4OVw5tDnsOcg5dDiYOzA1kDegMaQzVCzgLowoCCnIJ2wgxCJYHBQdwBtAFHgVhBJoD1wICAiwBXQCE/7H+0P0J/T78dfuP+pv5pvin96f2nPWa9JTzi/K08e3wNPCY7w3vsO567kzuRe5x7r3uGu+S7zzw4/Cn8XnyYvNl9G31jva69+v4Hfpk+578y/32/g4AGAEZAg4D9APBBH0FNgbJBl0H6wdqCNcIOwmnCeMJHwpGClcKUwo2ChsK4AmaCV4JGQnRCJgIXAgQCMUHggcvB+YGiQY2BtsFhQUuBdoEoARoBDYECwTcA6QDawMjA+MCnQJJAv8BrwFrASUB7wCzAIYAZwA8ACkAEgAFAAQA+f/1/+v/3v/a/9r/1P/N/73/pf+c/3f/U/8e/97+jP5G/gD+rv1Y/Qb9s/xs/BP8qfs5+7/6TvrN+UH5svgY+J/3LPfG9nD2Jvb49cr1vPW69cn19PUP9kz2mvb39m/38/eJ+Bb5sflV+vD6qftJ/Or8mv02/uz+pf9sACQB4QGaAkgD+QOfBEYF4QVlBvQGeQfwB3EI2AhCCaAJ9AkzCloKdgp2Cm4KWApDCjMKIAoUCgsK8QnnCcgJmAlZCQ0JqQhCCN4HZwf7BowGEwabBRcFrAQ/BLcDKgObAggCawHEAAsARv+X/t/9Sv2r/BD8hvvw+nP60vkj+Vz4g/eq9q31vfTD89TyEPJd8dHwePA38BbwE/A88GnwwfA28b3xXfIT8/Dz3vT09f32Ffg0+VT6evuc/Lv9y/7L/9IA4QHPArcDcAQvBd4FcAb0Bm0H2AdBCL0IFwl1CbgJ5gkECv0J0wmeCVUJ+AiSCCUIvQdkBxcHwwZwBhwGwgVkBfkEjgQfBK0DSAPUAnMCEAK9AXsBJQHgAIwAVQASAM7/m/9c/y//DP/s/tT+xP67/r3+zv7v/hb/Qv90/6v/5P8jAFMAbwCNALoA3ADtAAABIQE7AVkBbQFzAYcBggF1AVQBMgEOAeIArQB4ADwA//+2/2P/E/+7/mr+B/6k/U79/vyw/GD8G/zr+8X7m/t0+0P7F/vg+p36VfoL+r35fflE+RL57vi9+Kz4nPig+KX4zfj2+Bf5U/ml+Qv6bvrV+j/7sPs6/MP8Tv3L/Uz+0f5p//b/oABIAf8BzQKeA3sEUgUYBtgGkgdBCOoIgAkHCoYK9gpJC4ELqAu5C8MLpguVC2YLQAv0CqYKRArcCV4JxAg7CJUHAwdfBtAFQQW2BEUE2wNsA+sCeQISArIBLAGSAPv/YP/H/kT+uf1F/eH8jfxB/N77dPvY+gn6IPkk+CP3Bvbt9OzzDvNS8q3xH/Gq8EjwGPAH8A/wS/Cx8Dvx3PGl8pPzlfSr9bv2z/fo+P/5Hvsd/CD9BP7j/rz/nABjAScC7QKMAyUErwQxBa8FHQaNBgoHdAfiB1UIowjdCPwI8gjKCJIIOAjbB2IH+wajBk0G/gW2BWoFNAXiBI4EMgTMA2UDCAPAAocCYgI+AigCEAL4AdgBrQF/AUgBBAHBAI8AVQAjAPX/0f+l/3r/Uv9F/zf/Mv9F/2T/tf8EAHQA0gArAXoBrQHXAdQB1AHIAa8BjwF1AU0BMgENAeMA0QCnAHUALADi/5v/N//y/p/+Uf7w/Z39RP0W/dr8wPyy/Iv8nPyL/KH8kfxs/Gn8Y/xx/Hn8ivyO/J78gPyK/Ej8FPzE+1b78Pp8+j36+PnC+af5sfm8+QT6XvrO+j37k/sJ/JH8QP32/aP+Pv/W/2gABgGTAR0ClAIPA3UDzAMOBCEEbQRkBGcESQRuBIwEsQTLBAkFOgWOBQQGgAY9B+8H0wiTCUAKxAoRC1wLfQvGC+ILIQxFDH4MaQx0DGwMRwwwDPgLAgwDDCoMYAy9DKIMGgyWCvwHoAQzAMr78fam8i7vcuzI6nDp+ugd6Mzmo+SH4fDdGNo+16vVTtb22OTd/OPL6s7w7PWL+YL7Lf2N/hsBVwTnCC4ONROrF2EadxukGlcYahX2EQAPTQ34DOcNNw/+DxYQLg6dCs4Ew/0l9yDy5+/P78DxQ/Uj+Z/8nP6z/qr9D/wc+6H6xPrE+4n9sv8vAc4BaQGCAC//2P2D/Hz7VvtZ/A/+of9gAbsCBgSZBBwENgPzAVIBhwFHAjgEHwedCggODxDDEMwPAQ7YCy4JqAaABasGJgoqD6ETjha2FqcU2BF0D/IOVxDyEi4WmBmLHXYjmyl7L3AtKiCXB4zqL9NNw9+85bzgwF3IAM/b1HfWttRZ0BnICb07s3+xIbxXz/vlVPvzCkUYxyBpKFQszi02LmwrUyhZJoIp8i8RNPgxoCgXGR8Jj/pY8HfqJud06Ffpaevi7Xzw3vKA8GjsNuc+5XnpDPLD/cEIABFIFycZFRoOGk0Y1xX4DywKYQQr/5v8X/nO9brwd+qg5t7jAOUe5zbpuuv67AfwjfM3+tYDgwwaE5sWChibGbgZYxqlGZEW2hJCDzMONQ7XD9wQ6A/sC64H9QRqBJ0E4AVHB40JgAyQEDQUjBffG/Uf7ibYMHRBc0/ZRqEj0OzRvg+m0qHiq1W37sQCz7jW7diW1pDSuco8vF+vBK8oxWroUwcWGgsbQBiKFnYc/Cb2MGM44TZuLT0isBulGV0UAAfH9Qbk9tpa2mDgn+gX7ubz9PeY/aYFDQ/eFgcZFBgLGGcZ6xxDH5sdLBgjD7wI/ATSAw0EdQEA+y/wUuXM3AfXbdRP02zU3tYs3EnkVuwO9cv7QQAvBDsIQQ8dFnQbNCD0ISchnxydF6IRTAv2BnID0wOGA4gEjQN1/Zz4EfUC9zT9jgWtDawSoRNuFTQUsBJ+ErIVRBuoIBMn4CuELcosbCsxK5oxHjpzTG1AxRYM0qKYGYQBgHmOQpsCsMLECNZv4h3lP+RR3x/Qbshg0y741CU+PE0/4ysaGsIUJRlHKCMxyjMrJgEO4/k+74Lq1+CyzpHEdcRu0u3lWPPb+2b5kPsgBRcYFzDXQe1Jj0QHOU4uzSa2IM0afxCnBsT74vNX7YDlQd5z1A3KIcOewFjEYMkIz83U6dlk43rv0v0ZCWMQ0hUkGSMdmiGYI50i+RxGFWAMyQX3AHf8YPV07hbpnOhD61/vavVQ+/YBpwdODTIWCSCuKNorpCe1Ia0ajhiiGu0g7yb2JHwdmRG5Bqr9a/uV/qMHYA/bF9cZVxilGvskHTqhNSwSY9H/nSyMiZLuqIi+XNNp30/i898x27fW99Jwx+zFrdVN+zkhJzEcLCQVawPL/38N2yPjNDU5YiqfEWj7QfCC6bzh9NdL1+3ffO9X+6n+Mfwf+8UC9hLxJ5k6vkYyRwk/czDtIQ4V3wk7AXn65fTx8PLq4OOT2GnLlcCtuQa9m8cU1rXje+sY8Ejze/dZ/w0F8QzOFYogwyoIL5YreB/HD58Emv50/ND7bfnO9JbsNOS43CfYXNet3X3u0QPOGDAkuiYRJusiXiICJPAl+SgJKLwmRiP0HCkXxA6SB+j//fgp+PX5ZQCVBRsI/wTbAHEAWgikGiM1YlZ2Was8XPwhxlin76BMs4LC7dWw3EbdtdegyRq/g7N8qhOyMclc8rwVeybAIukKLfyG+44QpipNPa5CQDpNKw0c/Q3PAOryleg857/tUvlx/nT7kfBa5wnpRPYsDdIiATBBL7gkRBdcDL0FDQS+Ax4EdQF7/3f+mfp683zlkteKzq3Pctmy5OXrj+0463jrzu5x9e77fgCSCEgQwBl7Hxwg1RwpFSwNvQQ5/pH8lv4oARABG/y69Sfup+o16wjxp/ofAxQM5hFQF5caKxwVHQIeKR+qH+cdvRguEmALtAcxBcQEGgQ6BWAH/wevCIoGdgMrAokEEgwzFbobYSIWKhU2JEocRbopUO1xuCyaVZHUojWxGMKkxJbEosQ9xXLLEdDW0QvZu+puCrwnlTQzMSIcfA2gCwcbYjKHQZREMzV9HEMEyvEb5z/gVNzr3fPiF+tq79HuqOmS5DzoBffiEFAsVz/uQro3SSZxFcoLkQlOCp4IJwLJ+STxY+jZ3nDUhcxNy0fSbtz55kDucfCx78PvnfS7+2MFqQ/kGPAg8iaeKvEneh+jFOgITgCW+1b52fe29NnwU+s05mPkyOUW67DyuvuCBCUNaxWAHcoigSc4KrsrLizZKt4pOSN/G4URqwlrBIz+3/rp9Mzvx+518DH2Cfp//m0CpwTLCNAPQBqwJVAykkA7TOlDmidP+SDNVq6gnmOiX6ott+a/KMUGyqjLOdCF0BvT0tz7700KXR/FKnEoYh1qFVwV8x3jKzo2TDpfMHkedQk09YHn690W29jaCd5N4xvnd+gh6D3qOPEr/qQQJCO0L0I0cDEJKjsg8xhOFOYOtwf8/5T59PPt7X7n6d9P26jcdeAB5KzlJuet52zoT+s/8lz6BgTnDW8UFho5HOYd6xj8EdsLSAZzA6ABfABQ/3X6SvaJ8DrqC+qt6SnuGPNH+hcFxA6pGCMgXySWJpYl5yQSIvweXxlkEVwLjgV8AvEBQgLnA7kBn/58+hv30Pgg/50E9wfhCB0JxgyUEiscniYwLidBDkQvMtwEvc8IsOmdFafWtCXCJsg6yKTKvcxb0bLXUthb3EzrtgQNI7owwS8mHTQJqAJ2DKEhqzW/PPwyHRp+/lfqY+Ar4GDjnOpI8Fb0K/Tw8FjsduZE5hjxDwURHogyCz0EOQUqdRjVCbwD5wWeCYcLsAi4AuH4IOyE4XzZOtip3hvqsPV8+gz5mPGF6AjmdexN+t0IORRpGZQXuRLeC48Ec/2x+eL64P3uAsQEgQJG+yjy4euR6E/rk/Af94z94wKHCA4NmhEXFgwavRxPHVgbhxYOETQKwwXOA2EEHgjtCmgOlQzwBuEBQ/8CAgIF0wghCycLVQzFDeoSDRn1H8EkdyotNdkvhBaP6JbBm6zTps2zNb9kyZzJKcz+0WrWEN/45ZzndukA8m0IKh2SJlIjBxTCB4AFYBK4I4cuJC2eHCQGzfQ179XuHPHb8Iryh/CI7yTuW++871HwF/UiAIcQeiBJLMssvyNgE4gH/gBYAmEGIwqkCZsFnwFt/If27u7W6ZXnTOtv8nD72P0u+Arv9+Pe3rniNu58/fkHgA+gEZsMbwcQAQj9Zfm5+Ur9PwDKAf0Bef2e9aPtGOvx7PrzZv18BjQKcAjmBtUDnQQ1CKcMWxFxEjESLRHJDZcNrQs/DJ0OGBKiFoQanxweGyYXFhP/DBwJXgdKCgkMaw6XEYUSWhUyEUwTlhF1H4UXnP+v2lG9yLdzs2nBaMzY0FDTSNc14QfrMezt8MnlOOF85tn5qBAgF3kT3wEe9b/16wJ+EoAawxjxD38DAf73/QQBMQFn/xv+e/vA/vj/jgFs/AX3dfgkAZ4Q3RyyIaod/hMoCgEGygJwBOMD0QNbAw0CkQVlBJMBsfor8nPuIvEk+Ob+zfuC99rreePl4b7kIO0r8oL4RPwa+6j8+Pwk+0X5mvT39l33Ev5YBooIlAaT/n353vfs+toCswhmC40MTwyNDYIOExA+EFIPjg88EfAUJxZ5F2EUxhPJEkQWWBsDH9MdQxhrEiwN2QrBCL4J+gSlBOwEfwcJDJ0N8xB8DkwOuhFVAiHx9dpY0UPMFcVdz6DPy9LU0/fV+tsz2R3fUeI54K/lLu5n/uAGJwgjBk39mPsXAk0L9xTcFlgXxxGdC5kN7RCwEq0OIAjqA/L+2v1k/qf9Wfx1+8sBswtjE4wXkxX1D0gJewXiCEEJGAvVBxAEhP9g/N/+yf02/SX65PV28/Xx8PRj9p/yze8X7I/rROxj6kHv5+xs8N3wpvK/9yf2Uvoo93X3I/l/+g7/8gA7BM8HFga5BkMEQwR4BF8FWQm7DAARwhbQGV8ZYRUmEaYRVxJEF4IYURqDGv8bjhxJG9wYuRNYDX8HYgZHBq0HlgS7APv5Pfca+HL74wBuAYkAtvsC+QD5svnI/V371PE06HDfAeBG3Tffe+DT21rdr94b6Fjsre0m8NDsSO4q86z7UgNwAfj/aPsh+7cAEQjUDvkOLw4RD8APrBGhE5QQvwqQAocBrwQgCOkLKwwGC54ImgdPCF8GqAV7BZEGygfpBgUGLwFE/Kn5XPmL+aj5nPp1+435ifhj+Pb3+PU580fzlvP487H3m/ge+M70ofIg81ryUPVL+Ur9pf/yAMEBogG3AIkB3gAzAHsA6AERA1cE5gRICCEJ0As4D64QeRSPEuQTOBD6Dn0P0g7JEEAO2w9pEAEQKRB5DUoL7gbWAmMBcf5b/qj93fwb+/P30PbN9rP4z/pi/HH6zPmj9+L3+fiy+VD7/vls+fv21vYG9g324PU09t74fPqk/R4ARACP/yX+GP/s//oAjAEpAa8CRgOwBCcF0QUcBscHJQfDCKsJ/wiKCNkCiQBj/Ub+l/0H/xL9Bv1u/gr++P/O/s7+BQDX/tj/L//C/av99fi3+G30DPYw9+T41/xU+2L9Rvsh+V337/Va94r55fss/qAAuP7h/qz8vfvB/pX/6wU/CAALxA4DDLENCArmBnUH/wJxBzUFQAaGBswDYwZFBOkDOQTZAgYECQNqAfUBrf9bAJcAiwEpA8oEkwRMBUUCxwEG/xL9xPsq+lv6hfqX/Cf93vuz+bX2bPZ49NP1f/b89/z5BPqh/Cv84/7H/hwAsP/sABACXwMuAnQAIgBp/zoCnwLEBD8FUAQrBQUCnQKVAgYEBgVjBB8DhwM8A7IF4AXKBQIGxAO8A8kAN/+4/K76m/nm+Qr7VP2+/j7/Rf9F/er85vuh/KT9bP1u/fr7Uft6+0f7Mvwy/GT8nPwG/Wj+jP/r/7b/7/4s/xEAfQHTApYDLwRUBDYE+QOwA5kDfwOcAzYEdAUeB1IIUwg1B1kFdgPlAc4ANQALAAwA1v84/6T+fP7f/nD/xv+//4T/X/9f/1//Wf8x/wL/if4D/nX9H/33/Mz8kfw6/B78DPy6+9P60vmD+Tr66/u//Wr/XQCqAEMAnv80/6v/ZQBxAd4BSwJfAmkCEwK7AKL/Hv7V/QT+Cv+TAIwBXwKnAt0CaQPwAzUE7wPmArYB8gApARcC0AJ5A5kDEQPNAa3/fP2M+wv6Hfkg+VP5Qfpt+1z89/2F/vH/av9v/lj93fzy/F/8dPzg/ML+LgH3AxwGMwdfBqoDDgC1/FP7XvvI+1b8XP3X/wIDlwV/B94HEgf/BD4C1P88/uz9b/48/0oBCAQeB7oIBgj0BTgCgv7O+wT7TPxW/o8AIALJAoYCNgE3/zn95vt++zz7Mvss+5v7IPyk/BX9RP6I/40A4ABOAKL/gf7C/b79VP42ACACdgO+A1ADlALvAAP/Q/3D/HP9Cv/OAAYCmwKYAoQCXQL2AXUBmgDr/zX/DP/Q/wkBHAIbA8kCngLlAREBMwCw/pD9uvy5/HD9iP5X/x8AUQBGAK3/A/+Q/tP9NP12/AH9AP5d/1UAeQDd/7v+0/1b/YP9P/69/k//fv/W/1oAswDRAL0AeQCNAGEAIgD5/4z/uv/n/38A6ACFARYC0QEiAcT/zv6S/uX+9v+rAEwBowEQAqQCXwPSAwsE+wOeA18DLQNGAxsDlALdAQsBpwD0/yH/4/2I/G77cfoE+gv6Ivoz+n/6EPsZ/HD9Qv/PAOwBiwIzA7UDrgN8A6wC2wEYAf0AAQHlAEkAQv89/gT9RPzy+/L7ofxO/ef9u/6t/7EAewFhAVoBNgHBAUwCBAORA9UDzgMEAxoC1ADs/27/if6N/Vz8yvsw+w37Y/s1/Lf9IP9VAEgB1wFOAk8C+QG+ASMC4wLcA00EKATcA7ICkwEqADX/Tv6u/e78mPyP/AL9jv0U/m7+3P6K/xsA8wClAX4CCAM8A2IDPQMCA44CzQHFAIv/bv5f/aj8Yvxp/K/89fw9/aH9Nv7y/qz/RADyANABngKAAzIErQS9BEoEyQM2A5sCqAFYAAL/uf2v/Ob7jvuv+yT8svwC/X/9Nf40/xIAcgC6ABoB5wG5AoID2QO+Ax8DMgJ3Af4AtwA2AEz/R/51/Qb9Af0x/XD9if2O/Xr9iv23/QX+Vv60/iD/qf9dABEBpgH2AQIC2gG0AZwBggEoAYYAyf80/wr/Pv/D/0kAlwCSAF4AGQD5//H/zv/H////hQA5AccB5QGcATQBswA3AN7/vf/1/w8A8v/n/+T/GwA9ADcACADB/6//o/+Z/5j/q//X/5j/ff+U/63/t/8a/0z+pf15/cX9Kf5u/qf+DP+c/xUAagCxAM8A6QAXAXgB7gEqAi4C1wFWAf4A6QApAVQBUAEBAU4Axv9w/1n/af+L/87/6P/8/wUA/v8MABUABADN/5T/ff96/33/Vf9Z/2T/eP9D/+X+uv6N/ob+fv6C/qz+6f4e/yj/O/+H/wAAewC1AMIAvQCPAIAAeACqAPAACQHwAKYAVQBBADMAXwBoAFAAHgDh/+D/FQBKAEcAIAD4/w4AQQCFAKMApgCfAIgAfgBbADwA/P/J/63/mP+w/7b/q/+L/13/Yf9a/2D/Y/9T/0//K/8r/yT/If8R/w7/Df8E/y7/dv+9/9H/uf+//9P/EgB1ALgA1ACUAFUANQA8AFgAfgCcAL8A9wAyAXMBmwG8Aa8BhAFSAV0BggGoAbABhwFKASQB5QCNAAsAgv8C/43+ef6u/un+3/6g/kT+Iv5A/pz+1/79/s/+lv5//p3+EP99/97/1/+t/3f/bv94/47/mP92/0n/Tf9u/57/1//a/8n/rf+p/7r/xP/L/9D/4P8MAGEAtwD0ACwBYAGiAeEB9gHXAW4B4wBLANT/m/+j/9D/7P/d/6//hf9n/23/gf/L/wQAYgCkANEA6ADWALEAfgBYAFoAaABoAC8A1/96/x3/0f6Z/ob+k/6W/qf+wf7o/hP/P/+K/9T/HABVAGUAewCFAKkAzgDwAPQA3wDUANsA8AAVAT8BaQGOAZYBmAFrAUUBBAHYAKYAZwBOACwAOgBOAEoAUwA3ACwAGAACAPb/2P+6/6b/kf92/0H/AP+0/ob+ef57/oL+fv5v/n7+n/7r/j7/jv/L/+H/xv+h/5L/mP/G/wAAJgA6ADoAIAABANb/2P/b/+v/AAD8//z/4v/a/wQAdgDiADgBdQGSAa0BvgGVATUBuABBAPH/7v8lAF8AagA1ANf/d/8v/w3/Iv9J/3b/pv/Y/+r/3f+t/0z/2/6c/pz+yv4b/zT/Ef+6/lb+Ev4y/n/+7P5P/4X/wf/i/wEAKQBvANEATwG5ARMCQQIrAvEBtAGPAYIBmAGqAagBrwGbAZ4BngGgAZ4BbQExAdIAhQA9ABkA6v/J/7n/sv/D/8D/pf9s/yf/8/7S/sj+3/7m/tn+vv6p/rP+uP7C/rr+qv6g/qn+wv73/i7/YP97/4v/n/+5/+T/BwAVAAwA9v8HABkAUQBrAHUAcQBlAG4AdACXAJkApADHAPMAHQEvATUBMgE5AU8BcQFwATgB7ACFABwA1P+r/3v/cP9m/1L/Qv8G/7r+av4j/u392v3z/QT+Of5r/oj+o/60/tv+/f4g/1r/e/+Z/6H/mP+Y/6P/r/+6/9P/+/8wAF4AZwBlAGEAbwCgAPAATQGiAeEBHQIcAv8B5AHAAa0BjgGLAZkBmwGgAWcBLgH0AMEAvQCXAHwANgD+/9r/2//v//X/+//X/4//Vv8q/xr/Hf8e/zT/Nf8x/y7/Jf8q/zf/YP+L/5z/o/+P/3r/bf9f/3b/jP+5/9v/BQAlAE4AXgBdAEsAOQBOAGoAnQDBAOAA9wDzAAYBAQHfALAAXQAsAAwABAAwAGQAgwB5AFAAHwD+//T/5//+//7/9f/k/9v/0/+//6//pf+R/5H/cf9g/0v/Ef/8/sr+uP62/qT+zv7e/gf/K/85/zL/J/9F/27/sP/8/ywAbgB4AHYAZQBKAEYAPQBeAHgAdQCDAG8AUQBEAEMAdQB/AJMAmgCKAGUAPAAcACUAWACqAAkBSQFeAVoBOAEvAf4A0gCNAFoARwBQAGEASQAoAMv/rf+C/5n/sP+f/5b/Vv9P/0//Z/+p/8f/IwBiAMgA9wAXAQsByACWAE4AVwBXAIwAcgBOAPT/mf9G/wz/+v7b/u/+//48/2H/lv+z/8H/6////xgAOQBJAFoATgAlABQA+/8wADcAeACNAJ0AtQCJAIgATQBhADIASwAcACwAIwAwAC8ABQACAND/6v/H/+f/w//O/57/sv+2//T/LAA3AFEAHwApAPn////s/woA+f////b/GQBBAAsAQADU/0sAJgCUAKAAjACXABEASgBm//z/ef5N/7X8z/yd+zn6C/tg+L/6+fii+yn7+fwe/or/ogHrAfYEUwTmB8wG5AjvCEUJaQoJCSIKTAh4CKsGeQWTAyMCbADv/jr9qvs1+5v50Pl++BT51fhc+bz50/o0/Hn9Dv8r/34BtwDeAqwBgAIBAzQCygLHAQICYAGOAdj/6QDl/hsAKP/6/i7/Zf5W/3b99f7Z/LP/2v2O/7z/gP/kAWT/UwLe/8oC0QBOAnABIQFSAjv/FQEm/fP+XPzu/F38NfxS/X/77v2m+7v+nf2R/5IAEwFBA/oCowSUA/wEjwMcBBgDBAMEA+wB1AFQAFsANP9B/5r+Hv/S/lf/Hv8M/3r/uP52/4L+q/87/8f/s/+P/yUAiP/R/3j/zv/q/28ArQAhAcsB+AG/AlkC3AIjA/ACoQLKAVIBvgAtAB3/Bv88/m7+Bf4A/lr+lv6t/p/+rf5y/uH+Kf7n/W/9Sv3z+3H8qPoU+4D65/g5+h/4gfnY+HD5DvoH+1L85/1KAJIBfgXsBggKCQw5DrYP+xBhETMRoBFsD84OFwwpCqwHlQQUAjL+evwR+B73A/SY8mPyxe9d8fvvlfHe8sPzbfbF9wn6KvzA/ur/fQKTA0UE0wVGBY4GkwYzBqwFtgWWA7sDpAIEAb0Bd/83AIL/hf4i/4X+Gf6p/hX9rf3y/Nz7r/zJ+rr7hfq0+/r6EPzj/Fv+of8mAFgCFwKtBI8DfQUxBRoFtQWYBHYFuQR0BfoE4gSfBDsF+gSdBKUEYQO6A/IBewFVAG3/4f7J/d39PPx//T78dPyU/AD7Hf0m+2b8Wvz6+9H8UPys/JX8iv1L/d/+1f1G/pD+9fxy/XD7WfuW+pb6Rvrc+w/8Sf67AD8BegXRBXAJLQp1C6sM9QvXC5MJ7AijBvIEZgNSAYD/KP50/L77F/uD+a76Cvly+Xb5VvkV+q757foG+378Tv1D/x4AIgE4AtkCmgN9A9gDRwN4A8YBcgKjAFUAfgDm/goAWv9yAEwB0wGIAsYC8AJEAjUC3gBYAA3/Rv5m/ab8rvxg/H/9RP03/4L/bwBCAc4AjwFkADUAc/8O/73+Kv/y/zIAzgFLAiMDoAOrA+wDzQISApoAlP8o/jf9x/xE/Kj8zPxb/ov+o/+NAOgAZAEoAV4BzgDOAL//AABI/zL/pf9g/9T/UP/2/3f/c/8U/yz/1P5g/r7+ov4b/y//LAB5AIUBYAJxA7AEjwTUBW8FUAWqBIcDegKpAPD+Xv1O/O/6ifpN+ir6q/qV+4P8gP1l/p7/owBWASMCPwKDAkcCDwL7AV0BPAH2AMIAJQBDAD0AIwA5AFsA1QD6AJ8BfwGFAdgAZAAMANz+V/52/Tn91/y8/B/9o/0//pn+T/+b/7r/9v+m/xf/Df8G/6f+rv5y/t/+V//R/+UA5QHXAqoDTATLBNwE2wQiBEsD4gGJAJj/TP7w/Tb9Uv2t/ef9tv5x/z8AvQBQAS4BQAHUAO//PP8c/jn90/xp/C/8j/zn/K79Ov4A/7D/XgDOAFkB4QFwAkgDPQPsA7oDIwNmA6cCMQLDAccA4P9N/1v+3f2o/VT9gP3Q/VH+4f5u//j/cQBkAFEACwBk/77+df4S/mr+l/7O/sr/sv+NAPwAWgFuAYUBdAH8AN8AdgCQAIoAZACpADQBIQGOAXEBwgCWAFb/G/9X/q/97v2N/UP+P/4C/2f/Vv+U/5L/kf+b/6L/h/8iANT/swCSAA4BVAEUAYQB+gAEAYoAXgAIAPb/bwC7AKoB3QFjAlwCIQLuAVABmgAMAJb/P/8Y/+n+B/+i/rv+bv64/u3+6/5p/3b/5P8eAC0AXQAgADoACwD+/2n/3v4L/hn9kvwd/EH8mvwG/eL9cf4l/5v/7P8lACoAYgCNANQATQHUATcCuwL+AioDVAP4AvECRAKtAfAA9v+b/+3++f4Y/3j/8f9XAKAAywDwALcAsABHAEQA9v8BACYA//9RAFAAbwA3APz/av/h/i3+r/1L/e/8IP1R/Qj+lf6C/z0AzgArAS8BOQG7AI0AJQDb/7D/Xf9w/6P/MgCSAFcBtwEWAk8CRQIgApEBDgFEAK3/Hv/Y/qf+s/6k/sX+8/4M/0X/Pv9p/2n/Y/+I/3P/jv+p/8P/BQA1AHEAtACKAGoAPwDx/9P/gP9z/4z/rf8eAFAAewCjAI0AnACCAHgAeABTAC8A1v+U/2H/PP8a/yz/ev/2/7MAVAFEAvQCrgNTBMUE9gQRBT8FOwVIBVAFWgWSBeUFWAbgBl4HfgeIB1gH2AY+BkYFRQTKAmkBwf/7/fj70vmI9wP1pvII8J3tV+tI6cPnx+Zr5pDmaue16KnqGO29773ynvW9+Ln7xP6gATYEsgaeCF0KugvCDGgNxg3mDecN3w3VDcwNxQ3vDREOYw6CDkwO0g0xDToMGwuaCQoILgZGBIgCqQA1/6/9WvxQ+1/65PmH+VP5P/lO+Yj55PmW+jz7NfwT/Qf+9v66/1AAwQD2AAEBAQH6AMwAoQBVABEAAADa//n/QADRAJMBjgKnA8EE+QX+Bt8HhQgcCVQJNwnlCCoIQAfCBTUERAI8ADj+8/vy+b/3BvaD9EDzgfLO8aLx0vE+8vXyyPO+9NT1v/bO97L4cPkv+pP69PpU+4j78/tV/N78lP1H/jf/NgBPAWoCjQOwBL8FwQagBzsIzggXCTQJEAmcCL0HqgZnBc8DAAIbAC3+U/y++lj5Sfif90D3Sfej93P4c/m3+jL81v2r/1MBFgOsBB0GXgdcCEoJsQn+CdkJoQk0CY4ICQhaB8gGHQa8BYQFXwViBXkFpAXMBe4F9AXTBWkF0QQYBBMDFgLlAJX/Ff6K/N36//gU9zf1ZvOl8QHwj+5e7WLszOtd6x7rPOt66wPsruyn7cPuFvCs8THz1PSU9n/4jPqc/NX+CwE2A3oFswf6CTcMZw6kENYSBhUsFzIZ4xpaHGodMh6ZHoMeBB4mHQAcXxpnGAwWjhPgEDIOqgsFCbUGjwSsAj8BGAB9//b+0v7o/vD+AP/b/qf+4P2O/Nz6kvjE9cTyh+8g7LnoU+Vf4p7fpt083FXbZtv323Xdh99H4rXldemg7e/xVPbI+uv+wgJIBkgJJgxCDu0P9hCsEVkSlhKlEl8SEBLPEYER6hB8ELwPSQ+SDpMNZgz8CswJKAhHBvADmQGW/y790fqH+Ib2N/Xu8/XytfIM80D0w/Vs90P6Cf1KAHkDigZOCqsNJhF1FG4Xqxp9HdQf+SFQI6wlvCOQIWQfBh00Gs0SFwvBA5j87vXy7U3k89yQ1l/SBM3Ux+LFxcT+xEfFNMciy8HOw9P62CPe7+Sp6hjxnvZa/H8DQwiRDIEROBZAG6IdcyAdJNUmqSmuKmYrUCyZLKYsrCrTJ94lfiIbHhwYSBLxDBYGBP+99/zwauuf5ZLg6NtI2ObWX9W41DHV0dbl2YncIuBq5LboVO2x8Qj2jPrO/vUCVwZLCbwM0w9XEjYUTxazGFUanxu2HGkd9x2xHUEdXBznGnkZ9BbrE6EQMQ2iCY8FOQEL/T350fWl8qLv8+ze6jrpE+ip51nnbue7507ohOnp6oHsIe6u747xhPOE9VH3xPhU+pX76Pwv/gz/SwBFAWICvwMFBXwGzge1COEJ8grrCwkNgg3FDfkNFw7aDjEPSw8jD84OAg8kD04PJA9PDg0O5w3JDeINaQ1oDaEN5Q1KDuoNPQ1sDFYLGwqsB5UELwF9/VX6R/aL8Rnt1Oi85SPiPN4q2/bYJ9ha173Wo9dN2UPcYt+q4iXnVevG7yH0oPh5/ScBcgTYB0YLhQ5IEJYRThNCFQIXQBf8FnsXJhhGGMwWERXGE78SsRC7DQQKKQfvBIkBBP6t+i/4hPa99AbzUvI+8qXzQ/Sb9T74LvsU/lcAKATYB24LkQ9zE3kXbRw4INAjiydqLUkzly7xKR8pbypcJ0EZ3wtjAUX5HvLd5dLW+8tgxgXEMb1mtx+3i7iKugK7wL9Nxr7LsdIZ2A7fledD7qn1L/u7A8YNZBLjFrUdLSjOMGgy3TTzOdA/dENpQm9Axz2/PG06/jJiKvoiUBzKEgsGuvyS9Pzq1ODK1yPSVc1+ycDGLcRexRzJScxFzprR1tj83qTia+dB7Xjzxfef/F0CTgcqDYsSshe3HHwh/CZfKgMtTS9gMKUw3y5eLFcpciTWHsoYNBJ4CzsEC/4b+OTxuu3s6e/m8+QA5GTktOOp5JbmPOhY6kjsE+/s8CLzofZs+aL7+P1SAZ0E4wYHCq4NsA9FErQTTRXAFVUUSRSwD+AKoAavATf8EfSV7eDot+Nu4BDeSNz72ynd+uAn5A7nH+wk8Yr15/jJ/RYDRgWLCKILQQ+sEl4VeRkJHH8fCSTuJuYo8Sp6LS8v8CzTKp8pNCcRI6wdBBl+FOUP2AteBzQDEgAp/dj43vIN75bs7ufr4AraV9bN04jQds0jy0/LX83iz7jS6dVC24vhxebv63vx6veO/bYBIAamCvUOsRH8EgoV3RdhGhsbnRrsGtUbLhz+GrQYfRZEFFsRXw3sCLoEqgBc/AP4TvSc8X7vU+2C6+/qDetB6wnsV+0x797xwvQ/97z5Af1hAd4FwAhFC7AOlhJEFu0XNRnrHLMf0R8oIGwgeCECIaIgtyHQIbEhUiCXHuwfUiOKJ/EdDRErCLEGLQZu8+TdVc51xrLDPL5MtRWx/bFWu/fBssZw0UjbSuP65YjtfPYJ/DX+Df+4ApcGygmpDmUR/BbPIE4nlyoiKzQ0uj0jPMI0zC2kKiIm4hxQEfACgfgl8fbq7+Ox3WTcCdtk2Xjad94P41LkceQP6Izq4+0H8ODwPPLE8lz27PhU+in+fQOKCNQLRg+IFWUbnx/oIOcg1CBlINkeexhNEi0MMAYY/4v2EPGs7J/oi+Xx4mnii+R/55jqneyn7zz0vfiq+4z9DwANAi8D8wNaBWQHtwhQCsAMhA/GEn0VtRc1GIwYmRlKGNMU1A9ZC00Ggf9z+ZrzQu6W6ajlVeME4ePgneKF41PkhuV26LLr3O2S76XxefT297f7GP+wAWUGHwubEPYV7hWXGQUbfhyvHOoXlxbBEFkM8Qg2A/n+tPp1+OP2dfNQ9Gr1NPb89YX1J/m8+Av64voy+8H7gfs9/lsA8AC4A4IH5QrCDc0PKRWCF14YBhrpGo0b/xmCGpcaxxiwF/AXVxdkFMERHRDKC8kFof/m+XHxiec14IbY7dGtzP3JRsiexnLIGcw5z/7S4dZP26Te8eEm5grqnO5F8yv55/9WB+4PhBiMIcQpNzF6NwI71TzaO/Q4PDTsLK0kPBt7EuMJagEE+8b14PKy8KjumO647cTtzu2x7L/sVete6kPqu+rq7C3v9vFL9Ur6lP/GA3gIaQ2qEX0TABUZF2QYlhfaFeATxBGaERYShRQxFakY1x1xIu4nlithOMo9ezAVHwwPrw6pAnfnAc74temtvao8qwywtLGJvs7NXtl15mvx6/4c/Sjyle0g6ybtC+eU5EznHu4P/e4L+hucLflAB1GMUwdRe1HDTzlD/Cm+EYP+b++y5C7acdMq0GDW0+K/6w715v0MBv8Fiv+f+0r3J/A95Y7ax9Sw1KTc8+bt8ET9+Q3VH8srJDQ+OzA+GzlTLOgeZhIPBo35YuyD4kXezeCM58ztkPRG/JADQQggCQEICATL+4zwJuWP3GLXidWd1lLaBeLk7v/+SQ7nGkYlmiwLL+UsEShLIQsY5Az5ATD5+/O68pb0y/hv/lgF4AyYE5MYhBqFGAUTyAo+AWX3sO2h5TvfT9tE20/er+TX7HP15/2pBGcKzw3oDqsNAQoFBSD/jPoM9xf2jPfU+Z/+lQQJCyERmxXQGSwb2xfJFBEKdgDv9CXtEuYu3Y/cu9tP4b7pfvTt/kAGEBCFFyoXSRQIDscIfQET+HvyT+wz7QjxMfizAGUJmRRLHl8jFiZgJtQjsxtDEOYHF/+d9z7wQ+6s79H0Y/3ZBrcQEBlEITYlDSZhIpUbgBBlAon0D+gw36XYxNUf1vXZ8+D76RXzFvqe/bv9jPql9S3v8+fo4Ezbwtg52ijhh+sL+KwF0hNEIJEp2S8MMtouOieRHe4SBQf1+/7zO+8H7VbuoPNn+sEAngZkC/IM0QqJBroA3/jq7/LnvOGf3dbczeA46Afy1PykBxsRHxhwHVYfHx5WGeISUAtKBI7/wvxp/bf/rwQOCmsRehg9HTEf+BxPGjYUyw6aCRkG/wK9ApkFVQypFHkk9DTiMLIgJwstBbj6eOQAzZaya6gepEavJsCmz6jm/PdKA/UEqQWsDocJMPmM40jVQNXh2sLsbf+oEKQlyDmzSuNQTFWaVlJHRye7BHrsW9zZzkTEyL0dvR7JWODT9sQFkRDIGJIY7gzi/kL0EOmU3PDRTc9c1GvjC/uZFKUpWTrZSBNQa02rQvEzAyAYB7nvON4E1brTP9kz46/sG/g3BSMQlxPNDqsFMPlj6g3dhdOhzjfOpdRg4bTwXQF6E/0k7zA9NYgzBi2kIiYW8Aki/xn3ZvPw83H4swBgDCUXJx3NHH4YERF6Bmr4KemV20vRQ8zqy7DQfNnT5ln1+gL+DI4TzhU2FZQSIA0GBs79F/g79Rn2+/j6/f8EYAwEEmoV0xa8Fn4SlwwkBQH9n/XW75zu4u1z7m7w/PSq+nf/nQN+BVcGlQRMBPAA6PmZ9GXwGPG07bPvwPRC+fT/lAPlC2QPkhIKFOAQqg1WCI4GpgM//+X+1v8NAj0EzAcRDukQlxPCFDMTrhAYDRAMyQryBxYGxwQeBBwD/AL6BAwFngOfAjsCkwGIAMUA1QF1AQ8DDAXOBXMDsv8G/Wv3XfIt7X/pDOYT5EPnAex68r74Jf+jA1AE2ANPAu3+cvlX9Njwde4y7kXyP/l1AJ0H0g2yEmUUnBTXEhEO6QZt/5f5KvW98lXz6vYa+zYAbwYiDXERxBJ5EfsN6QebAUf7rfWT8arwS/N898/88gL+CCsM5gxTC/QIwgPf/Rv4mvNA8EvvLvG29Fn51v27AlwF0AXMA04AYvpu89vt0eql6VvqUu7j8pr3AP4DBZwLQQ/sEc4SiBH4DysPTw9OEEESARUFGDoa6x11ITIlESgHKT8qkSr0KzstLy2lLikkxRCX84je1s3wvb+yoKiVqRutobs6y4zZUefc8dT1lOyd3brTKM+hzp7R0tng6Pz7bhhgNHpJFlVuWlZYbUjAMfcbCApM++nwQOxx66PuTvlxBQcNXQ6qDcwJMf9H8ZPle90d2uDbKONv7LT3TQZNFbsggiaeKIMnKSJmGiQStwp1BN8AdADi/5z+pP4vAMn/5Puf91Hzde4V6lHnuOWL5EPmxerG71P0FPhP+0X9bv6Z/5oAmwGKAhoEjQaUCXsNAxK0FfUW2hX5EkAOSwiYAtP9vfnV9i326vdx+0cAqwX0Cc4LVAtiCYoGTgNbAFD+qv31/mwChgcWDfwRYxW4FqAV2RE+C08CafgA7wbnDuGi3RHdHN8s46zoqO6y8y33pPlX+/D71fsN/OX8f/5mAesF3wpTDxUTgBbSGFAZMxhgFWQRhgx4CHMFvQLoAKH/Ef/k/dv8T/x7+7D6K/nl9/T2p/ct+UD7IP0W/0wBPwJAA04DkQMiAwIDGwRZBFsGXAbPA0H/DvvM+Xr2/PSe8hrxou9X7hbv9Oxh7ZDvbPMt9FLzI/ak+Xn+pQKxB4AKuwz3EPoT1RSvE14VLhYAFv8TxhMsFK0V1BZ6FooUORGRD6cNSAsgCW4IoQmjChgObhGJEToNNAa7/mf0EevM45vf5dwx3UvhI+ZX65DwlfVc9vXyYe175+7h8N1t3Rrf7OM67NH3hAIBC+8RtxVFFcgQpgvlBb0A/v0j/p0AjwTbCjoR7xUuGNkXcRU2EZoMbQc+Ao/+vfxY/WD/VgLvBBoGBAbRA14AgPxJ+fH2rPT+8vbxN/KT82r1U/c2+OP3bfZq9LzyKPKJ84D2nPpt//kDjQfcCZQK+QiSBesBVv6/+oL4Jvke/IUAOwaLDCASsxbOGVsaZRicFYMTzhHjEb8TcRgHH/klai2+M6k5nTvyOlczqh+1AhTkTM24u1azPbNvuuLFx9OV4y3sru8M78Psa+MO1a/K7MbGy7DXwetMAeQV5CnfOrxBLzy9MPshBxEEAEj1EfBd7970c/+9CIILHgsJCAcAVPOv577fQ9yC32Xpa/a5AugPqRxnJWMnTyTCHhsXOw9zCTgHzweiC70RlxYdF/sTSg4gBdf4Zez74SXaKNYQ10fbvuBw5+zuoPTf9nD2WPRW8Svvou/48sP4+QD+CswUTxztIJ0iwCBlG0QUFQ2dBt8B/v/IAA8D8gW/CD8KJwktBR3/2Pc38P7p/eZJ5+Ppj+7o9Jb7lgHJBiIKmQoGCRIHNQUsBDUFxAeSCsMMtg5WD9MN8woZBm7/p/fV8KXrzedX5hHopOyi8uv4F/4KAjUESQXmBLQDogEGAVIBUQIuBBUGVAoKDgwQ8Q39DWMM2gnGCJEGWgNAABj/Mvxf+gX5wfcq9sT12fRx9V/3uPnJ/CAAOQPsBDAHHQjrB+0GvQXvBGQEagQFBc4FdgZnB48I5widB4EFTwIl/nL5X/VG8u3vFu9Z71rwyfIt9ov4lPqr+kT6hPgC+j33zPMz8WDyNPMu9Ub7AAB7BZsILAowBvwB5/9j/4/+g/4/AW0ENwi6CzcPXxCeEF4RlREbD2EKYgbHAokAeQDQAvkF8AlMDp8RqhEAD5YLEAjNBGYCegF4AXoCoATIB1YJ3QmqC1AOUA2PB+j+YPWD7Lvmi+Tp5DzniutX8M/yl/LQ8X7xIvBc7intZux97Pvvd/ZZ/RsDdwgIDcQPkRC4Dz4NRgpTCJ0HpgeTB3cHtwesB04GywNsAAz9pPon+SX48Pfi+A77p/21/8QA8wCtAEcATP+G/YX7Dvof+p/7W/19/68B8gL8AtABXf9N+9L2O/Ok8D/vue8L8zL4bP0IAlIFqAZiBpwFTARJApIAUQC7APwBYwTzBwkMLQ/OEc0SkhL6ECoPxQ2bDCYMsQzzDkUS6RTSF8kZvhvWHXEgaSPnJNonoyKYE/n6C+P4zXm+ark+vDvHEtOz4TLrBu7Z6lvnNeOX2z7V2dJB1TDcSep3+2gLBhopKIwy7zP3LQUkJxk/D4gK/AomDaQQDRWFF3gSMwcY+tjt9+Oc3s/fmOTo60z2rwFECQsLnQoeCDkDmv0f+uX4ivq5AeYMmhfoHgojjyPtHroVugpn/yH1He9G7lzwI/MO97P7hf4y/iX7O/bZ8PDsH+zv7RDxqfX5+wcDZgjUCuwK7AiKBekBXf9W/j//0AL9B/0Lvw2mDWYMTgnaBO//KfuF9//1xfap+Ob6qv0zAJ4B+QAn/wX8qfhL9pP2ifjh+0oAnwXLCnoOxA9CDlkLhQe7AxUAa/2T+zP7p/s6/EH8w/v9+vf5xPiK9vjzIPLv8S7zV/Ui+P/70P/WAp0ESwVRBLwCUgKKAygFugdfCioMBw1zDJ0LDwlfBtwDZgLvAdcBeQL4AjMDXAPxAo8BiP/t/XD8SfuP+t36+fq2+wb96/5TAB4BjwGJARQBNgB7/5L+1v2W/Qr+j/5X/kb+F/7p/WL99Px6/Nz7IfzC/Nf8Hvxg+636lfkq+aT5nPrf+8H90f/bACsBngEAAiQCBgJVAvgCGASoBVoH5wioCQ8KawobCm0I6gXgA2MC7QD4/5n/ZwCNALEAnwAgAB7/wv2g/Q35aPRk7pnrA+iP56nqzu4U9b35uADKArQDogJfAsgAl/5M/8r/kwFvA9IHMwoCDFENXA+UD8sNAwwcCs0IeQcrCVgK8wquChELwgpMCF4GNgTwAq8BhgOQBg4IzggMCUgJFAc7BS4E/ATCBioJJAvNCdsFff8m+cPxmOsP6P3mauh86n7tn+4x7n3szeod6RTna+aZ5qjoJOse70Pz1ffg/KIBXgbxCIkK9AphC+sLMw06D4MRqxP+FHcVFRQfERwNrwl3B1UGGgY+BpYGdQZfBaADywCk/RH7b/my+FL4ZPiw+Bf5kPkR+rz6Efsw+6D7UPxA/W/+GwCIAVgCmgL1AXkAXf6R/Fr7mvpD+lf6C/uf+x38Z/xZ/Ov7qvus/CH+rP/zAAYC8gJiAy4EegWqBxwKXwxqDiEP4Q7sDaEM8gorCUYIfwetBnQFCgRzAvz/p/3b+936FfqA+YP5IPm++Pr3mvdE99b2sfaV9vv2Kff/99741Pnz+jH8wf3r/v//PQD0/x7/Xf5a/rT+hf8KAcACKwQnBWIFKwWBBGQEhQRuBC4EWAOFA0sD5wKuAq0BJwEM/4n+mv0l/v3+WgAAAmX+3frG82/wGe2J7unzavk1AmgG1wsoCs8GyADM+lf4Qfe3+1EA5QUPCZIKHArwB54FcQR+BUoHIgpNCyAMyQkdCEAGqQViBnIHHwrcCqULFQouCKUFKwQwBq4JyQ8lFRoamxlpE+AGyPaS6Kbdv9ua39jp6/Q//2oEMQLh+V7srt+o1fDSnNbc35zqE/M0+aj6jfnz9jP27Pe6/M8Cngl4DmsQ7g/VDd8LVwqGCkIM1w5dETMTYBNcEp4Q+Q4VDjANYwz0ChQIyANu/pf5E/aL9GD1mfdh+oT8Pf2w/L/6e/jC9g/2vvZr+Pr6Y/3V/mz/cf+f/1UAegFUA6kETAWsBFIDcwFG//H9N/3S/U3+6/6J/qP9Tvwf+9b6j/oo+2T7OPx9/CT9cv2q/QD+lf7k/9gA8gF8AlADZQPSA/4DKAQKBMwDDQQlBIkEfgTOBDQFfQW9BXsFJwW9BKMElgQaBE0DHQIyAXgAsP/S/sX9ofyC+5f6//mH+e/4Z/jz91T4t/ib+Rv6V/pz+kD6BPux+4793v5iAEwB8wEPA5oDmQSTBAcF2wSPBOID5gJJAn8BXgHQAc0CvwPVA04DdAKeAYwBxwGLArsCHwPCAmICAAHu/zz/t/7y/5oABQO2AusBLP+x+/H5vffN+C75Jvvn/GX9Of6O/MT7/Pn9+HL5LPqu/DD+eP+l/7r+2P2h/En81vzx/aj/AwHBAT0ClgGlAWMBKAKKA7MErwZDB4gI1AhtCS8KVAoiCwcLlgvrC4EMNA2QDZsNMw3/C1AKzAecBLQBnP4L/bn7SfsK+036LPoh+dr4oPdo9rH0IvNi8mDyQ/Mh9AP1G/UY9cX0EfVn9Xr2uvcT+Vv6OPvm+zv8TvxZ/M38kP2k/oX/LwChAIQBegLFAwMFAgb9BqcHbAiLCDUIKQfvBWAFDQWcBe0FXgZFBpIFtASHA7wCdQF+AKj/YP97/2n/A//3/dv8xfs1+xX7R/vB+0L8I/3a/fD+vP9VALQAqQA4AXgBXwL4AuoD7gTxBUwHNQgqCcYJDApQCusJegkrCVUJFwtpDBUORg3+Cj8HAQOAAFf+G/42/cT8B/yl+3z7H/pY91zzee/77EHsC+0X70HwC/Gk8JzwIfGB8Z7yh/M09ab3f/o2/nsAYgIbA50D2wSfBUcH3wezCD0JJgqJC30MrAylCxUKYwjsBoUFzQS1AxYDdAIoAhACGwHr//r9bPzK+7b7kvzq/F/9wf3W/fD9M/3T/DH8Z/wt/cT+7QB2AqoDawOhAm0BhgAmAN7/JgCJAFABnAGoAR0BJQAg/0L+Sf5W/r3+uv6a/kz+rf30/BT8xfsG/LX8oP29/v7/3gBhAXQBZAGmAdABDALKAfUBFwKvAtIC5AL3ArgCdAKiAYsBYQGlAckACwCI/37/0f+e/2P/UP5b/Sr8rPtu+537mfsK/PH84/2z/l3+Gf5Z/XP9Pf6i/0MB1AGKAsAC0wL3ArgCPgM5Az4DoQMkBP0ESAWKBU8FkAS8A/8CbQKjAZwA7v9M/0b/e/84//z+Xf5l/jb+8/2x/Tr9Bf2s/P/8pP3Z/tP/LAB5ALsAEAEaAR4BfQEMAmwCfgJFAhICUQJVAo0C8QE0ATEBsADfAMb/KQD5/nv8Bfxn/HL+1frZ9oP2KPgR++D6ZvvZ/MX+vQDA/9z+a/4H/v781PkU+a766vzs/kkAgAIvBGAFRwaHBvwFyARUA7cBGwDd/20BTgJFAsgBngKJBOUF5gYfB1AHBQerBsoFRwT6Ar0BHQHjABQBnwE0AhUDsAPbAxAEzgOaA4ADJQOIAjUB9v8Y/8H+n/5T/kf+/f5XAGYB7wGtATEBXQCf//X+rP4Y/6L//P/1/7r/Sf+W/l79S/z4+5z8aP3i/SX+Q/6C/tD9wvxJ+2X6uPoV+8r7ZPz1/I79hv0m/ZL8B/xw/IL9B/8iAKQAEQGAALb/4v4y/mL+lv75/pv/QQC/AFgAjP9y/gr+oP1N/Xz9o/2S/g3/ov/a/24A8gBvAFoACwAbAdUBtwG1AoADjASYBOYEbAWzBO4ENQVIBfQFTwYpB6IHRwaPBSQF2gRQBE4D+QPpA/QDNQRkA1EDXwJ+AUoBkAC/AOwALwFnAMH+Zf6N/XD8Pfu7+qD6fPrI+rf7kvyO/Mr7TfsA+6r6k/r++o77Wfv++s76GvuT+5b7u/vX+wr8r/zQ/ET9uf1R/qn+Xv6i/j//w//N/4L/Rf8+/xj/Iv8O//r+gP8oACUB2gGOAl8DnQPcA7gDjQNkAxgDUgN5A9wDYASOBPwE5gR4BP0DPgNIA/8CfALxASgBIgGrAD0Anv/I/lT+k/1K/Sr9V/2q/ez9Pf6Z/uH+tv4E/1b/vP8EABEAkgDbAKkAXwA3AG4A3wBuAVMCpQJyAvYBmwH5AdMB/QEtAjQCfQJOAk4C+AElAZoA5f+i/7b/5/9bAIgA/AC/APT/Fv84/qD97/xi/On7ovuf++L7LvyD/MD8/Pzg/Nr8f/3p/Sj+A/6d/Vf9df2v/d/9Df55/mD/YgALAYsB3QHKAcgBjgFCAdgAxQDMAOkATQGsAT0CXwKBAnYCHQKsAUwBVwGoAeQB7gG9AVoBDQFuAN7/Lv/A/rb+u/7V/tL+5v79/hv/DP/m/rv+nP50/h/+0/2G/YT9m/24/Qj+UP6t/gP/Yf+s/6H/gf///rv+lf6k/gD/Rf+R/9b/EgBBAHwAnADqAFABwwEJAm8C1wK8AlsC0AFrASUB4gCaAMkAPAF6AbYB6AEXAvYBegGpAP7/hP83//z+qf58/ov+z/72/hb/N/8U/xv/Qv9L/0b/Qf9k/5X/zf8AADUAWgBHAG4AnQDIANEAwQC+AM8ABAFNAYgB2wEAAvUB7gGWAV0BIgHmAJ8AUwAPAAIARwCTAGEA6/+f/1b/Qf8M//n+6P69/pb+e/5i/kr+Pf44/lH+av6V/qL+0f7Y/pn+W/4//mL+nP7K/vn+Nf8v/xb//P7z/h3/Pv+C/+D/dgAoAZIBzQHKAbwBqQGTAagB6QEKAvIB6wHeAe4B6QHxAfMB0AGFAT8BAQHPAJ0ARAARAOX/1v+F/zz/8P6Z/m/+cf6Q/oL+eP5t/nH+o/76/mH/mf+r/6H/gf9V/y7/B//9/gb/Wf/b/2oA5QA2AWEBKQHMAGgAHADv/7D/n/+1/7b/s//L/9D/zf+1/7X/zf/u/w8AJQASAPj/2/+m/4j/XP9T/zf/K/9t/4j/qP+6/7//6v/0/+7/6//Q/73/pf+l/6X/ov+1/9f/9P8vAHIApgDVAPYAEAEpATgBQwFZAUkBXQFAASgBHgEkAScB/QDRAKQAlwCPAKEAlACFAHgAXwBHACUAHADo/6H/UP8b//D+//4W/0X/Z/+F/6z/ov+W/3j/Z/9j/2z/gP9w/3D/Zv9c/1//Yf90/5H/kv+A/3D/ZP97/5//sv+r/5v/h/93/3f/bf9n/3f/nP+t/7r/4P/r/xYAQABqAHUAeACDAIUAdQBnAF0AVwBuAJQAswC1ANUA3wDcAM8AtAChAIwAjACaALEAwgCxAIAAawBXADwAHwALAAEA/P8UAB4AMgA/AC8ACADR/7P/ov+A/2b/Rf8x/0L/V/+C/4v/ov+3/6j/pv+K/4//jP+M/6H/uv/h//7/CAAfAC0ARABXAFcAbgB0AHQAeABqAGEAYQBRAEkARwBKAEsAMwAbABsA+//o/9b/wf+1/6n/sv+v/6j/lP+C/3P/cP92/5z/uf/J/97/5/////z/BQAWADAATQBxAI0AggCDAJkAtADCAMgA1gDOALEAlABxAGsAZABiAHkAbgBrAG4AWwBGAC8AKAAvABsACgDx/9j/xP+z/8D/x//A/7L/lP9m/03/Of9B/0z/Vv9a/2H/Z/9u/3T/bP93/4j/rP+r/7//vP+9/9D/0//l/wIAGQAqADIAQwBYAGcAeQCAAJIAeQBlAEoAPAA6ACIALwAzAFEAXwB5AIoAjACGAHwAWwAYAOv/0f/L/8r/wf+6/7z/rf+Z/3H/af9p/1z/Zv9h/3H/e/+K/5j/ov+v/6b/ov+j/6b/q/+r/7n/4f/y/wsAIAA/AGUAdgB7AIIAhQCPAJcAtwCzALAAtQC/AOgA3gDZANQA1ADPAMIAtQCzALcArgCfAHkAUAAfAAEA4v/L/8H/uv+j/4T/Wf87/zv/Lv8//0j/UP88/zL/Mv8l/y//Lv9J/1D/Wf90/4X/kv+p/9b/+P8PABsANgBGAEoARgBQAF4AWwBRAFMAWwBbAF0AaAB+AIwAnQCrALQAqgCTAHsAVwBAACYAIAAVAB4AKAA9AFcAVQBQAC0ADADb/7n/n/+R/4r/gP+A/4D/fv+W/6n/vf+z/4//d/9n/2z/bf99/5H/qf/X//H/AQAbABYAJQAbABIAHwAjAD0ARgBdAHkAkAChAKoAsACjAJwAqQCwAJ0AgwByAIIAiQCKAIYAggByAFsARAAlAAAA4f/K/7n/q/+y/7f/xP/N/8n/zf/K/7//uf+h/47/hP+K/5n/pf+r/7X/y//W/+j/8v/4//H/9f///xEAEgAPAB8AHwAbAA8AEgAZAB8AJgA6AFgAawCGAIYAgAB0AG8AZQBeAEQALwARAAQABQD0/+v/4v/r//H/+f/8/wQAAADv//b/+f/v/93/wP+s/57/gP9c/0b/TP9X/2n/fv+Z/7f/w//Y/+7/9P/q/8v/tv+p/7P/x//k//X/DwApAEAASQBDAEYAQQBTAFcAWgBkAHsAhQCJAH8AeQBuAFcAQwAzACAAFAAMABQAIwA8AFAAYgBiAFgAQwAmAPb/xP+e/27/Z/9d/2n/gP+W/7n/sv+2/57/iv+C/3v/e/+E/4//ov+5/9P/3f/q/+z/8f/7//H/6//s/wEAIwA8AE4AZQBvAIIAiQCTAIwAfwBRADoANwA3AEQASwBbAGwAfwCAAHUAWgA/AD8AHwAbAA4AFgALAOz/1P/B/7n/pf+b/37/dP9z/47/nv+m/6H/t//G/8n/0P+//7n/r/+y/6//sv+2/7f/t/+v/7n/2v/x////+f8AABEAIgAvADwAOQA2ADkANgBEADwAQABUAHkAjwCUAIwAhgB0AF0APQAlACoAKAAoABIAAQD+//z/FQAZABsAFAAWAA4AAAD2/97/uv+b/5X/kv+f/6v/y//r//j////1/+L/zv+o/6//sP+6/83/5P/0/wQACwAAAOT/x/+y/7f/vP/a/wUALQBoAIkAlwCgAJAAZAAoAOj/x/+3/7X/uv/e//7/JgAwADIABQDY/6P/i/+K/47/tv/e/xQAMgAyADAAGwAPAAAA6v/H/7X/uf/L/9v/y//T/+D/4v/l/+T/7v/s/+j/7P///xIAMgBEAFgAVABXAFMARwBGAEYAQAA6ACwAIgAUAB8AOgBAAEoAWABrAGsAXQBHAB4A/P/a/87/zv/Q/+H/8f/y/wUAFAAyAEkARwBEADYALwAHAOT/q/+e/4D/dP+Z/47/v//N/xIAhgCnAKkAggCjAHUA0P+1/4X/eP8y/zv/4f/8/2oALwA5AIIAAQBOANH/OQCM/87/1/9BAL3/j/9eAIH/YgAa/0YDT/je94j3iv2N/F/84P9rAH0CmwGcBOADKgKyARUEkABm/7oBQAGwAZv/sAMiBNcClwXtA3cFsgEtADz/mP0I/gH+xf4SALr/6v2DAFH+VP4//jn/4ADO/eIADwCI/g/+Qv80/UT9OP5M/tX+d/5RAHH++QCI/s4AfQEG/0IC1//eARgB1v9oAg8A0AG+AYP9fPsy+7H++v0d/WH+8wBAAdYA1gByAtQCRgOHA+IBFQNvAAkBfABg/wsBPwKoAloD+QMSBuMCegFQAKz+Nv72/sz8Iv+I/NH8WPyz/Fz8j/pN/uf91QA5/7T+0QDc/Sf87v27/lr/5v5z/xUDuf8w/S//VP0iA03+9wAUBGoF/gbTAwQBSQATAd8AWQLIAL0B+gAOA6YDhf+cAan8xAEtAID9KgDTArAAx/4PAnP/SgBoAAr/Iv9v/nv6kvys/Fn7FfvE+0gBrf9u/RMB2QMNBEz+XP++/U4AT/tf+v/7ZQB5/CT90f8E/zkBovueAdT+0gQuAUIEwAXUB9EDMgXpAWcAdwKK/FD/2v9pBQAAgPx9/f/+1v1eAekE0AIfAwgDVgdkAQf7pvo5+9L3O/k+AQD7BQKx/VoApABRA+sBXAPcB/YDeQcRA7AA8fzO+nP4/vqi/r7+kv/+/68EmQG5/3f+bAJjBH8BzABD/4v7Svid+Y/1L/SV9msB+P3ZBbABygmsBUsAXgdFBiADzgCLBXoBjABGARb9x/xf/yMCVgFWAn4HgQilAjX/XQfcAkH8iPkA+xT59veU+u/3hPtC/KP7owCG/nwC+wPCBuEBtAN7BET8EALo/hT8Pf6X/bYBKALwAOgAhgKpAXsAcQEhAuAAnQTdAaMA0QEt/kD7qwA7/Pr9ngP3/EsCBwGO/N77SgCz+737E/39/ZYBuAKF/+0AIQH9/sH/jAF5A+gCtQL5//IBNwBK/VD/+/1rAcf+wAELA1UDYgBu/bkBGv9m/BsBDAAU/7kBBP3m/vMAhfsK/o4B2P5LAlUCyQLH/9wA4P9E/MEAQ/9t/84A0QBgAaAA2QKs/j8Ax/6lAR8BdAAlAWID/gD6/SIBrf3L/mP8Qv6d/m7/mAEs/3D/nvxC/iwBIf9S/4EC5AFQAVr/UwGO/AYCyv+n/h0CQP5/BuL/FwG5Afb//AGcAGcAbQGgBK/9Hv+M/dD/mwFA+u0AJf8gADICiP/N/44Bcv3l/vT9+v1a/8H+T/2V/j8B8vu9/+H++f8PABgD+P3IAUEAm///AW/+3wFZ/5sCWACDAsABswCnArwBwf4zAJsB7f7e/8b/Sf5W/vn/vP+0/uACAACqACAA0AH2AKP/P/7S/tj+I/7//ub93wBEAHIA2//Z/s8CtAEN/xL+uf/z/SQB3P6+/kAAmf50AMz9mwHHANwCSQAcAtUBkgLjABL+nQBO/Xv/j/9E/hr/rQCGACj+wQDaAej/+gA0AtAChwF4AcEBGP9l/tr/ev9V/4L+ff9XAWz9UADIAPb9T/8wAEUBA/+t/t4CTQBT/Ij7Cf/J/wf/9f+b/28CZACZANUBNQBC/jQBhQH4/5T/rAHEAD3+Y/89AFcADv5LAmsD4QHb/hP/mgMK/vf8igAXAQcBrv7LAMYCmP86/iUA3wA5Acv/9v8k/2z/TgCl/U79wf/hAQoBo/8q/18CGwFk/n7+9v9hAL79Mv9GAHr/Lv8IAFL/5/8l/6oAkwFT/9r/AgAyANX9av5t/2cAOP/A/wIAzwCaABj/iwGoAeEB7P/sAboA+QAJAX4AYgBq/wgAuAD0/wf/qf8DASgABf5XAOAAEwFYAK3+w//T/xgAP/8L/m8A9/6+/Xn9A/9VAAn/9/5AAAUA1gCU/1f+eP+j/7z/GQDW/8gAqQGv/7z/uwDvAIUB7wA0AVcBjwBtAZQARv9GALsA6AA2AP7/QwEVAREA4/57/ygBy/9V/2cABQBdAPb/4v5C/5n/PQAzAEv/zf8tAEH/Tv6e/VH+lP83/9H+hgAsAQQA1/8tACIAigAfAMn/NQGmAToASP8i/6L/lf99/w8AgQFuASgA1P+FAGEAAP8Y/5IAXQE6ADMAFAC1/yz/7f6I/0EAkABVACkAugD0AFD/Jf9u/wwAnv85/+7/kgARAIv+Qf/X/0YA+//a/+X/ZwC/AAgAGP8gAG8Ao/+R/8T/jQAKAJ7/Rf+L/wEAnwAjAJAAvgBJAOMA6P/+/8v/zf/a/73/WwAtAO//HgDi/8P/wf/i/8QAIgAeAAQAPACt/7P+Zv+o/2n/Bv/1/2QApv81/1X/PAA6AP//IADqAAMBbAD+/1gAVABKAPX/+f/JAAQBSwBa/8H/zf+9/+L+JgB/ANwAewB5AGEAdQBKAAoAe/+H//X/0/+H/yD/P/9n/9T++f6P/3QAnwA5AMv/YQBLAIwARv9DANT/MgDLACwA7P90AFMAvQAKAK4AGwFnALsA8v9yAPX/hf/R/9T/HwBGAN3/7//y/wQAYP9+/9T/xP+s/6z/aAAqAKv/tv+b/wcA0f+i/7z/TQAmALn/j/8lAOj/zf/X/woACwDg/+r//v+L/wIA2v/o/8D/JgB0AGEAy/8sACMACAARAAsAJgDU/8v/n/+R/1n/lv8h/7L/q//A/zIAFgBLAAgA9v8FACwAcgBLANT/dQB/AGoA5f94AGIAIgAHACoAkwASAL//3v/Q/6P/qP/k/2gABAA8AHYACABDAEkAAgDH/+v/9P/b/x3/S/+B/7L/F/9T/+X/3f+3/wwAKAAoAN3/w//y/+f/JQAFAPv/2v9HAEAA6/8LAGEAkwB8AD8AVwBYAEYAGwBXACgA5f9KAGoAPAAsAEQAqwBRAD0AlACkAIkADADA/9H/n/+f/6P/d/+l/7P/w/9u/4r/o/+L/4H/gP/d/8v/ov+S/0v/UP92/z//ZP96/87/IAALACUARAB/AHQA4f9eAFEAFgD+/87/HAAbALD/KgDMAOMA8gApASsBKQG/AFoAjwAvAKn/1//1/+7/+f/i/+f/3f8SAFUAZABxAFUARwAsAL3/Q//w/hf/SP9L/+/+af/d/7n/i/80/73/uf90/3T/4v8LAAsAw//i/+v/GwBUAAgAeAB8AKEAoQBaADYAIAA8AFcAYQB2ALgA5gD2AJcAewB0AF0AMAAwAIMAfACxAFAARwDx/w8A7v/a/7r/4P/0/8r/tv+r/6P/Qv9q/4T/1P/E/7P/+/+3/4j/KP9k/33/ev+C/4T/9v8IALX/uf8EABEANwD//xkAbAB8AFcAFQAyAFQAlwCJAFAAgwBuAE0ASgA2AGEAXgBdADAAKAAjAD8Azv+t/8n/BQD5/9D/9f/8/9j/pv/D/+j/HwAKACoATQDn/6n/n/+U/3H/w//Y/xYALwAlAB4ABADo/7f/zv/X/ygA5f/u/83/7v+8/3v/q/8CAHEAOQCPAMQAtQBQACMABQAcAEAAGABAAFAAdQAYAA8A/P/r/w4A5f8mABwARAA3AOH/tv+i/0n/av9u/23/0f+p/8v/2/+5/9f/vP+v/8f/pv/d/7f/hf+P/3j/Zv+t/+j/KQB4AL8A5gCuAIIAbgBhANP/lf/h/+//7/+8/+X/UAAzAAsAUACAALMAsQA8AAcABwD//8H/iP+W//v/AgAAABwAGAAFAOr/y/+m/57/1v/n/5b/dP+Z/7r/s/+2//X/MwA8ABIAOgACANj/5P+1//j/+P///yUAFAAIAPv/0P///zMANwBiAD8AqwDFAJYAeQBBAH8AjABVAEkAUQAEANr/kv90/7z/s/+f/7//8f8pAB4A4f+8/5//hP+y/5n/m//B/+L/4v+8/57/8f8EAOz/CwAPAEsANQAHAPv/7v+8/8r/vf/v/1oASgBDAAUAHgAbANP/tv83AFMAMACGAHsAoQBrADkALABVADAAZQBEAA8ACwDB/87/jv9d/1//i/+K/4X/8f8tABIACwAlACUAPwACAGEA7//l/yIAyv/v/woA7/8CANv/6P9HAAUADwAWAA8A1v/N/woA1//H/63//P8iANf/AAA8AAcA/P/v//z/+P/n/xIA2//Q/wgA8f+6/8v/0f/h/9f/+P8wAEEA9v8LAA4A5P/q/7r/4f8VAAcABQAeABIABAAOAPz/DwAwAEQAPwBLAC0AJgDU/5//yf/a/+7//v9KAHIAYQBOAEcAKgAHAAQA/P8CAPL/6v/e/7P/gf+m/6b/2/8EAA8AZQBHADoACAD0/9T/vf+w/+f//v/+/zkAEgAMABsAHgDu/wEAAgAYABQAy//G/5j/n/+i/9v/5f8bAFAAWwBiAFAAVQA/ABYA/v8HAPL/BQDQ/+H/0f+y/+L/9P/b/+j/9P/N/8r/x//T/8n/wf+5/+v////q//z/BQAmABYAMABEAEsARgBHADkAPAAoAB8ABQDx/9T/2P/O/9b/AQDi/9v/CwAKAPz/9f/4/xIA/P/0/w4AGAAYAPX/EQAKAP//+//7//7/2//d//T/AAD2//n/AQDa/9j/0f/h/+r/9f/0/w8AHgAVAAoADwAHABUAJQAcAGQARAA6ADoAFAAPAAAAAAAgAC0APQBEAEEAOgDx//L/1v/o/+H/6/8FAOv/8v/N/83/2P/H/8v/9f/h/wAA3f/T/9b/uf/J/7L/2P8EAAEABwAOAAoADAAHAPz/EQAjACwAJQAWABYAGwASAAcABwD+//v/+P////T/6v/1/wUA+P8OACYALQBQADkAJQAlAA4AAADq/+r/1/+5/73/yv/L/73/y//b/+D/7P/5/xQAEQALAAsAEQD1//X/8f/i/+v/5P/v/wAAAgARAB4ALAAyAB8AFgALABIABAAHABIAKQBLAD0ATQA3ACYAKQAeADIALQAmABwAIAAEAOf/zf/L/9v/8v/7/xEAHAAfAAsA8v/s/+7/8f/r//b/BAD//93/0//N/8H/1P/o//H/JgBBAEcATgA9ACoAGQAAAPb/CgAFABUADwAAAAQAAQAKAAcA+f/7/wgACwABAP//AADr/9D/1P/b/9P/1v/J/9b/3f/a/+X/9f/o/+L/6P/i/wAABwD+/wwACwARAB8AHgAlACUAIwAeACgAHwAeACAADwASABEABAASABsAHAAoADIAPwA1ACkAHgAOAAgA5P/g/93/uf+1/9H/5f/h//X/9v8IAAcA/v/7/wQA9P/1/wQACAAMAP7//P8FAAgADgAYABsACwAPAA4ABQAEAAwADwAcACUAIwAfAB8AJgASAPz/BAAEAAsAAgACAA8A/v/4//X/7//n/9P/2//r//n/+P/0//X//v/2/+7//P8ZABgAHAAUABIADgDu/9j/0P/a/97/7v/u//7/BQAUAAQADgAVAAEAAAAEAAwABwARAPn/5//n/+T/5P/i/9H/1//x/+//9f8IABkAGQAEAAQA///l/87/1v/k/+D/3f///w4A+f/+/wEAEgARAAgABQD5//H/4v/u/+z/9f/8/wEADwAVACAAIwAUAAoACgAEAAUACAAKAPj/7P/g/9r/2v/U/+H/7v/7/wIAFAAbABsAGwAVAAUA///2/+//5f/k/+H/9P/0//z/FAAPAB4ADwAOABYAHgASAA4AGAAZABwAIAAcAB4AIAAbAB4AGAAbABwAEQAOAAgABAD/////BAAEAP7/+P/5//T/5P/d/+H/5f/v//L/6P/n/+X/7v/v/+X/4P/h//T/8f/8//b//v8CAA4AEgASABgAGwAiABsAFgAWABUAHAAWABgAFQAWAA4ADwAHAAgADAAMAAUADwAmAB4AIAAWABQABAD1/+T/6//r/+z/7v/+////+f8BAAAA8f/b/+L/5P/e/+L/5//y//n///8EAAQAAQD+/wQAAADs//T/BQAOAAoAAgAIABgAFgAFAAoAFAAOAAwADgARAAcA/P/y//L/9P/v//L/+f8EAAIAEQAsACwANgAtACoAKQAfABYACwAFAPb/5f/i/+j/9f8AAAUAEQAmADMALwAoACkAGQAEAO7/3v/W/9f/3f/o//H//P8CAAgAHwAoACgAKQAcABUADwD2/+//4v/h/9P/xP+9/8b/1v/R/9j/5//5//z//v8BAPn/5P/T/8b/xv/B/7z/1v/s//z/CAAfACIAGAARAAoACAAIAAQAAgAKABEACAAHAA4AGQAWAAoABQAPABEADAAbABgADwALAAcADwABAPv/+P/u/+v/3v/v//L//v8AAAUACAAKAAgAAAD7/+7/6//o/+H/4f/l////FAAUABkAHwAiABwAEgAWAAoAFAAWAAwAFAAEABkAGQAcACAAGwAiAA8AAQD5//j/9P/v/+r/5P/Y/9f/1P/Q/8b/uf/A/9T/2v/k//T/9v///wAAAgAAAPz//v////H/7//0/+7/6v/4/wQADAARAAIABQAEAAcAAADy/+//6v/q/+r/8f/2/wUADgACAPL/7//x//7/BQD+/wsADAAKAAwA///0/+z/6v/r/+r/7//8/wUADAABAP///////wwAAgAIAAUA+P/y/+f/6//4/wcADgAVABgAIAAgABsAIAAiACgAMAAtACwAIwAoABkAEQAMAAgACgAIAA8AHAAeABsAEQAHAAgAAQAAAPz/7P/k/93/3v/e/+D/5f/y/+//9v8HABIAFQAUAAsABQD4//H////7/wAA+f/5//H/8v/5/wgAGwAcABwADwAPABYAFQAWAAwACgD+//T/AQABAAEAAgAIABkAHAAVAAwABAD+////+f/v/+j/6v/2/wUACwAVACMAHwAUABYAFAAFAPj/7P/y//T/9P/8/wQAEgAZACIAHgAWAAEA9f/l/+D/4f/i//L/+f8HAAoABwAKAAUACAACAP7/+P/8/wIABAD5//j//v/8//j/+P/8//7/+//v//n/+f8AAAUA//8BAPz/9v/7//X/7v/r/+H/2P/g/+r/8f/8//z/AQD7//H/6//q//H/7v8FAAgACgARAAwAEQACAAAACAD8//j/+P/y//H/7P/q/+T/7P/8/w4AEgALAAcA+//x/+z/7v/s////AAAKABUAFAARAAEA9f/y//T/+f8BAP7/BQARABYAFAAHAAQAAQAFAAgADAAAAAEAAAD+/////v8AAPn/8v/u/+7/6P/q/+v/+P8AAAgADwAHAAQA/v/u/+r/4f/Y/+T/9f8CAAcAAAD+//j/+P8AAAQA/P8EAA4ACgAOAAEAAAABAP//7P/x//v/+f/+//7/+/8BAPv/9f/x/+r/9f/v/+z/6//x//X/+f/4//X/+P/1//z////7//j/AAAHAAsADAAVAAoAEgAPABYAFAACAAgABQD8/////v/7/wEAAQAHABIACgAOAA4AFgAUABEACwACAAgABQAEAAAA9v/7//v//v8BAP//+P/r/+f/6P/l/+v/7/8BAAcAEQAOABQADwAPABYAEQAMAAwAAAD8/wEA//8HAAcABAAHABUAHAAjACoAJQAfABwAFgASAAwAEgAHAAAA+//7//z//v8AAAQAFAAUAA4AFgAYAAoAAAD4//H/8v/v//H/7//v//j/BQD8////+P/+//v/AgAIAPv/9v/7/wgADgAEAAUADAARAAgABAD+//n/AAASABQADgAKAAIAAAAAAAcADAAAAPz//P/+//v/6v/q/+z/6//o/+7/+f/8////BAD8//j/9P/4////BAAIAAQA//8IABEAEgAKAAQAAQD7/wQA/P8BAAUADAAYABgAHAAVAAwA/v8BAPz/9P/4//H//v8LABYAFQAbABgAFAARAAAA8f/s/+7/8v/2//T/5f/l/+T/6v/y/+7/7v/s//T//P/5//L/3v/g/9v/5f/s//n//v/4//v/9v/x//H/8v/v//n/+f/8/+//9f8EAA4ADgACAA4ADgAIAAUA/P/2//X///8AAPj/9P/x//7/AAAFAAIADgAWABsAIwAZABIABwAHAAIA+P/5//v//P/5/wEAAQDu/+T/5f/n//X/+P/0/+z/5//s////AQAIAAgABQAOABEAAQD8//z//P8EAAcABwAMABUADAAFAAgA+f/o/+X/6v/4//v/AAD+//7//v////T/4P/s//T//P8CAAoABQASABQAGAAYABQABQABAAQABwAHAP//+//1/wEA+f/q/+D/5f/0//H/7//r/+j/3f/l//T/9f/4/+//9P8CAAwACgACAPz/BQAFAPz///8HABQAIAAsAB4ACgALABIADwAMAPz/9f/0/+//+f/x/+T/2P/n/+//9v/7//L/6//1/wAADwAOAAcAEQAeACMALwAoABYAEQARABwAGQAPABIAFQAbAA4ACgDy//T/AQAMAB4AGwAcABgAGAAbABgA/v/2//j/+f/1/wIABwAMABQAGAAOAAIAAAD4/////////wAAAQAMABIAGQAOAAUA/v/2//z//v/7/wIAAQAHAA4AEgAVABUAFQARABQAFQAMAP//7P/q/+T/4v/b/+D/7P/x/+z/7v/1/wQACwAOAAoABAAAAAwACgD4//v/7//0//v/9f8RABsAGAAWABYAGwAiACIAFAARAA4ACgD+//n/8v/r/93/0//L/9T/2//q/+7/+P////H/4v/a/+X/2//g/+v/8v/7/////v8EAAUADAAMAAAA8f/x//T/9f/4//X/+//7//v/AAAFAPj/AAD8/wsADwAPAAsABAD///j/9P/1//b//v8HAAwAGwAjABsAHwAfABwAHwAPAAQAAAD4/+z/4f/b/9j/4P/1//v/BwABAAAAAAACAA8ADAAMAAEAAAD1//b/9f/0//n/+//0//n//v8CAAIABwAHAAUABQD+//z/+f/7/+//7P/u//H/6v/o/+z/7P/u//7/+P8BAAoADAAHAAIAAgD0/+j/4P/b/+j/5f/h/93/4f/n/+z/+f8BAA8AGAARABUAFQAMAAwACAAIAAEA+P/v//H/7/8BAAAABwAMAAgADwAIAAAA9P/y//v/7P/0/+7/7//4////CAACAAoADwAEAAEAAADy//X/9P/8//n/+/8CAAgACgAOAAwAEQAPABQAEgAMAA4ABwAFAAAABwAFAAsADgAIAA4AFAAUABEAGAAPAAoAFQAIAAIAAAD+/wcAAgABAAIABAAUAA4ACAARABIAGAALAAEA/P/x//X/4P/i/+v/8v8CAAEABwACAAEABQD+//n/AQD4//v/8v/x//b/8f/0/+v/5//q/+7/6P/0////AgD8/wIAEQAUAAoA/P/2//X/9f/r/+j/+P8MAAgADgAWACMAHwAVABEAGAAUAA4A///7//7//v/7//7///8LABsAGwARABIAEgASAAUADgAcABgAGwASAA8ADAALAP/////+/woACwACAAcAEgAUAA4ABwACAAIA+P/u/+X/7v/g/+j/7//u//7///8PABwAHAAjAB4AGwAWAAoADgAHAAgAAgABAAsACwAIABEAEgAHAAIA+//y/+7/6v/g/+D/5P/a/9b/3f/b/+v/5f/n/+L/4v/y//b//P8AAAIA/P/5//X/+f/7/wIABAACAAgADAAUAAwACgD8//X/+//u//L/+f///wIABQAHAAcABQAFAAQA//8BAPv/BQAHAAoADwAUABsAGQARAAIA7v/v/+//+P/5//n/BQAAAAQACwASABwAHwAVABQADwACAPz/9v/2//n/+//4//X//P8FAA4ADAAMABEAEQAMAAUA/P/5//j/+//1//n//v/5/+//+P/+//L/+f/1//n/DAASABQADAAbABwAHgAcABIACwAPABYAGwAZAA8ACgALAAoABAD+//b/9P/v/+X/5P/k/+r/7P/1//X/9f/0/+z/8f/y//n/+f/+//7/BAAEAPz/8v/l/+T/2//h/+L/7P/5/wEAEgAOAA8ACwACAPb/8v/i/9j/4P/l//T/+f8BAAIADAAeAB8AFQARABwAGwAgABgAEQAAAP7/+P/8//z/+P/u//X/+f8AAAgAAQAEAAIAAgARAAoA//8AAAEABQAMAAcABAAEAAIA/////wEAAAAKAAEA/P/4////BQAHAAEAAAAEAP///v/4//7/+f/1/+v/6//l/+7/AAAFAAsAFgAYABQADAAIAAsAAQD2/+//7//r/+v/7v/r/+//7P/q/+r/6//o/+z/AAD+/wAAAgAKAAoADAAFAPz/7//r/+r/5//x/wAACwAWABkAHwAfABsAHAAUABEABAAEAAEA/P/4//n/BQAEAAgADAAbACIAGQAfABwAIAAgABgACAD8//j/+f/q/+r/8f8AAA4ADAACAPz////7//v/+P/4//b////x/+r/6P/k/+r/6v/s/+X/7P/0/wIAGwAbABsAFQARAAIA9f/y/+7/7P/s//H/+P/+/wIADgAPABsAGAAcABQAGAAZABEADwAMAAsA/P/7//n///8IAAgAEgAUABUAFgAVABkABwD8//H/5f/g/83/zv/d/+z/7//y//j//v8FAAgAAQD///T/9v/u/+7/5f/u//X/7v/s//L///////n/BAABAAcACwARAAgAAgAHAAwAGQARAA8AEQAUABQAGAAMAAgABwARAAcABAD///j//v/v/+f/6//2/+v/7//n/+//9f/1//n/AAD5//z//P/4/wIABAAKAP//AAD1/wAA///2////+//4//H///8CAPz/8f/v//L/8f/7/+//7P/k/+T/5P/h/+D/5P/i/+f/6P/r//b/7v/r/+X/6v/k/+f/8v/+/wEAAAAMAAwADgAFAAQA//8IAAcACgAPABEAGwAZABYADAAEAAEAAQD7//b/+/8EABEAGAAbABgAHwAiABgAFgASAAsACAAFAAIABQARABgAJgAjACwAIAAeABQADAAKAAEA/v/2/wAAAAD///z/+f/7//v/9v///wcACwAMAP//AADu/+7/7v/u//H/8v8EAAAABQAAAAEA//8IAA8AEQABAPj///8IAAQA/P/5////AAD5////8f/7//z/CAAOAAsAFgARABQACAACAPz/9v///wAABQAHAAsADgAMAAUACAALAAIA/P/4//n/9f/2//H/5P/d/97/5P/v/+///v//////CgAVABkAGAAgABwADgAKAA8ABwAPAAgAEgARABIADgALABIACwAFAAQAEgAWACAAHwAUAAwADgAMAAsABAACAPv/8v/0/+7/7//x//T/9f/0//n/AQD1/wIA+//+//j/6P/r/+j/5//k/9v/4f/i/+r/7P/v//b/8f/2//T/9f8EAPb/9P/k/+H/4v/g/w==\" type=\"audio/wav\" />\n",
        "                    Your browser does not support the audio element.\n",
        "                </audio>\n",
        "              "
@@ -547,29 +571,28 @@
     {
      "data": {
       "text/plain": [
-       "[{'score': 0.9999880790710449, 'label': 'down'},\n",
-       " {'score': 7.452485419889854e-07, 'label': 'five'},\n",
-       " {'score': 7.436851205966377e-07, 'label': 'go'}]"
+       "[{'score': 0.9999935626983643, 'label': 'backward'},\n",
+       " {'score': 3.4823816008611175e-07, 'label': 'forward'},\n",
+       " {'score': 3.3890643180711777e-07, 'label': 'wow'}]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "from IPython.display import Audio\n",
-    "from optimum.intel.openvino import OVModelForAudioClassification\n",
-    "from transformers import AutoFeatureExtractor, pipeline\n",
+    "if isinstance(audio_sample, dict):\n",
+    "    audio_data = audio_sample[\"audio\"][\"array\"]\n",
+    "    sampling_rate = audio_sample[\"audio\"][\"sampling_rate\"]\n",
+    "else:\n",
+    "    # if audio_sample is not a dataset item, it should be the path to an audio file\n",
+    "    audio_data = audio_sample\n",
+    "    sampling_rate = None\n",
     "\n",
-    "model_id = \"helenai/MIT-ast-finetuned-speech-commands-v2-ov\"\n",
-    "model = OVModelForAudioClassification.from_pretrained(model_id)\n",
-    "feature_extractor = AutoFeatureExtractor.from_pretrained(model_id)\n",
-    "ov_pipe = pipeline(\"audio-classification\", model=model, feature_extractor=feature_extractor)\n",
+    "display(Audio(audio_data, rate=sampling_rate))\n",
     "\n",
-    "audio_url_or_file = \"https://datasets-server.huggingface.co/assets/speech_commands/--/v0.01/test/38/audio/audio.mp3\"\n",
-    "display(Audio(audio_url_or_file))\n",
-    "ov_pipe(audio_url_or_file, top_k=3)"
+    "ov_pipe(audio_data, top_k=3)"
    ]
   },
   {
@@ -586,16 +609,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "id": "5207a5af-3b53-43b3-ae5e-5b352c0f08d4",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:38.121136Z",
-     "iopub.status.busy": "2023-03-12T19:47:38.120930Z",
-     "iopub.status.idle": "2023-03-12T19:47:42.382362Z",
-     "shell.execute_reply": "2023-03-12T19:47:42.381733Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:38.121116Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -603,18 +619,20 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
+      "Provided model does not contain state. It may lead to sub-optimal performance.Please reexport model with updated OpenVINO version >= 2023.3.0 calling the `from_pretrained` method with original model and `export=True` parameter\n",
+      "Compiling the model to CPU ...\n",
       "Setting `pad_token_id` to `eos_token_id`:50256 for open-end generation.\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "[{'generated_text': \"Hello, I'm a language model, so you might consider changing your code to a similar type for Python 2 or 3.\\n\\nWhy Python 2\"},\n",
-       " {'generated_text': \"Hello, I'm a language model, so the second statement is true or true. You can also have both. It's not strictly necessary, but\"},\n",
-       " {'generated_text': 'Hello, I\\'m a language model, and we\\'re seeing it all in the Java world,\" he added.\\n\\nSo what might happen next?'}]"
+       "[{'generated_text': \"Hello, I'm a language model, so I'm really interested in programming. I've always been a programming student. But for a long time,\"},\n",
+       " {'generated_text': \"Hello, I'm a language model, because I don't think I ever spoke on paper to an editor. I'm simply someone reading a paper.\"},\n",
+       " {'generated_text': \"Hello, I'm a language model, I understand. Your mother was talking to you. No, well, my grandmother had said that she heard '\"}]"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -648,19 +666,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "id": "97569002-0c0a-4208-9b63-b2bab209fb81",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:42.383244Z",
-     "iopub.status.busy": "2023-03-12T19:47:42.383095Z",
-     "iopub.status.idle": "2023-03-12T19:47:48.887705Z",
-     "shell.execute_reply": "2023-03-12T19:47:48.887095Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:42.383228Z"
-    },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    },
     {
      "data": {
       "image/jpeg": "/9j/4QAoRXhpZgAATU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAAAAAAD/7QCEUGhvdG9zaG9wIDMuMAA4QklNBAQAAAAAAGccAVoAAxslRxwBAAACAAQcAgAAAgAEHALmAEVodHRwczovL2ZsaWNrci5jb20vZS9BdlNGTzd3bFF3TWxuRUJBbGdJUFpybkxmZ0Y1WTU2alRjR1IlMkJFMGlPZG8lM0QcAgAAAgAEAP/gABBKRklGAAECAAABAAEAAP/bAEMAAwICAwICAwMDAwQDAwQFCAUFBAQFCgcHBggMCgwMCwoLCw0OEhANDhEOCwsQFhARExQVFRUMDxcYFhQYEhQVFP/bAEMBAwQEBQQFCQUFCRQNCw0UFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFBQUFP/AABEIAQsBkAMAEQABEQECEQH/xAAdAAABBQEBAQEAAAAAAAAAAAAFAQIDBAYHAAgJ/8QARBAAAgEDAwIFAgQEAwgBAgYDAQIDBAURABIhBjETIkFRYQcUMnGBkQgVI6FCscEWJDNSYtHw8XKC4RclNDWSokNTY//EABsBAAIDAQEBAAAAAAAAAAAAAAACAQMEBQYH/8QANhEAAgICAgEDAwIEBQQDAQEAAAECEQMhEjEEEyJBBVFhMnEUQoGRFVKhsfAjM8HRBuHxQ2L/2gAMAwAAARECEQA/ANEE19VPGDgg9BoAkCHQA4JoAcEOggcE0WCFCaiwHBDosgXZqAFEY0AOCaCGKE+NAouw6AF2aiwFCDRYC7NRYHtmiwHBTjRYChNQB7ZoA9s0ALs0Ae2Y1FgLtGiwPBBosD2z41FgLs+NFge2/GiwG7BosBdg0WAmzRYHtmiwE2amwEMZ0WAhTGpATZ8aAE2DQAmzU2Ahj0WAhXRYDSg1NkibNACbDqRhpT40EUNKDQAhTGgkYUzoIGlNBIwoPUaAGFNTYE4j0WMPVNFgPCcaLAeE1FgO8PQQOEfxoJFEeoIHbOdFkChMemiwHBM+mosBQmoIYoj0EC+HoIF8P40Ae2Y0AKE0ALsOoAXZosDwTGoAXYNAC7NAHgvxqAFCZ9NDdEpWL4egg94egD2w6APbDoA94Z0AIVx6aAPbfjQAhTOgD3h6AG7NAHtmgBCmgD2w6AE2akBNmpsBCg0WA0posBPDJ1JIhjx6aCRvh6CRpTnQAhTU2A0pqbAaY9SAxk/TQAxk0ARsmgCwE+NAxII9QA8JosB6pjUWQOCHRYDvD1BAuzQTQ4R/GggcE1Fge2aLIHbfjRZAu341FhYoQ+2iyD2w6AF2agD3h6AHBBoAUR40WB7YfbQAvh/lqLA94eiwF2aLIHxU5kzyy4GSVGdUZZUl+5di23+w3ZnVxULsHroATYNAHtnGgD3h6AE2fOgg9s0Ae2amyRNmiwEKY0WAmzjtosD2zOpsBNg0WAhTRYCbM6AEKfGgBuzQAmznQAmw6AE2n21JI0roskQpnU2SNMfGiwGFP31IDGTjU2AwpxqQGMmpAsBNLYxIqagBwj/XQA8J8aAHBNRYDgvxqLIHBNFkC7NQAoj0EMUJoIHBNBAvh6AF8PRYCiPnUWAvh/GiwFEfHbRYHvD1ADtmgD3h/OgBQmoA9sGgD2z40AOWSKmYPMwVT5QT7ngazZ37V+6NOCPKTS+zE2YzxrRZmPbPjRYHvD0WB7w/jU2AmzOgD2z40Ae2aAPbNFgJs0AJs0Ae2akBNmoATZ341ICbPjQAnh6AEKaLATZosBDHn001gNKaLAbs0AIU+NBI3YNBNjSmgLGsvvqQGlM6mwI2j1JIwofbU2BOCu4DcMnsPfS2hyUJ20WQPWPUAOCagWx4T40AOEegBQnOiwHCP41FkCiP41FkDhHosgXw9AC+H8aAF2fGoAXw9Fge2aLAds1Fge8POiwF2fGiwF2c6iwF2aLA94fGiwPeHoAkhsz3mRaeNWdgd4VBycc/6ax+TkUIpv7m3xU3J19mMMetVmI9s1NgJ4eiwF8POiwE8PRYHvD0Ae2caLATafbUge8P40AJtHtoATw9ACFNACbDqbATZ8amwEKfGiwE2aAEKakBNh0ANKfGgBCg0ANKamwGmP41NgN8PRYDdmgBjJoJGlP10AMZM6ayT5JivlZYbgtRBcJ3MQzG4kLEHGfX89fOIZskalBtM9pPFD7aNr0X9Wr/AGylkjqnNTEXLK9wOWGfQHg410IfVM+HTfL9zN/AYsm2qOi9OfWmgqQsF7h/llSow8oy0Jb/AKT3118H1fFOlkVf7HOzfTckNwdnQ7bcaS7QGaiqI6mIHaXjOQD7a7MMscq5Qdo5M4Sxupqi4I9OIO2DQBCKum3Mv3EO4HBHiDIPtpeUfuTxf2LQTPrqSGhQmixaHBM+miwoXw9RZNC+HqLIF2fOiyD3h6iyaHCPPposKF8P41AUL4fGiyD3h6LAUJoAXYNQAmwaAPbNAFO4XRLaVRCxqWUugB2hcepPr68aweVK6idbwcXPky6Y8knGPXW6O0jlyVSaPbNSKe2Y0Ae2aAE2aAPbBoA9s0AeKaAE2fOpATZ8aAPbPjQAhTRYCFNTYCbNFgJs0WAmw+2pAaUz6amwGlNFgIU/XRYCFfjU2A0rosBpTQAhT31IDCmgBrR/GpsCMpqbAYU+NAHyxfZaimhpg1rp6qBlBgJg8yD0U+/GvlMGt0z6HPXwXaZ6+WBrZWxxQ7m3sZYgqkkejDsQMDUNq+SHjbXFlCo6fqKSOoeVlp4YyAqMdzvkZ3DHp+eNWetGTSfZV6b3fRND1bWWKSFKKvljVFAKwTN4ZPv+etGHLPEnwk0Z8qxtpSVhGX6k9RtRrTy3urIZcluOQc8ZA1sfneQ+psqXiYe1EIWLrq8RRw0lzvUk1LJyqyHJUf4Szd8Z+dUZfN8hx4KbLoeLhjK3FEN4raamvzv9nVKajCSSNkZb3XnByMHWGMsko3yNkoY7riaun6vufQkcarVyS04fatDV+YMDz5G75/M66Pi/VfIx1GW0c/yPp2Ke1phml+vsYu6U1ZavAp2ABZJdzq3rn0xrvw+rRk7lHRx5fTJJUpbNXR/WDpipVd9a1Mx3YSZCDwcf39Na19S8d/zUZJeDmTqjRdPdS2zqilae3VInVThlIKsv5g862Ys8My5Y3ZkyYp4nU0LeOqLTYHCV9bHBIV3hDksRnGcDS5M+LD/3JUTjwZMv6I2VJuvunaejmqpLrTrFEgkfJ8wB7cd+dU/xvj1fNF38HnTriMp/qJ0/VUS1UVepjZC6rtIYgew1VL6j4sVbmWLwPIl/KBH+slrWlttSlBXS09bIYxJHHkR4OMt7flrP/i/jcuN7Ln9MzpXRpbX1jaLsyCCsTMgLRhgQWUevPb141YvqniN1zorf07yUr42FaCvpLpEZaOpiqYwdpaJt2D7HXShkjkXKDtHPnCUHUlRZ2aeyscseeANLZNC+Hg9tTdkdCeH8aAFERYgAZJOMAahtLbBJvSHfyGO6Vq0s9NOZxDKwimUxbfKDu54b41xfI8lSftekdzxYSxL9z0tMaZ/DIxjGOc8fnrq4ZKUE0cnOmsjsbtOrrKD2zRYCeH8aLA94egD2zRYHimiwE2/GiwEMepsBPD0WB7ZosBCh0WAmz41NgJt+NFgIUzoAQp7aAG7TqQE2Z9NFgNKamwG7DqQEKfGoskTaDnjUkjSntoChpT31NkUMKakgYyfGpAY0epsD41slBNerLDU08oqjG5UKshJ75wV18syPhLi0e+inONply9dYVYojRyAM7gIRJlWJBzkeo44/LSRxL9VkzzOqLP8APa37bxI5t0TxmKSA53gAeUgnvrDOSVXp/BcsjasdbLK9cYpLgu4OMkI6ofyH+Wpj5UZSaTVEKKkrka+paktUVvllSSKGn80dLHtBTPfd/wA+e2rIz5t0W6ikTUfVFtuJSNYoPuWYqieGAdg5xkjT8ZJk8k/3BF7e5o0NzoqGKcBg20HxMc+qntjHfV0XHcZMqnyW4lnqm73WKLxEj8eAzRsEFOWMa7c8nt30sIxerGnKSVgiwzv1DcJVZKaklWVnMsx86sewI9e3bVkm4Irj7zS1VigqJq6m/wDy43F08SNvDwqjgnkZxzpFkeu6LHD+4Is90vvRdVK9CBTTOpiaZV3hlPIIJ9PbW7F5E8T5Y5UYsmCM1xlGxtV9T7nDVRVFf9vVTI3JniBJJ7njWXPyzycpttv8lmNrDFRjpIPdF9cUfUd4n++Sl8B1KeCsAwR3ByOeNYcsJQguN2asc4yezbdNRWyWumkiroamhnwtMiIMxSZ/ArD0PsdZMrmoq+/k0QUW+9BQXdp7tRW22yUdKs1Qscsa43BGYAlRjvnUY4X7pWwnKtROxda/RX/YO1dTXanrLlLS0VRTGhWpEb+KshVZBuABwGY625fHjTa0ZYZpXT2aGq+j0digqzT3hK6sg8B6unelEQRZCAGVhyf108Fm8df9DI0xJ+nm/wC7BMz9T03VN1Bf7RFCxazR+NNUo+I3X/pB5z8a0f4p9Qhyipp8fwZ34HiSp8asF9RWW6WqB1npqmKIRq8syoSsasPKSR763R+veRFVlxf2M3+FYW7hMggvi3IK0zwrUGMBUgi2BsDA49Dgavw//IMOOKjKLKc30eWSTlGS/sSJUbkDbMr7g66Mfr/gvuTX9DC/o/krqv7lu23yG0XKkqWKEhtwRsEkevBB/wAtNP6r4fkwljjP/wABD6d5OGUZuIOqPqFabhDcElkmoqtVMaP9uv8AUYjIC88bQB3HPxrFDc1waaOgofE0wpLMK+GlqhE0QmgRsPjJIGCeCe5B16DxZVjpvps4XlwrL7URFNbbMFHvD1IUe8PQRR7ZoJo94egihNmgKPbMamwoTw9FhQhTHposgQpnRYCbBqbATZoATYdACFdSA3YNTYCbNFgIU0WA3Z8akCOZ46dN0jrGucZc4GdQ2ltkpN9GI63+o9F0y1LF9ygaeN5V2+ZmC+gHzrhef9Tx+I4pvs3+P4zndoj6M6vi6gjpa1qmICXesgL8rxuXd6DjP7ab6b5y8vFzk6fyNnxcLikbaKWKoGY5EkA9UYEa7ikpbTMFNdisoAznH56myAdVXmko3lFTIIEjxmSThST6A+p1TPPDHfPSRascpL2k1PPDWQJNBKkkTjKupyDq2M4zXKL0VuLi6Y4oCODn8tWWRR8q9IdNvR1FJX2aWOYYxIkjDBB4PBH+evlOaV3GZ9Ax41FqUGVPq70cftaOpE6KWfBZRguxPAA/tjU+NmULsPIx3FbB9ipyr01BO7FXjJZYlICDb5VJ9zk642byVmyS9Ovb/wC9sIKkkzTUVlgu1KhWWRGomIcO3IUdyf3/ALaqh5McfJxLeKlpfBmutLheoaoAU6CiLCWGSMhgsa8AEnnPvrs+F6U4e1lM3O+tBDo2equdMlJCtPCZGJesZQ0iA5wB7emr8kFB9jxbl0dKqKemtNvaOHw8yIRI+MhzjksPnWZPk6NDVIxN7vl5udtkpYabwZ5EERdH2gc5B+Ma0JRjuRncptUgwbTS0VqqbhJH4cslGTPUBlZGYAcfJzznVHNtpIt4pKwP0/QU126de50bVK3CKXwEEQyHVsDa3x86unNwlxkVxipLkg1UdMywX+jq7o4pIjCNyO3AcDjawPbVfrLg4xHeP3KUjKfVOxPWFZ7ZSx1hKjxqinlBYY7eT/XVniz93vdFOaDa0iP6T2WXpurkud2qloqZYyuwjMj59h6as8uUci4w2yPHx8NzOhwzTXe60NxtsqwQUBkmeHwTEWyvlZT+Fjgd9c11GLjJdmvbknF9BGxXW3V6L1gluV62FDIBM2MlDkH9xpHzxSWO9ErjNObR0aL+IjqLr36S9WSXiiNLcLhUpPDVUrgwxJEVJVYyc+YL7+p1ryZYqXB7ujNCEnHmtHSOk/4k7L9Sem5brSWaqo7jcZqemrN8+6NEgYHcmB378cd+dLnzxwycZInFilljyXRpf5503cLx1hU01/loKq+0xiRblSFI6dzjBDDO4apjmwTcny/UWShlikq6Og2e8U8kVitplprgKtZYJ56dg6MsSeUn4PzrdCUWkk7Msk022jN9V9O9JteLtJU2WnrmtlHTSCMOYVP3E7LuLL64HH5aWWHHduJKySqr2AK36F2hJK+30N8uNuq6m4TxULKqypH4cYfa+7kjGfnVH8LjbbZb60qpAH6efT+19d9Kx3CpuM1FPNcGt0CTQZWSUDI+QCQf21kx+Lzi25UaJ5uLqjn96vUMFfLSrSR3D7aolp6qUR5ELITuOcZ9Ow99ZVHJhk0pU0XXHIk0rQO6c61sXU1dJQ0VW/2qFGjliJ4fJ8roRwOO+usvqHn+ND3u1+f/AGYX4nj55Wls1UN3vT3mvW5WiKGk374KqjkDI6k/8vcY9td3xv8A5FhUUsyaOJn+j5HJvGwlHXU8jFfECOO6vwdejwfUfF8lf9Oa/wBjj5fB8jD+qDLIXOuhZhao9tzqbIPbNFgIU0WB7ZqbJQmzRYUe2aLJIaiaOlieSVwiINzEnsPfQ3XYcb6BqdVWWScQrdaNpCniBVmU5X31X62O65L+5Z6M6vi6LVFcqO50xqKSpiqIASpkjYEAjvzp4zjNXF2hHBxdNbOH/UX+IHDS23pwPFOkhR6twMEDvt9ufU68f9R+tuN4vG7vb/8AR6DxPpqdTzdfYwS/xDdV2qM7ayGqZmxtqYw20fGMa5WH615kLUnf7o25fp3jy/SqND0f/FNWnnqS1p4LMB4tN5CgzjlT311sH16XWaN/sYp/Sotex1+5v7f9fLHcalo4+VycDOCRnAIz/lrqx+s+PJ0jG/pmRLfZoqj6o9P09TNB9xJI8QBfw4yQM+mfXWuX1LxotxcuimP07yJK0gxaOprXfYpJKOrSRYzht3lI/fWiHmYMiuM0Z5+HnxupROa/Vuuiu9ba4Kesp/DO5hIZhhHUjBK/mMa4n1PyMc3CCmqd/P2Ol4nj5IKTlF2YTrboqbqqODqVCsC01IIJojh33ZHnCjnGfXXzr6p9RjmyKMF0t/v8nexeJOEXNnNrdfZ7VdK61VVRsJJEYjU4JC8A/oSdZIZckYcsbaT72VcI8qmjS031QvXTKxvTVZhp4VP9Pb5ckeo9e2ur4/1jzMUlxlpfBXLwcUk3Rj+q/rn1DcayWYXKWOCVdojiyAjY5YD3Ouk/qnmZnfKgh4mGCqiTp36yXatraeGtr3r1LBSKznA9xpIeZ5MZ3kna/OzQ8GLjUYm7vX1C6jqbSs1rmnWjRj5o4c7QDjHHvntrb5H1PM1H08lJv/Ywx8S5P2hr6Y9cXzpa1Vn88SonhijXwI2U+YnncP75z663/Tvq0sUJPNK0ujNn8CUppRVGMo7xXWyoBtlILdPLH5lfJWTHqM8c689myRVc38noE2v06ZpbjYT1VZKFqqqKVf8Ax1QeYqw75/8APXWfJ5UMdx++i1w5pJ9mdo7O1LbrjWQzeI7MY5mVsgAdhj0OuQskuEYQ+P8AUlRqy509Pb6e00qq1TEauJNxY/i8vA57gknn40mPI1kcmtEJpL9wlbemKK52yhhr4BUBXeJPHfB45AOO/I1uweQo5VwdJ9V0RxjSshpqc9Dq9sKwLXV8wmpoV3LHt3chj+g11Oc57k+iEvT9vyzbS0UEwD1MRXK4ZFOR84Oq1liumXuLfwAbp0/ZrjiCSKeCZB/xEyvA+R/rqxZX2VyhGWmWZ7faulbBLJieeOUBBFVvuBXOe2MftpVJylomo44Ef086YaNVNtZ6OGQM6NHVgxIT7jt+/bGozZb3PY2GH+TRmL/DPeOq6YRqlakEgirdkxEcmCRvwTwD28utGNxjib+/RTJ3Ov7gfpqiuj9dVFuWgqKWBlli2qhZVB/D5vbtzqzJKPpKd7JipPI41oI9VW279WVESWmhNT9oohlLEIzleCze2fbSYZRgm8j7InGeR1BGspLhJ0zQWW1Xdik8i4enghZ3YMfKEbtx2Os1c3KUOi3eOozNTR9KUQsVfboI5qY1iuHBJJViMDAPbWV5W5qTfRdGCpxK3R3TJ6Os0dveeeqPjZYnnOT3x6D41ZlzLLLkRjxuC4o3dqqYp4DBBF9i9OOV8DwlbIzkD1PvrnSuLt7TNyqSroA1vXlPRX5bRU1UqSuEKu6YUhu2D+etSwpx5pGVz4y4NmrK3mCiFRbK/wDlbqQWk2AkLnzevGRkZ+dZFOMJDOPJUWv/AMcrr0Vd3q3SY0syQ0prSFnidB+Dejdgvp+etmLLmTtTt/ZmfLDGluNL8C9M/wAVNTSrVRzU8F3uc1TVVUFTch4TUssilQFEfDoQAMcEAjXTjnf/APRf2Mjxf5X/AHLH0G+tVDauk0t9ba6q+1dvuT3JqvxvB8OYIQDtxyo5GBzz20nrRwR9y76od4pZZdmdtlVBe7rWXq3V0stsuVVI8lAKUqIpWJLEnuBnPJ751yc8m2+a2boRUV7XoAdc01J0SUuMFIHSaoJeTABQlfwhh2HqM5GpwN5bg2JNLH7kMoOsq6tWgm/mhKU8RZqONBy/oS4+D+Htq54IbVdg8jbTsJ0PV8U04kq6OSlrXJikdiCr7RkcexB7jVM8DWoy0NGXzRrLH1jRVlMmH2byyCGQ4Ykew/112fC+q+V4L4ZPdH/b+pzfK+n4PK90fbI0cVypAsStNFC7AYjdwDr3fi+dg8uHLHL+nyeP8nw83jyqcf6l3broWYKPFcd8aLJIYaymqHdYp4pWQkMqOCVI7ggdtQpJ9MZxkttE23Opsh/k5d9WPrPT/T8PS0dL9/XhMud2I4c/h3e+fbXH836lDxk1Bcpf7fudXxfAnm3PS/3Ple99edQ9bXVfvbpUDxEKmCMlYwM55wdeNzeXnz+6ctHpMXjY8dKKBnjskphEhDou3KDhdc63BcrNLddnSOmfqxWdK9G1lpt9OZJpQSZWYbVLdzj1J11sP1j+HwrDiW39zm5PEjnyc38HIrqbzV1NTM4SnAYMvpkEfGufcZys6PDitGVbqALVMauWVNsmMDkE6veKuhE1ezT0NHcuqaqKGipzK7gSHxOAoB/EfjWaUVBXZa030jff7Jw2mmJmrRUViDtDwFP5+uudkyyb10WRg3LQMmu1VBTlKeQu4QnLEgkZz+p1EJNP7WX8X0j1m68em8WJ6uWmIXL+ICu8eoHzqZ+PN7T0UtpA+bqf+YsSoZFVuJSCP8++iWCSVsjk+zTdNfVeewCSBB46OBzJ6HGD/wCtc7J4vN8kWLLxNrYbzY+pK01C2+k/mSrvZ2iG5gPY6VYpR9jeiyot3Rl/q903WXPpypjssDSzL/WZI1Vmf3AxySMjWjx4rFlXqdGfLBuLUUfPtq6T6ruNdDDT26omkkyFLJjAHcn2/XXoFLHLUTnccifRsT9LOpLbPLGj0VQEP4onIdjjJAyOMDUSSlsv4Side+ilXPT9K+BW7gplbaQpZBzjue/bXnfJ/wC7+DZjXttnQVorTUVErrLVSFzxFLKQq8f4V/PSOSqkX6OZ0zQ0dRJR0oPlDvF4zbjnHAHwda/IeWa55f8AQxLjF8UaKqqa2rtsUEKGKVQAxjxgDjPftjOuas/qur1Gy6O9mKqo6iy1tdR0rssSEqj4PmdjjDH1GPU6fBCGVcm9/Aj06RXsRlkq6i3082yKiCpx5/DXPpnjHcasxSjjleXaf+pXxbXZ0OmpxC0FRKJayIssscakAxsAe5H76nx3Hx5XCNp/6FqjW+wtPb6fqa5U9dPaGkqoBtg8YhgwPJI29tdp5pQjxWm/9Bv1u6J7etZW19WtawpooiVjVvwqR3Ug9hrHhcUtytliUm6ZUlrqrx1HgCGKMZkjbB7nAIYd1P8ArrprjRW27LV1no5aKRrkCkCMYyh5B4yNo9dEbv2hLr3GN6dudts08lNSVElGkrhxUKMfv++r53Km0UxqOkXus6W0xQSVtHSiWYhh49PKUIbHGccd/wB9TjcrphKMe6KPQHWFRPR3erWoaVaQBp6Nx+FO2Qe+c6M+NR4r7j4sjdtAmxXi50fVlXDZHq0SRzIxEbFAxGWXJHIBOrnGLxpzKoykpvgP66r+pKXqK2105luJoxGE+3jOM7s+YDsffTYceJwcVqyvNLKpqXdGy6f61uAaukW0v4STmYN4zPLuPcBTyR+XA1heGHTZqjklfRbg6qqj1HG1yopUo52SOKRI9rxE8EkkjAHJ/wAtLLEuHsY/O5XItzG426rnpzXVktOYyiTMOe/BBPZsDudS1BxWg9yb2ZK3zV9k60nrb+lU8FLCVpqyRgy4JyM84Omyyxxw+1pfgrjzU7mv2KA+u9wrKqoghqvuWORJS+GNoHbt7a5krlC1Gn9x/Ue9leh+sU9AIbXVmmqqHLLJRyR7iV74z6geg1kUc8Xzuxll1xKVI1RV3+ir7VItRTy1ah12lFiJbjOPTXoMWaOXFJSVNFEm4yVdH0XU25IquarNVUNE8JQU0DBYGyOTjGc/OuRGVri0bWl2S9IVVLZ6OnjpoxSw7SNksoYj359Tqcqc9sMcqKf1DhluMtAYL7DbrfJkTUzKCs+OSN3bt6ftowNQT5R2TlVtbo5B1MlH07GgtcuaefEvgSSb/CYHsreoz8a1vyfbb7MjhXRlLz1zcqwU/wBzUSlFJ2uq52n8xrI3Ka4xYyk+2HLB9WaGwUbQ/eR/dtL4ilzuMKY9O5XPPPzrqYsOTKryKimWWOPSKd//AIiununKiqrJrbW3GCrjCTR+7g5JDsR29Ma1LxmkkpU19it5k7tXZrLb/EtF1hYhVdPV6xJCixvSVY8KSNgOCSSc8A851pjl87Eqx5L/AHMs8Xj5e4UBrp9X+oIq6rS4180azQqJFZsDbngj259RrPLzvNi3zldkrxcH8q6AtrkukTNerXVyRJUllcxv5cgjOfU51y15k8U3JSpv8mxwhONNIIXz6q9RWO3zUdN1G9Qm8M5PlZD6EH21pwed5MouCmyr+FwN8qujJ3K+TXjFZUMa9qiJd0nIycdz+Ws/KTk+b2zWtdFmkMNlolkNFHvkGPEY4DKex/THfVPNvTGelYOaNZqpJlSNIiRnz5DD1J1c2nGhEr2wxUUhFOrUlLuQ43MnJHBOePTWeosdwrotQR111oWiq1QQbBtLqBgdxyedLzUJdjqLa2ZepNrF0D1VFFKiuB5MEEDjnTvPNLUihtJ2b8zW/qPw56WZaOnXEKxRAKxb3wPT/PWWbt2Xr3la/wDTlTT0dVHQxSVVMjFZqiXyEFQM9+4+RpHNRatl0MUlbSOfQViyyyQrUJDUs/hIZm8ufz9da64pNiKbX7mwhsFPW08S1VLAahG3GVM+YAYJxpYzlFXHomVSf5AHUVHaqOdPAimQxDzusmFLfl2xo5Tnozy7oA1NZFMyqqI6kYPHJ1HBx3YtKw70TXrZr9DVfbPJEGC+XO3njOPjVE7ey6Mfk192EVTVu1sqZqaeOUNMEcgSrnJXjUcVJOyzi29aCVbJcaiqmahqKelp3VMQRyf1HyOQzHnjtq3BOOGKQuSG9EEHST3JIjWVypO7YMMWWDAHgsfTWp+RH4K3B0bey2aOzwVVLD4FRTn+pGiZ3BhyOPfWFq5cho6TiWrXUNSAz1EyQPNlUEy+Ju9+PfSU07BJmGr1jpatBEkFVNDCkZaPkAE8gnJ5zzxq5SyencloqlH3aGUN6ihnqKlqjZURLtUDlWO7zAgjjGvMpPG3we2Qm9pnrxXTta7jUrVUUNNUU6RkgZlMh/EcDkd++uzgzwUEqRLXtbTMGXirbmxsxENWkYZ3jwEniVlDD8x3OdLmtYeWTX/NFDTl0bi2dU0tH4yzRNUQyQpJCjPhBg4LAe5/76zePPJB7XZpjNLTNZ1F1VBJSrHShY6rhNkA2xjjvu9DyBra82TTl02WSfLrswt4u9za4Q/zCrJL+fwkXhyO5OuhCGGM1NR/Z/BlnOTCP3d3SqEtStQwk85jCDbt9MgHjvxrcuVVS/oyE53bI7lcash6Kk8d4kk3RR1eS4Q8k7W7jOR8a1RpbIlfSBriknZEpLXMKqIlhCJM+KxI4x7d9S3L7kqvhG4s966coEe3PTpQRVkfiTeLl1ViDlST2wdZXzl7u6LvatPQX6PjtcEslvp0ZJkkwwjhTFQDgq5bGSMevbVWWU+y7Eo9M0s12h6fkgM9XSUsTrsWB8M7MM+RQvqSRydZN5LSTNd8Kt6M7T9SWJ7itRPE8dyeb7eVFQ/0s8ec8duTkZ1rlDNxXF6M0cmNybktg+urKKO7KKaHZVLUMs1wLEsYwMArngDvxqyPOcW5vVdFUnCL9vf3A/UN5t0tXHfaOompZ3V4AUTfEsgxtfB5yRn99VcvSjwlsiUub5LsDH6z3WhSp+5navG3/jPCFb2z++ojT/THX7i+pOO2wZ1hdrb1J0kq1VPPSVKPnx4nLrMmc4OTkY1U8snJWiG00cuqwKb7aotgmWCQ4lqGweQcADtgenrrVC1GXNFL/A6jr4KysFvmjJE6lvF5B/MH0xoqoJ/I0UnKmdH+nl2g6LiqYKb/AH6mqmBnjqm5yMYII9tVtz7NPGC6fZob71/dOoKV6aCOWspaXiKSnyuDkfiP+LA4zqMepN1RE02qWyleeuKtpLY32q21YvIIQpBJ9cg++jlTd7Kt6DE92jTp+AVKiSrEbMpjkLcHJUEHjvquLUvnReotJWj5++pH1lHTz1VOsQnvGNiI4DRwH3YA9/j9/bXSxeHFu59fYx5vIk3o5f091rfuvuoILZV3SeKGoJ3RRHZHtHJyBjjAzzroQwYse4RRkeScu2dapOqui7C0VC1WGk2mORtniRu2Pw5Hc9v/ADOr/wByq/sZD6n3qgu5pkp6Y1cZQpDI9R4UIPHAA/X1BP8AnU5FqVoFfTSrn6GulJV1UMs1NVg09VQiRGDxk43dycfnyO/tpbJUaOpdWwXWO501RZb5BeaJCoktFUyLKIufwv2OO+CQfjSzqa2TTi7RtugLTXVlwgp6VFgG3xCrvlMHv2zrz2bFxblJf1NmNRvR0im6Wt9THUNUx0kyMwBxhm7dvnWfHkaqmaFHXZhurbbNZKyKngp1QHO3wU4PpjWjnytsVx+wVqbLUVPSVLR04KuHLTB1HlHvz2xqnm+VjNfBlrfbYammWnjUqFy5kbkN6AZHzzjUPNTtkRino2nQnThpfFhmnhlKgs8hyEjHtj41VOfJ84ouhBPQQ6i+nFVfVSV6qnaNyuGib0IO0j0J1Cnu2iZY70cb6o+mHUNlnkkqZHajPbcQrAeh4+NdGObBkSaWzLkwzT950L6RUdGaaok+3NdJEFZYZmHnfsuAf3yNc7yOSmt0jZ49cWmrH/XGmvFPa6EQRVkdUud8ijEKbu65/wAWB/nqPEljcm5NFmZZFFKJzv6Z/SWuute94uJNRHCCrRowKxHGA2c4/wDWtnkeYo/9OBnxeO37pGh+/tqbqZppWnppNsrRvkgDt++li5Q2+mLKlpsyVfe6StrK6GKqIiMmSGH4/bn01ZUnUpGVzTbXwBxc6SkrvAmfEi5zsUcD01Lxza5VoRSSZuT0bVz9PJdLTOapvD3NApBYfA5599ValLiaqpWmALfe7tPSySikdEHkzIMOWGtUscIriDnNofZbrLUVySSSPFJGxGSSMf8A31RPHFRtFalZ083avo7BTt4KyLVR743X/Efgj141kX5LbNT9OZa240n39VGYnhdo9hkxvUDB4+DqOL5aLF1bCF0ligkE9TIHfdsRYCcLg6texbORWGBp6OWSlElMGkGF271kA/EWPoe2CNNnV4+OXev2oxQiuNorC4xJdE+9WLw0csQCYyy8gDPrjg8++uPPx3w9pbyT0ErlcfuaanNPDiMSE+DlUZsAeXtyPn11j4OE/T/H7oS/hFmepjS2vFFTQURUYSCn2ufNjBOO2TnnnWj01PJFSbdfcslJVSBdK0NPBVCaq8SAyh2jUhFiUsMqM8nJ9NPLJOD9nx/qEdq7Nfdb7baS2SRwwyMQf6JxtVAGB3DOcnnHOtvjKOVccj7Yzko/pJLF4/UNY8k9KAicxu0YIye2T6n0499dRTUbiRCMm9kx6t/2fuVyje3xx/eR7JINxd6cD8K7yDwO+BjRHGklT6LHNRbVdmeTqlvFqKiSoLTQxkt45LEr8fJzrXL9JnTd2BYepf5lI7MMbQGEqnBA9sjVXKcB7j8mo6bttvudXTTNcKUOqlzT12WBIHCg+pPz20/rSUNr+wKMZPsiufUSy1cDh4oK+BsZg/HtIxtJ9tVxzxV8loXi5dASbqJ4a2JzSSNOjZEvLZOdV5czf/bYcJLs1qdQU0lpiim2Th2MyJtPiI5POT6nSyzZ1HlGP7kt6+5mL1crvaZJAY0heQkiSXz71x6Z4zjQ8vLGkwSa22ZSnuFfWJL4OKinVhwTkKfbGrYwTjcmRFSfQbgoKKeNhUQPG+/DL4mVYew1neTj0x3GyxfOnK22VUDiVWoJogYlkZOR+QPH66aOaHHrZM4cKaI+kbNX3u8NG9vkWmXGzbgBx67f89WZ/wBKa7Iht7Q3qXo5LJcFkiYVMD5d3YhmjPtj8s6FJRpy7Jljbdrop0PT9FDA9TU1U0dL4fAUDO46eXkOWkiFHVvo6Z01LDbunZ6O0VFSigrlpVGXJHJx3xrJOTk7se1pRBHUFiTw46yW4xVtSFDNCqefnPPJ0sZS/Q0NFfc419QeorhZoYbXBXCnrrgT/VZtop4sEk59CQMZHpnHJGux4uGH/coyZpteyz5uujfzGslWMSeIrNvZmyG+eeffXVWjni0kz0YHgHwyYGjZweSCfNz89v30y+5En8Gg6PaK33NJ6oMYghHPGM9vy1DISNBNTJW1Ze1V8UEi81MNQyrERjhjny5x69/bUUNv4Npb16cudPBLDMEliQeJUJF/QL+u31x+mNI0WphWkvdvqbTPS0FTHFUgNH46wCNAT2I3c5J9T76WmPZm5+sqrpOGCSkt8N4uEa5Zq6bhcdgRuB28HJUjOcZGOXi0Q9bNp9DPq7furpbzFdcPT02ySnnRsCKRmOYwTklcAkDJxjvzrh+fFQqUFt/Y2+I3kbTfR3q2X6LqC6wpKrO+xv6TpuDEY5PtjnXMb5KzcoNSoxfW3VUlpu9XSNN9uhUqVD4G0+mT3OqYxnNtx6KpJJ0YW2dTW+lqZnjqDI7MVUK+QBjGSD6/Gtb8fLlSVUZ4zUXo7P0LNQHp6ps10u1NDJcWVkqoCPEjB/wNngHtwONcuUJ45OSXR18UYuPFsjirU6Zu/hpWfzGiiLRoufKE7bwO3fXSj74VWzJJOEvuHKHp2o6wq6mWp3VxWlOKFWAIU9m76zTaxL7Ky1J5O9hH6TdCW6yrVXSesMtVBJuKsoXwgAeOeQfj41k8qblJJdGjBDim2evHVM3Vl0mSpqBDb448mmkXKsMeYk4z+2tEfHUY67KZZrf4MP0ZdDX3tukVo1pqOcttWmj3MFz+I/8Af51VlTS9V7DDOTlw6QA/iU6Et30/orBQ2Zo6SWunklmeWXdKRxyT7Dtz761eFkllnKc90U+ZjjGKSOHXS1R/bsouHgkgMwT1Oe/sddSGZ3uJxWyktmllq0aSeligU5aZ2P8AUHx859NXLJyjqxseJ5Ht0dTtF3m6epF+2rHjjJHnHZm/76xcLfR1oxx441ZLL1ILpUA1j7mYgE7QC37afg4uiOUWVq0xbcROivKuB5fMP19TqHLejPLvs1yXCOqjpokqFSmijQKCcBOeTj99U+nz9yL69to1Ft6ztVro5qaWrWFpDxJjccfHt21ChTKm60ZTqf6sM6EW+JWiUFWmdckn403C3ViOetHumaioijk3Iq7UePEnldOecAHB1w8+X1XW3+2xYV0D7lPS1zo7+QKW87ruRWPYH/4/66ypy5v29iTaegdSytW1CwK8s0UYOZZWXysV744zg5wOfTW2fHE+cVT+wjf8pWopJEuE61LbaQFiQ5DiQgHjA7e+tEJQVTkrYi5WwZJfYq6vqafCwiU7VkjbCg4Ayw9T+vtqHivb0RCbbp6NE933WQIqCsKBR4u3kqO5PsdY+Dc+TdGmGWo7RooOp6ylpoRQ1yqkkLUwduChPJAb0OtWHNNScsisuc38dAGto6qkoZFhqSSeCZvM5PBJJ9cnPOu9DyoZJaRRwe6ZRtsUsdartLF4JH9VSu7dxjI/XV0nGQKL7JrkkdLPFFT28ywOCC6thvz0koyS5cuiJL8F+g6hezqWgqBBMg2lkUAgfGe+NctrJJ0laFxycXpnpaR4KRq9iZKdhuM2MFz76lynL2mmacVy+CGO6PHsmhmK5GFCjOoUa/cJZW4klBcKlamSY+C4JwHLY/PnWlXNUmUbWwqtfT1tVGlZAFVhkOx3DU8PTu3Q3HYTlktFFbo5aSijkeVmjDonmHpk49c6I8ci4mhNJUjnf301TcqqJJVKxnILdwRqXiUexNt0XEqHq3Bil3FcDHJB/TSwgqti19zUWDqWnheDfLNFJE5XxFBBx8Y07ahFrsdPdDurJHNQrjYYKiMuJRyePc++kg1KO+yxtr9jOUVQ0sJgd1nhbhv8Xl+dCVPZW4Pj2bGWgv4ghWlcCk8ESvKAqlUAAAA7k6qfEhJpWAZKOS51vh2+olllVfPvjPl9P0/LTKTXukiFJtHzN/EAs1D1rPQzz+LNTf02wcj8IB/7a9L41PFFo5ua+bKvUv0rvvR/02obve6ans/3s6fawM2aqpVk3ZYA+RQMHB5yeQNRDyIZcjhDddjTwzxw5S1ZkbY8VPtabLdsA/4j8/GtXZl/JanWqpV+9ikEyScuByFGeAdQyVZPT9UyUEqNBg1CnyxpGpQceoII/t+ulHsMP1/NVRRfdsEMPPhxcLJ+foP27aXsblXZWqvqbWyI6xRQRGQgsyxHOcY/5sdvjTUK5NmcvF8nvjK1S6mRRkkDvpa+aB20d3+i9iqLL0upnhaKSvl8cZTDMcARp+2T8btcbyfIipOt0dHxsLcd/J9OfTOgMVUkV6qhbKWamkDshzICSPKD6e3OvOeVeV88Z2MPGK4TPfVX6EWiK9UvUDXOoraVBtNHMoJTK+XaV4Hf11d4fkz4vElT+5Xn8eK99nFa3pqy0E6SGCWmiaQIImXaWHuV7+vfXooynOH5OU4KLLnUt4oen4ofs5GFKDty6dvbP/mNYoQeRtZOzU8qgkosKdM/UPNzoIt8bUm9EaUgbJQ3deRzqvNg4ptdlkM1vZ2f/aqTpasrKiP7IoygCVlAJQ428+gz6a5npRytJI0+q4JshmqKoDq+sp/CimqaVI3i7gSY59eODwdXcFGUF8IXm2pP7mctP1Ago6xLXb6KmrKpIgktRUgsGbHJXPc4yNNk5Tk+L0ZYZFdV0Wuk/qTbrJ1WqQ2+WGaSN4llxukkPJ74zjPYDWbNCTgkzTjyqM/3DlGaT600F1qb509S0jwo8FBUVQIckfiODyOccjUZF/CNLHO/uXRazJ81+xw1f4R+rKyppoZqygprdPI22saoYge4C45Oty+pYV7km2YV4MrW1RZun8OcHRVU0dzuk9wpYeylQhlBHlAUnnnjOrI+fyjcY02WfwcYN70AKi01F0+4iSmeGn8TciLyqHsAMfGmWdRe5GJyTbT0HunbVTUUckZRjWxthqlsjZ8EemkyeQn30zRCeOFOL2Q3DpS4JNLcQsctNkSRiPjJHbv860+pi4qnsSSblYI/r19Y2IWiZMM4The/v/poW1pkSlbSSJXoFqVZvuFWTkZwcA4z6aIxVuwli+UwBJbZ3pTNWRtsRd7qhJ2fHGrdfyFLjJLZ0WklUPE1NShqjlTK0+A67eRgf5n515GXkzldKl+wqya0gWlclH/Rk2GklK+UplQcH1+P20s4ub517l/sUybUqB8UKR3I1gczmnRjJG/AT0V1x3766Mm+NP8AmLVLjK2Ot1tnpq9YowkrVMhIimz5/UksOy/lzk6r9SLfekLFb18mapXk8KSlqqQQoZpZIw0ecZfJ7+nGB8a6WX3NP8fAK66C1Pc3ihnitbpSlWXbIFJw2CM8/GsuPCssuM2M6oK2q5fao8VXPMgcCMLGFO9vVsY+NWfw/fGKfyKn0jRwiOugmgHmiypQ7fMFI4/LWHcHzWmXXVoWk6bWHeJKiGPYhJ385PoM9v8A1rV/E8kkr2NCdfAItlyndqlJInigkYpnYfMB6j9dddY+KVdl8Z3podcaaKOBnWnGO/jSjJPtxqYS/kQkoqJPYKyO70bUjzrsA4Rl7Dv2P5d9LOCi7a39x8bU0+T0Rw2Whefy1cgkA2U+47YjluSfftjXMy+TLluOjNKScqvRTioayS6EfcQxRw7t8YG4EjkYPb/3rdHKlj5LoV7DUcsF1p6Z5IlpHUFSu/nOOML/AH1zJ+TOLcXsnloQiml8Oji5aMBQXGGJx3xqvH5E1LlPpjRdujOVJFDVOqIEcdz2A/M66ak8kbT0FNvQT8OnES+FCoeIebbkZb3HvqjlSp/JtyQjGPt7ANPU1n3c0crNs7h05Yfp741qjGNWYY3ZZqa2ZaiOImTYfIC3ruPGRpmlH9I7ZoOnulLijTiClNTSEscIcHdnJXnudVZfJxOubpl6lHGzpHRfVD3CCalAlApkETI4GIs+mcZ9NJ+l/gi09oD3PqmKskhpUhRPCkLmaH+m7e5H9u+iM8bvRFXpHAYPpfD1NeqvqnqikrJ7jUVstS9D4i+FFHv8iNtB3HABPOPT31035ia9LE9JdlGPBFvnk7MP/EB1lUdTdTQUkyyU9FQqRFEx3BS+Mtx34A1s8LGoQbXyZ/Lyc5KPwjmLUY4b7gywDu8UZOD7YOOfz10UzCWJruptNNQIpjKSM7OTzg47n9ND2FhzpHo+vvF1pJaKiSsRX8Q03iKvjKDyFyw3H4Bz3xk8aqyJOLt0acMHOdJWa679OW66VjVFNRR0JWASVVquEDxSeMX4SA43YKebz47HHcAZYR46s6Hp3pxtf6o7N9Df4Nvp5/EHRX22Wj6jVlp63oKb7gWia2bqaPzlQTKXzKpIHmjHAYHB1pc1F1RZHxMWVe17K3Wn0ApPpb1VFB1r0FHZa6KLdHLaauSegrNgAEkSux748wLHBPKjWPJ4/kuD9PLa/K3/AHElihB3ONfsbv6PXGm+oU10tdBSukqRuYJWRWVXxwzE/h/TXmfK8f0VGUn2bcEoTTUQ5ffpN1DfZoDaayS4XIKplR5hCd3bHbBAAz39dX4c2CH61SEnhm3yi9nc7N01PQ/TSGyVkULX+SPb9vNKs2588Nuxkka5U5KWVzi9G2nwprZza7/TGssrTyVlBT3KaLKxQnGSWPr7cZ/bW5eRftjKjI8T7aMh/sNb7XHUR19sjqIammy1NUeZQwzjb651Y5ZJvlF9CRhXaMFUfy+2U7QQUcbKjB44FG3Y3rjOr483rI/6mfI4xdI6Lb/5fUwQLOJGQRrvQAupyMjGfb20sYcFaYydoLOIrdLLHR0slWa3vAowzAAbiw9gNJutjL7HMa6y3Wg6tkdYpY1ViyI3Azn0+dXwmo47ZncXGTYTprdXWdTdGuAiqwfEUIoJQD3b0PPbXOyTx5JKKQkZSi7TD8n1BoKq11c1XE0teIwvjpOUAY/9J75z6arywnrH8Gn1lTtWwdavqrcJ7YaQVUjxw8iLJIiwMbhqiXj8X+GVw8iaVMHdbdf3bqKjpk//AFUzMAoIywwP39NacUEu+iMnkTmqszP+2T2yUVAELSonh/0x+J/+pfcaf0eSozJ/JXqur6ytkheKIwCQqZ5NvDnGc/On9FVtjWHW6lqaK3LEY3kjfLgSk4Gfj0HxquMOUqvosTdASpkq41URROWm8+OABnjv7euuzinjSfJjNooURr7fV1ED07mU5GY+x/Ua0N451JMnHOUS3T5G9HBSQBQw9fzxqNA5NsIU9NEkQ8I4qWkAV43YRj55z8DXlJKauKX/ALMCTjpEl7S3UMFNQTPNA6gl5oZFZRuyfw/6/GseOWabeVVX+uhW9qypQ1lv/l1ZUwViVsko8GUbdmEycbfUZwO2um1KXFTjVbWzU6q07KdbVVVba680lc7sECPCrbdqjnI98Y5I76jHGGPIucf6/wDgqhqHYHtNaKy3W1bhs8PwwpaM+YBslWI9iBq/KnjnLgWuMklb0ELTTLJUGiU/bSzTrJJJjIwTjA+MajmoJTixoRXRqaKloDPFHup6liWKrjdjaeSfQe2py5MmPHyjeiykugnXXOOgpyaNAkPlDQ/4Gzxj4x378a5mNetTm/cTa7LD22a52+mipv6e6NpG3EBGxwAD+XbTwzRxZLyDOpPQIgepjqpLfKnhSjBy5ztwMj99elhOMoqad2SuS9pdnjmfbUTTpT4wzPJxkegGkyzhjSbFn3bLlnqrba6j7qpihq6QFlYFslj6cDn/ANaVzi48tkKVb+DHdTVQuFelTRbUiGQib9pI9AvzrAqf6l2ZJ23aPAVa0cG54w6LmTew3HIzggaq5RTcX0Tv5LTQiCCOtVVotwBwScknj+/vqtyTfDskqRVENVcBPHUt4dOMMRwZPYA/OnlGlTXYrdsr3eZXuMEk29ogeFUdzjI/TV2GXGEoosUqdMZV1dxurSvCBSKxIjklOFZwO+ffWzxscGuLds045couN7KnQlHV3W8OtypJxEisd8cZUAj1z6jGrfLksMPaylX8o6MnTdFJeIK5YlnUKWjqJ2BjcKuDlR2x3HzriT8qXpOCf/slsZBd4+pbhMLV4zCGLKtCjInDHILZ4J1n9OWKK9T5Euw1JY5ZIf5nLVPRrsPjLHP5we2Scemro5lGHFbZbqjEXCI2W4VMy1TTQLGcbs7ufgfnrpYpRnDaLEuK2DOlryKq7NDNKphd3UeKdqNxyd3pj2+NW5sSiuUFsmElJ1Z88fVI2K49a3Q2OpD0SeVZfFkZN2SDjflnHyoAHsdek8SOSOFLKqf/AD7HKzuLn7OgLbqX+WszTMktLOuFmU4A577Tz3BxkYODjtrTJVsqX5LqdKwXeCSoWVIlHHihu35j11FjKNgBbrX2VlpPHbw4XLqqN5QfcaKUtkJuPRt7V9VbrURrFVdTXGmpgoH2kWSrY4A3kkgc445x21S8cU+jWvLyrTkTW/6z1nQfWlv6m6Nkms93oJ1kWV5XcTY42yAnDKRkEEchvfTcbjT2MvKcMiyY1X/n9z7/ALL/ABF9F/xR/T2nTqexXmyzNmRzDCWgSqQfjp5jxjuDn04bOudPyl4zfJ7R6SGXB5OPl1+H/wC/kDXCttP086XttJ0tQU9PVV6r93URhSWC/iKjPl9PXjOvMuUs0nLI/wBjLqCSx/J2Ch69tTWG1mNoqQqqtI2xckAc5B5XJ9e+sTxyds0KUV2c0+pf1Ck/mdJU21Wtt0QNFuDhgoI4Kn3b51q8bEn+paKZyT38o5gv1FvHSF2eWKqkrZo5TLNHUSGXc+PXJ7841vyYoZvwY3llCdRIq+8XPryne9rSSUkQkBldFI8NxyFz/wBtWxhHA/cTU8n7mYu9famu6ZMjso2tDI3H559TzpZST6Q6wwcvc9nRYesobd03FELea2aPDRSgEFE74JHzrG2+TcXoqnJRXFbLXTf1KSqoY3SEx1ALsXZgVGeMY7nTqTScp7+wQm2jI3asqqi5z3OtuE7GWQhXdc4/L0GMapc+UeKWyjLJrbYA+/qr3d5oHdpImQsc4CfLEajgoRTXZki2+yvK09FWBZIDJGVIXHK7j7HVrpq0xn3QO6e/py3GSWba7NsaIHG7jPGmzO6SQq0Eal2oIfuo18QcbyoPlHrjVcVy0x1SMvenlimFXBHKFDCRmkH4s/P7a6KjS4NiOr0Ojv8ANfmiidxG5/CoIwVHt/fSrFw2x+V6C9vkqKqeSMVAnjZdzSA5A9hj31RJRjuh3Jx0WZUmm2R09RNHVSHyq5GT6EY9vbUQlF3yQnaDdguJZ8VhaskT+nISApyBx/21ZHIsbaXRZBpaK9fJFVU5mWBYpGcojREO3c4DDUxyz5UnoWWW2U7h1AKGCBYZWgapR0CRKAMBsZPx349jrjY8blNye0jHyctmVvV4qrrVEhlYRqF8MDACqDzxrdDHHHj+17LJNtfkMdPdOw9S2ySrpAaSolkOI438hIXzAj05Ge+qsmV4VHm9L7liqSuJarekqikjnhguVKagKFeBptpkUghwBj29tH8ZGWK3F1Y0otKl2CaX6e19PRTzLHGFhOxPDkC9hjYc4OR8++ml5cMjXaf7DQxTpuRWpXqx9nS4FJVNEPGWVjlSp4HznVqjGuXaKVa0aCKkNrRpY3YmWXl41IUtgnv6jI1jyZPUlxv4G3F2Go0j6ivVTTyPIaeNVlUKSBK+OO3oPb51lgnixpR7v/Q0RipaRq5/GraaCSWOFEimWN0BONoHGDxzn01h5RhJxb7G4v8AUVqhZKyqmLLCJWwFlMeQvHHI11IThGK22v3FcrewFcp46wTU1TsKxoWVh23A4GR31sUpxXdr89lUpdpg1a+GGmNE8SxzSq+EHJYD1z/5207lLu9FayNaZg7pUzR26mqIpGiJZwyOMFcHgAf663RjGT4sqm7inHsIW66xU7LFPUO0mzLFu/vzqh47dpBFpaZNdruIo/DkO+mkOVI52DvpVj3rsmUlHszadYsoxExSHfuHlAHPBwNa3gv9yp5L6Og9O1VPX2ovNVRRoT5XIyyj3xrmZYSg6SNKpxtsWSwWrqS31NBJNN9wG3LUoCQnPDAD002LLkwTUq0TCno6Q9wjoukBYTy0cSxxVBk2u/GDk+mRz8aryTlPJyaNMpa4nM7ss1BU0jitSWk3Y+38RQ6AjkY7jgcH99aY8Wmq2ZXoOTdb0fTPTdHLR+Mr7SzAxAKMnkDHHbsdYVgnmytSBzUUHbTc6fqezxx0PipT1YJaSqJlZWBBIbHoRzrJODwTufaLISvoyv1EaroK+qY0sixTU6xo0Z2DOOWB7MPTBx3Gu/4HDJi5S7TNVvjbKvT9hr7tQQC6wfyxTCTEyYLbiCpZgPU5yPz1qnXPli3YquWmYL6qfTyzfT+y0lEaOnmmjt81YlUW2VLOjqBuIIYqd45GOcjPGuvDPOTtr5SOfkxrHo5BaeqEsU9atytqXWlraf7fG4RyKA6sMNtbgFRxj0HPcHTJPIlTqjP8aBcnU9VH4sVJvp4HO1Vk28JnIBO0D2yfjViWthYHqlmMm+UFiSfN3B/XTaQWW+n7V/O7xRUJqEpFqZkiMzjyxhjjcfgdzz6aSclGNhptI+vPo59B4ujYrj/tCtqv9IzCWlaSkD7cZy2HU8FcHGfT9dcfyMvLcdHQxw9PvZveprzSWujgoKJjDHNF4axwjYDgY2r6DjGuNkxXK0bPU4KomS/nn8olkV1eZI2QKzLhkJxz+Z500cfJaBTo6LPeVulimg8Tem5Zg7qBnJGF+SB6jWJKns0Oa0jHXW41FTJ9zNvnogxBaXgduB+fxrXCFLXZn58n+DIwVyLfTyUc5xvzknGRkds8ftq5wco0wjKpm6k60qbh0bTW/diSOqMkhjwA6YwM+v6axpQhJpmhZHOkY659MVNfUPVJV/ZybgSAAxI+PbVsZr7WV5oNS10a2zwvHAX8VfH27vCc4LD047ayTq3oo5JaoieaOWsko4CjnYZn2KMp78+moScY2zO5bpAeW/ySwNBLLE6f8PZK5Usc53e3bjTemou0itt3TMhUVsFTe1eld4zFINwQYDDJJBPx/lraovhsF3o11bDDAieJJ47yYfaCRsU+49NYVbG7MtUXCkp7vFMgV1EmGiyR4nqefT01tjBuDTF1dmlaRbrRTMoakgcYDQMCVJHGAfTWVXFr5CW0BpbS8drkpGnNdV4KlGbA2/4dq9sj11oWROXJ6Qq74lTpekWjp5LeaNIqzJV55BnG7OF+D+WrMsm5ck9DRaWmiK2W97OHhcAVAm2tJFuDNjt+mNLOXN2gihlLdHmral6afxPtQdsgB3ZHOB8jT8NU/kW1G6EorvWXaUSo7GZcSbRgDOeSff8AXUShGCEjLkzRWU4qWSaWSmqZO5CrwBySAffOkUnGtaGa5OjAyXOSomniXMpKnwS74wc8nTvEoSVmRz5NJEVLWstFOC7oMDxUK5IIPH751ZJK6ouU62GOm79DDbq+mQiCoDqvjxtkFe+zHznk6x+Tik5R+UaISSi/uaHoKvjknmkV4xUQIULTeaQgjHCnjaPX11n8mHHHtdsswzttv4I791NJa7zMkhaTxImjlhflXZuRj8xznU4PH9THcV89iyk4tmes90gr62KoJIqI/wCmsW0sW7gEn44P6DW6eNr2/BRCabs0N1uxgpKG21c6TsZQ/iKx2sBx5Txg47599YngjyeSI8pf5maKiqaNo6iWkk3u0yhdjfhAXsB/iH+o1z+E7SkjSpJXQanuNxjkaIQkAfibHBGPxH25Gj+HxS3ZcsvtopPeqQRNU7zHURAtMiLhSM/ix6HWqGBr2fHwYZ5ovdAi4XqLxoFFOiLMx3GQ5A478a0KDrvor52VJFakrJKyCuaOEx7N0MYJPOe/pqH7oKLWxk62jI9dVlVWtFLTJFOm78acGNRz+HW/xUoe2RXkTe0YprjJTXQFZDKQDvdhkDPc66LgnGjM7UtGtpKEXS0+NJL4km4LHEo8hznO4/tjWKS4PRpUdbJqDpez00yTSSzERDJU42M3xpZZ8jVUTxilYaukaXGnipKSNaKcglmKkKw9Bge4Gs0ZOPultDP3aRNa6K72CCCtmCrGWMTQA7nVeCHPpjQpYs03CyVCUfcVrh1hVNXwxTUv3LyMShOQgOfXP662RwxptOiHN2aPpOx0VuWa9XBlNf8A1Pto2/FnvuDdsfB1zfIySn/04dfIy1tg7rPq82iyGolRUaSURlpGBcxtwxUNnkc/lxqcHj+pOk//ANK5zpWDrB1bTT3dkilqbXbxHHHEhjYKWByASMDOPnnOrcuBqG0myIS39jsNHfaK/q9FcYGlRY8wvVoC4QsPw/Of31R4mKcJNp/2OpjnLjT6CtPa7fSTlIWkaAOXzIN3OBxrtRio6JbPlH+JHorqpes7r1HM0lTZallgp2SoDGKHgLEUGMDcOBjknuTrv4EpYU/t/uczLjnKTmla1/T7HEAs8c5RFab/AKcZ/wDWrWr0zM0XaKramqKaaWKSAB8o+Ccke36kar410RVbDIt9z69riKRlqpUBaSSd1iWMHjLO2BkkcdzxqqU1j3ISUq2wOlnqY7lNQLtlnQusn27CUKq53kYPOACeO/66aPvpkr7vo+1Ppxb7j0l9O7dQtXxXpKdQ0NXTo22SNxuQDccnhh7cY9tc7L7pOkdWEWorZR+ocMq21KiOo+1faTsC5DcjIB9O2quCfY03SMDD1H9rbJKmfh95U+Y5U+hI1keNuVIVScVs6L9Puqv51akWfZCtOgjGQADz6fPOsGbD6UvvZPqdAL6jWS6ypG8colgnk3kyjb4SjGCABznGMa04M2OHaLI3P9IO6SkvN+qkoKjCHILh49ipgHBLHvps9R2h+eSXtl0vwHKvp2qoIzRy1AmHBcw4IDAZGD/3+dc9yTldF0OHGiW2TSVk8UEhaR9mGKt5hjjWmXCEeRQ27olrqqKigkIhYVH/AA1j3EmTntk/vrKnJvZTJv5A/wDNlpIWnkjAlXJjw2AT6g45OncOTKn9wJcqyouGJZIY08NMyVEQPly2cn582r0opU2JZFb44rRUSPLAJ4UY+Z2yrZ7Ee+pk5SpJjRTQWo7vXXKqdJKmNYeRLlvMiA53f3GqZQUN0Ly+GWrubZTz7AIbiyHOxYyJG3cf37/loi5v8DSkkrKa3RI6qOm8U0qhxseTzKi+oJHoPTTOFK+yt38jq6ZrbI0KysytJ5vLwFI757jSpcuxXaIKh5DXwwfcFoWbc1QPPtPyR6Z4/XViVxbosT+BIJHo7jPFWSxREYVJlbdtOO/H56HH2polNxYyzW/7G21C1cixVKVBkyMlTk9xkeo1M5W010K/kGdTlLT9vV0cclOamLCKMN585bt341djXqJqXwQ/btdhW0XAVksBeJvFaMeLO58oBHH5YOqJLj0TG7uiunT9BSzUb7lhjdDlyCcYxq6TlKQqhEdWWKCWpqplgWN5CBtJI24Uc/t/npnS1ZPBN3RkIk8W61kcWIxJjwmAO0sOMkDV7/7abFaV10FFvcvTVsp5VpqVJp5J4pGVirFcBQPyOSe/fWeXjxzab7othN4Y2vkL00rXqrtsrxI0IUGTxCAxwOc/px+2s7wSxRkoN0NUp1sntNqC1s8NIX2LK0oCHasR3Ht/zZUftqcjrH7/AP8ARuEYNqg3SCy9ROY5amOKaOMp4gGATz6H31zpY8uLfwK+Mnsp9NWtekrjPDX1ZlVo1ZUSPO9Q2Qf0yOfz1pnL1VyiiF7bs2C2+RpapqLzGWMOzucgKxPmBPqNY1OKS5k8HuiGCH7Wvip5oJpRPHsk3RgoOO7EfHOrHNtOURVGqTOc3y3i2zT1D1ElSgQsitkKCfw8jvxnj411cUvUVVRmlFLpi2e8zXnpuGGD/gRbhJInGCOTkfHbVWSCxZW5fI0JNxoo0NXJWU0+aTa8JKsHBwPbOtDil8jRbadoH22wNa7/ACVElUhAG9lhAYsh7jHpjV2TIp46SFjHjK7N7HZQ1XQlLc5oapTI0hYAR4H4uOx5GubLL7HvaNTp1o9dbbSwIlO83gwyFcZXlucEjnnk6iE21dFMkkq+DR9PUs0NFL95FDJJHkLMygswHrg9uONYcsuUlw+Ro6TsGtcGuDR0zInhzkkxM+B3I/TkavhD03yXaBTb7Mr1X03PTyytFMrSKN8UWcDA9BrrYM3NJtFcov4MtL1RcPtFpZ6kwNCCAky4O48/rrR6ML5JdlXJmul6Z+6o6T+bILhZpEWXw5J85kIwGyDkDnO3XMWZqT9LUi6r76Lsf8wtciW2Kinq6OjUALKwVdxyUI45Ix3PIx86pajkfO6bGUZNqKR0Pp6BWt6yiJocgLtkbJGTydaPGxu22zoxXGNAn6m9X1XQvSqta1NRcqmQpCJBkKwGSfyA5Ou5gwqb2Z8s+K0cZqPqo93+nUtov5ravqyXqGlr0ukkSy0sFIgO5ERRlSGCkrg7h+Wu1BxSjj6jZzm58uaew31Y/S166GvPU9M1ulvf27Pup2/qRy8KQ5OCWPttAx+erc6i054zKnKDpsw15+k1RdLLFcsyR0kdIKmILKrswZdxbaOwyP21kXt0zZhcMlqTp/BymppIaekpHjm8Qzxl3TP4CDjB/wA9FurorlVJph6lnj6Fu3i09SKiZqViCFXhyeAeT5Tj3zg+mpwzuXJroqblJUjUfTL653npSqgoq+rnqbGo2x0vDCAZ7LnsvxnSTwqStdmuGVw76PpupSHqKxhwqTQyJ4yl+QwP+Ej5/wBNciT4WjpR3sxNV0UMOZKdKhnk8YrsyWHoB/YaxwzcndUZ5XJ20aCgvNHaaKIfbj+ZSy7XVQF8FfUYHHp31RllPLKn0VzTlJWaE7Lhb6dp3kMiR+MTGcqwycAk8dtV1Fdo1Y4tNUCK61z2u3S3KMO1MpMZUHuGOQx+B21Xj9zr5Njk1avQ+2zvVZWam8Hcu7cmQG/XUZKjtu2Z7vRdpZYLUz1Cr4oHlIAztBPYH11W1y9o6qKsD3euNz8SopIkeenODTyErxg4YDtnURTi6l8mOeRt0YjqK6xPRws0YWYhnZ0PGB/r341uhB2JklSQNo+oJzHAskciW+ZiuSuQ3GDz2znUyxp9doq5WbLqq15t1LJFAIkmXweZck5GQVPbWXFN8m38Frt9GEslTPZ7o1urUlO9G2h8Ddx7nuO3Gt+RKUecTNu2maulv9HGkM8isrQqNmxfMG7HLfP9tYnFvQW0gZ1FeJK1dyKqRKuckDOc/wCerMcKdljdobTVC190qaGeo8FkUSs7ndvPrqZLilJIXTbVmkaqgjhMZkjEKKP64TYXxggYH5ao3ZaqRneqaWa928XShLTrDKBNGU27FHYk+p/L01qwuMXwkVyTkriQ1Nzp2cyeNklgEi584HfnUqPxRD1sLW6x1XUljppaen2/bTbhI7jLAA5Vc+3r8aplNY5NX2Vyyrj+wcjofsIWeI0807psdSVaNSeCGHGfg+mqlvTMzyzb0Z6avlM0TQpkDI2SrkY7Dga6SahGmdB66CNLUgUda9RGfEIxkcn2JH+WsbyRv2hy+xnZopbR1FBIIGlkeMMYW7+Y8DHrnWjeTF38i/zGQ6qo3NxlLuzIszBoYh+F85Yc47cjW2MdKMfgSSuVGo+nlVNdGmlp6cLUKQjysRgoe2F99UZJeh+p6NEJNbaN5dCyUM9NLRSUsUojWOWFt8kmAck47AHXFeR5JqV3/sLLJKcuL6Alm6WtFguMkEldU19Ydrq0cQ8JCDnaxPPPOrJeRkzx6SRT6fCV8jVVVV1Pe7RUvTxQ0oYbYDKAMRg8ntxnHbWCEcGOVN2aXKTVIw9x6+utpiSzV9vNJNU4jDoQQqZwcEevr+uugvFxzfqwdpFfOS00aSG81dLaGq6muVogzLH597suBz8HGqnCE9RWxpNxV2PsVzp+oYmjqaaOopUPiL4nfI7Y/wDONNOLx9PZEZqRTuNJDNUxloWpYZFZV+0AG0EjHGMenrqI2o/ditplaw9J1lFW1AqbgtTRVIyqSDnwwMDd7f66tyZk4pQjTQqXH50EW6Qp45HqoYlUU8YRWjbJdA3J5+NJ606pvsZr5QYttt+0tDy1Tnw5RuD7wCq84yv9tZpybkuI0Wq2Q0lpp1uME/jxTUkSEhZDuVhjGBnsdWucnBxqmNSWwZcr6sNLUxrSyHxZPCQvyS2DwvwR208MTckUSbrXyZKzU9xjuFbUNAwgUBdhfLREknlfy1tm4OKiUQjK7YJe83JrpJKJAwjB43cY+BraoQUUixJp9mmt1itt4paarulQKvCsWp9pAkB7DIwQB76yznlg3HGq/Jaop7YLrOh5rZJUziaOWhVR4CxTsXG05yN3p/208cykla38icKYMtfUdbFURvc6ispQytLEA5Qbl9ee+Rp3hiv0pMWE3GSbOu9G9aGDpuGeSF54ZJRHHK45YnkZHxrSlFOkdNSc0pAr6hXCovtqQw0TR1K+JArEcIrEFhu7c4Guh43yzNn+D5yutXJR1E0LAo6MVPHrnWxmXZ61dJr1VBUHctPNEhfxiOf/AIj3J9tLdENWjU9K9E9X3Gw1vgdRz0k8aiGioJpiy1GQcoN3C5GAPT8tM5JuqF9P5Zym72e721VWuoqqmSH+kvjRkBfXAP7nRroEkgRqRiSnZRKm8sI8jdt749caZNitH2b0/daastcFsglkaOnhQeOwx4o2+UnHvrzXkOUpWdOHVBeOaipY5IRIizKQfGfPBx298DWSUWnZdo5t1VUGDqWnWlQVDyJzFC4Cn1zye/PbWvDGMoNyZVxc5VFHZo+jami6bWefxKWocbdsyFCAVH+BsHH565zbWTi0bYwr3Jlbp36RUlXaZb1/t8WqaGPbW2Cup5I3qC/KiFs4IUAHPb8taZZpzThHH+zQ78eCgpxnb+UETJT01OqpgQIoCq/c++uJKMm7M2/kz10vcdDVCWIvI0a/1IkHlxnHI9RjV0YOijK66MtcpprjVmoo4XRGQo6sN28HPm/Ma0x4pVIzNKT7M71PaGpbLHLM/wB065QhAcKnuNa8MlLSEnqNspW2aho6CCijjeWWKRZnTxSUmPfgHscaJJttjRarQZpY7lNWpOAy0Tk7DMCI0Pp+XtnVMuKi0+wSd2Dj1N4tWYKoK4EmF8UZZWHG7P76f0/baIbVUOuT0GyNKSednXe8qyABWx7e2oipfKK5fhgyuvz2zxA2JYKobfEEOSpAGBj9dWwx81+xHJptGSt90qq+9yyFHR3j5yOVAHP+WtssSjFUK7bs6dZ0or1Z6eSoq5aaoCiJQnG8j0z+XGuXk5Y5dGhK0hq3qCnvMtuXxTQeH4aiQ4bHrnHf203C4832I5OMqQGgoqWkv5eVvBp6NC9NxkNJwQGU/iGM8a0yk5Y6Xz2RJU6NfabzHKrxNTwUMcj/AHDzIzbdmcN5RnA9PTWRwtX8mBpbTQ+7UsEsaGnpZqKfc1QF3nblceVQR5ht5OTxnUxjJMVS4vRvK202ShpKuaEGOSfj+pwQvvx2HrjXG5Z5yip9I9Bxgrswlxovsllj+9DJLKEIxwB/zfOuxHG8kbqjDJKPyCOp6d6e7W6oiUzViPGtOxPBZW7lT78YGuh46Tg20RKVV9znXXnSV6t/USGCV6mv8TxpURs4Zjxz27+mteDLFxbl0Q007NV9NxfLNff5RWUmypqF8VSRwmB+Fjjg85/XWXy3hlic29GzHLbjI6pb7FVWKcTwCSrqfDIqGlfBIJ8uB6415SeaGROL0vgnio7jsbLerZFL4E0kJBfe6kkvv99x9fjTRhNq0VtoD3Hqn7K8SCCqCP4XCswEePy9SNWRwXGmheVOrMj1pX2S7VS+NK5rWdVdqcZDkduf8Oul4yy44NJaFm0wfbrTXgVMD0RgpzMIaeSZm3ybvX2ORj9taOUNO9/JXKL40zTWKGq6cSRJniJgJhaONgwx689vX01RljGbtFceUAtS1UD2qpqTJKso4VNw2jBzwPYY1TKMnJIflaYNoeoVaF4ZXWUtGMgdgQc4zqxwplKkvlhCi6xmpqQJSRKYwcvsTdkk+uqn46btjLM1qIXi6ghuMvkpSadVDyO6jHPHI9ec6X0uK72SsluugZ1JTS9P20ywwJDSSLlCHDd/f2/LVmDjklTeyySVWzIWjqtrnHT76v7ZabvLIgYEg4B59cZxrXPFxb1dmVTrTYD6Yu5unVRpJqnZBUgASqckZ4P799X5YKGPlXRGOVzph23WSjSpYwSyVscTESCqXGBnHcH4zocpNK9GqlZHd77SW640yqiGmhjZcKff/ER786eMG4uxJSp6IqHr2go2kglaNUyDHHG3lT3LD1z8aZ4XLZWp12U67ofqG/1lRcZU+2tisWhE75Ecffv7ar/isWNKK2yZQk3fwdEs9MLX0ituel+yeaMmnnbP9Uj/ABjPbOe51mxZJTz8k7+/4N2G4qjL0fVVfJ9Rqfpy5SxLEgiWSPfhSdm/OSe5GP2GvUePFRhr5Kszcp0yve7Rbura2oFRSiCczkLInG1WY8Acdu/6acWgT1NYn6KtFf8Aabnj8RZYp0TzbBghmx+HOcY7jjQlYrLMV1mtvTlJU13+7tURKyR4AYjgZB9AF/XUdB2W7HR0v1GTYwP28IVBEzZwAcck9sjUEvRzP6u/SeXopoq+mYS0UjbJUyN8T+hIH+E+/bII1YmhGmjm8MW86uUfkrcqPq76W26S9dK2QohSojpUj8g80uF4z8gH9tedzyj6kkdXArgrNBdOm6ia5zUFW6rUbgWblc9tpz7HSxcJK0WtW6Z9P/wzfw92O+9F2z/aO02WhuEN7iulwuFzkXxpYIpAKeniY/h5RyRkbt3OeNeh8OGBeM5yVt/6HPyc1n4rS/B9LfxK3PoTqvp4f7UXK20ngSMlMZqjEkiumONmSy55K+m3Oud9SUHiW1a3+f6GzwlKEnKcXx6/H9T8zvqvfaj6OXjpVbX1Jb7/AFVSprZaakVpooUBwoy34gx7cDtrj44x8zFPFJNLq+mdPI34jg4tP5LVV1cKlTUSyJ90y+KIQo2k9yAPz7DWD0FFcF0jFPLzk2ZGm69e4+PLTqKdkbaSRgZOOP7nV0/H49szykpbQ22dRydOQNHKd77yqsreUBu/Pr/pqueP1HZmTikG6OuoqikqEmSN4YozFgsOAw52k/Oq5KUWqZD3utHLf5RWUFwlrWAgo2kZIlLbnXGBgj0P566jlGUVH5Kb4O2aa3dUwR0ngIxqoEJ8SJ3JRsc8/qe2sssTbv5LVNPZl+qrolfFBWJtiMed4jGFP6e+tGGDi3EmbTjYJW8ZEUu+afefDdW4CrnIC++ruF/go5InvNx+zWlZZHZ1CKEdcjA5DH59NJCN2hno9SSzwUFVcpYlDTP4oAIyVyc8dwNTacuEWOnxVstWq+09PRvJJOUx/wAGPGWUnnP9sfrpZwcnVE9LsM1V4rbnCzxo/i0uJAgUYcNgkgfnqlY1DT+RLcmbodGUHU30h61vVVETfrZAKmmIcrtGAAMA4zuJ10PDx45Qk38FGeclNJHJLdQ17UlMJhNv8YeNUcqypgZXA9fz9dZm43oMsWkmzWdL9Q/zG51tojuLQU2VjM0IDHAJ/CzfhJGAdJlx8Ep1bM76M1W/W4VsdOzeN4gwrBR2+R760rxeN0dB5JS7No1ypUo4a2VJXkWCKeRwhUFcsNx9vTOs0VJpwstyR1Fr7C9SXyOl/ktxq0BWaJaiKONuNhJ2YPcZxnWuONxw8EUzrkmWqijp+qHpayp3VU4bfHTLIzhiq5QMBjsfXWWDcG0Xwhzd9mw/h5p7t9TOuX6drzNb5Hp6icVG1f6bRoDsBPocgZ1E/DxeRJLlqhMk3jRhLh1hVWmrqmrfHSWBpKaZ1U8lSRwf07/Oub/CJPiqHcqOXXL6j1b1qPu8i7lwfPwT359ddeHiRUaKed9kFZ1Y9ezDxBu2DGcg9u+mXjqL6ElKujQ9L9X2vpFGkvFNNJW1CBoZY3VlK9s49Of11Rl8fJm1jei1L017vk2dL9TbdW9Mb69PGkxJHA27gHvnj15/TGs/8LOM6j+LKXk+5lKTr/7i0REuoEkrREjuABnkn9861Px6kZXKUXRWl6vkSF1VjLGMAlOwyMn9QP8APTLAm7J5SIabrOKKCFd6HIKhR3GD66JYW70NFNo19kv60duiNPUQtLMQdqt5xgnJ9gORrPKNvo2uCx4lNPYMputJIWo/AURssexsNnxOScn3OrHjTTTOe00wDN9Qai9wvDNK4O52SN144479tXR8aMNol8kqZm4rlNJNPRoWKyAuYl9fXjWrgqUiI45S3QQs2y2XamlnnEShlO8HOARxquVyi0kaPQadksXUNVSdSbmqDCiSbJRH5lKA98n3HGmWNOHRMZOLv5HdT9XxyTSx01MlPHwYHH4s+59wRp44/uI5tGbt9YZ63xpHG4cnCg5P5atktUim/cbin+qtwWNaa6wGoo1JyqeU/GT7ZwcfGsD8KN3DTLVOXTOt/SDqgXtLjJcJHqqFWC/dSruPGCFGedZJYeE1x0/sdDxW3fLo5r9frzFb/q5HWW4LBUU1LCXmiP4mGSrfB27RrteHKTx2xPJpZKR7pv6iSXquqZpIPFkADykDCke7e+TwO3fW4pT0a2+dYKnSN7mFKBUGnwJwAEDsT798Ak4GoYy2ckt9nvXVFtE+8vEQyLJM/dgAcD9/76XsY6R0N4f0v6eequM0SpMyuyDa2444IbPz7Y1PRBnr91RF1eamnhmjnV33gOQCwx6n4/uPy1KA5Z1dZBZK6FYhsjnQOI88o3Zh+/bVtujPJH3J/DZ0Dbqr6cWDrzqy7w9OdH0iwwVVbIR4mVQsfBQ53sQMn2HodeZz405Sl+TtePHkkvwdu/iF6U+n9Dcumafp2/tdLnVUTVq0UkOWemAABDKo2tkjytg4B1Q4xSuBonjpOUtNGw+iVH0pQ9OXut6xr7PbbPDT0y1EnURRot67pVOHOCUBAGOcnXb+kRlLHNS2rMX1BrF6dadf7nFv4jOqfpX15elv3Q3UtuuhtuKaSko6JoWA27vEXyqrqS2MrntjJxqPq0MUcceP6m6MmHNOVqT0fK/TvQ0VyFzvl1kkpzUVLszrNsYICdoAHO3jtrp4fpmXJhjOLSVFH8fig3GSbZl2erNbM8NYVUsW3cjC+muK8aSpov29oErUz2sSqkhnhl7tgjI0zxqW/sLbiS/zueYs8hHhwqpSBh3znkHSeikS6d2Q1F6kNUkpciGJEBbkBvXHyRqfRSQrj+dEty6qqLxUeIr+dFEhA7Agcn541XHCoick2/wVaW+tapQsZPiMVdgDkAd+Pz400sfLsI6dRIrrf1plqKKUGUSDOEx5WzkZ/LOmhibqQ9acWQ2i60tJUI9Xu8FWyuB6amWNtaIUFHsszX1+pb8oipnemQqWC4BwBj/PSLEscKbLYrm+ieguKpX1NO6CIbHiBkY8/B+c+mieO0nEZq9FC41T22eVBiOo8yu2Pw858v6Y1MI8kmZ8kWg90T1FOayaNZA0tVGImEnIAHpqjPCl+xGOR0Kx3O9Wnpvqih8QLR3KCONp5VIVU3Zyo9xj199TimoxlGKu0PLCpSi2+jk9VcnssiPS1ss23/8AzqzR59+NXQhy01RmzSrQLgvE9BULVUphhPib/MMndg8fII/TVzgmuMjKmbWn/h7u1Evj3W92q2rHhyom8V155GB66yS82L1GLZ6VeDL+eSRuOmLMlfWUlKld4EH2ahqh+QQKgKSI/wDFwx1PzJ0VKMbhGTpdf6gn6/rK1xs9ts4DikphAxXCnKsRyPnPb01sVL9RknFzft6Oh/wqfRzqTr+2daV8ldR2agsdtaqapqlMniS8+HAAD5Q2D5vTAwDnXM8zLDGku7Ojgg0qD/086L6gputTWV5joqBYS2YJx5sjke/yfy1j5KLXDsvj47jJuXRyj6wV0dkSW1JcBdAZHlMkADYU8jnsdW+Nj5y5tUY/Jioz0fPlTUF5Cdm34I13oxOO5bpEbu07E8jI/wAI1KVFivsgk3jacsdvvq2NNENv5LtPdKmOOOEOTEhJVPQE99VuC7EptkqJ9tCV8QshOWX0zqHs1cIrbFkqSJ1MMjOGj2vk9iRg41CVIGoyeiwban2sc33SI+Ttjxls/J0t7qi3gqux4u8tDLAY3Y+FzhzuG/1xj01HBMWck1TLS3B/tXgWjDSSAbJtxypPf9TzpXjV22LGPtca7BzzbTGG8QSKu3LHjHoBp+NkyqkmWrZc1t9TBURgl0P+IZxqHjbTTFXkRhTIKid62p2vMIhuJA28DJ+NMoqCKpZ03otS2KtikjVjuR87WAOHxqIyTDkpK47JLj09PHS09RIr5byYHOMep9tWLXQrVRuSG263PFXKXwQvo3GeNOoatlcI+4u1YaYPE+MsT8afjfRY9nVPohC1zpJLZFcI6SvWZZhE7ZWZQOQF9/nXC8yTwSWTjaNOPOorglswn16tdZZ/qG9PXNC0z08T5hOV2EHb+uBzrd4OSOTFyiVZGpS7Mj1deqmlnjt9HM1PQwIhEMflDOVBLMB3OfftroLbpkg6l6wuIpHoZql5KOT8SMeAfcabjXRNnT+iOt6O2dKOJYFiNNGDtXcfEwpDck/iYgfHm9McrVMLtHMOpeoq/q26SVlbMSGPkhH4Il7BVHsBxouheyrbKfbVRkN5sjHOP8tK5WMkaz6mr4Vbb6UOzClp41wz78Ejc2D+Z090hZn1T9L/AKhWHrD+Cb/Yu6pI13t19C05VfJ4YQlDx2/EAffWBwxptS+d/wBTXi9WUU8fxo5V9CPqD1X1F9TLnc7nUy3Gaqp5WlmqB+N9wGR7Nkay+TGEcainRask5tuRof4p7NW9X2603SDbHRWmFjVKzHLFnHmA5GRyOdU+B5cMcnifbKc8n5EoqXwh/wBMemalbZcKuumg+0KRhXaXMTDbnPbJxkDHoc6by8+PyHGKdNDvC8LqTB1RBS1sN7pZKiO4nZ4yHb4bZIOCqtzjI9M869p9OnHN4bg/i0ee8lennUovs5vLRTzJJJCJo8nzK6kZP5HXl/UidX1H/Ki3Z6etCNNPTLU0yEhssB+mDqqWaMZUL6mRdrQCq4pKiqDRxtGFPDlQvHpq/nH7ic5fYiez1lYJVYPAjN5coWC/PGp5x+BuTbL1P0TX22N/uZJ0zHkskBbKn1xn40jyxfRasXF3YPl6Vulv8OoMbCPBYtUIU3D8tQssHqx4x4bsrGKmqKxXr5JBExy4p1G/9M8ae2l7RucL3/oRXi3iSd5bPT1T0KEKrVCjcOPUjjTR/wD99lc4NyvH1+RlpFVRTipiXbKfLvPp8ge+pkk1THhcXYQuEf8AM6uOXwWp029+QWI7nnkn/vpUuK7LXTdlWGgvFxrAsdBU1rL/AExshZtw/Qf30XCK26KorJJ7Vm4+nX0V6uvV4SoNlq6GlyX3zRFFx8A99YvI8jHGNJ2PDxskpcuNHV7v0bfvDrbfVW+ppKaOASRNPiOF8csS3OMd8aw4ZxgnK9l0sGS6aOC9dfZ2qtEVNI1RMoBlUx+RG5JwfX89djDyatnFzRfJ2jJJdZmoZad5QInYMVXAzjOOe+OdaWtlTVdH1QfoFKoKQXRII3IJDNI+Tjkkka8j/iD7kjZ/FM0vTH0s/wBnKauq6i4tN9nQiKQwgISviiTIYjj0Guh4flyzZaUas0vM5qOvh/7gCy/SiT6jU0t9qK/wZJZXRQI85CnGT+Zzo87zZYM/pxWjCp5b9p0qy2DqDoejo7bZ6p5LPca9DekRQscsaRsY9w7kB/8APWD14ZscnkVSXTv/AEo6eHypw7Wv2Nu8UFXSTU3geA8iFfERBwCMHvrF60k7Na8+L04s571T9IJ+p6JaOW8LTUcYAjhp6FF2j8wc6vh5Xpvlxt/uJPy1NU0/9DEyfwfWWqG6W9VjNnGUhTH6861f4rkXUTG5Y5bcX/oQV/8AB3QVEifb3aaM8ZZqf0/Q99MvquT5iRcPiI63/wAFtubJqrvXOxzt8CnUAfnuPOiX1bI+oIlcfmLET+C6hhn3fzuuJB/C1KnPx31H+K5q/Qv9Rdp2ol0/wVUsinZdplLDA/3MMQP/AOWl/wAVyfMV/cmsj/lRWX+Bmm3q03UlWQe4WnVf276b/F8nxBCPHlZah/gatak7uoK8j0Pgpkaj/Fs3+VErHkRYh/gc6f8AAZWvFyZyR5yiAj8hjR/iuf8AyoFjdCU38D9j8SNDfbky458if9tH+K5/8qF9Kb1YZX+CXpvCeJebpJGowqkphR7dtJ/ifkfCRd6cvuPj/gu6MQsDPc5t3qJQMf8A9dR/iXlP7f2Kni2E6D+EjoaidZYzdFkRg4xMGxj800kvqHkS02v7DLHxejb130n6araEUdVRrNGMAAwqrY/NQNc1TywfKM2h3LJVX/oBZf4f+iJ3c/yeoZnXBCzOqn24Grl5nkpf9xmeUJSZXg/hi6FjlScdPTtIG9ZpT/Y+mnfn+W9OZHoy/wCWG6D6CdHUk++HpWlLk58SeIsc++TqmefyJreR/wByfQmzRUX0ntNDP49JZKGjmHmMsUG1vzyBxrM/Ul7XJv8AqPHx8i6PhT+Lm5W66fVCnqrYUkpRRJAZ4xhZHSSQMw+OQM+uNe98HwsnhYVHL3Lf7WZrtvZxC71H3Fa7bQmceVfy100W3ZQJ05IZluTSdO0tOVLNG7pvzxtODj3Jzn8h+elrYAtXIGooAlZQJbhTo2SDIoOPz1W0OmWerbhLXXyqeRxI4kK71OQccAj9NP2Uv7HbP4PwvVPVNy6OmdClZELlBA5w00lN5pI1P/M0Jcgevh65Pnx4weVdpUbfF7kvwfV/0J+l9u6f6N8aG3O01VUTSHdHuwA5AAONeT8+blmab6ovyYk3o1P1D+mVb1n0VebJb6GVq6vpzBBEI1BeQ4KgZ9zrP4j/AOvDjt2LDClJOXRS6H+mV76XsphulukpaKRgad9q/wBRgo8bIB4IfI59tXeVilGp5F3a/sy7Oo5oQivhf+Tln8QdPH0x1T0NXwxRpU1EtTTHxkGWTarD8wD/AJ69f/8AE5VlyQXVI4HnYFCCZ1Sj+mlgqViqJenleVo1YyPGM5wD2OdePzTaySSerf8AudGHjRpPiFY/p7YoEXZYKbHcqY0/7azuf5Lf4dfESaHoy3ISBZaSJB6+Ggx/bStx+46wNdISXo2jlgkjejplRgM+VMHUqST0S8UmtlCr+nFrrBmSigmDKVIEmBg/lplPj0yPQb+QfJ9FenKhf94sdHIF43SzOw2+2M6ZeTkT0yP4eS+SqfoV0emCem7LHg7gVizp/wCLz/52T6L/AMyJJfo30uAXNjtuGHAEOR+3bQvJzf5mRwl/mCNJ0RaLcN0FroEAICn7ZMD8uNK8033JjrlHqQ+ex0rAFqClkfsH+2TGmUm1tiylOXbHU1vanceBSQjaO6gLn9tHJpdhGWRdMsrUVwXPhxJjjaSOdSp/lj+rm+5DMtZKjq4ppEIO5CAeNHNivJlfbMlX/TLpy51DTT9P2mZ3OW3RZJPzq6OfKtKT/uUSg32QxfTnp+ibdB0/ZYl3EE/ZqT/lqZZ8j05MTi10aWB4Hj3FVfPYJFwD+usnXyVqn8X/AEAvUVshrqSthkjqVjkeLKU6hXfsAqj1J9vYa6301tZeV9I0LGmlaKfQt06b6YsNupLhcmo46hp5U2Q72z4jf09vfcPLkemddrJ9Ieebz5MiSZhyZEnUEa/p+eg6lpkq6CqYwf8AN5WyfXkca5Hn+Ji8FpRbla7GwReW23VBhbLFuBMryfkAOf21xuSNnoL7lv8AksMqeYVDk8eXjSuSGeCL7ZLD00i8eDUHn/mxpecSV48fyWh0mzEYWdT/APLOkeRFq8b9ywvSyr+NsY//ANj/AP30ry/ZFq8aPyV5enaGFyXqIlbOTl+2hZJNVQr8fGntjBRWunUoauLj/qYk6hSf2I9LEvkqvDbVwDUlgD3QMDprk/gThi+40yW2HA8WVznszH9++mTkHHF92O+8tobczSbiOwLHTe4jjjJF/lxO9kmAJwc540lyJ44/ksr/AC4Bzja2Mjd/70vOXwTxgTJNRpTpKdkauOM4yP76PUn9g9i+SOS7QYAgqofKc447anlkfwLyh8Mie7yzS7VliwefKVx/bTcn8iOS+5DLdFhIaSopgw7Mrc6lbfQnOK7ZAnUiqSi1qbh2UMc51Lv7C+qv8xZgv0koZWnVc+pZQD+udFOhlP8AJ6oqpaiGSKSrVYpQUOKgAlSCCO+pi5J2Ptn5p/XLoi59D32ptN3ZpaulkZ6apQhoammbs6/9WQAw9DnX0vH5cfOwxzR7Wmvscvi8cuLOW1tNI0SVQjIjk43YwN3qBqxFseihjOmGLAhY0fi8bFfYeRnJGRx+h0EfJagoTLR+OuSgO1vg6rloEg30xb6cVnjGYSSRKZREnfj/AM9NKrb2O6SsAV8hkqpXPBLE86cqZtfoN9QofpX9Yejeq6qBqqhtV0gnq6dG2tLTbtsyA+hMbOM/Oqc0Izg4yVoshJwdo/TeTqK32WljpLRBNT0cUspC1MoceGWJTkY82Dyex9NeJ8p4M8+UI8S1eVx7lYW6D+r9F011BHd56SO9vTKTTwGcxpHKOzNgHcB7ajxZY/GyrK1ddCS8uMlSkWOtvrv/ALV2C1W9bZT277KWWZ5YHLGVnyXyCOASeO+ONavL8yHlQjBwqnZXHyVB2myOL6t9BpFJJUfTK0XWplh8FJ7rM1Z4aZywQOvlJPcqQe3trR431GHiQ4YYVf5Enmxzdz2Yu5fUOirKuqnhV6SFpGZYIclYlzwi5GcD51xJuEpuVVZb/HR/JRbr6J5Y1c1EaYJ82V3Y+NLUCP42K7THDrhKqZ2j8d1C93yB/fQ+ERf45PqLBtX9RTTzSKlNPMuPnv7DGm4IR+f9oF6h62W4QpNT0Hhq+ch3cNx/zA6R8eh15t9RIJeqamLc2FZQMFMEn4xzqaj9hH5Uq6RXPVtR9xyqSMOMBgdv6amox3RX/FzvpFqo6nq8Bl8LaeSVbjUaol+XkX2I06juEkasmzaQGIwSR+ek5L7AvLyPZY+6udUQYZ40UnzSP6DHx86X1a+Bn5GV9MQV12hZP94Ta2e6kkDR6qq6F/iMyfZHJNdcOHqPDYHbhUGME8Y/++l/iI/CI9bPL+Yc4rYhg17SHO0sBnH5403r18CyyZouuZQkhrYmM8lTJ9uckAk5GO/HfQ83zRU55b3JjGM0jyFHn7A/iI/PGp9cjlk+7LCXKobHhyMjKO5wB/npuMDSs6XVi2261yXujrKjZUinDOkLElS+MBiR7DPGtuDyV491HsmPmSj2rM90xb36Pqqyrtyq9XUSu7yVGW2yO+5ioP4R2HGrfI82Xk41jmvaiteTKM3NLYc6flrrJFPFSNBEk8zymJIyEQsdzAf/AFEn9dZ8mZZYKEt0PHyZRd0E4erLwxZfERHXniI7T+udZeMCxebPqi0erLzTIWYrIMZ8pIOdHGC+CxebL7CDrO+sVZKhIySeG5Px30v/AE/sT/G5PhEx6j6glAcVSKrHB3HnP551NR+ET/GyGz3O8zIQ9dGzZPLdv89Q4oSXlyZUmuFTGwkeen8QD8ecY/IZOo4lb8l/YuQ3SZthV0JYZPOCCNR6aYv8TIU3AGQFqqmTK85PnJ0KKWiHnm/kgkucTxK8t0UwyHCyFwBn1AIGp40VvNJ9yGNcqORiFuvjkHlElAwP17ajRDyt/wAwktZQK7I08q5G4ATAhhxj8tSlfwJ6nxZEbpRmV0aeokO38MeGwPkjUaWmRzJcW4KZkqRHJns7BmYfA06UQciF6innfbTSKT64BPOlnJR+CLvo8tTSwgQPKIzGoIRBn9/Y6mMo9NE2yg9zpGVmR3cgbmZkO0n2B1Lk10heVjqe60lRIUgVhuTc26MhUPbHOrOS/mZPJvoXx3hjU1CVUwBI2ogxt7Z76VSj0mNykghTeNLTrIkcu3aBgxkkD/X9NS8serJubAnWn03tX1UsctrvVBKJEJ8Go2KkkDkd42JHxkdiONW4fMlglyxv9/yNGMpPs/OTqWzSWi4VFCJPuPs5poC6nKZSRlJB9jjOvoWOfOCl90ao9AQnB1YOHul7J/P4LrEJVjeKnM6A92KnOB+mdU5J+nQjdUS9GTQtPUUlQVEU6bcuAQD3H9/XOrGN8lywWqaHqWnV6Rpomcq0Z43oQQcfp/ppUNRmK6QPUybc7d3+LvqUJ8kSngjvkYxqX9wZ+k1tpaegtFtSogmkqFpYUmD8+cRqGHJ7bge2vms1JybT+TA3Deg39tFNbmWliFIzDfGkCkH8+2pjipW3sS0+kVzDmoRJZC3BEiwsAQe3fH/30ekkTbFolppVkcxKscR8Pe0hBbg+w9QNNDGn8kJsZWxEeG9OoEKDmPBfI/8AP100lFfJDsRbdVVnnCxwxgkhicsy5wAf2zqtuAe5hCKCVoyKianRA54iTIK59Qe/5aq9SCLHbQ3+XS100e2vkiQnd/TTYO/f4Hx+Wk5xIcWyJukKzxJ5HuckqtlVLeYKvf8AXj39tK8tdB6LGUFunLuBGtTxlPEYIXwe5AHGNSssmtKyVDjpkE1GpJl+3TyOSI4XGEJ9z30jnlfSJ4qrCopB4CFI40KgDDe57DvqeOTuxm4paRGqVDhUaDw8csImLE8YGf1P99V8Zp7I5JodS2a4vTykRjcV3KFUdiRgf5/rxqIwfyJYQoOnbqs7PNC8rQ5DM68Aen/nbT+jb2x0mgdeYqyklJqWQRE4fwVztOpeNR7FlJlOVpY5mMKGp25dGTswI7H9v051LS+Ni3L4BQmvks8jJHGYi3EjSbsA+uPnTJQbuRF5RaSS5s4+4jhMfhKBIoYBjk5xg6ZrH3EEpyfuLCRM0X9KaJcDjnnPpp7tEV9itPVVES7GraeGbOH8M5CrnPPHf9tR+5H7sq1F1hRnmNZBJFHwzkkBT7f+9PGDfSIbX3LdNdI1aOAVEjLIgkG2NgpOe+7t+mn4yi6dDqqErJHpX8SFpC8nDb5VAC59s6inehWqI4pQIZWas3O44R5dpPPGMemocWmSurHNdkKeM0SwtnYSpLBx6aWML0gUr3RZhqJah2lhZPABUMxXGfy9Bj500opdEpuxzyfdtJNG7rTjjeSDj37froqTfQN2RzoJWieiafYU2sjAE5984/z01MilWiWdKRsuKaoaoK8P4hycemOBpHjbdtj1H7FJKa1NVReJhaoDcsE5JZFxzyM59Tp/+olQvtQdSttkfkEFMgHYkhsn3Ax86VYW+2NzivgH1T09VOUaqgjOwk0yosatx3JPJOrIwUVRDab7ESpjr1RftwMjIYqqE498ZwP+2jjF7Fux9PcdqNHKVjyuXipxujZT84/851U4x5XElPVMmtVYk0JSgpjGp8q7AAB+XtpJxr9RKk3+kupVSUtsVKtoPF3BcRhufXGff50vOL0ok+5LbInW5VlNFVQqoypXwxwWbPLMPbGeM6SEoRl7h3zkuQPpum7hFOsq1cNPIMHwY5MHJOSSADppZMfS2VKE+7LkbVscigyirrEBUI5bZx7tj9tTyg9NDVJashlaWqk+5qTNI2CrCNWAUD0HGOPUnVkXD4Fd3spUl8raqriEcKvC3lEpqtxwD2wBge/5alpVYqbui31NLI9sual2SMQMQ4l8yHY2MAjjnHrnVUMs3Ne3Vofj9z876aGV+nZQreYqGYkZO3tj45wdfUL+Toxjoy+CSffTDdFu1V8ltqjLExQsjRkj2YEH/PSSjyVEPZDTZMmR30zA7RSwQv0Ot1q8fzKYiOEBSAsQGOPntzpdWWbo45XqFqWIbdk5JPvojsrRP0/Smuv1upgMmapijA/NwP8AXS5XUJP8MVn6eXKimoq9ZZrfJWHzeSGXgMT/AIcnvznGvmTy0tHN4vtjbeHaYzPTwwv5n3iU5AGcZ5wR3/LWf1Z3aHpLsdNbKoz+LBBCsO3zSyTevGAvHJ507yzq2R30SwdLVC0c1VJWNKxA2iAY2jnPH+LSc5ONqxlFrtjpLXSUgWWsrJYaeI7fEYDliRxx+Z1DbfwwquwgsMEbGShpyoxsBcECTGCScj09vnVigntIHJ9Ir1LVbQJJLFCC5Xw8FWJA7/qefz0KD+UGwW6XNYixkiigmyWQEbmYeinHbHP6eujg18ApSXyR0tDdagxxNHulU/jWQt5cHAxjBPPP56ZQ+5FyIqy3VaHwYqmONWUlt5JOCM7c44Bz/fVlUtCt/FlZbQgpyiyRRSiA7ZHkyc9uMfPA0ia+RqjWmT0UteyeC1TDLhmbam3zeu3Pr6aVZH0OoqS7LyzVtFDUBakUgb/hgjxCrZyNpA9j8entqeTSJ4xXbJY+oEmjKTXGqmkTJxToCZGHbt79s++p5b2wuGq2T0/VPhQwmn+9nLwEssp845I28+40ynXQc4/CB9XeiNjTUjThgWXMvmQE/gwDkkc+mlcmuwWSN9FeY0Na7h7fDTKCpiKucc8e/PHv7ai03sHkV/pQjXb7SRIaVoAjkqYyBltvfv3/AE7HTcvsR6rRVa/Qxsjh4QVJxG0XK+xznBHftzpr3ZDzO7RnHo46BGjnrEpNybYDISXdvYD2+dWtpbirKq+7KU1DUWqOMlpSZCdrNDvDAg55xnHfV0HDJt1YrTRPbaSzzU32mVR2XAVkbbn/AJsH1799W+/4IXHonlpzWNDJTV0cFOn4o5GIIA4yAPXj11FvprYVex1XSGaSBnr08KYgghAdo7AbvTOiLu67Br8k7RGVEWIwijOPE8UElyOwyTx+nvqV10AsET1cYMcE6OWKjcCFAHb41S8sY6SJ7I46KpiqcNJCC2d0fiYRiBgMQexGp9V1bQUwjNQziKMK0lRG2DviwM5x2IPProWZSJ4tHqmnr5hGscTblIKRtL6cj3+O2m9RS0HFkNXRjape5SQzgEOisvmG4Dse3ccaFkSIop11tnVoYnhqKieVmVEwDCW9GY8HGO/pqxtP5FcWOslsENcs0tREniIY8FmPm/6eeBj/AC1WmmTFUP8AsLU9eJpLf9xLEi7qnLDtk9z7DH59tU96UhrX2DMdZRVcMqwhI/B25dAAFB7DHbucatUdUHfQPusF7rxTpSoxpQzKpaYIsgz6DGTjn40jUIg1J6NXRNNDQoI0jjlRdz71ypHrj37HWGpN6RbtI9FNUzESTFUC5KllAQ/p3xrTGD7pC22UbvdryvgNTxwrS5KbgRs+O3fjJ76aUIr+UG5fDPUldcE2fcNSKzEEFF3sMDtn0yNLGEFK2iLlWyC72mok80lVVxrvzG9KuFfupHPrgj++m4xXRDT/AJipUVktnhempaVyzkx+L+JlK8+Ze3b10cE++xba6JqW6eD4LGNoS3meF1wMggD885PbtjUenFURyY633hLjJU+BAlRHMT5aaFnJP4WHrz8DjjTe2DuyU3ekfn7QUzQR1lE4LeE0kbD1ypK8j9NfQoyuKZ2IbRm7pQLSGJ1PLjJX21Yn8MJLQOfToVBnpi0tc6h/RVxk40r+w6VnYfqBcY7V0xRUQiMRWnwDxkD8QGR376UdnCZ2LSEk5Onj0Uo1X0jtMl8+qHSlDHgNLc6fJbsAJAxJ/QHWXzJ+ngnL8MWfWj9G7d1Nc65pnqEgaQTGQS08flOXPYf9I/TGvm0pv+VHOSk+whcbnUilCU0NHBKwU5l2k9wfIBx2J478ai210Nxl9yrb7zcDOkEsIqwWbaVAjXBOck8euP8ATUJ7pjRjMjl6tvH27JaLdFQUxwC0i8oDwW98d+2mUqeuhXGfRm7TDdKW4NVy+DJUSbWKGUtHIwJOSO6k5HPrwdK5bVFcYO+zQxXavmgqYg6NU+L4eAGbBJIYA9iQeAe2BpvUklQ7inpMhpLHT1HjIz1QChoi5Y4Zly3Kg8HJI454OotXTCollqaeWB4nYvCAZY3YA4OMnnvnOMfnpeaaqxklRcr5Ki3JTxPU+HPtQqceZRjk8DkkHP76Z5eOrIaX2A9ZDI9SSZjUrHM+JAVCs23lV9SePXHfSuXLTkRqMv2PV9HHSo1WkLmWbDxqj5LkAZ8v5t/Y6rfHsZzW+KEoYGlp56qNQzwYCsWMZc+m1exzo9vwKn90GDQyuyh3jpYni3LEV3M7gZz3+CAfnTNJ/IXsHxWmC03BMicRsviNKF2n8P5kA55A9ce+pqKaTYnT0WKrp2BaNJF3VIkAmXwQSZyQxH5eUE9sDHPPGra4pJBSaszNPcciCna0uhR94qANzO4yMNg4APAz+mqvUdFad/BeobSyVFO8c0UYfa4iY7myMEZHYYwQV9e/IPDJukxunRfgprbPdab7QsXFQyyTnMpHOMBeCORnJzjPxo5L4BO6oE3mxUQrHVKj+oTuQI6kK4CkD2IPPrx+uhykhWldsor4yVC1TUHnXgsz8pgH8IwfTXTlLFJcS/aekLSdQFqaTitYu+I8RNgkjy4OOP8ATnVUljTXHRKtptga5q9VNGYo5aOaMAM1U4WPGfcc5znjTRaivuVtX+C5Q9DUtfLHVXWtoRUBAkLwSv5j34zjntx86SWWfUYsZY18s0NTZ6Opjgp5qiCrKkAO8O/H+ncazLknpVZY66bKDUNmaZYKKGGVmYLsWRdgIH7j8vnV75xWxFxukXbTXJGJYLlVUjqSBHBCwGVBxnBPPOklye0i2Cj/ADOya5UEW9Y4I4IYySvihPKV9D78HHOqovbjQsvwiG1U7NHHBQ/bTJ5pVEY3KQO4Ud/XVc21KmRG30etVuuDNNDK0cEbKeHpmQAk8+v+WhyraLFB3Vl006W8Z+8oKeGoABxGFIfGDnPJwM/nn408ZUvcwpN1Amho5HRpXrmO8RlSFEgVQSCRnkE6l51+43p/LKi9MmFJvtg1RMT4gE5yA2MkAe3wNQ/IkR6dfp2MutslU+BUKjp5VkGd4kYtgLjOcD079tVrPKwlBLthmls9FRTxyRW8SNLwJjHgQsqgA7e3fHHzq5Zl0HGukQVIq2gElDHGrFDIJpwd0Skkk4Hc+Uj9dVuaohQcuiKqe6NSeE1XBHONkvirwVUAjJB9yc6olla+RvTcl2RS28F3guFW1R4SL4RTMbMCAAfbOc/nnTKUm+2PPHGK2LcOnrYUqYo1lkdvMtMjswVfQbfQ8kfqdXcp1oqpXpFqh6dpVoyWppkVU2lWbcFiLAjOT3HPzjRBTe2K+PTLdRa7VR4r5zERFgwkzEkEtjIGeB6Y07T3QrcY+5k1oqbNUTb6SMRl4/FCzAh2Hf8AF6jgcj1Ok0ldhGcbtII23+TyVkMUEcTq5kIaVdw3bsEKPcZz+mq+Sv7j80ukS0RipqpHNTDHIZFmSIQ+GPDO08MOM8Y7/n306aa0Lzm+j8+uounvs/rD1vbfKEhuNYyA8AozM68D/pYa+j+JPnghJfZG/E1Vs5Lf3/3xhggKcAEYOtcdseX2Be7OrBDoP0igFVeBTkBvEOMEZzpJFsA79aaqMVngwnC5C7QQQMDAOe+eP7aUmb0cjkOXY+mdWrSKUar6W9Q1fR/XVnv9LTTVIt1QssscB2s0ZyrgE8AlSRzrJ5WH18MsV02iJRclSPujoH609M/U24vS0klXa62MAx09xUQzy787/DZSVblVyM9ifnXgfJ8LyvFjymk190ZJYpRdyOlyWg0Er/78k0vhBY12ZyQOVOO59j7d8a5ybI5NPTKtPRVMluqJZpzPIhVWhKhZW8rZC5OOCuDjgfro91P7C8pL9wdRU1VMu2qSWmkaFfHhaMgt58NggkhgQWx27AaT3XQluT9xO/SbVE/itUPHUmdY4zEV2grnZtHrlf7g6FGX9R2kyzIqWqnkd5UnfxFCR1B2huQe49iOQRzg99QlJPYWkrstz9QCnuEkVldW8CISF48SbSx3EbW7kZBHuGGiUG+mK2u0D46uqkqKhGil2O6pnZhUcHduJAGcgggfp6aWOFK/uRZLtkq7iiIrrIqYWokQhi4IG5QeR5j3Pr2B1coe6kS6ZCsbVEEkkQRckYZsRtK2TyCBhScqM8gADUpKW0hf3C1s6engnDVMIqPAj34chlaLeSVOO34cnHx20yxlkXx6IKGwRSfcr4zSRxN4khE5TJUMVKkjOCMZAzk+2pUE99ix+5PSXCOJoRUTwJTRT52xLklyASN2RxwPUjk+/LRlS0RyKlyrIqCnZVkU/wBZ0JlzhcZZJEyOAxzgc++ANDVOxrpdAynvr3aeaWGAUlvgqI4IVpsMXQMCxVQO59eRwTpXKLlsROUv2Lc7Us9wqlroHlp3m3SRxcleThtwwcKQx/LJ51FLk2y1RT0wZcLhbv6irQxRxtLv3RRsDMpyEBIO4eYHBPyD8S+NdaKqUkD7hfa2Cjjpp6WN0CrMu6HlV5IBHByPMSG9BnnVijUdkOTqkiGjqqmuvk7pCimJWDx1MSsAM5OTx3UrjHfGT6ae+nREYylJ0gJaaq6x1SwVUsUr5UGUHBUkcDtgkDJ9tXSikhFKV6J7hHd71QJNSVaw28ytE+47ZSM/OCCcfHY6sgox+BpcpLsrVXT891t0cM1ZURR8kyJIvhspzhuMnPcc/wCR06ywh0heLa2Vem4LZaoJ6Sor6ur3yeGisVDIoxljnJydvcc9xnnUT8mT0tDJxWmGv9ximjgWjp4YZVCCoKuFB9clTx+ZP99UuVvbJdL4KVP0vbIz95TrTLUMzBamGYgh8nOATgntx3AOk5uv1WTa+C7R2SpWKD7mshqZZHy0kNMjEIPUnHcYPAOlnKFaY8Yu9sKVFwp5qWlWeeabwgIm3xBJHIGQSoGMntgazOKk9aLpfYksnUrLSmoitMcbbSkecb93Plwex5APPfViwQXbIjO91sI019uEtZ9qsAO1iGjyAyjBY7dwwTkf3wNPHBBDvLK6SKtyudbZJ1jf7aEht3isxOOSTjj0HI5yfTUT43xSF5OBBLXVaVoqRMKimEG6Jhk5ZivH5gEcDP8AbUrEn2HKd2Om6geSOmqY65aWRP6oSYkFcrtPfk8HOBg5HbVM8cbST2K5Nr7D6eGuqXEjNHPUruBWLJbjvyO5x+2s0cKcv1DuNKxz22qliAUtLGuHRllwT5u2T7YyffGtKhhxvuxFGVWFaiyStcMhvEMeQZ+TuIzwBxx650c8adFjWyGShKU9LF9v4s1RIzSMqbvDAxkH8zz/AJ6X1IJa7B7dJaM3EldJVKJIGCmpBii8DAZcBQQ3fIAxg8c8adTTrZVx/Afiqam0VBE9LJEylikE4YvuOGWPAODkarc3FlySUt9InobuKmGqKLEGWFPGpwgVkG7zFecYHBx6g50ym6tFU8ik7qiKpoIKGan+9ipjSBzTVFPsDBVYqysT3wGOT+Xtpla7K5NR1IgrJksMDVdHF/SVBE5yN4Ck7dg9RjVdWS58VdGoo71DK8UgoPCURFBIyhAvl/4mOcAkscjj09dSpL4RY3q0gLTXWqllqaaaKWmE7FzG0JV1AI2pHkkMG4OT27451FNaZVzb0fI31Lhmpf4nrulZEwerMBdCOX8SmQD4OeOf117/AOl2/Fjf/Nm7BbWzinX9EKW+TeXaGPb5Hf8Avrrw7Lp/gyzLjVrER076HoI7w9VIhaOEZ49WJCgfH4s5+NUyLoFD6sVyVHVFSsUheOMkkkYOf/eoRXPs59q4g2XTtfW2qgVIfDp4j52mkBySR/21mk7ZohcVo3HRd8kkET09wJKRuk+7CN2wUU/4geODjURWx5vlE7h/C79cqmvv9T091NNJVXCnimqKGrl8zSxImWhYj1VVJB5JGV9teZ+r+HGFeRjVff8A8M5GWKj7kdrrepbfSS22GNmGIwUkB3DDO3kYKOSpwMYzuONeQ5OlRl5paLs3VcdMqLtnqHkHiI+8MIgSRz2xt2A459f1e38BzaIJ7mlyt0ckNXLRSPG24HD8IfJIq8fIwRkZ9ckaW7qiFO+mQ008MaSpTl6vuZZanc5jyMbccEdxzgYY6ja/SF6pAuqvbUdQ5VWeSdRO6NT4Ktyq5PB8TyMcdvw++nqSXIRt/Yv1fVV1ilqoBEGramiplMaqzeICSQxBGQT+EcDt69zbbb0x7auI49RXGOelqvt0SraGVgrNjBUZfc2fO5Gdo4OVwOcalKVp/JPufwQx9U1NPDGU8Skkklkp2+6TCxAc8t6EenAyMc+UjQnT0LbrZbqOq4LfRsyuZwsZELR8PJgqQhyexf0GOx582nu+h7SWi9Jc4XSAMWjhlG+OaOTJj7Fdhzgc7hg57HPbUppJJdEt0tjqkJU2irLCJYnZHbEoKrhskjI7ttxj3ORwDpWlv8kumijWw2+uudwjmllFbSMojmGVVgy+bfjOMgbiO2Memh1Em1K2+wZb6m3x1lMlBVxoIF8OFXOAzhcsrMAcldzMM9sDnjSvvRMZpJV8Aq63uFac0lLLIktLI7yrIXRk8vlUE5BGNpz2O4jSvpRKnP7F6juE8yf0p2paR/6s6Rxf1F3eVmU9nG3B5x685GrIyuI8Zu/bovXlaSG1ikhnWaqbEdQ4BE8mZOURgxO3Z2APfA/xcu3aqx24rSYKqbY0T0yW9Enm3Nslgm3QlEYFmYE85yo24zhiOwI0L7IRNPfyZ6hudJTrFWSU0u9iFd8YZDggkKTnIwOf8tbHhf3M0eK2wrLVp92vjP8A7v4B3IoXO5iSqkgHcMHn3I0jwvasstNlKoW+28UskUaVgVHWommCALHgEY9Sw4P644zqPTjBXIsim0WaezV9ZBSz1gp5aZ/6bNG4ZwByGDY8vdQPYZ0nGBHf6iOWB6dfEpw9XNBKi+GsR2lcluPTGTwO3cZGk9JO9kct2EbQsNe0VJNRpvd3ljaZshGB2sufyAPvn8tVvEl8jxlH9NBCkoamSthkR6eeRISqRwxFccMFznAPmI79z+Wl4Rf6iyMmpqS7Bd3pKyrkEXjeK8U4CtSN5yCFIz2GAePTHroc1BUkK3ObbsuRW6mVZFlWqSF2MGHTkqD+Idzw3xyNUyzSWqFUb7GVMtDS3YBDWJEIiN0UgyhAGwc/OBn5Gro5JvYsmrpBGGkhhmLS1zTyzIc75AwYlgV5x6c86JbQ6mrthyntUMEInndDSwv4e9pQQxxg5B7Dtz+p1TKUvuXudf0JKaK2M8tTFKplhjEjoIvNsPCjB/8Aq7fHbVXFyfZZHJBe5iM0NsWaS3JIJ1KNvKllOQc4PGMeuMj350Si/wCUJTg0uEa/qV6KrmiaaamMrqfMSyeKoBH+H1Xk8988aX0/ixF25JaJpmmd6F8ssaMxnk8QKrHO1V2nuR8dv11KxxSoi2tsrWirmo95qZhTU0hdA04/4m4YAxge/Ykf6asgoqylSaZoPtpbTFM9dU/cmRMhCwLplSA49wBt5xnjRUE26GcpK02VaWirULpb6xp7gp8WMTtiMyMoXDKScH4z2I1Mcjb0iv3dJgKrtV0prvJ4kC4LnwmOPOQAxwM8j0wfQ8aqcpPQrhK9ktZSVVdao5JpVC1DKiqwG4puAYsOwGAcE9+NLylpN9jOMpIsrSxRI9E9AphhqZTFVSqVUSEgAsPTdg9h659dWKUv0shwpN1pFitqKG2wzF4C7xESQSzKMny5KBc5H+uRwNaoR5dA/bplqm6zhqKhq+novvqKnMZ/mcJHi+JMWUIFb/GuxSVb/mGfbWmWNpkKS/Uj47+u033P8SD1YXz1FNSSZSMpkhGUEDP/AEjtr2H0u149P4bN+B3E4j9TqoVd8ebZsMztLjHI3HOP3zrrrs0TsxjHJ1aIjvP0Boo6fpu518kZfPiKO2MKpb19yAP11XLsujpHKesZvFuNQ/8Ailct+51H8xXIzIGTjVpBrLlVyTWxN7vFEQEWMD0UAAnWP5NMn7QBRXKotdSJIHK4PI9DrTSaM6dG1k6take3dS2moFHdKWTDIG53Ae3cqwJB+CdUZcUcsHjmrTKppSVP5Pv3pm60fUdits9Mnh1VTTx1aRqyeHDwGeM5GAQpIwcHj37/AC2WLhNwXw6ObSsrXGoo7vFWSUcYoJpqaMpWSZDKpCMY2AUgsBk7uxxgeumnxq2K+LutDaKkjjqzWlnFU8vh/wC94WHaPKCE5UBj5s+4IOhKnpDpOtHqgzWmlMq1BTxqYBWpzkMUyHLE/wCJgRuX3zzqV1ZDuK7NF/KLeorpJ1BS4p4aTpHtcjKkMCTliSGHBwQMfOnSTLUluP3EunUENPQyXGWjEvjTxO9SyMoJRNqKG7AKAAO2D+ei3XIS/bbM/wBY9YzUsx+4p4FjmhUyRRkHAUkJhlJy21sn1BB00rb2S246aKNhuFesTVlVaI1p1lEVS4A/psrqQACeDjcfTPPqRpWqToWKbdgeLqGK5GOkjgjKQOXeZYzIzBnU8tnPBKsM8AMRyGxqab3ITekkOk6/ax3Sq2QtSwyybzTE71RkJU9iQcFxzxwcn21ZV7XRLddBvp7rApMtLX2xkt0pZTP4PEjFgrFc5DKNnbA5LD3w2ki6FP8AXqxl1usVwrY0ppI456iQLN9yzRjwwCqecHKtsJIBOcce2am72yttaSK1NBNZKqGnlWCqNEq+OYWyGdNxDIisrEDlCCeckkgkDS8Y6SZLqPeyG41M8i1tXNK1dEJKWKohEh8VQ+5ViYHkjO3B5wMZzp+DmrYklLbRWrbHU0U9RR1CrR1lHs8SJEcqmByBgNj8ZJGOdhA+Vlj7sFF3xa2i5HDW2m6rLUVj0vjeItLLBAHNQOSduWXCjLc+hX2AGoim9seuLt6KUtNXWUMTdvGM8s6BJYtkjou0+UenCnuMZXHPOrf5dCuHF6Yi/SO5NQzGlu7HfKZTNJmTzAE54IAHJP6+urP4p/YFjddlr/YKtqKygepun41DxmAsGlKAhSoPBOTnLH31S8/dF3F65GmnLWe2vb6GeI3GRWkj+6cFHIwAhwcDJ9+/zgaSMlN02WOTjFpdkLVbVtNTQTMIUl3B6dYVzCMLvYEYzzvwDnHv21MeEXa2UuTlHegbU2O7ymKl+5SaUozJIh24CncreGCN3Kg+ncn01e86T0R6erbtlO1fTquiZJmuMzMzJIKKEB2EjY3YZccDk49z+eq5+SpaSF9L+Zhe09O3Sghlmp6ueSBclKd14ZmdicnuMe34fXWaU5S6LIQk02HLXYrsFnqEKVDBMS7lCBVI4JxghsnHqO+kak9seONp7ZFNavsbxunNcjSohMZkLLkITyMHGcEEnGONQm7GlipsZZbaV/3pKKFqWpdowsco3BN3LbP+kKT+f76hN9sq4fNF+ahtEEtGKSNx4O9YZWB24LHOPXJyBgju2jne2PwgnXRRpKVHiqzNSCppzGBPChaNWcjse53BQe3GONQt9oEqttHv5TMsNwuZqJ6arkP9MSMG8ikHw2Y8jAyvHoT20vuq2S4pXo0NnpjE1K8lZElEsDCZ0my8gOwj0zkZPIz21eptRT/BcljVJ9CQXBfvQlOZoxEqIiSAuQCTsGfThuR6HPoNVuUm9FTkk/b0NS8COc0dRDBLFE2FqmAXYWwqKoODg7f1yP0TbCOZR1JWStW0EZnrKh/GWF38SJiWICd2XcOeQME59vXluHL5E5xJmro5KOBY5aaes8VY1qXCqs6bdwBByOQTzgY9Ox07hatA8iZVF0p6edJKeSDxSx2mqI4Tnedy9xnAye5YdhjUrW0Q5K1QNul2mrKNXjq4UqlfKFGJWNzxgk/4RvPJ5GMd9R7dEuXH9x9NV+DUJFLUQqYZhmJVUxTAY2DGcgYznnnPtqmldsrjN3VhhIFv0HkjxEZfGepghZknK5b1OSQCCWIGCfQasX4LHb0Zqt6dp6nqOJ5JTUNCBUy0u8rEsqICMjOfnAJB2Edzq6OVx6KZNOWxgtCUdpDvUNU0s7rVlYiWUuVHIJ5A8jZHcHVj8iT0kJXyfNH19udsP146er6WRmoza4GaYMJPE2yzjcMfGBhueNe3+kycsLtfP/o3+N+g4Z9Y6V6XrKrJj2QSu0kRC7QVJzwPTknXbj2a2YQ6sFPof6bSrZPorUVEkTP9zHUSEMDgAOFU/nnP7aT+Ys/lOK1im6V8jjJ8xOTqtPbKJPYFlj8E4PfVydjJlo3OaaGOJyXVBgar4Ifk6pjDEZYyyqWwD29NMlRW+zR/Svoap+pHXdo6fpkZlq5h47KQNkK+aRsngYUHGfUgeusnm5142CWT7dfuRLrR+kNmiFtsj26iZKUmmjiqYYYiZCI32sgyMnDMMtgDGMZwM/M5ZG+TXbKJY+Cr9rGW+gaiqYI45xVUklUJnWPa6NKpZipwvoWwzDyqCBwe0ObbSZU4xvTtFi20FOTBOJ3BhladJ6mVVJOWcHkchcc4AzsPzqIummittrTEWrt1z6fQUkKUrwSlpsjxZ5vMQ0pj9FIYY4Awc8+kuSUaQ0pKkqK0lxNTaanwKKaRkVFjkZy/26+JnaGPI5IAx8986nkPHJF2qMcJ7pT2+qgrLdPRV0TytVQ1BKqVEnDKuQCRyxIOMFTyDzKnUmjPJSS2thSngrXuNM1SPGq4acMtVVMT4kGSdxhBwSykgkE44JGew8qpJl6vlUt/n/6LFZZqOzQ/cwyrVUldJG8dC0DEKVZ+FYZO3AGCx5yRjOoUl2iOMYbStMGUXR1NVvVNbqlaWrgK10dLEpMbhQECyKo353kjIP8AiORjV3NtUxZQ4Sav/wBFe4dNVN7mejpWjirZoWysXkRXRHDYIGGGfNuDEkpgnvpVJfKGnFaUfsVZemb1090hK11g+6q6iMbac4ZoMEuXI/Cq7XO7sc4bupwclJ2Vu1DYbounIFjoIqtIzJRA0pq5gSpjYKOB68uAG7ggD14RzkuyUuJahoYEr1uFYYlmSfwn8WCVI+EZtrJGc7Tx5fcdwMk2RkpbfwRBxVuTBV96ZuS1VRHLV0dLTVyRkUyAiKNkHDZbzAjJbJOQD+gZ5F1QdJ7pMqW+0rFTss9bJEsammZ6ZkAdwrAtICCMbWZgex+OQa+e9ohOK22Vz0jUwVtWlzlplnaF6emioCC0khZcb3YEjuCoHPAAPfULJUqJjFX7zVWiO81tE86ypUU1CBEZ6qAIojLhCgLAMi4ODg+UkHGWJI253rolJ8aroo2XpqvL1c0VzId8GSIuSmzJ4CgYBxu5HfAz8zxbHcGlprZHU2SpoqmRqioSnpCSsccgKMVjcMSp77Tx+mdLKPEoabe2eNzdHp6eqrNjT+aCqKhC644I7kKxyoLc8caFFIbnWmy9R3S2TWyQxVMlYGkcpI/lUgKMI3HP4kHH6kaGm9UOpKO47QWN7akFQZad7ZFFkL4kRBA8PJQ4znBOD6e2fWXF29dFinGq6LcVXT0sJq6hmNFMBJHHBDlg+89242j8IORwM6VRGi0k4y0CKeWVBXSGriEhmRQiNlVww/Ao/ESuSADjI7gnUrHoqjJ7bYR+8jlVblRwlxjzF12MUx+IoTz+Eep/EDqXCMfkdzctxRVpLzcbdC1U7NRbl8Yqq4bzMoQs3HcHLDjGCffQo0yFlabvX/PkvXKWooEUoEuslNJiWeNhtJJG9yO7KQV98fmNVSS67JnJrp2/+WCqk19wWnlZB99EpqIqWQFhjLDeP8KMrEDn/pPfUJ0ij3S2uynVXq8Wint0c/2YmiKxyPLKo8QknerE8EgEY9eQPbQnugfNRNK1TLcaSh8STw6MMqicjEZl2lidg82MbPMRjOO+caJbVl0YOVNPX5BX3NeKdBT0sCQyzMwqERn3up/qEFR+I5jwoGd3fAzqKuNGZ8q/BLIl9+0pIoI6qlihLlg4wrYY7sE/hYjb+PHOPQnUJUQ1k/SxzR1rVcciUUkVXVTGGKEt4aKCu5SS3/DKsdufTAz76ZtA4uwNR014t9w+zqHaqp6ibKsF3EAHGO/DbRjGfNkd8cNyi1Qm1pjp7JV3bxKa21aMJ9sdME/pspUZIDE4GA/pknGptJJGiONTbaLsNNLb4H+4rIJlCGCoRAyhV2AMVxnA57dsEYIJA1XbT6I41dgaC62+qvJt1WslR4rpMKt9qxJTugaNix5K72BI74Jzpl1snlBy4ysOQ3GjoqKtlheGlNPEIGZHWREaRWQOOCP6nmOMkBSQTqFFPsOSi2ooLWCpENNQtLUxxVLrIfCL4lMW8kFhuyASGzt4A2YGdQ2ouwu/dJgqO63K59OSRvUTXJIYv6EJV0WTzltiscFSSCcN79zjSW5Kv7EqMpx70jBfW/p2sv308+0tM09FdrksLwUdNucTyDGYmYgeHktj/wCXBA11Ppko+N5Mck1a/wBrGUEpJnx9QW+5UnVi0F0pKmiuUIaCWlqIisqNyNpU4IPOvo8Zqfuj0b4jvqp1L/tNDQRvCFqrZmmMgGCyHsCMf4Sp/wD5aeOmWM5/S0zVlXDTxlQ8jqi7jgZJxyfbVgqPpDrOWKyfSWltFvn8Snp6eNfE/CJPOMtj5O4/qdVFj6OD0FQI2qV3BWI4/vpV0Z5dguuk8aY8fGdWxVDpleMEkAalkktTKJFQKoG0Yzjk/noFR9jfwwdAVHQXSJvtTRU81wviQzhKiD+rFTK7MixPzgvty3ByNo7jXgPrHm+tm9Ffpj/uZczknTWj6QTqG31FPQLWVDtHWSeA4pwR4jK2SpLd48bUzjGR25OuBapkReN/qYRo79SpBVTMI6iseVo6SmwFEYLmNSPZSnt2HfB0l1ciOS2k9lbxaeW+fbwUSyRvC0QiAXb4rAuQGA4JY4I4yQfy017ByUmuX7FSmulr3wRw14oo1/pYeRTKz7ihBXPcEldw4GQM88rfFfgXlBK0Ca69xUNZBDS1U1N4NQROlwwJqdQ22MAABRtJOffd6ehbk6Dko/pdAug60pembtRAyLRRTnEk0Gz7gw4LMqlshQrc4OcB8cjVkbvk/wD7EWVJ02G5qteoaqOWnj8H7pYQbpPIkMEAcjcT5QUXarDb5gSWxgnUcW3rs1Qx+q16b/dvpf8AEV7lTyUdXPEkxuL0KPEpps+dthG0qTwvD9vNkg41CTToplUG920SUXUkUMkdYq+BTTeFG5nUKsS4UY3N5iCQxPIHl0K3tA8vyxt8uUhEc1ekTRmF5YZvEEayEYz+HDAEtu3A+wxgasVvQSyNpJlT717jQkTk25PuWRVBaVVKliUI/EjbTkHJGJFz30/FxVvootVvpgyo6jkr5YqVzT0UTFZkpQRKhhfdh+cE8gKwA3D99TUUm/gr58k0BJqqsa3yABp68Sosu2RAsvh8l93GDghdh7n5wNTFR0kxU29FG39dVEU9ZW1dNJO1ukWiaJ0dGkVQSQygDJLeGMjuAD+Wt8Za+5Cvv7E0VfT1taY2ma2RVcTVMKrTl0kUu6qEAUjauxwAwxknjHOqePBc3sEiLqTqW61ktBUyyvCI4F+3eJcy7RtRY4wMBlTBOBliM+x1bGEZK2uhpSdprQKg6kqpLMixwstwiZZHjkVlSONnyzqSeQ53AAcnbk99R6cVO5dD+p7aR06MmOzRxg+WeKmaTPJYswDc9xkemoilxTC2kQXKslmqbVE7Ax7VO3aOc7Qc++R31SNP4AF8maS1XGuO37tZZVWVVAKhVQqBjsAWPHbnSxb5Mpi7WxWqpbZSUstOwV2eSlJZQ48LxIG24bIHIGff11bD5J5NUaitkeSutoeR3D1sULbmJyhiLFfy3AH89VXuh70v3CCu089bRSMXp4HimjUnkOxG4lu57DueNUrSNsttr7BeOxUNvqGqaeARTRSBkYMcAqCBxnHYnVsSlRVKXyCK2sniu9FRpKy0ssdVM8QPlLqi7T8YyRx6caSbdsq+UWavFvs9H4CqglmdHUqGDKAAAQcj1Ok+Ea+MVeiFZGpGgSE+Gi1CuEH4cgEA47HgDU223f3Kcy4uNAmluFRJ0fHUGU+OtLvEgwCCYVJP7k6T+aitusaohepcXKgYrG7GOKUl41bztuVjyO5CqD+Q1EtOkK31/wA+TS9eRJa7taKGlURUlZZYJ54gMhnxKc89uQO2NW5Ek4/sWZUo1X2KtLXTzWiljaVgk00iuqeUYCsRjHblR2+fc6XtbLZvpGotlXMOmKmfxXMqxMcsc7s7gdwPDdh3zqY/pY8G3bZV6jY01HS+ETH4sbo4XjKsEJH5ZZj+ukm6qinJpaMp1ZcaihuwFNJ4Aan7RqFxhEIxjtyc5H+mkW1K/gryNpJoOyUMFPXQiKMRrIEjZU4BDFg3Hucd+/f3OrJa/wBC1rdDlt1Lc56CKqp45ozUxQlWUYZGqY0ZT7gqcHPfj2Gox+6aT61/uDSdX/zoA/yO3ia4VApIhLRSQrT+XyxjtgL2xjjt2AHYDTxbblZTJVkdfBeprbTSmxzNCpkaOWoJ/wD+m3v/AP3fHtuOqZajaLEk2Zjp6ulrerOo6ecRzRW2RDSB4lJh7EgHGcHJyDwfXOkxJbRUm3Jr7BC2SPW2CPx2aQTCBpBnAberM2R7Ejt2HYcHVjSUnRfSor9PFq21T3Cd3lraeV6WOdmO7wvFKbD/AMw2qBzn37nVl0gTcoW/g4h9RrZSP/EBe1+2jVaS2UIgCKFEfl9Ma999G34ab+7N8VT0c++sEEQv3RqiJFDyKHKqAX83qfX9ddef6ZFmTo4Tav8A9yp//kNaJCHe/qPRwwdDRiNAoT7ZRg+m0/vpEO+jhCsRcEOecZ/sdQv0lUuhk/cL6Hvq0SPZZsKg1kGRz9xDz/8AXqqb0/2Y0ixLSQyUdxmZAZEmgVW9gwfcP1wNKpOl+zIT0fav0uq5bv1BTU9U2+np/DihiUBFjTew2qFwAMe3bn31828mK5dfJhUm5bD3Vt5rbf0uJaepeOT/AHtd2c8JN5Rz7bj/AG9hrn8U5JMrcmmi3WVMorLQodgrxSEqDgZAcjA9MH20JKhLdo0V4LQdA9OTxO8Uwngh8SNyrbZHIfJHckevf50vyzRFKUVf4K0FtpqyGVZ4vFAihrV3knbNJtV3X2yD6cZ57860S6KeKfZmeqK6apmqhK4f7aBxESoyoJ5GfnA76r4pWTlSVJEt3kFd1Tbqeojhlp1EkIhaFSm0RRgArjBxnv3/AG1fHpv7f+h+8iv/AJoqV5JnraFiXpYKl0jjc7go3n3/ACBz3zz31kk3yQj/AEJjup6+otHWfUX2spQvAszF/Pl3L7mO7PPYj2IBGCBrTxT7XZTLTdHhcamvmv8AFUTNIlPbp3jzwQVeoVeRycBVAz7aIpKaS6/+hU7exnWk0lntUH2jtEC6uQWLAnCHJBz6sf31biWkvyPLVotQTyNEFLsRKZ3fJ/ESxXn9P/ONO4qmKtxojvMrW2wyU9MfBjp6pfDKjzgF1BG7uQQzcE45z31GJJt2Wv29Fe0VU1S4qJJGad2pEaTOCQ1SgYZ+QNUQ/XXx/wDpEFfJsm6NxUXqISgS/wC6Qy5cbiWeVUcknvlQBj4Htplp0hcbfQL6oLJCjB3ylX4S5YkKqNMFAHpgHHGrl+toj4o0NRxDbKXvAq0+1W5I8pHB75x66y49yf8AUef6qKkltpoXDRx+G009RHIyEglROQFyOw+Nbsi/6jXwWwS5L+p//9k=",
@@ -674,12 +692,12 @@
     {
      "data": {
       "text/plain": [
-       "[{'score': 0.4759259521961212, 'label': 'flat-coated retriever'},\n",
-       " {'score': 0.10909564793109894, 'label': 'Labrador retriever'},\n",
-       " {'score': 0.08196048438549042, 'label': 'Great Dane'}]"
+       "[{'score': 0.4759257435798645, 'label': 'flat-coated retriever'},\n",
+       " {'score': 0.10909581184387207, 'label': 'Labrador retriever'},\n",
+       " {'score': 0.0819605216383934, 'label': 'Great Dane'}]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -716,33 +734,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 16,
    "id": "1cd9423b-3cba-4cf9-b58a-bffbde08738d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:48.888614Z",
-     "iopub.status.busy": "2023-03-12T19:47:48.888417Z",
-     "iopub.status.idle": "2023-03-12T19:47:52.868441Z",
-     "shell.execute_reply": "2023-03-12T19:47:52.867833Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:48.888595Z"
-    },
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "[{'score': 0.0960492491722107,\n",
+       "[{'score': 0.09604837000370026,\n",
        "  'token': 4827,\n",
        "  'token_str': 'fashion',\n",
        "  'sequence': 'i am a fashion model'},\n",
-       " {'score': 0.09326528012752533,\n",
+       " {'score': 0.09326566755771637,\n",
        "  'token': 2535,\n",
        "  'token_str': 'role',\n",
        "  'sequence': 'i am a role model'}]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -789,29 +807,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 17,
    "id": "5d9cedee-902c-41b2-b6ef-1c04bbd8498e",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:52.869399Z",
-     "iopub.status.busy": "2023-03-12T19:47:52.869151Z",
-     "iopub.status.idle": "2023-03-12T19:47:53.395475Z",
-     "shell.execute_reply": "2023-03-12T19:47:53.394997Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:52.869376Z"
-    },
     "tags": []
    },
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    },
+    {
      "data": {
       "text/plain": [
-       "{'score': 0.5305245518684387,\n",
+       "{'score': 0.5305243730545044,\n",
        " 'start': 12,\n",
        " 'end': 75,\n",
        " 'answer': 'an open source toolkit for deep learning inference optimization'}"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -845,26 +863,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 18,
    "id": "755096b0-406d-4167-8642-5b4b093e2bc5",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:47:53.396122Z",
-     "iopub.status.busy": "2023-03-12T19:47:53.395987Z",
-     "iopub.status.idle": "2023-03-12T19:48:00.052492Z",
-     "shell.execute_reply": "2023-03-12T19:48:00.052125Z",
-     "shell.execute_reply.started": "2023-03-12T19:47:53.396109Z"
-    },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the encoder to CPU ...\n",
+      "Compiling the decoder to CPU ...\n",
+      "Compiling the decoder to CPU ...\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "'Das Haus ist wunderbar.'"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -884,16 +904,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 19,
    "id": "c0f096f2-0cd3-40ab-9661-1c7209c6a670",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:48:00.053145Z",
-     "iopub.status.busy": "2023-03-12T19:48:00.052965Z",
-     "iopub.status.idle": "2023-03-12T19:48:00.056985Z",
-     "shell.execute_reply": "2023-03-12T19:48:00.056530Z",
-     "shell.execute_reply.started": "2023-03-12T19:48:00.053133Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -906,7 +919,7 @@
        " 'translation_en_to_ro']"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -918,16 +931,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 20,
    "id": "ebf97e9c-d1e1-4908-8a3a-bad24ee3a34f",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:48:00.057929Z",
-     "iopub.status.busy": "2023-03-12T19:48:00.057694Z",
-     "iopub.status.idle": "2023-03-12T19:48:00.399891Z",
-     "shell.execute_reply": "2023-03-12T19:48:00.399417Z",
-     "shell.execute_reply.started": "2023-03-12T19:48:00.057914Z"
-    },
     "tags": []
    },
    "outputs": [
@@ -937,7 +943,7 @@
        "[{'translation_text': \"Qu'est-ce qu'un modèle de séquence à séquence?\"}]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -967,26 +973,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 21,
    "id": "59df852f-e9bb-4f96-91d9-23f4e4577ea0",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:48:00.400753Z",
-     "iopub.status.busy": "2023-03-12T19:48:00.400401Z",
-     "iopub.status.idle": "2023-03-12T19:48:04.459054Z",
-     "shell.execute_reply": "2023-03-12T19:48:04.458437Z",
-     "shell.execute_reply.started": "2023-03-12T19:48:00.400729Z"
-    },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    },
     {
      "data": {
       "text/plain": [
        "[{'label': 'nl', 'score': 0.994126558303833}]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 21,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1018,19 +1024,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 22,
    "id": "87f633c0-3334-4ef0-942a-5bdec807568d",
    "metadata": {
-    "execution": {
-     "iopub.execute_input": "2023-03-12T19:48:04.459956Z",
-     "iopub.status.busy": "2023-03-12T19:48:04.459670Z",
-     "iopub.status.idle": "2023-03-12T19:48:07.863986Z",
-     "shell.execute_reply": "2023-03-12T19:48:07.863615Z",
-     "shell.execute_reply.started": "2023-03-12T19:48:04.459935Z"
-    },
     "tags": []
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Compiling the model to CPU ...\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -1070,6 +1076,14 @@
     "- Notebook: [Post Training Quantization of a question-answering model](https://github.com/huggingface/optimum-intel/blob/main/notebooks/openvino/question_answering_quantization.ipynb)\n",
     "- Examples: [Quantization Aware Training examples](https://github.com/huggingface/optimum-intel/tree/main/examples/openvino)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0606fb02-2367-4573-8461-7fc8c065ece6",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -1088,7 +1102,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.10.12"
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {

--- a/notebooks/openvino/question_answering_quantization.ipynb
+++ b/notebooks/openvino/question_answering_quantization.ipynb
@@ -846,9 +846,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "FP32 model size: 436.07 MB\n",
-      "INT8 model size: 182.41 MB\n",
-      "INT8 size decrease: 2.39x\n"
+      "FP32 model size: 436.50 MB\n",
+      "INT8 model size: 181.84 MB\n",
+      "INT8 size decrease: 2.4x\n"
      ]
     }
    ],
@@ -858,7 +858,7 @@
     "    Return OpenVINO or PyTorch model size in Mb.\n",
     "    Arguments:\n",
     "        model_folder:\n",
-    "            Directory containing a pytorch_model.bin for a PyTorch model, and an openvino_model.xml/.bin for an OpenVINO model.\n",
+    "            Directory containing a model.safetensors for a PyTorch model, and an openvino_model.xml/.bin for an OpenVINO model.\n",
     "        framework:\n",
     "            Define whether the model is a PyTorch or an OpenVINO model.\n",
     "    \"\"\"\n",
@@ -866,7 +866,7 @@
     "        model_path = Path(model_folder) / \"openvino_model.xml\"\n",
     "        model_size = model_path.stat().st_size + model_path.with_suffix(\".bin\").stat().st_size\n",
     "    elif framework.lower() == \"pytorch\":\n",
-    "        model_path = Path(model_folder) / \"pytorch_model.bin\"\n",
+    "        model_path = Path(model_folder) / \"model.safetensors\"\n",
     "        model_size = model_path.stat().st_size\n",
     "    model_size /= 1000 * 1000\n",
     "    return model_size\n",


### PR DESCRIPTION
- use streaming dataset for audio example to fix permission issue with URL
- change pytorch_model.bin to model.safetensors for size comparison
- speed up quantization notebook test by using only 10 samples
- update half() messaging (no longer needed to do half() on GPU)

The diff for the inference notebook is large because I ran it again and outputs/metadata changed. 