### PR TITLE
loading generation config if it is part of model

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -158,6 +158,14 @@ class OVBaseModel(OptimizedModel):
         """
         dst_path = os.path.join(save_directory, OV_XML_FILE_NAME)
         openvino.save_model(self.model, dst_path, compress_to_fp16=False)
+        generation_config = getattr(self, "generation_config", None)
+        if generation_config is not None:
+            try:
+                generation_config.save_pretrained(save_directory)
+            except Exception as exception:
+                logger.warning(
+                    f"The generation config will not be saved, saving failed with following error:\n{exception}"
+                )
 
         self._save_openvino_config(save_directory)
 

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -78,7 +78,10 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         self.encoder_model = encoder
         self.decoder_model = decoder
         self.decoder_with_past_model = decoder_with_past
-        self.generation_config = GenerationConfig.from_model_config(config) if self.can_generate() else None
+        if self.can_generate():
+            self.generation_config = kwargs.get("generation_config", GenerationConfig.from_model_config(config))
+        else:
+            self.generation_config = None
         self._openvino_config = None
         if quantization_config:
             self._openvino_config = OVConfig(quantization_config=quantization_config)
@@ -217,6 +220,19 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             decoder = cls.load_model(file_names["decoder"], quantization_config)
             if use_cache:
                 decoder_with_past = cls.load_model(file_names["decoder_with_past"], quantization_config)
+
+        try:
+            generation_config = GenerationConfig.from_pretrained(
+                model_id,
+                token=token,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                local_files_only=local_files_only,
+            )
+            kwargs["generation_config"] = generation_config
+        except Exception:
+            pass
 
         return cls(
             encoder=encoder,

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -107,6 +107,13 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             openvino.save_model(src_file, dst_path, compress_to_fp16=False)
 
         self._save_openvino_config(save_directory)
+        if self.generation_config is not None:
+            try:
+                self.generation_config.save_pretrained(save_directory)
+            except Exception as exception:
+                logger.warning(
+                    f"The generation config will not be saved, saving failed with following error:\n{exception}"
+                )
 
     @classmethod
     def _from_pretrained(

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -763,6 +763,18 @@ class OVModelForCausalLM(OVBaseDecoderModel, GenerationMixin):
             init_cls = cls
 
         enable_compilation = kwargs.pop("compile", True) and not load_in_4bit
+        try:
+            generation_config = GenerationConfig.from_pretrained(
+                model_id,
+                token=token,
+                revision=revision,
+                cache_dir=cache_dir,
+                force_download=force_download,
+                local_files_only=local_files_only,
+            )
+            kwargs["generation_config"] = generation_config
+        except Exception:
+            pass
         causal_model = init_cls(
             model=model,
             config=config,

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -224,6 +224,14 @@ class OVBaseDecoderModel(OVModel):
         dst_path = os.path.join(save_directory, OV_XML_FILE_NAME)
         openvino.save_model(model_to_save, dst_path, compress_to_fp16=False)
 
+        if self.generation_config is not None:
+            try:
+                self.generation_config.save_pretrained(save_directory)
+            except Exception as exception:
+                logger.warning(
+                    f"The generation config will not be saved, saving failed with following error:\n{exception}"
+                )
+
         self._save_openvino_config(save_directory)
 
     @classmethod

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -21,7 +21,7 @@ from typing import Optional
 import torch
 from parameterized import parameterized
 from sentence_transformers import SentenceTransformer, models
-from transformers import AutoConfig, AutoTokenizer
+from transformers import AutoConfig, AutoTokenizer, GenerationConfig
 from utils_tests import MODEL_NAMES
 
 from optimum.exporters.onnx.constants import SDPA_ARCHS_ONNX_EXPORT_NOT_SUPPORTED
@@ -70,6 +70,8 @@ class ExportModelTest(unittest.TestCase):
         "stable-diffusion-xl-refiner": OVStableDiffusionXLImg2ImgPipeline,
         "latent-consistency": OVLatentConsistencyModelPipeline,
     }
+
+    GENERATIVE_MODELS = ("pix2struct", "t5", "bart", "gpt2", "whisper")
 
     def _openvino_export(
         self,
@@ -123,6 +125,41 @@ class ExportModelTest(unittest.TestCase):
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_export(self, model_type: str):
         self._openvino_export(model_type)
+
+    @parameterized.expand(GENERATIVE_MODELS)
+    def test_export_with_custom_gen_config(self, model_type):
+        auto_model = self.SUPPORTED_ARCHITECTURES[model_type]
+        task = auto_model.export_feature
+        model_name = MODEL_NAMES[model_type]
+        loading_kwargs = {"attn_implementation": "eager"} if model_type in SDPA_ARCHS_ONNX_EXPORT_NOT_SUPPORTED else {}
+
+        model = auto_model.auto_model_class.from_pretrained(model_name, **loading_kwargs)
+
+        model.generation_config.top_k = 42
+        model.generation_config.do_sample = True
+
+        if getattr(model.config, "model_type", None) == "pix2struct":
+            preprocessors = maybe_load_preprocessors(model_name)
+        else:
+            preprocessors = None
+
+        supported_tasks = (task, task + "-with-past") if "text-generation" in task else (task,)
+        for supported_task in supported_tasks:
+            with TemporaryDirectory() as tmpdirname:
+                export_from_model(
+                    model=model,
+                    output=Path(tmpdirname),
+                    task=supported_task,
+                    preprocessors=preprocessors,
+                )
+
+                use_cache = supported_task.endswith("-with-past")
+                ov_model = auto_model.from_pretrained(tmpdirname, use_cache=use_cache)
+                self.assertIsInstance(ov_model, OVBaseModel)
+                self.assertTrue(ov_model.can_generate())
+                self.assertTrue(ov_model.generation_config is not None)
+                self.assertIsInstance(ov_model.generation_config, GenerationConfig)
+                self.assertTrue(ov_model.generation_config.top_k == 42)
 
 
 class CustomExportModelTest(unittest.TestCase):

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -161,6 +161,16 @@ class ExportModelTest(unittest.TestCase):
                 self.assertIsInstance(ov_model.generation_config, GenerationConfig)
                 self.assertTrue(ov_model.generation_config.top_k == 42)
 
+                # check that generate config remains after repeated saving
+                with TemporaryDirectory() as tmpdirname2:
+                    ov_model.save_pretrained(tmpdirname2)
+                    ov_model = auto_model.from_pretrained(tmpdirname2)
+                    self.assertIsInstance(ov_model, OVBaseModel)
+                    self.assertTrue(ov_model.can_generate())
+                    self.assertTrue(ov_model.generation_config is not None)
+                    self.assertIsInstance(ov_model.generation_config, GenerationConfig)
+                    self.assertTrue(ov_model.generation_config.top_k == 42)
+
 
 class CustomExportModelTest(unittest.TestCase):
     def test_custom_export_config_model(self):

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -164,7 +164,7 @@ class ExportModelTest(unittest.TestCase):
                 # check that generate config remains after repeated saving
                 with TemporaryDirectory() as tmpdirname2:
                     ov_model.save_pretrained(tmpdirname2)
-                    ov_model = auto_model.from_pretrained(tmpdirname2)
+                    ov_model = auto_model.from_pretrained(tmpdirname2, use_cache=use_cache)
                     self.assertIsInstance(ov_model, OVBaseModel)
                     self.assertTrue(ov_model.can_generate())
                     self.assertTrue(ov_model.generation_config is not None)


### PR DESCRIPTION
# What does this PR do?

there is misalignment with behaviour how we convert model and how to load in generation config part. In some cases, generation config parameters can be different from default and not provided in config. I see issue with attempt to run whisper-tiny with pipelines due to difference in generation config, when openvino model loaded and when original pytorch model (due to obtaining generation config from model config instead of using provided with model before conversion)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

