### PR TITLE
Convert i64 input tensors to i32 for GPU plugin 

### DIFF
--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -133,8 +133,7 @@ class OVBaseDecoderModel(OVModel):
         self._first_iter_beam_search = False
         self._second_iter_beam_search = False
         self.update_pkv_precision()
-        if "GPU" in device:
-            self.update_int_precision()
+        self.update_int_precision()
         if self.is_dynamic:
             self.model = self._reshape(self.model, -1, -1)
         is_stateful_supported = ensure_stateful_is_available(warn=False)
@@ -213,6 +212,8 @@ class OVBaseDecoderModel(OVModel):
                 self.request = None
 
     def update_int_precision(self):
+        # OpenVino GPU & CPU plugins do not support i64 type so internally converting i64 type tensor to i32.
+        # To avoid runtime type conversion, setting i64 tensors to i32 tensors.
         ppp = PrePostProcessor(self.model)
         for key in self.model.inputs:
             in_name = key.get_any_name()

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -217,7 +217,7 @@ class OVBaseDecoderModel(OVModel):
         ppp = PrePostProcessor(self.model)
         for key in self.model.inputs:
             in_name = key.get_any_name()
-            if key.get_element_type() == Type.i64 and ("input_ids" in in_name or "position_ids" in in_name or "attention_mask" in in_name):
+            if key.get_element_type() == Type.i64 and in_name in ["input_ids", "position_ids", "attention_mask"]:
                 ppp.input(in_name).tensor().set_element_type(Type.i32)
         self.model = ppp.build()
 


### PR DESCRIPTION
# What does this PR do?
OpenVINO GPU plugin does not support int64 natively so i64 inputs are always converted to i32. To avoid runtime conversion, updated IO tensor precision to i32




Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

