### PR TITLE
Fix diffusers requirement for quantizing models

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -48,7 +48,7 @@ from ...exporters.openvino import export, export_pytorch_via_onnx
 from ...exporters.openvino.model_patcher import patch_model_with_bettertransformer
 from ...exporters.openvino.stateful import ensure_export_task_support_stateful, ensure_stateful_is_available
 from ..utils.constant import _TASK_ALIASES
-from ..utils.import_utils import DATASETS_IMPORT_ERROR, is_datasets_available
+from ..utils.import_utils import DATASETS_IMPORT_ERROR, is_datasets_available, is_diffusers_available
 from ..utils.modeling_utils import get_model_device
 from .configuration import OVConfig, OVQuantizationConfig, OVQuantizationMethod, OVWeightQuantizationConfig
 from .modeling_base import OVBaseModel
@@ -325,7 +325,8 @@ class OVQuantizer(OptimumQuantizer):
         remove_unused_columns: bool = True,
         **kwargs,
     ):
-        from optimum.intel.openvino.modeling_diffusion import OVStableDiffusionPipelineBase
+        if is_diffusers_available():
+            from optimum.intel.openvino.modeling_diffusion import OVStableDiffusionPipelineBase
 
         if save_directory is not None:
             save_directory = Path(save_directory)
@@ -335,7 +336,7 @@ class OVQuantizer(OptimumQuantizer):
         if calibration_dataset is not None:
             # Process custom calibration dataset
 
-            if isinstance(self.model, OVStableDiffusionPipelineBase):
+            if is_diffusers_available() and isinstance(self.model, OVStableDiffusionPipelineBase):
                 calibration_dataset = self._prepare_unet_dataset(
                     quantization_config.num_samples, dataset=calibration_dataset
                 )
@@ -373,7 +374,7 @@ class OVQuantizer(OptimumQuantizer):
 
                 if isinstance(self.model, OVModelForCausalLM):
                     calibration_dataset = self._prepare_builtin_dataset(quantization_config)
-                elif isinstance(self.model, OVStableDiffusionPipelineBase):
+                elif is_diffusers_available() and isinstance(self.model, OVStableDiffusionPipelineBase):
                     calibration_dataset = self._prepare_unet_dataset(
                         quantization_config.num_samples, dataset_name=quantization_config.dataset
                     )
@@ -385,7 +386,7 @@ class OVQuantizer(OptimumQuantizer):
             if quantization_config.quant_method == OVQuantizationMethod.HYBRID:
                 if calibration_dataset is None:
                     raise ValueError("Calibration dataset is required to run hybrid quantization.")
-                if isinstance(self.model, OVStableDiffusionPipelineBase):
+                if is_diffusers_available() and isinstance(self.model, OVStableDiffusionPipelineBase):
                     # Apply weight-only quantization to all SD submodels except UNet
                     quantization_config_copy = copy.deepcopy(quantization_config)
                     quantization_config_copy.dataset = None


### PR DESCRIPTION
quantization.py now imports `OVStableDiffusionPipelineBase`  which requires diffusers to be installed, but that should not be required for quantizing non-diffusion models. This PR changes this so `OVStableDiffusionPipelineBase` only gets imported if diffusers is available. This is safe because the class is only used in `isinstance` calls, and if a model is a stable diffusion model, diffusers will definitely be available.