### PR TITLE
Added custom OV configs for VAE encoder and decoder

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -98,6 +98,8 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Optional[Union[OVWeightQuantizationConfig, Dict]] = None,
+        vae_decoder_ov_config: Optional[Dict[str, str]] = None,
+        vae_encoder_ov_config: Optional[Dict[str, str]] = None,
         **kwargs,
     ):
         self._internal_dict = config
@@ -116,7 +118,11 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
         else:
             self._model_save_dir = model_save_dir
 
-        self.vae_decoder = OVModelVaeDecoder(vae_decoder, self)
+        default_vae_ov_config = deepcopy(self.ov_config)
+        if "GPU" in self._device:
+            default_vae_ov_config.update({"INFERENCE_PRECISION_HINT": "f32"})
+
+        self.vae_decoder = OVModelVaeDecoder(vae_decoder, self, vae_decoder_ov_config or default_vae_ov_config)
         self.unet = OVModelUnet(unet, self)
         self.text_encoder = OVModelTextEncoder(text_encoder, self) if text_encoder is not None else None
         self.text_encoder_2 = (
@@ -124,7 +130,11 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
             if text_encoder_2 is not None
             else None
         )
-        self.vae_encoder = OVModelVaeEncoder(vae_encoder, self) if vae_encoder is not None else None
+        self.vae_encoder = (
+            OVModelVaeEncoder(vae_encoder, self, vae_encoder_ov_config or default_vae_ov_config)
+            if vae_encoder is not None
+            else None
+        )
 
         if "block_out_channels" in self.vae_decoder.config:
             self.vae_scale_factor = 2 ** (len(self.vae_decoder.config["block_out_channels"]) - 1)
@@ -716,11 +726,6 @@ class OVModelVaeDecoder(OVModelPart):
         outputs = self.request(inputs, share_inputs=True)
         return list(outputs.values())
 
-    def _compile(self):
-        if "GPU" in self.device:
-            self.ov_config.update({"INFERENCE_PRECISION_HINT": "f32"})
-        super()._compile()
-
 
 class OVModelVaeEncoder(OVModelPart):
     def __init__(
@@ -736,11 +741,6 @@ class OVModelVaeEncoder(OVModelPart):
         }
         outputs = self.request(inputs, share_inputs=True)
         return list(outputs.values())
-
-    def _compile(self):
-        if "GPU" in self.device:
-            self.ov_config.update({"INFERENCE_PRECISION_HINT": "f32"})
-        super()._compile()
 
 
 class OVStableDiffusionPipeline(OVStableDiffusionPipelineBase, StableDiffusionPipelineMixin):


### PR DESCRIPTION
# What does this PR do?

Introduce a way to provide custom OV configs for VAE Decoder and Encoder models in SD pipeline. This is useful to specify inference precision of these models. Example usage:
```
pipeline = OVStableDiffusionPipeline.from_pretrained(
    model_path,
    device="GPU",
    vae_decoder_ov_config={"INFERENCE_PRECISION_HINT": "f16"},
    vae_encoder_ov_config={"INFERENCE_PRECISION_HINT": "f16"},
)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

