### PR TITLE
Add version info to OpenVINO models

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -32,6 +32,12 @@ from optimum.exporters.onnx.convert import check_dummy_inputs_are_allowed
 from optimum.exporters.onnx.convert import export_pytorch as export_pytorch_to_onnx
 from optimum.exporters.onnx.convert import export_tensorflow as export_tensorflow_onnx
 from optimum.exporters.utils import _get_submodels_and_export_configs
+from optimum.intel.utils.import_utils import (
+    _optimum_intel_version,
+    _optimum_version,
+    _torch_version,
+    _transformers_version,
+)
 from optimum.utils import DEFAULT_DUMMY_SHAPES, is_diffusers_available
 from optimum.utils.save_utils import maybe_save_preprocessors
 
@@ -81,6 +87,10 @@ def _save_model(model, path: str, ov_config: Optional["OVConfig"] = None):
 
         compress_to_fp16 = ov_config.dtype == "fp16"
 
+    model.set_rt_info(_transformers_version, ["optimum", "transformers_version"])
+    model.set_rt_info(_torch_version, ["optimum", "pytorch_version"])
+    model.set_rt_info(_optimum_intel_version, ["optimum", "optimum_intel_version"])
+    model.set_rt_info(_optimum_version, ["optimum", "optimum_version"])
     save_model(model, path, compress_to_fp16)
 
 

--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -33,6 +33,7 @@ logger = logging.getLogger(__name__)
 STR_OPERATION_TO_FUNC = {">": op.gt, ">=": op.ge, "==": op.eq, "!=": op.ne, "<=": op.le, "<": op.lt}
 
 _optimum_version = importlib_metadata.version("optimum")
+_optimum_intel_version = importlib_metadata.version("optimum-intel")
 
 _transformers_available = importlib.util.find_spec("transformers") is not None
 _transformers_version = "N/A"

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -45,6 +45,7 @@ from optimum.intel import (
     OVStableDiffusionXLPipeline,
 )
 from optimum.intel.openvino.modeling_base import OVBaseModel
+from optimum.intel.utils.import_utils import _transformers_version
 from optimum.utils.save_utils import maybe_load_preprocessors
 
 
@@ -113,6 +114,9 @@ class ExportModelTest(unittest.TestCase):
 
                 if task == "text-generation":
                     self.assertEqual(ov_model.stateful, stateful and use_cache)
+                    self.assertEqual(
+                        ov_model.model.get_rt_info()["optimum"]["transformers_version"], _transformers_version
+                    )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_export(self, model_type: str):


### PR DESCRIPTION
Versions of optimum-intel and dependencies can have an impact on performance/accuracy. This PR adds transformers, torch, optimum and optimum-intel dependencies to the openvino_model.xml file (the OpenVINO version is already there). This is really useful when debugging issues, or looking into differences.

Example (`<optimum>` is added):
![image](https://github.com/huggingface/optimum-intel/assets/77325899/5cbd6935-d293-4c48-8924-a58a4540fbfb)

@eaidova @AlexKoff88 