### PR TITLE
revert rotary embedding patching for recovering gpu accuracy

### DIFF
--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -41,7 +41,7 @@ from optimum.intel import (  # noqa
 )
 from optimum.intel.openvino.configuration import _DEFAULT_4BIT_CONFIGS
 from optimum.intel.openvino.utils import _HEAD_TO_AUTOMODELS
-from optimum.intel.utils.import_utils import is_openvino_tokenizers_available, is_transformers_version
+from optimum.intel.utils.import_utils import is_openvino_tokenizers_available
 
 
 class OVCLIExportTestCase(unittest.TestCase):

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -95,21 +95,21 @@ class OVCLIExportTestCase(unittest.TestCase):
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 8 --all-layers",
             0,
-            32 if is_transformers_version("<", "4.39.0") else 34,
+            32,
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --awq --dataset wikitext2 --num-samples 100 "
             "--sensitivity-metric max_activation_variance",
-            6 if is_transformers_version(">=", "4.39") else 4,
+            4,
             28,
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --scale-estimation --dataset wikitext2 --num-samples 100 ",
-            6 if is_transformers_version(">=", "4.39") else 4,
+            4,
             28,
         ),
     ]

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -236,7 +236,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 quant_method=QuantizationMethod.AWQ,
                 scale_estimation=True,
             ),
-            18 if is_transformers_version(">=", "4.39") else 16,
+            16,
         ),
         (
             OVModelForCausalLM,
@@ -250,7 +250,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 dataset="c4",
                 quant_method="awq",
             ),
-            18 if is_transformers_version(">=", "4.39") else 16,
+            16,
         ),
     )
 


### PR DESCRIPTION
# What does this PR do?

this is temporal solution for unblocking model running on GPU with openvino<=2024.3, bf16 accuracy will be fixed later, when openvino runtime will be ready handle it.

