### PR TITLE
improve doc around supported tasks and accelertor options

### DIFF
--- a/optimum/intel/pipelines/pipeline_base.py
+++ b/optimum/intel/pipelines/pipeline_base.py
@@ -171,6 +171,12 @@ def pipeline(
             The task defining which pipeline will be returned. Currently accepted tasks are:
 
             - `"text-generation"`: will return a [`TextGenerationPipeline`]:.
+            - `"fill-mask"`: will return a [`FillMaskPipeline`].
+            - `"question-answering"`: will return a [`QuestionAnsweringPipeline`].
+            - `"image-classificatio"`: will return a [`ImageClassificationPipeline`].
+            - `"text-classification"`: will return a [`TextClassificationPipeline`].
+            - `"token-classification"`: will return a [`TokenClassificationPipeline`].
+            - `"audio-classification"`: will return a [`AudioClassificationPipeline`].
 
         model (`str` or [`PreTrainedModel`], *optional*):
             The model that will be used by the pipeline to make predictions. This can be a model identifier or an
@@ -185,8 +191,8 @@ def pipeline(
             is not specified or not a string, then the default tokenizer for `config` is loaded (if it is a string).
             However, if `config` is also not given or not a string, then the default tokenizer for the given `task`
             will be loaded.
-        accelerator (`str`, *optional*, defaults to `"ipex"`):
-            The optimization backends, choose from ["ipex", "inc", "openvino"].
+        accelerator (`str`, *optional*):
+            The optimization backends, choose from ["ipex"].
         use_fast (`bool`, *optional*, defaults to `True`):
             Whether or not to use a Fast tokenizer if possible (a [`PreTrainedTokenizerFast`]).
         torch_dtype (`str` or `torch.dtype`, *optional*):

--- a/optimum/intel/pipelines/pipeline_base.py
+++ b/optimum/intel/pipelines/pipeline_base.py
@@ -192,7 +192,7 @@ def pipeline(
             However, if `config` is also not given or not a string, then the default tokenizer for the given `task`
             will be loaded.
         accelerator (`str`, *optional*):
-            The optimization backends, choose from ["ipex"].
+            The optimization backends, choose from ["ipex", "inc", "openvino"].
         use_fast (`bool`, *optional*, defaults to `True`):
             Whether or not to use a Fast tokenizer if possible (a [`PreTrainedTokenizerFast`]).
         torch_dtype (`str` or `torch.dtype`, *optional*):


### PR DESCRIPTION
# fix documentation
Prior https://github.com/huggingface/optimum-intel/pull/739 removes 'ipex' as default accelerator and 
seems is the only supported one in MAPPING_LOADING_FUNC. removed inc and openvino from options

also, updated list of supported pipeline tasks to match those of optimum/intel/ipex/modeling_base.py

Fixes # 742


## Before submitting
- [x ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

