### PR TITLE
Disable message about ONNX configs on export

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -564,6 +564,7 @@ def export_from_model(
             kwargs_shapes[input_name] if input_name in kwargs_shapes else DEFAULT_DUMMY_SHAPES[input_name]
         )
 
+    logging.disable(logging.INFO)
     export_config, models_and_export_configs = _get_submodels_and_export_configs(
         model=model,
         task=task,
@@ -578,6 +579,7 @@ def export_from_model(
         legacy=False,
         exporter="openvino",
     )
+    logging.disable(logging.NOTSET)
 
     if ov_config is None:
         if library_name == "diffusers":


### PR DESCRIPTION
On exporting a model, the log currently shows:
```
Using the export variant default. Available variants are:
    - default: The default ONNX variant.
```

This may give the impression that ONNX is used for model export. 

This PR disables INFO level logging from the `_get_submodels_and_export_configs()` function. This info is not relevant for OpenVINO users, and logging messages higher than INFO level will still be shown.

Tested with optimum-cli and API. 

optimum-cli before:
```
$ optimum-cli export openvino -m gpt2 gpt2-ov
INFO:nncf:NNCF initialized successfully. Supported frameworks detected: torch, onnx, openvino
Framework not specified. Using pt to export the model.
Automatic task detection to text-generation-with-past (possible synonyms are: causal-lm-with-past).
Using the export variant default. Available variants are:
    - default: The default ONNX variant.
Using framework PyTorch: 2.2.2+cpu
```

With this PR:
```
$ optimum-cli export openvino -m gpt2 gpt2-ov
INFO:nncf:NNCF initialized successfully. Supported frameworks detected: torch, onnx, openvino
Framework not specified. Using pt to export the model.
Automatic task detection to text-generation-with-past (possible synonyms are: causal-lm-with-past).
Using framework PyTorch: 2.2.2+cpu
```

@echarlaix I thought this was easiest, and I really don't think we need these info level log messages for OpenVINO. If you think it's better to address from the Optimum side that would be fine too!