### PR TITLE
add protein preediction task for ipex

### DIFF
--- a/notebooks/ipex/protein_prediction.ipynb
+++ b/notebooks/ipex/protein_prediction.ipynb
@@ -1,0 +1,257 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Use ipex optimization on a remote model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We use a protein model [mila-intel/ProtST-esm1b](https://huggingface.co/mila-intel/ProtST-esm1b) to show how to apply ipex optimization on a remote model."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/jiqingfe/miniconda3/envs/ipex/lib/python3.10/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    }
+   ],
+   "source": [
+    "import functools\n",
+    "from tqdm import tqdm\n",
+    "import torch\n",
+    "from datasets import load_dataset\n",
+    "from transformers import AutoModel, AutoTokenizer, AutoConfig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Prepare datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def tokenize_protein(example, protein_tokenizer=None, padding=None):\n",
+    "    protein_seqs = example[\"prot_seq\"]\n",
+    "\n",
+    "    protein_inputs = protein_tokenizer(protein_seqs, padding=padding, add_special_tokens=True)\n",
+    "    example[\"protein_input_ids\"] = protein_inputs.input_ids\n",
+    "    example[\"protein_attention_mask\"] = protein_inputs.attention_mask\n",
+    "\n",
+    "    return example\n",
+    "\n",
+    "\n",
+    "def label_embedding(labels, text_tokenizer, text_model, device):\n",
+    "    # embed label descriptions\n",
+    "    label_feature = []\n",
+    "    with torch.inference_mode():\n",
+    "        for label in labels:\n",
+    "            label_input_ids = text_tokenizer.encode(label, max_length=128, truncation=True, add_special_tokens=False)\n",
+    "            label_input_ids = [text_tokenizer.cls_token_id] + label_input_ids\n",
+    "            label_input_ids = torch.tensor(label_input_ids, dtype=torch.long, device=device).unsqueeze(0)\n",
+    "            attention_mask = label_input_ids != text_tokenizer.pad_token_id\n",
+    "            attention_mask = attention_mask.to(device)\n",
+    "\n",
+    "            text_outputs = text_model(label_input_ids, attention_mask=attention_mask)\n",
+    "\n",
+    "            label_feature.append(text_outputs[\"text_feature\"])\n",
+    "    label_feature = torch.cat(label_feature, dim=0)\n",
+    "    label_feature = label_feature / label_feature.norm(dim=-1, keepdim=True)\n",
+    "\n",
+    "    return label_feature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def zero_shot_eval(device, test_dataset, target_field, protein_model, logit_scale, label_feature):\n",
+    "\n",
+    "    # get prediction and target\n",
+    "    test_dataloader = torch.utils.data.DataLoader(test_dataset, batch_size=1, shuffle=False)\n",
+    "    preds, targets = [], []\n",
+    "    with torch.inference_mode():\n",
+    "        for data in tqdm(test_dataloader):\n",
+    "            target = data[target_field]\n",
+    "            targets.append(target)\n",
+    "\n",
+    "            protein_input_ids = torch.tensor(data[\"protein_input_ids\"], dtype=torch.long, device=device).unsqueeze(0)\n",
+    "            attention_mask = torch.tensor(data[\"protein_attention_mask\"], dtype=torch.long, device=device).unsqueeze(0)\n",
+    "\n",
+    "            protein_outputs = protein_model(protein_input_ids, attention_mask=attention_mask)\n",
+    "\n",
+    "            protein_feature = protein_outputs[\"protein_feature\"]\n",
+    "            protein_feature = protein_feature / protein_feature.norm(dim=-1, keepdim=True)\n",
+    "            pred = logit_scale * protein_feature @ label_feature.t()\n",
+    "            preds.append(pred)\n",
+    "\n",
+    "    preds = torch.cat(preds, dim=0)\n",
+    "    targets = torch.tensor(targets, dtype=torch.long, device=device)\n",
+    "    accuracy = (preds.argmax(dim=-1) == targets).float().mean().item()\n",
+    "    print(\"Zero-shot accuracy: %.6f\" % accuracy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Load datasets and model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "raw_datasets = load_dataset(\n",
+    "    \"mila-intel/ProtST-SubcellularLocalization\", split=\"test\"\n",
+    ")  # cache_dir defaults to \"~/.cache/huggingface/datasets\"\n",
+    "\n",
+    "device = torch.device(\"cpu\")\n",
+    "\n",
+    "protst_model = AutoModel.from_pretrained(\n",
+    "    \"mila-intel/ProtST-esm1b\", trust_remote_code=True, torch_dtype=torch.bfloat16\n",
+    ").to(device)\n",
+    "protein_model = protst_model.protein_model\n",
+    "text_model = protst_model.text_model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Apply ipex optimization"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Passing the argument `library_name` to `get_supported_tasks_for_model_type` is required, but got library_name=None. Defaulting to `transformers`. An error will be raised in a future version of Optimum if `library_name` is not provided.\n",
+      "/home/jiqingfe/miniconda3/envs/ipex/lib/python3.10/site-packages/transformers/modeling_utils.py:4193: FutureWarning: `_is_quantized_training_enabled` is going to be deprecated in transformers 4.39.0. Please use `model.hf_quantizer.is_trainable` instead\n",
+      "  warnings.warn(\n"
+     ]
+    }
+   ],
+   "source": [
+    "import intel_extension_for_pytorch as ipex\n",
+    "from optimum.intel.generation.modeling import jit_trace\n",
+    "\n",
+    "protein_model = ipex.optimize(protein_model, dtype=torch.bfloat16, inplace=True)\n",
+    "protein_model = jit_trace(protein_model, \"sequence-classification\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Evaluation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 2773/2773 [05:06<00:00,  9.06it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Zero-shot accuracy: 0.447890\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "logit_scale = protst_model.logit_scale\n",
+    "logit_scale.requires_grad = False\n",
+    "logit_scale = logit_scale.to(device)\n",
+    "logit_scale = logit_scale.exp()\n",
+    "\n",
+    "protein_tokenizer = AutoTokenizer.from_pretrained(\"facebook/esm1b_t33_650M_UR50S\")\n",
+    "text_tokenizer = AutoTokenizer.from_pretrained(\"microsoft/BiomedNLP-PubMedBERT-base-uncased-abstract\")\n",
+    "\n",
+    "func_tokenize_protein = functools.partial(tokenize_protein, protein_tokenizer=protein_tokenizer, padding=False)\n",
+    "test_dataset = raw_datasets.map(\n",
+    "    func_tokenize_protein,\n",
+    "    batched=False,\n",
+    "    remove_columns=[\"prot_seq\"],\n",
+    "    desc=\"Running tokenize_proteins on dataset\",\n",
+    ")\n",
+    "\n",
+    "labels = load_dataset(\"mila-intel/subloc_template\")[\"train\"][\"name\"]\n",
+    "\n",
+    "text_tokenizer.encode(labels[0], max_length=128, truncation=True, add_special_tokens=False)\n",
+    "label_feature = label_embedding(labels, text_tokenizer, text_model, device)\n",
+    "zero_shot_eval(device, test_dataset, \"localization\", protein_model, logit_scale, label_feature)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "ipex",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Hi @echarlaix . I want to add an example of protein prediction to show users how to apply ipex optimization on a loaded remote model. I choose [protst model](https://huggingface.co/mila-intel/ProtST-esm1b), which is a SOTA model for protein prediction. Would you please help to review and merge it? Thx!