### PR TITLE
Limit PyTorch version

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -35,9 +35,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         # install PyTorch CPU version to avoid installing CUDA packages on GitHub runner without GPU
-        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
+        pip install .[openvino,openvino-tokenizers,tests,diffusers] onnxruntime --extra-index-url https://download.pytorch.org/whl/cpu
         pip install transformers==${{ matrix.transformers-version }}
-        pip install .[openvino,openvino-tokenizers,tests,diffusers] onnxruntime
     - name: Test with Pytest
       env:
         HF_HUB_READ_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import re
 import subprocess
+import sys
 
 from setuptools import find_namespace_packages, setup
 
@@ -27,7 +28,7 @@ except Exception as error:
     assert False, "Error: Could not open '%s' due %s\n" % (filepath, error)
 
 INSTALL_REQUIRE = [
-    "torch>=1.11",
+    "torch>=1.11,<2.4" if sys.platform.startswith("win") else "torch>=1.11",
     "transformers>=4.36.0,<4.43.0",
     "optimum@git+https://github.com/huggingface/optimum.git",
     "datasets>=1.4.0",


### PR DESCRIPTION
`optimum-cli export openvino -m tiiuae/falcon-7b --weight-format int4 falcon-7b-ov-int4` results in an error with PyTorch 2.4 on Windows: The specified module could not be found. Error loading "[...]fbgem.dll" or one of its dependencies.

IPEX installs a lower version of PyTorch already so this change should be safe while we look into this.