### PR TITLE
[Gemma][Llama] fix bf16 min_dtype

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -274,6 +274,7 @@ class GemmaOpenVINOConfig(GemmaOnnxConfig):
     ) -> "ModelPatcher":
         return GemmaModelPatcher(self, model, model_kwargs=model_kwargs)
 
+
 @register_in_tasks_manager(
     "llama",
     *[

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -19,7 +19,7 @@ from packaging import version
 from transformers.utils import is_tf_available
 
 from optimum.exporters.onnx.config import TextDecoderOnnxConfig, TextDecoderWithPositionIdsOnnxConfig
-from optimum.exporters.onnx.model_configs import GemmaOnnxConfig
+from optimum.exporters.onnx.model_configs import GemmaOnnxConfig, LlamaOnnxConfig
 from optimum.exporters.tasks import TasksManager
 from optimum.utils import DEFAULT_DUMMY_SHAPES
 from optimum.utils.input_generators import (
@@ -34,6 +34,7 @@ from .model_patcher import (
     BaichuanModelPatcher,
     ChatGLMModelPatcher,
     GemmaModelPatcher,
+    LlamaModelPatcher,
     MixtralModelPatcher,
     QwenModelPatcher,
 )
@@ -272,6 +273,23 @@ class GemmaOpenVINOConfig(GemmaOnnxConfig):
         self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
     ) -> "ModelPatcher":
         return GemmaModelPatcher(self, model, model_kwargs=model_kwargs)
+
+@register_in_tasks_manager(
+    "llama",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text-classification",
+    ],
+    library_name="transformers",
+)
+class LlamaOpenVINOConfig(LlamaOnnxConfig):
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
+    ) -> "ModelPatcher":
+        return LlamaModelPatcher(self, model, model_kwargs=model_kwargs)
 
 
 class QwenDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -287,6 +287,72 @@ class ChatGLMModelPatcher(DecoderModelPatcher):
         for block in self._model.transformer.encoder.layers:
             block.self_attention.core_attention.forward = block.self_attention.core_attention._orig_forward
 
+# transformers/models/llama/modeling_llama.py
+# transformers/models/gemma/modeling_gemma.py
+def _update_causal_mask(self, attention_mask, input_tensor, cache_position):
+    if self.config._attn_implementation == "flash_attention_2":
+        if attention_mask is not None and 0.0 in attention_mask:
+            return attention_mask
+        return None
+
+    dtype, device = input_tensor.dtype, input_tensor.device
+    min_dtype = torch.finfo(dtype).min
+
+    # workaround CVS-137270
+    if dtype == torch.float32 or dtype == torch.float:
+        print("use torch.finfo(torch.bfloat16).min as WA for issue CVS-137270")
+        min_dtype = torch.finfo(torch.bfloat16).min
+
+    sequence_length = input_tensor.shape[1]
+    if hasattr(getattr(self.layers[0], "self_attn", {}), "past_key_value"):  # static cache
+        target_length = self.config.max_position_embeddings
+    else:  # dynamic cache
+        target_length = (
+            attention_mask.shape[-1] if isinstance(attention_mask, torch.Tensor) else cache_position[-1] + 1
+        )
+
+    causal_mask = torch.full((sequence_length, target_length), fill_value=min_dtype, dtype=dtype, device=device)
+    if sequence_length != 1:
+        causal_mask = torch.triu(causal_mask, diagonal=1)
+    causal_mask *= torch.arange(target_length, device=device) > cache_position.reshape(-1, 1)
+    causal_mask = causal_mask[None, None, :, :].expand(input_tensor.shape[0], 1, -1, -1)
+    if attention_mask is not None:
+        causal_mask = causal_mask.clone()  # copy to contiguous memory for in-place edit
+        if attention_mask.dim() == 2:
+            mask_length = attention_mask.shape[-1]
+            padding_mask = causal_mask[..., :mask_length].eq(0.0) * attention_mask[:, None, None, :].eq(0.0)
+            causal_mask[..., :mask_length] = causal_mask[..., :mask_length].masked_fill(padding_mask, min_dtype)
+        elif attention_mask.dim() == 4:
+            # backwards compatibility: we allow passing a 4D attention mask shorter than the input length with
+            # cache. In that case, the 4D attention mask attends to the newest tokens only.
+            if attention_mask.shape[-2] < cache_position[0] + sequence_length:
+                offset = cache_position[0]
+            else:
+                offset = 0
+            mask_shape = attention_mask.shape
+            mask_slice = (attention_mask.eq(0.0)).to(dtype=dtype) * min_dtype
+            causal_mask[
+                : mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]
+            ] = mask_slice
+
+    if (
+        self.config._attn_implementation == "sdpa"
+        and attention_mask is not None
+        and attention_mask.device.type == "cuda"
+    ):
+        # TODO: For dynamo, rather use a check on fullgraph=True once this is possible (https://github.com/pytorch/pytorch/pull/120400).
+        is_tracing = (
+            torch.jit.is_tracing()
+            or isinstance(input_tensor, torch.fx.Proxy)
+            or (hasattr(torch, "_dynamo") and torch._dynamo.is_compiling())
+        )
+        if not is_tracing and torch.any(attention_mask != 1):
+            # Attend to all tokens in fully masked rows in the causal_mask, for example the relevant first rows when
+            # using left padding. This is required by F.scaled_dot_product_attention memory-efficient attention path.
+            # Details: https://github.com/pytorch/pytorch/issues/110213
+            causal_mask = AttentionMaskConverter._unmask_unattended(causal_mask, min_dtype)
+
+    return causal_mask
 
 class GemmaModelPatcher(DecoderModelPatcher):
     def __enter__(self):
@@ -300,6 +366,27 @@ class GemmaModelPatcher(DecoderModelPatcher):
                 layer.self_attn.rotary_emb.inv_freq = 1.0 / (
                     rotary_emb.base ** (torch.arange(0, rotary_emb.dim, 2, dtype=torch.int64).float() / rotary_emb.dim)
                 )
+
+        self._model.model.original_update_causal_mask = self._model.model._update_causal_mask
+        self._model.model._update_causal_mask = types.MethodType(_update_causal_mask, self._model.model)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.model._update_causal_mask = self._model.model.original_update_causal_mask
+        del self._model.model.original_update_causal_mask
+
+
+class LlamaModelPatcher(DecoderModelPatcher):
+    def __enter__(self):
+        super().__enter__()
+
+        self._model.model.original_update_causal_mask = self._model.model._update_causal_mask
+        self._model.model._update_causal_mask = types.MethodType(_update_causal_mask, self._model.model)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.model._update_causal_mask = self._model.model.original_update_causal_mask
+        del self._model.model.original_update_causal_mask
 
 
 SUPPORT_SDPA = is_torch_version(">", "2.1.0")

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
+from transformers.modeling_attn_mask_utils import AttentionMaskConverter
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from transformers.utils import is_tf_available
 
@@ -287,6 +288,7 @@ class ChatGLMModelPatcher(DecoderModelPatcher):
         for block in self._model.transformer.encoder.layers:
             block.self_attention.core_attention.forward = block.self_attention.core_attention._orig_forward
 
+
 # transformers/models/llama/modeling_llama.py
 # transformers/models/gemma/modeling_gemma.py
 def _update_causal_mask(self, attention_mask, input_tensor, cache_position):
@@ -300,7 +302,6 @@ def _update_causal_mask(self, attention_mask, input_tensor, cache_position):
 
     # workaround CVS-137270
     if dtype == torch.float32 or dtype == torch.float:
-        print("use torch.finfo(torch.bfloat16).min as WA for issue CVS-137270")
         min_dtype = torch.finfo(torch.bfloat16).min
 
     sequence_length = input_tensor.shape[1]
@@ -353,6 +354,7 @@ def _update_causal_mask(self, attention_mask, input_tensor, cache_position):
             causal_mask = AttentionMaskConverter._unmask_unattended(causal_mask, min_dtype)
 
     return causal_mask
+
 
 class GemmaModelPatcher(DecoderModelPatcher):
     def __enter__(self):


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

`min_dtype` of torch.float32 type in Llama/Gemma's _update_causal_mask() will converted into bf16's `-infinity` by CPU plugin (due to design of https://www.felixcloutier.com/x86/vcvtneps2bf16 instruction).

this PR fixes it by using `torch.finfo(torch.bfloat16).min` to replace `torch.finfo(torch.float32).min`, they are very close in magnitude but won't cause `-infinity` issue.

```python
>>> torch.finfo(torch.float).min
-3.4028234663852886e+38
>>> torch.finfo(torch.bfloat16).min
-3.3895313892515355e+38
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

