### PR TITLE
Fix saving preprocessors for models with remote code

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -323,6 +323,7 @@ def main_export(
         fn_get_submodels=fn_get_submodels,
         preprocessors=preprocessors,
         device=device,
+        trust_remote_code=trust_remote_code,
         **kwargs_shapes,
     )
 

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -493,6 +493,7 @@ def export_from_model(
     fn_get_submodels: Optional[Callable] = None,
     preprocessors: List = None,
     device: str = "cpu",
+    trust_remote_code: bool = False,
     **kwargs_shapes,
 ):
     if ov_config is not None and ov_config.quantization_config and not is_nncf_available():
@@ -605,7 +606,7 @@ def export_from_model(
             generation_config.save_pretrained(output)
 
         model_name_or_path = model.config._name_or_path
-        maybe_save_preprocessors(model_name_or_path, output)
+        maybe_save_preprocessors(model_name_or_path, output, trust_remote_code=trust_remote_code)
 
         files_subpaths = ["openvino_" + model_name + ".xml" for model_name in models_and_export_configs.keys()]
 


### PR DESCRIPTION
# What does this PR do?

preprocessors for some models with remote code  failed to saving using optimum-cli due to the absence of info that they should be loaded with trust_remote_code for saving. This PR fixes such issue


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

