### PR TITLE
Add openvino tokenizers directory

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -357,6 +357,7 @@ def main_export(
 
     # hide openvino import when using other exporters
     from optimum.exporters.openvino.convert import export_tokenizer
+    from optimum.intel.openvino.utils import OV_TOKENIZER_FOLDER
 
     if convert_tokenizer and is_openvino_tokenizers_available():
         if library_name != "diffusers":
@@ -367,7 +368,7 @@ def main_export(
 
             if tokenizer is not None:
                 try:
-                    export_tokenizer(tokenizer, output)
+                    export_tokenizer(tokenizer, output / OV_TOKENIZER_FOLDER)
                 except Exception as exception:
                     logger.warning(
                         "Could not load tokenizer using specified model ID or path. OpenVINO tokenizer/detokenizer "

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -34,6 +34,7 @@ OV_ENCODER_NAME = "openvino_encoder_model.xml"
 OV_DECODER_NAME = "openvino_decoder_model.xml"
 OV_DECODER_WITH_PAST_NAME = "openvino_decoder_with_past_model.xml"
 
+OV_TOKENIZER_FOLDER = "openvino_tokenizer"
 OV_TOKENIZER_NAME = "openvino_tokenizer{}.xml"
 OV_DETOKENIZER_NAME = "openvino_detokenizer{}.xml"
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -39,7 +39,7 @@ from optimum.intel import (  # noqa
     OVStableDiffusionPipeline,
     OVStableDiffusionXLPipeline,
 )
-from optimum.intel.openvino.utils import _HEAD_TO_AUTOMODELS
+from optimum.intel.openvino.utils import _HEAD_TO_AUTOMODELS, OV_TOKENIZER_FOLDER
 from optimum.intel.utils.import_utils import is_openvino_tokenizers_available
 
 
@@ -140,7 +140,9 @@ class OVCLIExportTestCase(unittest.TestCase):
                 )
                 return
 
-            number_of_tokenizers = sum("tokenizer" in file for file in map(str, Path(tmpdir).rglob("*.xml")))
+            number_of_tokenizers = sum(
+                "tokenizer" in file for file in map(str, (Path(tmpdir) / OV_TOKENIZER_FOLDER).rglob("*.xml"))
+            )
             self.assertEqual(self.EXPECTED_NUMBER_OF_TOKENIZER_MODELS[model_type], number_of_tokenizers, output)
 
             if number_of_tokenizers == 1:


### PR DESCRIPTION
As discussed in https://github.com/huggingface/optimum-intel/pull/580#discussion_r1557865119 when the openvino export of tokenizer was made default in the CLI, it was agreed that we should have them in a `openvino_tokenizer` directory 