### PR TITLE
Export hybrid StableDiffusion models via optimum-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,16 @@ It is possible to export your model to the [OpenVINO IR](https://docs.openvino.a
 optimum-cli export openvino --model gpt2 ov_model
 ```
 
-You can also apply 8-bit weight-only quantization when exporting your model : the model linear and embedding weights will be quantized to INT8, the activations will be kept in floating point precision.
+You can also apply 8-bit weight-only quantization when exporting your model : the model linear, embedding and convolution weights will be quantized to INT8, the activations will be kept in floating point precision.
 
 ```plain
 optimum-cli export openvino --model gpt2 --weight-format int8 ov_model
+```
+
+Quantization in hybrid mode can be applied to Stable Diffusion pipeline during model export. This involves applying hybrid post-training quantization to the UNet model and weight-only quantization for the rest of the pipeline components. In the hybrid mode, weights in MatMul and Embedding layers are quantized, as well as activations of other layers.
+
+```plain
+optimum-cli export openvino --model stabilityai/stable-diffusion-2-1 --dataset conceptual_captions --weight-format int8 ov_model
 ```
 
 To apply quantization on both weights and activations, you can find more information in the [documentation](https://huggingface.co/docs/optimum/main/en/intel/optimization_ov).

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -211,7 +211,12 @@ class OVExportCommand(BaseOptimumCLICommand):
 
         library_name = TasksManager.infer_library_from_model(self.args.model)
 
-        if library_name == "diffusers" and ov_config and ov_config.quantization_config.get("dataset"):
+        if (
+            library_name == "diffusers"
+            and ov_config
+            and ov_config.quantization_config
+            and ov_config.quantization_config.dataset is not None
+        ):
             if not is_diffusers_available():
                 raise ValueError(DIFFUSERS_IMPORT_ERROR.format("Export of diffusers models"))
 

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -161,7 +161,7 @@ class OVExportCommand(BaseOptimumCLICommand):
         return parse_args_openvino(parser)
 
     def run(self):
-        from ...exporters.openvino.__main__ import main_export, get_relevant_task, export_optimized_diffusion_model
+        from ...exporters.openvino.__main__ import main_export
         from ...intel.openvino.configuration import _DEFAULT_4BIT_CONFIGS, OVConfig
 
         if self.args.fp16:

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -19,8 +19,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 from ...exporters import TasksManager
-from ..base import BaseOptimumCLICommand, CommandInfo
 from ...intel.utils.import_utils import DIFFUSERS_IMPORT_ERROR, is_diffusers_available
+from ..base import BaseOptimumCLICommand, CommandInfo
 
 
 logger = logging.getLogger(__name__)
@@ -212,7 +212,6 @@ class OVExportCommand(BaseOptimumCLICommand):
         library_name = TasksManager.infer_library_from_model(self.args.model)
 
         if library_name == "diffusers" and ov_config and ov_config.quantization_config.get("dataset"):
-
             if not is_diffusers_available():
                 raise ValueError(DIFFUSERS_IMPORT_ERROR.format("Export of diffusers models"))
 
@@ -222,13 +221,11 @@ class OVExportCommand(BaseOptimumCLICommand):
             class_name = diffusers_config.get("_class_name", None)
 
             if class_name == "LatentConsistencyModelPipeline":
-
                 from optimum.intel import OVLatentConsistencyModelPipeline
 
                 model_cls = OVLatentConsistencyModelPipeline
 
             elif class_name == "StableDiffusionXLPipeline":
-
                 from optimum.intel import OVStableDiffusionXLPipeline
 
                 model_cls = OVStableDiffusionXLPipeline
@@ -239,7 +236,9 @@ class OVExportCommand(BaseOptimumCLICommand):
             else:
                 raise NotImplementedError(f"Quantization in hybrid mode isn't supported for class {class_name}.")
 
-            model = model_cls.from_pretrained(self.args.model, export=True, quantization_config=ov_config.quantization_config)
+            model = model_cls.from_pretrained(
+                self.args.model, export=True, quantization_config=ov_config.quantization_config
+            )
             model.save_pretrained(self.args.output)
 
         else:

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -105,6 +105,16 @@ def parse_args_openvino(parser: "ArgumentParser"):
         help=("The group size to use for quantization. Recommended value is 128 and -1 uses per-column quantization."),
     )
     optional_group.add_argument(
+        "--dataset",
+        type=str,
+        default=None,
+        help=(
+            "The dataset used for data-aware compression or quantization with NNCF. "
+            "You can use the one from the list ['wikitext2','c4','c4-new','ptb','ptb-new'] for LLLMs "
+            "or ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit'] for diffusion models."
+        ),
+    )
+    optional_group.add_argument(
         "--disable-stateful",
         action="store_true",
         help=(
@@ -195,6 +205,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                 )
                 quantization_config["sym"] = "asym" not in self.args.weight_format
                 quantization_config["group_size"] = 128 if "128" in self.args.weight_format else 64
+            quantization_config["dataset"] = self.args.dataset
             ov_config = OVConfig(quantization_config=quantization_config)
 
         # TODO : add input shapes

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -268,6 +268,22 @@ def main_export(
 
         GPTQQuantizer.post_init_model = post_init_model
 
+    model = TasksManager.get_model_from_task(
+        task,
+        model_name_or_path,
+        subfolder=subfolder,
+        revision=revision,
+        cache_dir=cache_dir,
+        use_auth_token=use_auth_token,
+        local_files_only=local_files_only,
+        force_download=force_download,
+        trust_remote_code=trust_remote_code,
+        framework=framework,
+        device=device,
+        library_name=library_name,
+        **loading_kwargs,
+    )
+
     # Apply quantization in hybrid mode to Stable Diffusion before export
     if (
         library_name == "diffusers"
@@ -275,19 +291,16 @@ def main_export(
         and ov_config.quantization_config
         and ov_config.quantization_config.get("dataset", None)
     ):
-        import huggingface_hub
-
-        model_info = huggingface_hub.model_info(model_name_or_path, revision=revision)
-        class_name = model_info.config["diffusers"]["_class_name"]
-        if class_name == "LatentConsistencyModelPipeline":
+        class_name =  model.__class__.__name__
+        if "LatentConsistencyModelPipeline" in class_name:
             from optimum.intel import OVLatentConsistencyModelPipeline
 
             model_cls = OVLatentConsistencyModelPipeline
-        elif class_name == "StableDiffusionXLPipeline":
+        elif "StableDiffusionXLPipeline" in class_name:
             from optimum.intel import OVStableDiffusionXLPipeline
 
             model_cls = OVStableDiffusionXLPipeline
-        elif class_name == "StableDiffusionPipeline":
+        elif "StableDiffusionPipeline" in class_name:
             from optimum.intel import OVStableDiffusionPipeline
 
             model_cls = OVStableDiffusionPipeline
@@ -306,22 +319,6 @@ def main_export(
         )
         model.save_pretrained(output)
         return
-
-    model = TasksManager.get_model_from_task(
-        task,
-        model_name_or_path,
-        subfolder=subfolder,
-        revision=revision,
-        cache_dir=cache_dir,
-        use_auth_token=use_auth_token,
-        local_files_only=local_files_only,
-        force_download=force_download,
-        trust_remote_code=trust_remote_code,
-        framework=framework,
-        device=device,
-        library_name=library_name,
-        **loading_kwargs,
-    )
 
     needs_pad_token_id = task == "text-classification" and getattr(model.config, "pad_token_id", None) is None
 

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -268,27 +268,12 @@ def main_export(
 
         GPTQQuantizer.post_init_model = post_init_model
 
-    model = TasksManager.get_model_from_task(
-        task,
-        model_name_or_path,
-        subfolder=subfolder,
-        revision=revision,
-        cache_dir=cache_dir,
-        use_auth_token=use_auth_token,
-        local_files_only=local_files_only,
-        force_download=force_download,
-        trust_remote_code=trust_remote_code,
-        framework=framework,
-        device=device,
-        library_name=library_name,
-        **loading_kwargs,
-    )
-
+    # Apply quantization in hybrid mode to Stable Diffusion before export
     if (
         library_name == "diffusers"
         and ov_config
         and ov_config.quantization_config
-        and "dataset" in ov_config.quantization_config
+        and ov_config.quantization_config.get("dataset", None)
     ):
         import huggingface_hub
 
@@ -321,6 +306,22 @@ def main_export(
         )
         model.save_pretrained(output)
         return
+
+    model = TasksManager.get_model_from_task(
+        task,
+        model_name_or_path,
+        subfolder=subfolder,
+        revision=revision,
+        cache_dir=cache_dir,
+        use_auth_token=use_auth_token,
+        local_files_only=local_files_only,
+        force_download=force_download,
+        trust_remote_code=trust_remote_code,
+        framework=framework,
+        device=device,
+        library_name=library_name,
+        **loading_kwargs,
+    )
 
     needs_pad_token_id = task == "text-classification" and getattr(model.config, "pad_token_id", None) is None
 

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -284,6 +284,44 @@ def main_export(
         **loading_kwargs,
     )
 
+    if (
+        library_name == "diffusers"
+        and ov_config
+        and ov_config.quantization_config
+        and "dataset" in ov_config.quantization_config
+    ):
+        import huggingface_hub
+
+        model_info = huggingface_hub.model_info(model_name_or_path, revision=revision)
+        class_name = model_info.config["diffusers"]["_class_name"]
+        if class_name == "LatentConsistencyModelPipeline":
+            from optimum.intel import OVLatentConsistencyModelPipeline
+
+            model_cls = OVLatentConsistencyModelPipeline
+        elif class_name == "StableDiffusionXLPipeline":
+            from optimum.intel import OVStableDiffusionXLPipeline
+
+            model_cls = OVStableDiffusionXLPipeline
+        elif class_name == "StableDiffusionPipeline":
+            from optimum.intel import OVStableDiffusionPipeline
+
+            model_cls = OVStableDiffusionPipeline
+        else:
+            raise NotImplementedError(f"{class_name} doesn't support quantization in hybrid mode.")
+
+        model = model_cls.from_pretrained(
+            model_id=model_name_or_path,
+            export=True,
+            quantization_config=ov_config.quantization_config,
+            cache_dir=cache_dir,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            force_download=force_download,
+            use_auth_token=use_auth_token,
+        )
+        model.save_pretrained(output)
+        return
+
     needs_pad_token_id = task == "text-classification" and getattr(model.config, "pad_token_id", None) is None
 
     if needs_pad_token_id:

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -387,7 +387,7 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
                 self.__call__(**inputs, height=height, width=width)
             else:
                 self.__call__(*inputs, height=height, width=width)
-            if len(calibration_data) > num_samples:
+            if len(calibration_data) >= num_samples:
                 break
 
         self.unet.request = self.unet.request.request

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -96,6 +96,7 @@ _HEAD_TO_AUTOMODELS = {
     "stable-diffusion": "OVStableDiffusionPipeline",
     "stable-diffusion-xl": "OVStableDiffusionXLPipeline",
     "pix2struct": "OVModelForPix2Struct",
+    "latent-consistency": "OVLatentConsistencyModelPipeline",
 }
 
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -187,8 +187,7 @@ class OVCLIExportTestCase(unittest.TestCase):
     def test_exporters_cli_hybrid_quantization(self, model_type: str, exp_num_fq: int, exp_num_int8: int):
         with TemporaryDirectory() as tmpdir:
             subprocess.run(
-                f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} "
-                f"--task {model_type} --dataset laion/filtered-wit --weight-format int8 {tmpdir}",
+                f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} --dataset laion/filtered-wit --weight-format int8 {tmpdir}",
                 shell=True,
                 check=True,
             )

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -26,6 +26,7 @@ from utils_tests import (
 
 from optimum.exporters.openvino.__main__ import main_export
 from optimum.intel import (  # noqa
+    OVLatentConsistencyModelPipeline,
     OVModelForAudioClassification,
     OVModelForCausalLM,
     OVModelForFeatureExtraction,
@@ -37,7 +38,6 @@ from optimum.intel import (  # noqa
     OVModelForTokenClassification,
     OVStableDiffusionPipeline,
     OVStableDiffusionXLPipeline,
-    OVLatentConsistencyModelPipeline,
 )
 from optimum.intel.openvino.utils import _HEAD_TO_AUTOMODELS
 from optimum.intel.utils.import_utils import is_openvino_tokenizers_available


### PR DESCRIPTION
# What does this PR do?

* Extend optimum-cli with `dataset` option
* Support export StableDiffusion models after hybrid PTQ via optimum-cli

Example:
```bash
optimum-cli export openvino --model SimianLuo/LCM_Dreamshaper_v7 --task latent-consistency  --dataset conceptual_captions --weight-format int8 <output_dir>
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

