### PR TITLE
Added passing of CI var to docker.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build_doc_docker_image:
 doc: build_doc_docker_image
 	@test -n "$(BUILD_DIR)" || (echo "BUILD_DIR is empty." ; exit 1)
 	@test -n "$(VERSION)" || (echo "VERSION is empty." ; exit 1)
-	docker run -v $(CURRENT_DIR):/doc_folder --workdir=/doc_folder doc_maker \
+    docker run -v $(CURRENT_DIR):/doc_folder --workdir=/doc_folder --env CI=$(CI) doc_maker \
 	doc-builder build optimum.intel /optimum-intel/docs/source/ \
 		--repo_name optimum-intel \
 		--build_dir $(BUILD_DIR) \

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build_doc_docker_image:
 doc: build_doc_docker_image
 	@test -n "$(BUILD_DIR)" || (echo "BUILD_DIR is empty." ; exit 1)
 	@test -n "$(VERSION)" || (echo "VERSION is empty." ; exit 1)
-    docker run -v $(CURRENT_DIR):/doc_folder --workdir=/doc_folder --env CI=$(CI) doc_maker \
+	docker run -v $(CURRENT_DIR):/doc_folder --workdir=/doc_folder --env CI=$(CI) doc_maker \
 	doc-builder build optimum.intel /optimum-intel/docs/source/ \
 		--repo_name optimum-intel \
 		--build_dir $(BUILD_DIR) \


### PR DESCRIPTION
# What does this PR do?

Pass CI variable to docker container.

Fixes # 

OpenVino may send telemetry data. To disable telemetry sending in CI "CI" variable is used, that is set in most CI pipelines.
Docker does not pass outer env variables to container, so "CI" var is needed to be passed explicitly to prevent telemetry sending from docker container. 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

