### PR TITLE
[OV Optimum] Keep ShapeOf on Parameter / ReadValue in case of added beam_idx -> Gather

### DIFF
--- a/optimum/exporters/openvino/stateful.py
+++ b/optimum/exporters/openvino/stateful.py
@@ -81,7 +81,9 @@ def fuse_cache_reorder(
         consumers = parameter_output_port.get_target_inputs()
         gather = opset13.gather(parameter_output_port, beam_idx, opset13.constant(gather_dim))
         for consumer in consumers:
-            consumer.replace_source_output(gather.output(0))
+            if consumer.get_node().get_type_name() != "ShapeOf":
+                # shape content doesn't change. keeping ShapeOf ops on Parameter (or ReadValue in stateful case)
+                consumer.replace_source_output(gather.output(0))
     ov_model.validate_nodes_and_infer_types()
 
 


### PR DESCRIPTION
# What does this PR do?
In the case of inserted `beam_idx -> Gather`, we keep `ShapeOf` operations on the original `Parameter` operations (`ReadValue` operations after the model becomes stateful). This helps avoid special handling of such ShapeOf operations in runtime (CVS-143648).

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [N/A] Did you make sure to update the documentation with your changes?
- [N/A] Did you write any new necessary tests?

