### PR TITLE
Update compression config for psmathur/orca_mini_3b

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -85,7 +85,6 @@ _DEFAULT_4BIT_CONFIGS = {
         "group_size": 64,
         "all_layers": True,
         "dataset": "wikitext2",
-        "quant_method": OVQuantizationMethod.AWQ,
     },
     "bigscience/bloomz-560m": {
         "bits": 4,

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -84,7 +84,6 @@ _DEFAULT_4BIT_CONFIGS = {
         "sym": True,
         "group_size": 64,
         "all_layers": True,
-        "dataset": "wikitext2",
     },
     "bigscience/bloomz-560m": {
         "bits": 4,


### PR DESCRIPTION
# What does this PR do?

Disable AWQ for `psmathur/orca_mini_3b` model.

**Reason for changes**

Applying AWQ leads to higher PPL compared to without AWQ:
| Precision         | PPL   |
|-------------------|-------|
| FP16              | 16.95 |
| INT4, without AWQ | 17.44 |
| INT4, with AWQ    | 17.51 |



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

