### PR TITLE
add XPU support for `IPEXModel.from_pretrained`

### DIFF
--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -324,7 +324,7 @@ class IPEXModel(OptimizedModel):
         if not self._is_ipex_exported:
             use_cache = "past_key_values" in self.input_names
             dummy_inputs = prepare_jit_inputs(self, self.export_feature, use_cache)
-            if "cpu" not in str(self._device):
+            if self._device.type != "cpu":
                 dummy_inputs = recursive_to_device(value=dummy_inputs, device=self._device)
             for _ in range(2):
                 self(**dummy_inputs)

--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -129,7 +129,6 @@ class IPEXModel(OptimizedModel):
         **kwargs,
     ):
         OptimizedModel.__init__(self, model=model, config=config)
-        device_map = kwargs.pop("device_map", None)
         if device_map is None:
             if is_torch_xpu_available(check_device=True):
                 self._device = torch.device("xpu:0")
@@ -137,27 +136,6 @@ class IPEXModel(OptimizedModel):
                 self._device = torch.device("cuda:0")
             else:
                 self._device = torch.device("cpu")
-        else:
-            if isinstance(device_map, torch.device):
-                self._device = device_map
-            elif isinstance(device_map, str):
-                if device_map in ["auto", "balanced", "balanced_low_0", "sequential"]:
-                    raise ValueError(
-                        "When passing device_map as a string, the value needs to be a device name (e.g. cpu, xpu:0). "
-                        f"'auto', 'balanced', 'balanced_low_0', 'sequential' are not supported."
-                    )
-                self._device = torch.device(device_map)
-            elif isinstance(device_map, int):
-                if is_torch_xpu_available(check_device=True):
-                    self._device = torch.device(f"xpu:{device_map}")
-                elif torch.cuda.is_available():
-                    self._device = torch.device(f"cuda:{device_map}")
-                else:
-                    self._device = torch.device("cpu")
-            else:
-                raise ValueError(
-                    f"device_map should be either be a string, an integer or a torch.device object, but found {type(device_map)}"
-                )
         self.model.to(self._device)
         self._dtype = self.config.torch_dtype if self.config.torch_dtype is not None else torch.float32
         self.model_save_dir = model_save_dir

--- a/optimum/intel/utils/modeling_utils.py
+++ b/optimum/intel/utils/modeling_utils.py
@@ -169,3 +169,16 @@ def get_model_device(model: torch.nn.Module) -> torch.device:
         # The model had no parameters at all, doesn't matter which device to choose
         device = torch.device("cpu")
     return device
+
+
+def recursive_to_device(value, device):
+    """
+    Recursivley move the tensor element in `value` to `device`
+    """
+    if isinstance(value, (tuple, list)):
+        return type(value)(recursive_to_device(v, device) for v in value)
+    elif isinstance(value, dict):
+        return type(value)({k: recursive_to_device(v, device) for k, v in value.items()})
+    elif isinstance(value, torch.Tensor):
+        return value.to(device)
+    return value

--- a/optimum/intel/utils/modeling_utils.py
+++ b/optimum/intel/utils/modeling_utils.py
@@ -178,7 +178,7 @@ def recursive_to_device(value, device):
     if isinstance(value, (tuple, list)):
         return type(value)(recursive_to_device(v, device) for v in value)
     elif isinstance(value, dict):
-        return type(value)({k: recursive_to_device(v, device) for k, v in value.items()})
+        return {k: recursive_to_device(v, device) for k, v in value.items()}
     elif isinstance(value, torch.Tensor):
         return value.to(device)
     return value


### PR DESCRIPTION
## What does this PR do?
This PR adds XPU support for loading a Torchscript model using `IPEXModel.from_pretrained`. Below is a test example: 

```python
import torch 
from transformers import AutoTokenizer
from optimum.intel import IPEXModel

model_id = "faaany/bert-base-uncased-float32-traced"
model_id_tokenizer = "google-bert/bert-base-uncased"
model = IPEXModel.from_pretrained(model_id)
tokenizer = AutoTokenizer.from_pretrained(model_id_tokenizer)
inputs = tokenizer("Paris is the capital of France.", return_tensors="pt").to("xpu")
print("________________")
print(model.device)
with torch.no_grad():
    outputs = model(**inputs)
    embeddings = outputs[0][:, 0]
    print(embeddings)
```

Please note that `faaany/bert-base-uncased-float32-traced` is just a test model, which is traced from "google-bert/bert-base-uncased". Since I didn't load any tokenizer config, so I pass `model_id_tokenizer` to `AutoTokenizer` in the example above.
