### PR TITLE
Update OV quantization docs and QA notebook according to the recent changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Post-training static quantization introduces an additional calibration step wher
 
 ```python
 from functools import partial
-from optimum.intel import OVQuantizer, OVModelForSequenceClassification
+from optimum.intel import OVQuantizer, OVModelForSequenceClassification, OVConfig, OVQuantizationConfig
 from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
@@ -145,7 +145,8 @@ calibration_dataset = quantizer.get_calibration_dataset(
 # The directory where the quantized model will be saved
 save_dir = "nncf_results"
 # Apply static quantization and save the resulting model in the OpenVINO IR format
-quantizer.quantize(calibration_dataset=calibration_dataset, save_directory=save_dir)
+ov_config = OVConfig(quantization_config=OVQuantizationConfig())
+quantizer.quantize(ov_config=ov_config, calibration_dataset=calibration_dataset, save_directory=save_dir)
 # Load the quantized model
 optimized_model = OVModelForSequenceClassification.from_pretrained(save_dir)
 ```

--- a/docs/source/optimization_ov.mdx
+++ b/docs/source/optimization_ov.mdx
@@ -84,7 +84,7 @@ Here is how to apply static quantization on a fine-tuned DistilBERT given your o
 
 ```python
 from transformers import AutoTokenizer
-from optimum.intel import OVQuantizer, OVModelForSequenceClassification,
+from optimum.intel import OVQuantizer, OVModelForSequenceClassification, OVConfig, OVQuantizationConfig
 
 model_id = "distilbert-base-uncased-finetuned-sst-2-english"
 model = OVModelForSequenceClassification.from_pretrained(model_id, export=True)
@@ -95,7 +95,8 @@ save_dir = "ptq_model"
 quantizer = OVQuantizer.from_pretrained(model)
 
 # Apply static quantization and export the resulting quantized model to OpenVINO IR format
-quantizer.quantize(calibration_dataset=calibration_dataset, save_directory=save_dir)
+ov_config = OVConfig(quantization_config=OVQuantizationConfig())
+quantizer.quantize(ov_config=ov_config, calibration_dataset=calibration_dataset, save_directory=save_dir)
 # Save the tokenizer
 tokenizer.save_pretrained(save_dir)
 ```

--- a/notebooks/openvino/question_answering_quantization.ipynb
+++ b/notebooks/openvino/question_answering_quantization.ipynb
@@ -51,7 +51,7 @@
     "import transformers\n",
     "from evaluate import evaluator\n",
     "from openvino.runtime import Core\n",
-    "from optimum.intel.openvino import OVModelForQuestionAnswering, OVQuantizer\n",
+    "from optimum.intel.openvino import OVModelForQuestionAnswering, OVQuantizer, OVQuantizationConfig, OVConfig\n",
     "from transformers import AutoModelForQuestionAnswering, AutoTokenizer, pipeline\n",
     "\n",
     "transformers.logging.set_verbosity_error()\n",
@@ -286,11 +286,11 @@
     "**NOTE:** if you notice very low accuracy after post-training quantization, it is likely caused by an overflow issue which affects processors that do not contain VNNI (Vector Neural Network Instruction). NNCF has an `overflow_fix` option to address this. It will effectively use 7-bits for quantizing instead of 8-bits to prevent the overflow. To use this option, modify the code in the next cell to add an explicit quantization configuration, and set `overflow_fix` to `\"enable\"`:\n",
     "\n",
     "```\n",
-    "from optimum.intel.openvino import OVConfig\n",
+    "from optimum.intel.openvino import OVConfig, OVQuantizationConfig\n",
     "\n",
-    "ov_config = OVConfig()\n",
-    "ov_config.compression[\"overflow_fix\"] = \"enable\"\n",
-    "quantizer = OVQuantizer.from_pretrained(model, ov_config=ov_config)\n",
+    "ov_config = OVConfig(quantization_config=OVQuantizationConfig(overflow_fix=\"enable\")\n",
+    "quantizer = OVQuantizer.from_pretrained(model)\n",
+    "quantizer.quantize(calibration_dataset=train_dataset, save_directory=int8_ptq_model_path, ov_config=ov_config)\n",
     "```\n",
     "\n",
     "For more information, see [Lower Numerical Precision Deep Learning Inference and Training](https://www.intel.com/content/www/us/en/developer/articles/technical/lower-numerical-precision-deep-learning-inference-and-training.html)"
@@ -317,7 +317,8 @@
     "\n",
     "# Quantize the model\n",
     "quantizer = OVQuantizer.from_pretrained(model)\n",
-    "quantizer.quantize(calibration_dataset=train_dataset, save_directory=int8_ptq_model_path)"
+    "ov_config = OVConfig(quantization_config=OVQuantizationConfig())\n",
+    "quantizer.quantize(calibration_dataset=train_dataset, ov_config=ov_config, save_directory=int8_ptq_model_path)"
    ]
   },
   {

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -280,7 +280,7 @@ class OVQuantizer(OptimumQuantizer):
             raise TypeError(f"`ov_config` should be an `OVConfig`, but got: {type(ov_config)} instead.")
         quantization_config = ov_config.quantization_config
         if quantization_config is None:
-            if weights_only is None or weights_only is True:
+            if (weights_only is None or weights_only is True) and calibration_dataset is None:
                 if weights_only is None:
                     logger.info(
                         "`quantization_config` was not provided, 8-bit asymmetric weight quantization will be applied."

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -287,6 +287,11 @@ class OVQuantizer(OptimumQuantizer):
                     )
                 ov_config.quantization_config = OVWeightQuantizationConfig(bits=8)
             else:
+                logger.warning(
+                    "`quantization_config` was not provided, but calibration dataset was provided, assuming full "
+                    "model quantization is intended. In the future, please provide `quantization_config` as an "
+                    "instance of OVQuantizationConfig."
+                )
                 ov_config.quantization_config = OVQuantizationConfig()
 
         if isinstance(self.model, OVBaseModel):


### PR DESCRIPTION
# What does this PR do?

Follow-up to #638:
- Update OV PTQ documentation
- Update QA model quantization notebook
- For backward compatibility, change quantization config creation logic so that PTQ will be applied if quantization config was not provided explicitly, but calibration dataset was provided.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

