### PR TITLE
[OV]: load and convert llms in original precision

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -301,9 +301,11 @@ def main_export(
         and task.startswith("text-generation")
         and getattr(config, "torch_dtype", torch.float32) in [torch.float16, torch.bfloat16]
     ):
-        if is_openvino_version(">=", "2024.2") and config.torch_dtype == torch.float16:
+        if ov_config is not None and ov_config.dtype in {"fp16", "fp32"}:
+            dtype = torch.float16 if ov_config.dtype == "fp16" else torch.float32
+        elif is_openvino_version(">=", "2024.2") and config.torch_dtype == torch.float16:
             dtype = torch.float16
-        if is_openvino_version(">=", "2024.3") and config.torch_dtype == torch.bfloat16:
+        elif is_openvino_version(">=", "2024.3") and config.torch_dtype == torch.bfloat16:
             dtype = torch.bfloat16
 
     if dtype is not None:

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -28,8 +28,8 @@ from optimum.exporters.onnx.constants import SDPA_ARCHS_ONNX_EXPORT_NOT_SUPPORTE
 from optimum.exporters.openvino.convert import export_from_model
 from optimum.intel.utils.import_utils import (
     is_openvino_tokenizers_available,
-    is_transformers_version,
     is_openvino_version,
+    is_transformers_version,
 )
 from optimum.utils.save_utils import maybe_load_preprocessors
 
@@ -104,6 +104,7 @@ def main_export(
     stateful: bool = True,
     convert_tokenizer: bool = False,
     library_name: Optional[str] = None,
+    model_loading_kwargs: Optional[Dict[str, Any]] = None,
     **kwargs_shapes,
 ):
     """
@@ -217,6 +218,9 @@ def main_export(
         model_name_or_path, subfolder=subfolder, revision=revision, cache_dir=cache_dir, token=token
     )
 
+    if framework == "pt":
+        import torch
+
     if library_name is None:
         library_name = TasksManager._infer_library_from_model_name_or_path(
             model_name_or_path=model_name_or_path,
@@ -235,7 +239,7 @@ def main_export(
     do_gptq_patching = False
     custom_architecture = False
     patch_16bit = False
-    loading_kwargs = {}
+    loading_kwargs = model_loading_kwargs or {}
     if library_name == "transformers":
         config = AutoConfig.from_pretrained(
             model_name_or_path,
@@ -286,19 +290,28 @@ def main_export(
                 "Please provide custom export config if you want load model with remote code."
             )
             trust_remote_code = False
+    dtype = loading_kwargs.get("torch_dtype")
+    if isinstance(dtype, str):
+        dtype = config.torch_dtype if dtype == "auto" else getattr(torch, dtype)
 
     if (
-        not do_gptq_patching
+        dtype is None
+        and framework == "pt"
+        and not do_gptq_patching
         and task.startswith("text-generation")
-        and getattr(config, "torch_dtype", "float32") in ["float16", "bfloat16"]
+        and getattr(config, "torch_dtype", torch.float32) in [torch.float16, torch.bfloat16]
     ):
-        if is_openvino_version(">=", "2024.2") and config.torch_dtype == "float16":
-            loading_kwargs["torch_dtype"] = torch.float16
-            patch_16bit = True
-        if is_openvino_version(">=", "2024.3") and config.torch_dtype == "bfloat16":
-            loading_kwargs["torch_dtype"] = torch.bfloat16
-            patch_16bit = True
+        if is_openvino_version(">=", "2024.2") and config.torch_dtype == torch.float16:
+            dtype = torch.float16
+        if is_openvino_version(">=", "2024.3") and config.torch_dtype == torch.bfloat16:
+            dtype = torch.bfloat16
 
+    if dtype is not None:
+        if dtype in [torch.float16, torch.bfloat16]:
+            patch_16bit = True
+        loading_kwargs["torch_dtype"] = dtype
+
+    logger.warning(loading_kwargs)
     # Patch the modules to export of GPTQ models w/o GPU
     if do_gptq_patching:
         import torch

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
+from transformers.utils import is_torch_available
 
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig
@@ -38,6 +39,11 @@ from .utils import clear_class_registry
 
 if TYPE_CHECKING:
     from optimum.intel.openvino.configuration import OVConfig
+
+
+if is_torch_available():
+    import torch
+
 
 _COMPRESSION_OPTIONS = {
     "int8": {"bits": 8},
@@ -218,9 +224,6 @@ def main_export(
         model_name_or_path, subfolder=subfolder, revision=revision, cache_dir=cache_dir, token=token
     )
 
-    if framework == "pt":
-        import torch
-
     if library_name is None:
         library_name = TasksManager._infer_library_from_model_name_or_path(
             model_name_or_path=model_name_or_path,
@@ -316,8 +319,6 @@ def main_export(
     logger.warning(loading_kwargs)
     # Patch the modules to export of GPTQ models w/o GPU
     if do_gptq_patching:
-        import torch
-
         torch.set_default_dtype(torch.float32)
         orig_cuda_check = torch.cuda.is_available
         torch.cuda.is_available = lambda: True

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -370,11 +370,6 @@ def export_pytorch(
             patcher = config.patch_model_for_export(model, model_kwargs=model_kwargs)
             patched_forward = patcher.patched_forward
 
-            if patch_16bit_model:
-                from openvino.frontend.pytorch.patch_model import __make_16bit_traceable
-
-                __make_16bit_traceable(model)
-
             @functools.wraps(patched_forward)
             def ts_patched_forward(*args, **kwargs):
                 for i in range(len(dict_inputs)):
@@ -388,6 +383,9 @@ def export_pytorch(
             patcher.patched_forward = ts_patched_forward
 
             with patcher:
+                if patch_16bit_model:
+                    from openvino.frontend.pytorch.patch_model import __make_16bit_traceable
+                    __make_16bit_traceable(model)
                 check_dummy_inputs_are_allowed(model, dummy_inputs)
                 sig = inspect.signature(model.forward) if hasattr(model, "forward") else inspect.signature(model.call)
                 inputs = config.ordered_inputs(model)

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -104,7 +104,7 @@ def export(
     model_kwargs: Optional[Dict[str, Any]] = None,
     ov_config: Optional["OVConfig"] = None,
     stateful: bool = True,
-    patch_16bit_model: bool = False
+    patch_16bit_model: bool = False,
 ) -> Tuple[List[str], List[str]]:
     """
     Exports a Pytorch or TensorFlow model to an OpenVINO Intermediate Representation.
@@ -156,7 +156,7 @@ def export(
             ov_config=ov_config,
             model_kwargs=model_kwargs,
             stateful=stateful,
-            patch_16bit_model=patch_16bit_model
+            patch_16bit_model=patch_16bit_model,
         )
 
     elif is_tf_available() and issubclass(type(model), TFPreTrainedModel):
@@ -290,7 +290,7 @@ def export_pytorch(
     model_kwargs: Optional[Dict[str, Any]] = None,
     ov_config: Optional["OVConfig"] = None,
     stateful: bool = False,
-    patch_16bit_model: bool = False
+    patch_16bit_model: bool = False,
 ) -> Tuple[List[str], List[str]]:
     """
     Exports a PyTorch model to an OpenVINO Intermediate Representation.
@@ -372,8 +372,8 @@ def export_pytorch(
 
             if patch_16bit_model:
                 from openvino.frontend.pytorch.patch_model import __make_16bit_traceable
-                __make_16bit_traceable(model)
 
+                __make_16bit_traceable(model)
 
             @functools.wraps(patched_forward)
             def ts_patched_forward(*args, **kwargs):
@@ -408,6 +408,13 @@ def export_pytorch(
                     "A stateless model will be exported instead. It may result in sub-optimal inference performance."
                     "Provide a model that can be converted to OpenVINO without fallback to ONNX conversion path."
                 )
+
+            if patch_16bit_model:
+                from openvino.frontend.pytorch.patch_model import unpatch_model
+
+                unpatch_model(model, "_openvino_module_extension_patch_orig_forward")
+                model.to(torch.float32)
+
             return export_pytorch_via_onnx(
                 model,
                 config,
@@ -474,7 +481,7 @@ def export_models(
     model_kwargs: Optional[Dict[str, Any]] = None,
     ov_config: Optional["OVConfig"] = None,
     stateful: bool = True,
-    patch_16bit_model: bool = False
+    patch_16bit_model: bool = False,
 ) -> Tuple[List[List[str]], List[List[str]]]:
     """
     Export the models to OpenVINO IR format
@@ -526,7 +533,7 @@ def export_models(
                 model_kwargs=model_kwargs,
                 ov_config=ov_config,
                 stateful=stateful,
-                patch_16bit_model=patch_16bit_model
+                patch_16bit_model=patch_16bit_model,
             )
         )
 
@@ -710,7 +717,7 @@ def export_from_model(
         stateful=stateful,
         opset=opset,
         model_kwargs=model_kwargs,
-        patch_16bit_model=patch_16bit_model
+        patch_16bit_model=patch_16bit_model,
     )
 
 

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -385,6 +385,7 @@ def export_pytorch(
             with patcher:
                 if patch_16bit_model:
                     from openvino.frontend.pytorch.patch_model import __make_16bit_traceable
+
                     __make_16bit_traceable(model)
                 check_dummy_inputs_are_allowed(model, dummy_inputs)
                 sig = inspect.signature(model.forward) if hasattr(model, "forward") else inspect.signature(model.call)

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -66,8 +66,8 @@ from .model_patcher import (
     PersimmonModelPatcher,
     Phi3ModelPatcher,
     QwenModelPatcher,
-    UpdateCausalMaskModelPatcher,
     RotaryEmbPatcher,
+    UpdateCausalMaskModelPatcher,
     XverseModelPatcher,
 )
 
@@ -540,24 +540,6 @@ class MPTOpenVINOConfig(MPTOnnxConfig):
         self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
     ) -> "ModelPatcher":
         return MPTModelPatcher(self, model, model_kwargs=model_kwargs)
-
-
-@register_in_tasks_manager(
-    "phi",
-    *[
-        "feature-extraction",
-        "feature-extraction-with-past",
-        "text-generation",
-        "text-generation-with-past",
-        "text-classification",
-    ],
-    library_name="transformers",
-)
-class PhiOpenVINOConfig(PhiOnnxConfig):
-    def patch_model_for_export(
-        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
-    ) -> "ModelPatcher":
-        return RotaryEmbPatcher(self, model, model_kwargs=model_kwargs)
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -105,6 +105,7 @@ def patch_update_causal_mask(model, transformers_version):
     if is_transformers_version(">=", transformers_version):
         model.model._update_causal_mask = types.MethodType(_llama_gemma_update_causal_mask, model.model)
 
+
 # initialization of sin/cos cached in bf16/fp16 leads to accuracy loss
 # reinitialize them to save in float32 before export
 def _reinitialize_cos_sin_cached_fp32(rotary_emb):

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -285,6 +285,13 @@ class OVBaseDecoderModel(OVModel):
 
         stateful = kwargs.pop("stateful", ensure_stateful_is_available(warn=False) and use_cache)
 
+        torch_dtype = kwargs.pop("torch_dtype", None)
+
+        model_loading_kwargs = {}
+
+        if torch_dtype is not None:
+            model_loading_kwargs["torch_dtype"] = torch_dtype
+
         main_export(
             model_name_or_path=model_id,
             output=save_dir_path,
@@ -298,6 +305,7 @@ class OVBaseDecoderModel(OVModel):
             trust_remote_code=trust_remote_code,
             ov_config=ov_export_config,
             stateful=stateful,
+            model_loading_kwargs=model_loading_kwargs,
         )
 
         config.is_decoder = True

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -281,7 +281,7 @@ class OVBaseDecoderModel(OVModel):
         if load_in_8bit is None and not quantization_config:
             ov_export_config = None
         else:
-            ov_export_config = OVConfig(dtype="fp32")
+            ov_export_config = OVConfig(dtype="auto")
 
         stateful = kwargs.pop("stateful", ensure_stateful_is_available(warn=False) and use_cache)
 

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -78,6 +78,7 @@ class ExportModelTest(unittest.TestCase):
         model_type: str,
         compression_option: Optional[str] = None,
         stateful: bool = True,
+        patch_16bit_model: bool = False,
     ):
         auto_model = self.SUPPORTED_ARCHITECTURES[model_type]
         task = auto_model.export_feature
@@ -170,6 +171,32 @@ class ExportModelTest(unittest.TestCase):
                     self.assertTrue(ov_model.generation_config is not None)
                     self.assertIsInstance(ov_model.generation_config, GenerationConfig)
                     self.assertTrue(ov_model.generation_config.top_k == 42)
+
+    def test_export_fp16_model(self):
+        auto_model = self.SUPPORTED_ARCHITECTURES["gpt2"]
+        task = auto_model.export_feature
+        model_name = MODEL_NAMES["gpt2"]
+        model = auto_model.auto_model_class.from_pretrained(model_name, torch_dtype=torch.float16)
+        stateful = True
+
+        for supported_task in [task, task + "with-past"]:
+            with TemporaryDirectory() as tmpdirname:
+                export_from_model(
+                    model=model,
+                    output=Path(tmpdirname),
+                    task=task,
+                    preprocessors=None,
+                    patch_16bit_model=True,
+                    stateful=stateful,
+                )
+                use_cache = supported_task.endswith("-with-past")
+                ov_model = auto_model.from_pretrained(tmpdirname, use_cache=use_cache)
+                self.assertIsInstance(ov_model, OVBaseModel)
+                self.assertEqual(ov_model.use_cache, use_cache)
+                self.assertEqual(ov_model.stateful, stateful and use_cache)
+                self.assertEqual(
+                    ov_model.model.get_rt_info()["optimum"]["transformers_version"], _transformers_version
+                )
 
 
 class CustomExportModelTest(unittest.TestCase):

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1013,6 +1013,30 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
                 f"generation config : {gen_config}, transformers output {transformers_outputs}, ov_model_stateless output {ov_stateless_outputs}",
             )
 
+    def test_load_with_different_dtype(self):
+        set_seed(SEED)
+        model_id = MODEL_NAMES["llama"]
+        pt_model = AutoModelForCausalLM.from_pretrained(
+            model_id,
+        )
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+        texts = ["this is a simple input"]
+        test_input = tokenizer(texts, return_tensors="pt")
+
+        ref_logits = pt_model(**test_input).logits
+        torch_dtypes = [None, "auto", "float32", torch.float16]
+        if is_openvino_version(">", "2024.2.0"):
+            torch_dtypes.append("bfloat16")
+
+        for dtype in torch_dtypes:
+            ov_model = OVModelForCausalLM.from_pretrained(model_id=model_id, export=True, torch_dtype=dtype)
+            ov_logits = ov_model(**test_input).logits
+            self.assertTrue(
+                torch.allclose(torch.Tensor(ov_logits), ref_logits, atol=5e-3),
+                f"values are not close for {dtype if dtype is not None else 'None'}, max diff = {torch.abs(ov_logits - ref_logits).max()}",
+            )
+
 
 class OVModelForMaskedLMIntegrationTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES = (

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -544,7 +544,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                     save_model_patch.assert_called_with(
                         unittest.mock.ANY,
                         unittest.mock.ANY,
-                        ov_config=OVConfig(dtype="fp32"),
+                        ov_config=OVConfig(dtype="auto"),
                         library_name="transformers",
                     )
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -236,7 +236,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 quant_method=QuantizationMethod.AWQ,
                 scale_estimation=True,
             ),
-            16,
+            8,
         ),
         (
             OVModelForCausalLM,
@@ -250,7 +250,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 dataset="c4",
                 quant_method="awq",
             ),
-            16,
+            8,
         ),
     )
 
@@ -567,7 +567,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                         save_model_patch.assert_called_with(
                             unittest.mock.ANY,
                             unittest.mock.ANY,
-                            ov_config=OVConfig(dtype="fp32"),
+                            ov_config=OVConfig(dtype="auto"),
                             library_name="transformers",
                         )
                         compression_params = {


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

allow loading bfloat16 and float16 models in original precision for conversion. It significantly reduces memory consumption and loading time during model conversion for large models

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

