### PR TITLE
auto mapping class

### DIFF
--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -23,7 +23,6 @@ from typing import Dict, Optional, Tuple, Union
 
 import intel_extension_for_pytorch as ipex
 import torch
-import transformers
 from huggingface_hub import hf_hub_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from intel_extension_for_pytorch.cpu._auto_kernel_selection import _enable_tpp
@@ -41,6 +40,7 @@ from transformers import (
     GenerationConfig,
     GenerationMixin,
     PretrainedConfig,
+    is_torch_xpu_available,
 )
 from transformers.dynamic_module_utils import get_class_from_dynamic_module
 from transformers.modeling_outputs import CausalLMOutputWithPast, ModelOutput
@@ -138,7 +138,7 @@ class IPEXModel(OptimizedModel):
         warmup: bool = True,
         **kwargs,
     ):
-        if transformers.is_torch_xpu_available(check_device=True):
+        if is_torch_xpu_available(check_device=True):
             self._device = torch.device("xpu:0")
         elif torch.cuda.is_available():
             self._device = torch.device("cuda:0")

--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -228,6 +228,12 @@ class IPEXModel(OptimizedModel):
                 raise ImportError("`torch>=2.0.0` is needed to trace your model")
 
             task = TasksManager.infer_task_from_model(model_id, subfolder=subfolder, revision=revision)
+            if cls.export_feature != task and cls.export_feature == "feature-extraction":
+                logging.warning("Map the model class to {_HEAD_TO_AUTOMODELS[task]}")
+                cls = eval(_HEAD_TO_AUTOMODELS[task])
+            else:
+                task = cls.export_feature
+
             config.torch_dtype = torch_dtype
             model = TasksManager.get_model_from_task(
                 task,
@@ -237,14 +243,6 @@ class IPEXModel(OptimizedModel):
                 _commit_hash=commit_hash,
                 **model_kwargs,
             )
-
-            if cls.export_feature != task and cls.export_feature == "feature-extraction":
-                logging.warning(
-                    "Infer model's task is {task}, will map the model class to {_HEAD_TO_AUTOMODELS[task]}"
-                )
-                cls = eval(_HEAD_TO_AUTOMODELS[task])
-            elif cls.export_feature != task and cls.export_feature != "feature-extraction":
-                raise ValueError("Assign the wrong class for the {task} task, please use IPEXModel to load")
 
             return cls(model, config=config, export=True, **kwargs)
 

--- a/optimum/intel/ipex/utils.py
+++ b/optimum/intel/ipex/utils.py
@@ -14,8 +14,12 @@
 
 
 _HEAD_TO_AUTOMODELS = {
+    "feature-extraction": "IPEXModel",
     "text-generation": "IPEXModelForCausalLM",
     "text-classification": "IPEXModelForSequenceClassification",
     "token-classification": "IPEXModelForTokenClassification",
     "question-answering": "IPEXModelForQuestionAnswering",
+    "fill-mask": "IPEXModelForMaskedLM",
+    "image-classification": "IPEXModelForImageClassification",
+    "audio-classification": "IPEXModelForAudioClassification",
 }

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -124,9 +124,17 @@ class IPEXModelTest(unittest.TestCase):
         if not isinstance(self.IPEX_MODEL_CLASS, IPEXModel):
             return
         model_id = MODEL_NAMES["llama2"]
-        model = IPEXModel.from_pretrained(model_id, export=True)
+        model = IPEXModel.from_pretrained(model_id, export=True, task="text-generation")
+
+        # Test re-load model
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            model.save_pretrained(tmpdirname)
+            loaded_model = IPEXModel.from_pretrained(tmpdirname, task="text-generation")
 
         self.assertEqual(model.model.original_name, "LlamaForCausalLM")
+        self.assertEqual(loaded_model.model.original_name, "LlamaForCausalLM")
+        self.assertEqual(model.__class__.__name__, "IPEXModelForCausalLM")
+        self.assertEqual(loaded_model.__class__.__name__, "IPEXModelForCausalLM")
 
 
 class IPEXModelForSequenceClassificationTest(IPEXModelTest):

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -120,7 +120,7 @@ class IPEXModelTest(unittest.TestCase):
         _ = pipe(text)
         self.assertEqual(pipe.device, model.device)
 
-    def test_auto_mapping(self):
+    def test_assign_task(self):
         if not isinstance(self.IPEX_MODEL_CLASS, IPEXModel):
             return
         model_id = MODEL_NAMES["llama2"]


### PR DESCRIPTION
Hi @echarlaix. This PR enables auto mapping for model class, which mean we can use `IPEXModel` to load any supported task, for example `IPEXModel.from_pretrained("meta-llama/Llama-2-7b-chat-hf")` will map the `IPEXModelForCausalLM` class to export the model.

The usage is the same as `AutoModel` from transformers.

