### PR TITLE
Added a warning for missing --weight-format argument

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -192,9 +192,9 @@ def parse_args_openvino(parser: "ArgumentParser"):
 
 def no_compression_parameter_provided(args):
     return all(
-        map(
-            lambda x: x is None,
-            (
+        (
+            it is None
+            for it in (
                 args.ratio,
                 args.group_size,
                 args.sym,
@@ -203,7 +203,7 @@ def no_compression_parameter_provided(args):
                 args.num_samples,
                 args.awq,
                 args.sensitivity_metric,
-            ),
+            )
         )
     )
 

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -635,9 +635,9 @@ def export_from_model(
             if is_nncf_available():
                 from ...intel.openvino.configuration import OVConfig
 
-                ov_config = OVConfig(quantization_config={"bits": 8})
+                ov_config = OVConfig(quantization_config={"bits": 8, "sym": False})
 
-                logger.info("The model weights will be quantized to int8.")
+                logger.info("The model weights will be quantized to int8_asym.")
             else:
                 logger.warning(
                     "The model will be converted with no weights quantization. Quantization of the weights to int8 requires nncf."


### PR DESCRIPTION
**Reason for change**

When the following command is executed
```
optimum-cli export openvino -m TinyLlama/TinyLlama-1.1B-Chat-v1.0 --sym ./tiny-llama
```
the model will be exported with compression to int8_asym, despite `--sym` argument was provided. This is because when `--weight-format` argument is not provided, the default compression is applied, and by default int8_asym is applied.

This behavior has lead to some confusion. Because int8_sym was expected to be applied in such case.

**Changes**

Add a warning stating that compression parameters will not be applied because precision was not specified with `--weight-format` argument.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

