### PR TITLE
Expose default int4 config getter function

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 """Defines the command line for the export with OpenVINO."""
 
-import json
 import logging
 import sys
 from pathlib import Path
@@ -213,7 +212,7 @@ class OVExportCommand(BaseOptimumCLICommand):
 
     def run(self):
         from ...exporters.openvino.__main__ import infer_task, main_export, maybe_convert_tokenizers
-        from ...intel.openvino.configuration import get_default_int4_config, _DEFAULT_4BIT_CONFIG, OVConfig
+        from ...intel.openvino.configuration import _DEFAULT_4BIT_CONFIG, get_default_int4_config, OVConfig
 
         if self.args.library is None:
             # TODO: add revision, subfolder and token to args

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -212,7 +212,7 @@ class OVExportCommand(BaseOptimumCLICommand):
 
     def run(self):
         from ...exporters.openvino.__main__ import infer_task, main_export, maybe_convert_tokenizers
-        from ...intel.openvino.configuration import _DEFAULT_4BIT_CONFIG, get_default_int4_config, OVConfig
+        from ...intel.openvino.configuration import _DEFAULT_4BIT_CONFIG, OVConfig, get_default_int4_config
 
         if self.args.library is None:
             # TODO: add revision, subfolder and token to args

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -213,19 +213,7 @@ class OVExportCommand(BaseOptimumCLICommand):
 
     def run(self):
         from ...exporters.openvino.__main__ import infer_task, main_export, maybe_convert_tokenizers
-        from ...intel.openvino.configuration import _DEFAULT_4BIT_CONFIG, _DEFAULT_4BIT_CONFIGS, OVConfig
-
-        def _get_default_int4_config(model_id_or_path, library_name):
-            if model_id_or_path in _DEFAULT_4BIT_CONFIGS:
-                return _DEFAULT_4BIT_CONFIGS[model_id_or_path]
-            if "transformers" in library_name and (Path(model_id_or_path) / "config.json").exists():
-                with (Path(model_id_or_path) / "config.json").open("r") as config_f:
-                    config = json.load(config_f)
-                    original_model_name = config.get("_name_or_path", "")
-                if original_model_name in _DEFAULT_4BIT_CONFIGS:
-                    return _DEFAULT_4BIT_CONFIGS[original_model_name]
-
-            return _DEFAULT_4BIT_CONFIG
+        from ...intel.openvino.configuration import get_default_int4_config, _DEFAULT_4BIT_CONFIG, OVConfig
 
         if self.args.library is None:
             # TODO: add revision, subfolder and token to args
@@ -260,7 +248,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                 and self.args.awq is None
                 and self.args.sensitivity_metric is None
             ):
-                quantization_config = _get_default_int4_config(self.args.model, library_name)
+                quantization_config = get_default_int4_config(self.args.model)
             else:
                 quantization_config = {
                     "bits": 8 if is_int8 else 4,

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -41,11 +41,10 @@ from ...exporters.openvino.stateful import model_has_state
 from ..utils.import_utils import is_nncf_available, is_transformers_version
 from ..utils.modeling_utils import MULTI_QUERY_ATTN_MODELS
 from .configuration import (
-    _DEFAULT_4BIT_CONFIG,
-    _DEFAULT_4BIT_CONFIGS,
     OVConfig,
     OVWeightQuantizationConfig,
     _check_default_4bit_configs,
+    get_default_int4_config,
 )
 from .modeling import _TOKENIZER_FOR_DOC, INPUTS_DOCSTRING, MODEL_START_DOCSTRING, OVModel
 from .utils import ONNX_WEIGHTS_NAME, OV_TO_NP_TYPE, OV_XML_FILE_NAME, STR_TO_OV_TYPE
@@ -781,7 +780,7 @@ class OVModelForCausalLM(OVBaseDecoderModel, GenerationMixin):
             init_cls = cls
 
         if isinstance(quantization_config, dict) and quantization_config == {"bits": 4}:
-            quantization_config = _DEFAULT_4BIT_CONFIGS.get(config.name_or_path, _DEFAULT_4BIT_CONFIG)
+            quantization_config = get_default_int4_config(config.name_or_path)
         quantization_config = cls._prepare_weight_quantization_config(quantization_config, load_in_8bit)
 
         enable_compilation = kwargs.pop("compile", True) and not quantization_config
@@ -816,7 +815,7 @@ class OVModelForCausalLM(OVBaseDecoderModel, GenerationMixin):
 
             from optimum.intel.openvino.quantization import OVQuantizer
 
-            default_config = _check_default_4bit_configs(config)
+            default_config = _check_default_4bit_configs(config.name_or_path)
 
             if default_config:
                 logger.info(


### PR DESCRIPTION
# What does this PR do?

Expose a quite useful function for getting default int4 config which also tries to read `model_id` from `config.json`. Moved it from `exporters.openvino` to `configuration.py`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

