### PR TITLE
Fix data collision in caching in InferRequestWrapper

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -132,9 +132,10 @@ class InferRequestWrapper:
             data_hash = hash(data.tobytes())
 
             # Avoid data copying if tensor contains data encountered earlier
-            if data_hash not in self.tensor_cache:
-                self.tensor_cache[data_hash] = copy.deepcopy(v)
-            copied_inputs[k] = self.tensor_cache[data_hash]
+            self.tensor_cache.setdefault(k, {})
+            if data_hash not in self.tensor_cache[k]:
+                self.tensor_cache[k][data_hash] = copy.deepcopy(v)
+            copied_inputs[k] = self.tensor_cache[k][data_hash]
         self.collected_inputs.append(copied_inputs)
 
     def __call__(self, *args, **kwargs):


### PR DESCRIPTION
# What does this PR do?

`InferRequestWrapper` collects inputs data and use dict `tensor_cache` to avoid extra data copying. Value of each item of inputs is converted to hash as `hash(input_tensor.tobytes())`, hash set as key of `tensor_cache` and `deepcopy` of value set as value. If inputs has several items with same tensor value, but different structure, for example `{'input0': tensor([[11]]), 'input1': tensor([11])}`, they would have same hash and one of this value would be collected with wrong shape. This pr fixes it.

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

