### PR TITLE
Disable future warnings/info messages on import

### DIFF
--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import logging
+import warnings
 
 from ..utils.import_utils import is_accelerate_available, is_diffusers_available, is_nncf_available
 from .utils import (
@@ -25,8 +26,14 @@ from .utils import (
 )
 
 
+warnings.simplefilter(action="ignore", category=FutureWarning)
+
+
 if is_nncf_available():
+    logging.disable(logging.INFO)
     import nncf
+
+    logging.disable(logging.NOTSET)
 
     # Suppress version mismatch logging
     nncf.set_log_level(logging.ERROR)


### PR DESCRIPTION
Importing an OVModel shows info messages and warnings that are not relevant for optimum-intel end users. That's not an issue in a script, but in notebooks/demos it can be distracting. This PR disables the INFO message from NNCF, and FutureWarnings that result from imports in `__init__.py`

![7025d07633b6ca9f8cfb18d483d600fc](https://github.com/huggingface/optimum-intel/assets/77325899/d5191523-2356-48bf-b7fd-483c2e6795a4)
