### PR TITLE
disable tpp for un-verified models

### DIFF
--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -110,8 +110,8 @@ def ipex_jit_trace(model, task, use_cache):
             sample_inputs.pop("past_key_values")
 
     # Use Tensor Processing Primitives to accelerate linear, see https://arxiv.org/abs/2104.05755.
-    # Only ipex >= 2.3.0 supports tpp.
-    if is_ipex_version(">=", "2.3.0"):
+    # Only ipex >= 2.3.0 supports tpp. The tpp is only verified for llm in generation tasks.
+    if is_ipex_version(">=", "2.3.0") and task in _IPEX_EXPORTED_GENERATION_TASKS:
         _enable_tpp()
     model = ipex.optimize(model.eval(), dtype=model.dtype, inplace=True)
     # Disable repack while jit tracing to reduce the memory


### PR DESCRIPTION
Fix #810 

Hi @echarlaix . The tpp is only verified for llm in generation tasks, it may have some error when enabling it for a normal model like:

```
model = IPEXModel.from_pretrained('sentence-transformers/all-MiniLM-L6-v2', export=True)
```
The error will be:
```
free(): invalid pointer
free(): corrupted unsorted chunks                                                                                                                                                                            
LIBXSMM_VERSION: unconfigured (2147483647)
SPR/SP      TRY    JIT    STA    COL
   0..13      4      4      0      0
  14..23      0      0      0      0
  24..64     24     24      0      0                                                                                                                                                                         Registry and code: 13 MB + 336 KB (gemm=28 gemv=4 meltw=10)
Command: python tpp_bert.py
Uptime: 0.098529 s
Aborted (core dumped)
```

