### PR TITLE
Use int32 as default int for export

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -584,6 +584,7 @@ def export_from_model(
         preprocessors=preprocessors,
         library_name=library_name,
         model_kwargs=model_kwargs,
+        int_dtype="int32",
         _variant="default",
         legacy=False,
         exporter="openvino",


### PR DESCRIPTION
# What does this PR do?

as discussed in https://github.com/huggingface/optimum-intel/pull/781
openvino runtime implicitly converts int64 inputs into i32. For reducing overhead internal data conversion, convert models with int32 inputs.

There is no intention to merge, just checking for understanding impact


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

