### PR TITLE
Fix model caching for diffusion models and multiple GPUs

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -671,7 +671,7 @@ class OVModelPart:
             if (
                 "CACHE_DIR" not in self.ov_config.keys()
                 and not str(self._model_dir).startswith(gettempdir())
-                and self.device.lower().split(":")[0] == "gpu"
+                and "gpu" in self.device.lower()
             ):
                 self.ov_config["CACHE_DIR"] = os.path.join(self._model_dir, self._model_name, "model_cache")
 


### PR DESCRIPTION
Align with modeling_base and modeling_seq2seq where we already check for `"gpu" in self.device.lower()`. 
This enables model caching to be automatically enabled for devices like "GPU.0"

