### PR TITLE
skip saving gen config if saving failed

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -614,7 +614,12 @@ def export_from_model(
         model.config.save_pretrained(output)
         generation_config = getattr(model, "generation_config", None)
         if generation_config is not None:
-            generation_config.save_pretrained(output)
+            try:
+                generation_config.save_pretrained(output)
+            except Exception as exception:
+                logger.warning(
+                    f"The generation config will not be saved, saving failed with following error:\n{exception}"
+                )
 
         model_name_or_path = model.config._name_or_path
         maybe_save_preprocessors(model_name_or_path, output, trust_remote_code=trust_remote_code)


### PR DESCRIPTION
# What does this PR do?

some models haму generation configs that produces warnings during validation (example of model https://huggingface.co/lmsys/vicuna-7b-v1.5), save_pretrained method of such configs throws error. This PR skips saving generation config if it is treated as invalid.
