### PR TITLE
Ipex patching for llama, falcon, gpt2

### DIFF
--- a/optimum/exporters/ipex/model_patcher.py
+++ b/optimum/exporters/ipex/model_patcher.py
@@ -74,10 +74,9 @@ def patch_op(m, target_m, new_op_name, new_op):
 
 def _patch_llama_model(model):
     """
-    Patch falcon model:
-        1. Disable SDPA so the attention mask will be compatible to ipex attention.
-        2. Use IAKV cache
-        3. Linear fusion with (2 Linears + Silu + Mul) and (Linear + Add)
+    Patch llama model:
+        1. Use IPEX Rope and IAKV cache
+        2. Linear fusion with (2 Linears + Silu + Mul) and (Linear + Add)
     """
     convert_functions(model, LlamaModel, "forward", _llama_model_forward)
     convert_functions(model, LlamaRMSNorm, "forward", _ipex_rms_layer_norm_forward)
@@ -89,7 +88,7 @@ def _patch_falcon_model(model):
     """
     Patch falcon model:
         1. Disable SDPA so the attention mask will be compatible to ipex attention.
-        2. Use IAKV cache
+        2. Use IPEX Rope and IAKV cache
         3. Linear fusion with (Linear + Gelu) and (Linear + Add + Add)
     """
     model.transformer._use_sdpa = False

--- a/optimum/exporters/ipex/model_patcher.py
+++ b/optimum/exporters/ipex/model_patcher.py
@@ -14,7 +14,7 @@
 
 from transformers.models.bert.modeling_bert import BertIntermediate
 from transformers.models.falcon.modeling_falcon import FalconDecoderLayer, FalconForCausalLM
-from transformers.models.gpt2.modeling_gpt2 import GPT2Block, GPT2LMHeadModel
+from transformers.models.gpt2.modeling_gpt2 import GPT2Attention, GPT2Block, GPT2LMHeadModel
 from transformers.models.llama.modeling_llama import (
     LlamaDecoderLayer,
     LlamaForCausalLM,
@@ -28,9 +28,10 @@ from optimum.intel.utils.modeling_utils import replace_customized_linear_with_li
 
 from .modeling_utils import (
     _IPEX_MINIMUM_VERSION_FOR_PATCHING,
+    _gpt2_block_forward,
     _ipex_rms_layer_norm_forward,
     _IPEXFalconDecoderLayer,
-    _IPEXGPT2Block,
+    _IPEXGPT2Attention,
     _IPEXIntermediate,
     _IPEXLlamaDecoderLayer,
     _llama_model_forward,
@@ -87,7 +88,8 @@ def _patch_falcon_model(model):
 
 def _patch_gpt2_model(model):
     model.transformer._attn_implementation = "eager"
-    convert_class(model, GPT2Block, _IPEXGPT2Block, model.config)
+    convert_class(model, GPT2Attention, _IPEXGPT2Attention, model.config)
+    convert_functions(model, GPT2Block, "forward", _gpt2_block_forward)
     return model
 
 

--- a/optimum/exporters/ipex/modeling_utils.py
+++ b/optimum/exporters/ipex/modeling_utils.py
@@ -224,7 +224,8 @@ class _IPEXAttention(nn.Module):
         use_cache: bool = False,
         **kwargs,
     ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-        # Please see the original model's forward to check the parameter
+        # For llama inputs: https://github.com/huggingface/transformers/blob/v4.43.4/src/transformers/models/llama/modeling_llama.py#L308
+        # For falcon inputs: https://github.com/huggingface/transformers/blob/v4.43.4/src/transformers/models/falcon/modeling_falcon.py#L370
         if past_key_value is None and kwargs.get("layer_past", None) is not None:
             past_key_value = kwargs.pop("layer_past", None)
         bsz, seq_len, _ = hidden_states.size()

--- a/optimum/exporters/ipex/modeling_utils.py
+++ b/optimum/exporters/ipex/modeling_utils.py
@@ -354,11 +354,6 @@ class _IPEXLlamaMLP(nn.Module):
         del self.__dict__["_modules"]["up_proj"]
 
     def forward(self, hidden_states: torch.Tensor, residual: torch.Tensor = None, **kwargs):
-        """
-        Args:
-            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
-            residual (`torch.Tensor`): residual tensor to the layer of shape (batch, seq_len, embed_dim)`
-        """
         if hasattr(self, "linear_silu_mul"):
             mlp_gate = self.linear_silu_mul(hidden_states)
             if hasattr(self, "mlp_linear_add"):
@@ -392,12 +387,6 @@ class _IPEXFalconMLP(nn.Module):
         residual: torch.Tensor = None,
         **kwargs,
     ):
-        """
-        Args:
-            hidden_states (`torch.FloatTensor`): input to the layer of shape `(batch, seq_len, embed_dim)`
-            attention_output (`torch.Tensor`): attention output tensor to the layer of shape (batch, seq_len, embed_dim)`
-            residual (`torch.Tensor`): residual tensor to the layer of shape (batch, seq_len, embed_dim)`
-        """
         mlp_hidden_states = self.linear_gelu(hidden_states)
         if hasattr(self, "linear_add_add"):
             output = self.linear_add_add(mlp_hidden_states, attention_output, residual)

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -382,9 +382,9 @@ def _llama_gemma_update_causal_mask_legacy(self, attention_mask, input_tensor, c
                 offset = 0
             mask_shape = attention_mask.shape
             mask_slice = (attention_mask.eq(0.0)).to(dtype=dtype) * min_dtype
-            causal_mask[: mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]] = (
-                mask_slice
-            )
+            causal_mask[
+                : mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]
+            ] = mask_slice
 
     if (
         self.config._attn_implementation == "sdpa"
@@ -1678,9 +1678,9 @@ def _dbrx_update_causal_mask_legacy(
                 offset = 0
             mask_shape = attention_mask.shape
             mask_slice = (attention_mask.eq(0.0)).to(dtype=dtype) * min_dtype
-            causal_mask[: mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]] = (
-                mask_slice
-            )
+            causal_mask[
+                : mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]
+            ] = mask_slice
 
     if (
         self.config._attn_implementation == "sdpa"

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -382,9 +382,9 @@ def _llama_gemma_update_causal_mask_legacy(self, attention_mask, input_tensor, c
                 offset = 0
             mask_shape = attention_mask.shape
             mask_slice = (attention_mask.eq(0.0)).to(dtype=dtype) * min_dtype
-            causal_mask[
-                : mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]
-            ] = mask_slice
+            causal_mask[: mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]] = (
+                mask_slice
+            )
 
     if (
         self.config._attn_implementation == "sdpa"
@@ -1678,9 +1678,9 @@ def _dbrx_update_causal_mask_legacy(
                 offset = 0
             mask_shape = attention_mask.shape
             mask_slice = (attention_mask.eq(0.0)).to(dtype=dtype) * min_dtype
-            causal_mask[
-                : mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]
-            ] = mask_slice
+            causal_mask[: mask_shape[0], : mask_shape[1], offset : mask_shape[2] + offset, : mask_shape[3]] = (
+                mask_slice
+            )
 
     if (
         self.config._attn_implementation == "sdpa"

--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -506,11 +506,7 @@ class IPEXModelForCausalLM(IPEXModel, GenerationMixin):
         batch_size = input_ids.shape[0]
 
         if model_type in {"mistral", "llama", "falcon"}:
-            num_attention_heads = (
-                self.normalized_config.num_key_value_heads
-                if hasattr(self.normalized_config, "num_key_value_heads")
-                else 1
-            )
+            num_attention_heads = getattr(self.normalized_config, "num_key_value_heads", 1)
         else:
             num_attention_heads = self.normalized_config.num_attention_heads
 

--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -64,7 +64,7 @@ from ..utils.modeling_utils import MULTI_QUERY_ATTN_MODELS, recursive_to_device
 logger = logging.getLogger(__name__)
 
 
-_IPEX_SUPPORT_MODEL_TYPES = ("llama", "bert", "vit", "falcon")
+_IPEX_SUPPORT_MODEL_TYPES = ("llama", "bert", "vit", "falcon", "gpt2")
 _IPEX_EXPORTED_GENERATION_METHODS = ("sample", "greedy_search", "beam_sample", "beam_search", "assisted_generation")
 
 
@@ -485,6 +485,7 @@ class IPEXModelForCausalLM(IPEXModel, GenerationMixin):
             "persimmon",
             "mistral",
             "falcon",
+            "gpt2",
         }:
             self.prepare_inputs_for_generation = _ipex_prepare_inputs_for_generation
         else:

--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -64,7 +64,7 @@ from ..utils.modeling_utils import MULTI_QUERY_ATTN_MODELS, recursive_to_device
 logger = logging.getLogger(__name__)
 
 
-_IPEX_SUPPORT_MODEL_TYPES = ("llama", "bert", "vit")
+_IPEX_SUPPORT_MODEL_TYPES = ("llama", "bert", "vit", "falcon")
 _IPEX_EXPORTED_GENERATION_METHODS = ("sample", "greedy_search", "beam_sample", "beam_search", "assisted_generation")
 
 
@@ -479,7 +479,13 @@ class IPEXModelForCausalLM(IPEXModel, GenerationMixin):
             else:
                 self._reorder_cache = self.model_cls._reorder_cache.__get__(self)
 
-        if is_transformers_version(">=", "4.38.0") and model_type in {"llama", "phi", "persimmon", "mistral"}:
+        if is_transformers_version(">=", "4.38.0") and model_type in {
+            "llama",
+            "phi",
+            "persimmon",
+            "mistral",
+            "falcon",
+        }:
             self.prepare_inputs_for_generation = _ipex_prepare_inputs_for_generation
         else:
             self.prepare_inputs_for_generation = self.model_cls.prepare_inputs_for_generation.__get__(self)

--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -505,8 +505,12 @@ class IPEXModelForCausalLM(IPEXModel, GenerationMixin):
         d_k = self.normalized_config.hidden_size // self.normalized_config.num_attention_heads
         batch_size = input_ids.shape[0]
 
-        if model_type in {"mistral", "llama"}:
-            num_attention_heads = self.normalized_config.num_key_value_heads
+        if model_type in {"mistral", "llama", "falcon"}:
+            num_attention_heads = (
+                self.normalized_config.num_key_value_heads
+                if hasattr(self.normalized_config, "num_key_value_heads")
+                else 1
+            )
         else:
             num_attention_heads = self.normalized_config.num_attention_heads
 

--- a/optimum/intel/utils/modeling_utils.py
+++ b/optimum/intel/utils/modeling_utils.py
@@ -113,6 +113,9 @@ def _find_files_matching_pattern(
 
 
 def replace_customized_linear_with_linear(model):
+    """
+    Replace custom linear to torch linear so ipex could recognize and replace them to ipex linear.
+    """
     if isinstance(model, torch.jit.ScriptModule):
         return
     if not model.training:

--- a/optimum/intel/utils/modeling_utils.py
+++ b/optimum/intel/utils/modeling_utils.py
@@ -20,7 +20,7 @@ import torch
 from huggingface_hub import HfApi, HfFolder
 
 
-MULTI_QUERY_ATTN_MODELS = {"falcon", "gpt_bigcode"}
+MULTI_QUERY_ATTN_MODELS = {"gpt_bigcode"}
 
 
 def get_model_device(model: torch.nn.Module) -> torch.device:

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -368,6 +368,24 @@ class IPEXModelForCausalLMTest(unittest.TestCase):
         #     f" speedup: {without_pkv_timer.elapsed / with_pkv_timer.elapsed:.3f}",
         # )
 
+    @unittest.skipIf(is_ipex_version("<", "2.3.0"), reason="Only ipex version > 2.3.0 supports ipex model patching")
+    @parameterized.expand(IPEX_PATCHED_SUPPORTED_ARCHITECTURES)
+    def test_patched_model(self, model_arch):
+        model_id = MODEL_NAMES[model_arch]
+        patched_model_id = MODEL_NAMES["patched_" + model_arch]
+        ipex_model = IPEXModelForCausalLM.from_pretrained(model_id, export=True)
+        exported_model = IPEXModelForCausalLM.from_pretrained(patched_model_id)
+        tokenizer = AutoTokenizer.from_pretrained(model_id)
+        tokens = tokenizer(
+            "This is a sample",
+            return_tensors="pt",
+            return_token_type_ids=False if model_arch in ("llama", "llama2") else None,
+        )
+        inputs = ipex_model.prepare_inputs_for_generation(**tokens)
+        ipex_outputs = ipex_model(**inputs)
+        exported_outputs = exported_model(**inputs)
+        self.assertTrue(torch.allclose(ipex_outputs.logits, exported_outputs.logits, atol=1e-7))
+
 
 class IPEXModelForAudioClassificationTest(unittest.TestCase):
     IPEX_MODEL_CLASS = IPEXModelForAudioClassification

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -369,7 +369,7 @@ class IPEXModelForCausalLMTest(unittest.TestCase):
         #     f" speedup: {without_pkv_timer.elapsed / with_pkv_timer.elapsed:.3f}",
         # )
 
-    @unittest.skipIf(is_ipex_version("<", "2.3.0"), reason="Only ipex version > 2.3.0 supports ipex model patching")
+    @unittest.skipIf(is_ipex_version("<", "2.3.0"), reason="Only ipex version >= 2.3.0 supports ipex model patching")
     @parameterized.expand(IPEX_PATCHED_SUPPORTED_ARCHITECTURES)
     def test_patched_model(self, model_arch):
         model_id = MODEL_NAMES[model_arch]

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -284,6 +284,7 @@ class IPEXModelForCausalLMTest(unittest.TestCase):
     # High optimized model llama is not supported assisted decoding for now.
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_assisted_decoding(self, model_arch):
+        # Patched models are not support assisted decoding for now.
         if model_arch in self.IPEX_PATCHED_SUPPORTED_ARCHITECTURES:
             return
         model_id = MODEL_NAMES[model_arch]

--- a/tests/ipex/test_modeling.py
+++ b/tests/ipex/test_modeling.py
@@ -213,6 +213,7 @@ class IPEXModelForCausalLMTest(unittest.TestCase):
         "blenderbot-small",
         "bloom",
         "codegen",
+        "falcon",
         "gpt2",
         "gpt_neo",
         "gpt_neox",
@@ -224,7 +225,7 @@ class IPEXModelForCausalLMTest(unittest.TestCase):
         "mpt",
         "opt",
     )
-    IPEX_PATCHED_SUPPORTED_ARCHITECTURES = ("llama2", "distilgpt2")
+    IPEX_PATCHED_SUPPORTED_ARCHITECTURES = ("llama2", "distilgpt2", "falcon")
     GENERATION_LENGTH = 100
     SPEEDUP_CACHE = 1.0
 

--- a/tests/ipex/utils_tests.py
+++ b/tests/ipex/utils_tests.py
@@ -56,4 +56,7 @@ MODEL_NAMES = {
     "vit": "hf-internal-testing/tiny-random-vit",
     "wav2vec2": "anton-l/wav2vec2-random-tiny-classifier",
     "xlm": "hf-internal-testing/tiny-random-xlm",
+    "patched_falcon": "Jiqing/patched_tiny_random_falcon_for_causal_lm",
+    "patched_distilgpt2": "Jiqing/patched_tiny_random_distilgpt2_for_causal_lm",
+    "patched_llama2": "Jiqing/patched_tiny_random_llama2_for_causal_lm",
 }

--- a/tests/ipex/utils_tests.py
+++ b/tests/ipex/utils_tests.py
@@ -25,6 +25,7 @@ MODEL_NAMES = {
     "codegen": "hf-internal-testing/tiny-random-CodeGenForCausalLM",
     "convnext": "hf-internal-testing/tiny-random-convnext",
     "distilbert": "hf-internal-testing/tiny-random-distilbert",
+    "distilgpt2": "Jiqing/tiny_random_distilgpt2",
     "electra": "hf-internal-testing/tiny-random-electra",
     "flaubert": "hf-internal-testing/tiny-random-flaubert",
     "gpt_bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",

--- a/tests/ipex/utils_tests.py
+++ b/tests/ipex/utils_tests.py
@@ -28,6 +28,7 @@ MODEL_NAMES = {
     "distilgpt2": "Jiqing/tiny_random_distilgpt2",
     "electra": "hf-internal-testing/tiny-random-electra",
     "flaubert": "hf-internal-testing/tiny-random-flaubert",
+    "falcon": "Jiqing/tiny_random_falcon",
     "gpt_bigcode": "hf-internal-testing/tiny-random-GPTBigCodeModel",
     "gpt2": "hf-internal-testing/tiny-random-gpt2",
     "gpt_neo": "hf-internal-testing/tiny-random-GPTNeoModel",


### PR DESCRIPTION
We plan to support 

- bert (**done**)
- vit (**done**)
- llama (**done; refactored in this PR**)
- falcon (**enabled in this PR**) 
- gpt2 (**enabled in this PR**) 
 
for patching ipex OP in 2024. The patching contains indirect kv cache and linear fusion. It brings significant speed-up for text-generation tasks.


I refactored the `exporter/ipex/modeling_utils.py` to make the codes as clean as possible.