### PR TITLE
Fix inference for batched inputs for llama

### DIFF
--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -441,8 +441,7 @@ def _llama_gemma_update_causal_mask_latest(
     # difference with original modeling
     # using minimum from dtype with larger bandwith (floa32) may lead to overflow
     # during execution on platforms with default lower precision (bfloat16, float16)
-    min_dtype = torch.finfo(torch.float16).min
-
+    min_dtype = torch.finfo(dtype).min
     sequence_length = input_tensor.shape[1]
     if using_static_cache:
         target_length = past_key_values.get_max_length()

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -1181,10 +1181,10 @@ def _phi3_self_attn_sdpa_forward(
             use_cache=use_cache,
         )
 
-    # TO DO: remove llama imports when transformers with phi3 support will be released
-    try:
-        from transformers.models.phi3.modelling_phi3 import apply_rotary_pos_emb, repeat_kv
-    except ImportError:
+    # TODO: remove llama imports when transformers >= v4.41.0
+    if is_transformers_version(">=", "4.41.0"):
+        from transformers.models.phi3.modeling_phi3 import apply_rotary_pos_emb, repeat_kv
+    else:
         from transformers.models.llama.modeling_llama import apply_rotary_pos_emb, repeat_kv
 
     bsz, q_len, _ = hidden_states.size()

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -1180,11 +1180,7 @@ def _phi3_self_attn_sdpa_forward(
             use_cache=use_cache,
         )
 
-    # TODO: remove llama imports when transformers >= v4.41.0
-    if is_transformers_version(">=", "4.41.0"):
-        from transformers.models.phi3.modeling_phi3 import apply_rotary_pos_emb, repeat_kv
-    else:
-        from transformers.models.llama.modeling_llama import apply_rotary_pos_emb, repeat_kv
+    from transformers.models.phi3.modeling_phi3 import apply_rotary_pos_emb, repeat_kv
 
     bsz, q_len, _ = hidden_states.size()
 

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -1180,7 +1180,10 @@ def _phi3_self_attn_sdpa_forward(
             use_cache=use_cache,
         )
 
-    from transformers.models.phi3.modeling_phi3 import apply_rotary_pos_emb, repeat_kv
+    if is_transformers_version(">=", "4.41.0"):
+        from transformers.models.phi3.modeling_phi3 import apply_rotary_pos_emb, repeat_kv
+    else:
+        from transformers.models.llama.modeling_llama import apply_rotary_pos_emb, repeat_kv
 
     bsz, q_len, _ = hidden_states.size()
 

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -699,7 +699,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         self.assertTrue(ov_model.use_cache)
         self.assertEqual(ov_model.stateful, ov_model.config.model_type not in not_stateful)
         tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
-        tokens = tokenizer("This is a sample output", return_tensors="pt")
+        tokens = tokenizer(["Today is a nice day and I am", "This is me"], return_tensors="pt", padding=True)
         tokens.pop("token_type_ids", None)
 
         ov_outputs = ov_model(**tokens)
@@ -734,8 +734,6 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
             tokenizer.pad_token_id = tokenizer.bos_token_id
         # Compare batched generation
         tokenizer.padding_side = "left"
-        tokens = tokenizer(["Today is a nice day and I am longer", "This is me"], return_tensors="pt", padding=True)
-        tokens.pop("token_type_ids", None)
         ov_model.generation_config.eos_token_id = None
         transformers_model.generation_config.eos_token_id = None
         ov_model.config.eos_token_id = None


### PR DESCRIPTION
Fix inference for batched inputs for fp32 model coming from `min_dtype = torch.finfo(torch.float16).min`