### PR TITLE
fix loading models from cache

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -132,7 +132,11 @@ class OVBaseModel(OptimizedModel):
 
         if isinstance(file_name, str):
             file_name = Path(file_name)
-        model = core.read_model(file_name) if not file_name.suffix == ".onnx" else convert_model(file_name)
+        model = (
+            core.read_model(file_name.resolve(), file_name.with_suffix(".bin").resolve())
+            if not file_name.suffix == ".onnx"
+            else convert_model(file_name)
+        )
         if file_name.suffix == ".onnx":
             model = fix_op_names_duplicates(model)  # should be called during model conversion to IR
 


### PR DESCRIPTION
# What does this PR do?
After these changes https://github.com/openvinotoolkit/openvino/pull/24781 openvino will be not able to use symlinks as paths for reading models. symlinks are produced by HF Hub API during saving models in cache. This PR should resolve problem with reading models downloaded from hub

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

