### PR TITLE
Add INT4 config matching based on model folder name and model short id

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -189,7 +189,7 @@ def _check_default_4bit_configs(model_id_or_path: str):
             return _DEFAULT_4BIT_CONFIGS[original_model_name]
 
     for model_id, config in _DEFAULT_4BIT_CONFIGS.items():
-        short_id = model_id.split("/")[1]
+        short_id = model_id.split("/")[-1]
         if model_path.name == short_id:
             return config
 

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -179,13 +179,19 @@ def _check_default_4bit_configs(model_id_or_path: str):
     if model_id_or_path in _DEFAULT_4BIT_CONFIGS:
         return _DEFAULT_4BIT_CONFIGS[model_id_or_path]
 
-    config_path = Path(model_id_or_path) / "config.json"
+    model_path = Path(model_id_or_path)
+    config_path = model_path / "config.json"
     if config_path.exists():
         with config_path.open("r") as config_f:
             config = json.load(config_f)
             original_model_name = config.get("_name_or_path", "")
         if original_model_name in _DEFAULT_4BIT_CONFIGS:
             return _DEFAULT_4BIT_CONFIGS[original_model_name]
+
+    for model_id, config in _DEFAULT_4BIT_CONFIGS.items():
+        short_id = model_id.split("/")[1]
+        if model_path.name == short_id:
+            return config
 
     return None
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -903,6 +903,13 @@ class OVQuantizationConfigTest(unittest.TestCase):
             value = prepared_config.__getattribute__(field_name)
             self.assertEqual(value, reference_value)
 
+    def test_for_no_short_id_duplicates(self):
+        short_ids = set()
+        for model_id in _DEFAULT_4BIT_CONFIGS.keys():
+            short_id = model_id.split("/")[1]
+            assert short_id not in short_ids
+            short_ids.add(short_id)
+
 
 class InferRequestWrapperTest(unittest.TestCase):
     MODEL_ID = ("openai/whisper-tiny.en",)


### PR DESCRIPTION
**Changes**

Consider a case when HF model is downloaded via model repo cloning, e.g.
```
git clone https://huggingface.co/openlm-research/open_llama_3b
```
Sometimes `config.json` for a model won't contain a valid `_name_or_path` field. In such case we won't be able to match a default int4 config for it.

This PR adds an additional option to match the config: by the model folder name. 

Because of the fact that such processing might result in duplicates, a test is added to preventively catch this.

**Related tickets**
149069


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

