### PR TITLE
Enable autoround quantization

### DIFF
--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -90,11 +90,11 @@ if is_itrex_available():
     from intel_extension_for_transformers.transformers.llm.quantization.utils import convert_to_quantized_model
     from intel_extension_for_transformers.transformers.modeling.modeling_auto import save_low_bit
     from intel_extension_for_transformers.transformers.utils.config import (
+        AutoRoundConfig,
         AwqConfig,
         GPTQConfig,
         ITREXQuantizationConfigMixin,
         RtnConfig,
-        AutoRoundConfig,
     )
 
 
@@ -256,6 +256,12 @@ class INCQuantizer(OptimumQuantizer):
                 raise TypeError(
                     "`quantization_config` should either be an instance of `neural_compressor.config.PostTrainingQuantConfig` or "
                     f"`intel_extension_for_transformers.transformers.utils.config.ITREXQuantizationConfigMixin` but got: {type(quantization_config)} instead."
+                )
+
+            if isinstance(quantization_config, AutoRoundConfig) and is_neural_compressor_version("<", "2.6.0"):
+                raise ImportError(
+                    f"Found an incompatible version of neural-compressor. Found version {_neural_compressor_version}, "
+                    f"but neural-compressor v2.6.0 or higher is needed for AutoRound quantization."
                 )
 
             if not isinstance(quantization_config, (GPTQConfig, RtnConfig, AutoRoundConfig)):

--- a/optimum/intel/neural_compressor/quantization.py
+++ b/optimum/intel/neural_compressor/quantization.py
@@ -94,6 +94,7 @@ if is_itrex_available():
         GPTQConfig,
         ITREXQuantizationConfigMixin,
         RtnConfig,
+        AutoRoundConfig,
     )
 
 
@@ -257,9 +258,9 @@ class INCQuantizer(OptimumQuantizer):
                     f"`intel_extension_for_transformers.transformers.utils.config.ITREXQuantizationConfigMixin` but got: {type(quantization_config)} instead."
                 )
 
-            if not isinstance(quantization_config, (GPTQConfig, RtnConfig)):
+            if not isinstance(quantization_config, (GPTQConfig, RtnConfig, AutoRoundConfig)):
                 raise ValueError(
-                    f"Weight-only quantization is only support RTN and GPTQ algorithm now! But got {quantization_config}"
+                    f"Weight-only quantization is only support RTN, GPTQ and AutoRound algorithm now! But got {quantization_config}"
                 )
 
             if calibration_dataset is None and isinstance(quantization_config, (GPTQConfig, AwqConfig)):

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ TESTS_REQUIRE = [
     "einops",
     "tiktoken",
     "sentence-transformers",
+    "auto-round",
 ]
 
 QUALITY_REQUIRE = ["black~=23.1", "ruff>=0.0.241"]


### PR DESCRIPTION
Needs `neural-compressor >= v2.6.0`  to avoid  incompatibility with [`itrex`](https://github.com/intel/intel-extension-for-transformers)  

coming from missing `n_samples` argument and `train_bs` / `bs` mismatch  :
https://github.com/intel/intel-extension-for-transformers/blob/v1.4.2/intel_extension_for_transformers/transformers/llm/quantization/utils.py#L397
https://github.com/intel/neural-compressor/blob/v2.5.1/neural_compressor/adaptor/torch_utils/auto_round.py#L19
