### PR TITLE
Remove default trust remove code for predefined datasets

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -757,9 +757,6 @@ class OVQuantizer(OptimumQuantizer):
 
             dataset_metadata = PREDEFINED_SD_DATASETS[dataset_name]
             datasets_kwargs = {"split": dataset_metadata["split"], "streaming": True}
-            if is_datasets_version(">=", "2.20.0"):
-                datasets_kwargs["trust_remote_code"] = True
-
             dataset = load_dataset(dataset_name, **datasets_kwargs).shuffle(seed=self.seed)
 
             input_names = dataset_metadata["inputs"]


### PR DESCRIPTION
Removing `trust_remote_code=True` when loading a dataset from [`PREDEFINED_SD_DATASETS`](https://github.com/huggingface/optimum-intel/blob/a05203f079f9110df92446e5def6ef19959fa909/optimum/intel/openvino/utils.py#L106) :
* [conceptual_captions](https://huggingface.co/datasets/google-research-datasets/conceptual_captions)
* [laion/220k-GPT4Vision-captions-from-LIVIS](https://huggingface.co/datasets/laion/220k-GPT4Vision-captions-from-LIVIS)
* [laion/filtered-wit](https://huggingface.co/datasets/laion/filtered-wit)

for now loading automatically the dataset `conceptual_captions` when specified in the quantization config will fail as `trust_remote_code=True`  is needed for datasets with a python loading script for `datasets>=v2.20.0`

cc @lhoestq