### PR TITLE
fix pipeline accelerator default to ipex not ort

### DIFF
--- a/optimum/intel/pipelines/pipeline_base.py
+++ b/optimum/intel/pipelines/pipeline_base.py
@@ -150,7 +150,7 @@ def pipeline(
     feature_extractor: Optional[Union[str, PreTrainedFeatureExtractor]] = None,
     use_fast: bool = True,
     token: Optional[Union[str, bool]] = None,
-    accelerator: Optional[str] = "ort",
+    accelerator: Optional[str] = "ipex",
     revision: Optional[str] = None,
     trust_remote_code: Optional[bool] = None,
     torch_dtype: Optional[Union[str, torch.dtype]] = None,


### PR DESCRIPTION
# What does this PR do?
Pipeline accelerator backend can be selected between ["ipex", "inc" and "openvino"]. The args description mentions 'ipex' as default but default was set to 'ort'. 

Fixes #735 


## Before submitting
- [x ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

