### PR TITLE
disable export=False in IPEXModel

### DIFF
--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -204,7 +204,9 @@ class IPEXModel(OptimizedModel):
         **kwargs,
     ):
         if not getattr(config, "torchscript", False):
-            raise ValueError("`config.torchscript` should be set to `True`, if your model is not a TorchScript model and needs to be traced please set `export=True` when loading it with `.from_pretrained()`")
+            raise ValueError(
+                "`config.torchscript` should be set to `True`, if your model is not a TorchScript model and needs to be traced please set `export=True` when loading it with `.from_pretrained()`"
+            )
 
         # Load the model from local directory
         if os.path.isdir(model_id):

--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -204,7 +204,7 @@ class IPEXModel(OptimizedModel):
         **kwargs,
     ):
         if not getattr(config, "torchscript", False):
-            raise ValueError("`torchscript` should be set to True to load TorchScript model")
+            raise ValueError("`config.torchscript` should be set to `True`, if your model is not a TorchScript model and needs to be traced please set `export=True` when loading it with `.from_pretrained()`")
 
         # Load the model from local directory
         if os.path.isdir(model_id):

--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -203,6 +203,9 @@ class IPEXModel(OptimizedModel):
         subfolder: str = "",
         **kwargs,
     ):
+        if not getattr(config, "torchscript", False):
+            raise ValueError("`torchscript` should be set to True to load TorchScript model")
+
         # Load the model from local directory
         if os.path.isdir(model_id):
             model_cache_path = os.path.join(model_id, file_name)


### PR DESCRIPTION
Hi @echarlaix . I think we should disable `export=False` in `IPEXModel` because we propose that the ipex optimization contains jit.trace. After this PR merged, I could update the ipex example and readme (#594 #595 ) to clarify it. Thx
