### PR TITLE
ov compile only mode

### DIFF
--- a/optimum/exporters/openvino/stateful.py
+++ b/optimum/exporters/openvino/stateful.py
@@ -24,9 +24,11 @@ from optimum.exporters import TasksManager
 from optimum.intel.utils.import_utils import _openvino_version, is_openvino_version, is_transformers_version
 
 
-def model_has_state(ov_model: ov.Model):
-    # TODO: Provide a better way based on the variables availability, but OV Python API doesn't expose required methods
-    return len(ov_model.get_sinks()) > 0
+def model_has_state(ov_model: ov.Model, is_compiled=False):
+    if not is_compiled:
+        # TODO: Provide a better way based on the variables availability, but OV Python API doesn't expose required methods
+        return len(ov_model.get_sinks()) > 0
+    return len(ov_model.query_state()) > 0
 
 
 def model_has_input_output_name(ov_model: ov.Model, name: str):

--- a/optimum/exporters/openvino/stateful.py
+++ b/optimum/exporters/openvino/stateful.py
@@ -24,11 +24,11 @@ from optimum.exporters import TasksManager
 from optimum.intel.utils.import_utils import _openvino_version, is_openvino_version, is_transformers_version
 
 
-def model_has_state(ov_model: ov.Model, is_compiled=False):
-    if not is_compiled:
-        # TODO: Provide a better way based on the variables availability, but OV Python API doesn't expose required methods
-        return len(ov_model.get_sinks()) > 0
-    return len(ov_model.query_state()) > 0
+def model_has_state(ov_model: ov.Model):
+    if isinstance(ov_model, ov.runtime.CompiledModel):
+        return len(ov_model.query_state()) > 0
+    # TODO: Provide a better way based on the variables availability, but OV Python API doesn't expose required methods
+    return len(ov_model.get_sinks()) > 0
 
 
 def model_has_input_output_name(ov_model: ov.Model, name: str):

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -134,9 +134,8 @@ class OVModel(OVBaseModel):
         Use the specified `device` for inference. For example: "cpu" or "gpu". `device` can
         be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
         """
-        if self.compile_only:
-            logger.warning("`to()` does not supported in `compile_only` mode")
-            return self
+        if self.compile_only and isinstance(device, str):
+            raise ValueError("`to()` is not supported in `compile_only` mode, please intialize model without this option")
 
         if isinstance(device, str):
             self._device = device.upper()

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -440,8 +440,10 @@ class OVModelForFeatureExtraction(OVModel):
         **kwargs,
     ):
         if compile_only:
-            logger.warning("`compile_only` mode will be disabled because it does not support model export."
-                            "Please provide openvino model obtained using optimum-cli or saved on disk using `save_pretrained`")
+            logger.warning(
+                "`compile_only` mode will be disabled because it does not support model export."
+                "Please provide openvino model obtained using optimum-cli or saved on disk using `save_pretrained`"
+            )
             compile_only = False
 
         save_dir = TemporaryDirectory()

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -134,7 +134,7 @@ class OVModel(OVBaseModel):
         Use the specified `device` for inference. For example: "cpu" or "gpu". `device` can
         be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
         """
-        if self.compile_only and isinstance(device, str):
+        if self._compile_only and isinstance(device, str):
             raise ValueError(
                 "`to()` is not supported with `compile_only` mode, please intialize model without this option"
             )

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -135,7 +135,9 @@ class OVModel(OVBaseModel):
         be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
         """
         if self.compile_only and isinstance(device, str):
-            raise ValueError("`to()` is not supported in `compile_only` mode, please intialize model without this option")
+            raise ValueError(
+                "`to()` is not supported with `compile_only` mode, please intialize model without this option"
+            )
 
         if isinstance(device, str):
             self._device = device.upper()

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -134,6 +134,10 @@ class OVModel(OVBaseModel):
         Use the specified `device` for inference. For example: "cpu" or "gpu". `device` can
         be in upper or lower case. To speed up first inference, call `.compile()` after `.to()`.
         """
+        if self.compile_only:
+            logger.warning("`to()` does not supported in `compile_only` mode")
+            return self
+
         if isinstance(device, str):
             self._device = device.upper()
             self.request = None
@@ -435,6 +439,11 @@ class OVModelForFeatureExtraction(OVModel):
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
+        if compile_only:
+            logger.warning("`compile_only` mode will be disabled because it does not support model export."
+                            "Please provide openvino model obtained using optimum-cli or saved on disk using `save_pretrained`")
+            compile_only = False
+
         save_dir = TemporaryDirectory()
         save_dir_path = Path(save_dir.name)
         # This attribute is needed to keep one reference on the temporary directory, since garbage collecting
@@ -469,6 +478,7 @@ class OVModelForFeatureExtraction(OVModel):
             config=config,
             load_in_8bit=load_in_8bit,
             quantization_config=quantization_config,
+            compile_only=compile_only,
             **kwargs,
         )
 

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -440,6 +440,7 @@ class OVModelForFeatureExtraction(OVModel):
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
+        compile_only = kwargs.get("compile_only", False)
         if compile_only:
             logger.warning(
                 "`compile_only` mode will be disabled because it does not support model export."

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -82,7 +82,7 @@ class OVBaseModel(OptimizedModel):
                 "Please provide `compile=True` if you want to use `compile_only=True` or set `compile_only=False`"
             )
 
-        if self.compile_only and not isinstance(self.model, CompiledModel):
+        if self.compile_only and not isinstance(model, CompiledModel):
             raise ValueError("`compile_only` expect that already compiled model will be provided")
 
         if self.is_dynamic and not self.compile_only:
@@ -207,14 +207,16 @@ class OVBaseModel(OptimizedModel):
         model_save_dir: Union[str, Path] = None,
     ):
         logger.info(f"Compiling the model to {device} ...")
-        if isinstance(file_name, str):
-            file_name = Path(file_name)
+        if isinstance(model, str):
+            model = Path(model)
         ov_config = ov_config or {}
 
-        if model_save_dir is None:
-            model_save_dir = file_name.parent
+        if model_save_dir is None and isinstance(model, Path):
+            model_save_dir = model.parent
         if "CACHE_DIR" not in ov_config.keys() and (
-            not str(model_save_dir).startswith(gettempdir()) and (device is not None and "gpu" in device.lower())
+            model_save_dir is not None
+            and not str(model_save_dir).startswith(gettempdir())
+            and (device is not None and "gpu" in device.lower())
         ):
             # Set default CACHE_DIR only if it is not set, if the model is not in a temporary directory, and device is GPU
             cache_dir = Path(model_save_dir).joinpath("model_cache")

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -241,7 +241,7 @@ class OVBaseModel(OptimizedModel):
 
         if self.compile_only:
             raise ValueError(
-                "`save_pretrained()` is not supported with `compile_only` mode, please intialize model without this option"
+                "`save_pretrained()` is not supported with `compile_only=True` mode, to save your model please initialize your model with compile_only=False"
             )
         dst_path = os.path.join(save_directory, OV_XML_FILE_NAME)
         openvino.save_model(self.model, dst_path, compress_to_fp16=False)
@@ -681,7 +681,7 @@ class OVBaseModel(OptimizedModel):
         """
         if self.compile_only:
             raise ValueError(
-                "`reshape()` is not supported with `compile_only` mode, please intialize model without this option"
+                "`half()` is not supported with `compile_only=True` mode, to use this option please initialize your model with compile_only=False"
             )
         apply_moc_transformations(self.model, cf=False)
         compress_model_transformation(self.model)

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -219,14 +219,10 @@ class OVBaseModel(OptimizedModel):
             cache_dir = Path(model_save_dir).joinpath("model_cache")
             ov_config["CACHE_DIR"] = str(cache_dir)
             logger.info(f"Setting OpenVINO CACHE_DIR to {str(cache_dir)}")
-        if file_name.suffix == ".onnx":
-            compiled_model = core.compile_model(
-                file_name, device.upper() if device is not None else device, config=ov_config
-            )
-        else:
-            compiled_model = core.compile_model(
-                file_name, device.upper() if device is not None else device, config=ov_config
-            )
+
+        compiled_model = core.compile_model(
+            file_name, device.upper() if device is not None else device, config=ov_config
+        )
         if "OPENVINO_LOG_LEVEL" in os.environ and int(os.environ["OPENVINO_LOG_LEVEL"]) > 2:
             logger.info(f"{device if device is not None else 'AUTO'} SUPPORTED_PROPERTIES:")
             _print_compiled_model_properties(compiled_model)

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -65,13 +65,13 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         self.config = config
         self.use_cache = decoder_with_past is not None
         self.model_save_dir = model_save_dir
-        self.compile_only = kwargs.get("compile_only", False)
+        self._compile_only = kwargs.get("compile_only", False)
         self._device = device.upper()
         self.is_dynamic = dynamic_shapes
         self.ov_config = {} if ov_config is None else {**ov_config}
         self.preprocessors = kwargs.get("preprocessors", [])
 
-        if self.is_dynamic and not self.compile_only:
+        if self.is_dynamic and not self._compile_only:
             encoder = self._reshape(encoder, -1, -1, is_decoder=False)
             decoder = self._reshape(decoder, -1, -1)
             decoder_with_past = self._reshape(decoder_with_past, -1, -1) if self.use_cache else None
@@ -389,7 +389,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             sequence_length (`int`):
                 The sequence length.
         """
-        if self.compile_only:
+        if self._compile_only:
             raise ValueError(
                 "`reshape()` is not supported with `compile_only` mode, please intialize model without this option"
             )
@@ -404,7 +404,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         """
         Converts all the model weights to FP16 for more efficient inference on GPU.
         """
-        if self.compile_only:
+        if self._compile_only:
             raise ValueError(
                 "`half()` is not supported with `compile_only` mode, please intialize model without this option"
             )

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -193,14 +193,12 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                     os.path.join(model_id, encoder_file_name),
                     kwargs.get("device", "CPU"),
                     kwargs.get("ov_config"),
-                    True,
                     model_save_dir,
                 )
                 decoder = cls._compile_model(
                     os.path.join(model_id, decoder_file_name),
                     kwargs.get("device", "CPU"),
                     kwargs.get("ov_config"),
-                    True,
                     model_save_dir,
                 )
                 if use_cache:
@@ -208,7 +206,6 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                         os.path.join(model_id, decoder_with_past_file_name),
                         kwargs.get("device", "CPU"),
                         kwargs.get("ov_config"),
-                        True,
                         model_save_dir,
                     )
 
@@ -253,7 +250,6 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                         file_names["decoder_with_past"],
                         kwargs.get("device", "CPU"),
                         kwargs.get("ov_config"),
-                        True,
                         model_save_dir,
                     )
         try:
@@ -394,8 +390,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                 The sequence length.
         """
         if self.compile_only:
-            logger.warning("`reshape()` does not supported in `compile_only` mode")
-            return
+            raise ValueError(
+                "`reshape()` is not supported with `compile_only` mode, please intialize model without this option"
+            )
         logger.warning("Some part of the model's decoder do not support static shapes and will be kept dynamic.")
         self.is_dynamic = True if batch_size == -1 and sequence_length == -1 else False
         self.encoder_model = self._reshape(self.encoder_model, batch_size, sequence_length, is_decoder=False)
@@ -408,8 +405,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         Converts all the model weights to FP16 for more efficient inference on GPU.
         """
         if self.compile_only:
-            logger.warning("`half()` does not supported in `compile_only` mode")
-            return self
+            raise ValueError(
+                "`half()` is not supported with `compile_only` mode, please intialize model without this option"
+            )
         apply_moc_transformations(self.encoder_model, cf=False)
         apply_moc_transformations(self.decoder_model, cf=False)
         compress_model_transformation(self.encoder_model)

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -240,10 +240,10 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                     decoder_with_past = cls.load_model(file_names["decoder_with_past"], quantization_config)
             else:
                 encoder = cls._compile_model(
-                    file_names["encoder"], kwargs.get("device", "CPU"), kwargs.get("ov_config"), True, model_save_dir
+                    file_names["encoder"], kwargs.get("device", "CPU"), kwargs.get("ov_config"), model_save_dir
                 )
                 decoder = cls._compile_model(
-                    file_names["decoder"], kwargs.get("device", "CPU"), kwargs.get("ov_config"), True, model_save_dir
+                    file_names["decoder"], kwargs.get("device", "CPU"), kwargs.get("ov_config"), model_save_dir
                 )
                 if use_cache:
                     decoder_with_past = cls._compile_model(

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -191,11 +191,26 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             else:
                 encoder = cls._compile_model(
                     os.path.join(model_id, encoder_file_name),
-                    kwargs.get("device"),
+                    kwargs.get("device", "CPU"),
                     kwargs.get("ov_config"),
                     True,
                     model_save_dir,
                 )
+                decoder = cls._compile_model(
+                    os.path.join(model_id, decoder_file_name),
+                    kwargs.get("device", "CPU"),
+                    kwargs.get("ov_config"),
+                    True,
+                    model_save_dir,
+                )
+                if use_cache:
+                    decoder_with_past = cls._compile_model(
+                        os.path.join(model_id, decoder_with_past_file_name),
+                        kwargs.get("device", "CPU"),
+                        kwargs.get("ov_config"),
+                        True,
+                        model_save_dir,
+                    )
 
         # Load model from hub
         else:
@@ -228,15 +243,15 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                     decoder_with_past = cls.load_model(file_names["decoder_with_past"], quantization_config)
             else:
                 encoder = cls._compile_model(
-                    file_names["encoder"], kwargs.get("device"), kwargs.get("ov_config"), True, model_save_dir
+                    file_names["encoder"], kwargs.get("device", "CPU"), kwargs.get("ov_config"), True, model_save_dir
                 )
                 decoder = cls._compile_model(
-                    file_names["decoder"], kwargs.get("device"), kwargs.get("ov_config"), True, model_save_dir
+                    file_names["decoder"], kwargs.get("device", "CPU"), kwargs.get("ov_config"), True, model_save_dir
                 )
                 if use_cache:
                     decoder_with_past = cls._compile_model(
                         file_names["decoder_with_past"],
-                        kwargs.get("device"),
+                        kwargs.get("device", "CPU"),
                         kwargs.get("ov_config"),
                         True,
                         model_save_dir,

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -175,16 +175,21 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
 
         quantization_config = cls._prepare_weight_quantization_config(quantization_config, load_in_8bit)
 
+        compile_only = kwargs.get(compile_only, True)
+
         # Load model from a local directory
         if os.path.isdir(model_id):
-            encoder = cls.load_model(os.path.join(model_id, encoder_file_name), quantization_config)
-            decoder = cls.load_model(os.path.join(model_id, decoder_file_name), quantization_config)
-            if use_cache:
-                decoder_with_past = cls.load_model(
-                    os.path.join(model_id, decoder_with_past_file_name), quantization_config
-                )
 
             model_save_dir = Path(model_id)
+            if not compile_only:
+                encoder = cls.load_model(os.path.join(model_id, encoder_file_name), quantization_config)
+                decoder = cls.load_model(os.path.join(model_id, decoder_file_name), quantization_config)
+                if use_cache:
+                    decoder_with_past = cls.load_model(
+                        os.path.join(model_id, decoder_with_past_file_name), quantization_config
+                    )
+            else:
+                encoder = cls._compile_model(os.path.join(model_id, encoder_file_name), kwargs.get("device"), kwargs.get("ov_config"), True, model_save_dir)
 
         # Load model from hub
         else:
@@ -210,11 +215,16 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
                 file_names[name] = model_cache_path
 
             model_save_dir = Path(model_cache_path).parent
-            encoder = cls.load_model(file_names["encoder"], quantization_config)
-            decoder = cls.load_model(file_names["decoder"], quantization_config)
-            if use_cache:
-                decoder_with_past = cls.load_model(file_names["decoder_with_past"], quantization_config)
-
+            if not compile_only:
+                encoder = cls.load_model(file_names["encoder"], quantization_config)
+                decoder = cls.load_model(file_names["decoder"], quantization_config)
+                if use_cache:
+                    decoder_with_past = cls.load_model(file_names["decoder_with_past"], quantization_config)
+            else:
+                encoder = cls._compile_model(file_names["encoder", kwargs.get("device"), kwargs.get("ov_config"), True, model_save_dir])
+                decoder = cls._compile_model(file_names["decoder", kwargs.get("device"), kwargs.get("ov_config"), True, model_save_dir])
+                if use_cache:
+                    decoder_with_past = cls._compile_model(file_names["decoder_with_past", kwargs.get("device"), kwargs.get("ov_config"), True, model_save_dir])
         try:
             generation_config = GenerationConfig.from_pretrained(
                 model_id,
@@ -288,6 +298,11 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             if use_cache:
                 task = task + "-with-past"
 
+        compile_only = kwargs.pop("compile_only", False)
+        if compile_only:
+            logger.warning("`compile_only` mode will be disabled because it does not support model export."
+                            "Please provide openvino model obtained using optimum-cli or saved on disk using `save_pretrained`")
+            compile_only = False
         # If load_in_8bit and quantization_config not specified then ov_config is set to None and will be set by default in convert depending on the model size
         if load_in_8bit is None and not quantization_config:
             ov_config = None
@@ -315,6 +330,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             use_cache=use_cache,
             load_in_8bit=load_in_8bit,
             quantization_config=quantization_config,
+            compile_only=compile_only,
             **kwargs,
         )
 
@@ -344,6 +360,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             sequence_length (`int`):
                 The sequence length.
         """
+        if self.compile_only:
+            logger.warning("`reshape()` does not supported in `compile_only` mode")
+            return
         logger.warning("Some part of the model's decoder do not support static shapes and will be kept dynamic.")
         self.is_dynamic = True if batch_size == -1 and sequence_length == -1 else False
         self.encoder_model = self._reshape(self.encoder_model, batch_size, sequence_length, is_decoder=False)
@@ -355,6 +374,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         """
         Converts all the model weights to FP16 for more efficient inference on GPU.
         """
+        if self.compile_only:
+            logger.warning("`half()` does not supported in `compile_only` mode")
+            return self
         apply_moc_transformations(self.encoder_model, cf=False)
         apply_moc_transformations(self.decoder_model, cf=False)
         compress_model_transformation(self.encoder_model)

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -237,7 +237,9 @@ class OVBaseDecoderModel(OVModel):
         """
 
         if self.compile_only:
-            raise ValueError("`save_pretrained()` is not supported in `compile_only` mode, please intialize model without this option")
+            raise ValueError(
+                "`save_pretrained()` is not supported with `compile_only` mode, please intialize model without this option"
+            )
         model_to_save = self.model if self._pkv_precision == Type.f32 else self._original_model
         dst_path = os.path.join(save_directory, OV_XML_FILE_NAME)
         openvino.save_model(model_to_save, dst_path, compress_to_fp16=False)
@@ -345,7 +347,9 @@ class OVBaseDecoderModel(OVModel):
         width: int = None,
     ):
         if self.compile_only:
-            raise ValueError("`reshape()` is not supported in `compile_only` mode, please intialize model without this option")
+            raise ValueError(
+                "`reshape()` is not supported with `compile_only` mode, please intialize model without this option"
+            )
 
         if height is not None:
             logger.warning(f"`height` set to `{height}` will be ignored during reshaping operation.")
@@ -799,7 +803,7 @@ class OVModelForCausalLM(OVBaseDecoderModel, GenerationMixin):
             model = cls.load_model(model_cache_path)
         else:
             model = cls._compile_model(
-                model_cache_path, kwargs.get("device", "CPU"), kwargs.get("ov_config"), True, model_cache_path.parent
+                model_cache_path, kwargs.get("device", "CPU"), kwargs.get("ov_config"), model_cache_path.parent
             )
 
         model_type = config.model_type.replace("_", "-")
@@ -854,7 +858,9 @@ class OVModelForCausalLM(OVBaseDecoderModel, GenerationMixin):
                 )
 
             if compile_only:
-                raise ValueError("quantization is not supported in `compile_only` mode, please intialize model without this option")
+                raise ValueError(
+                    "quantization is not supported with `compile_only` mode, please intialize model without this option"
+                )
 
             from optimum.intel.openvino.quantization import OVQuantizer
 

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -142,7 +142,7 @@ class OVBaseDecoderModel(OVModel):
         self._first_iter_beam_search = False
         self._second_iter_beam_search = False
         self.update_pkv_precision()
-        if self.is_dynamic:
+        if self.is_dynamic and not self.compile_only:
             self.model = self._reshape(self.model, -1, -1)
         is_stateful_supported = ensure_stateful_is_available(warn=False)
 
@@ -178,6 +178,9 @@ class OVBaseDecoderModel(OVModel):
 
         if use_cache ^ self.use_cache:
             raise_error(self.use_cache, use_cache, "use_cache")
+        
+        if self.compile_only:
+            self.request = self.model.create_infer_request()
 
         if not self.compile_only and enable_compilation:
             self.compile()
@@ -379,6 +382,8 @@ class OVBaseDecoderModel(OVModel):
 
     def compile(self):
         if self.request is None:
+            if self.compile_only:
+                self.request = self.model.create_infer_request()
             super().compile()
             self.request = self.request.create_infer_request()
 

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -129,7 +129,7 @@ class OVBaseDecoderModel(OVModel):
         )
         self.is_dynamic = dynamic_shapes
         use_cache = kwargs.pop("use_cache", True)
-        model_has_sinks = model_has_state(self.model, compile_only)
+        model_has_sinks = model_has_state(self.model)
         self.use_cache = any("past_key_values" in key.get_any_name() for key in model.inputs) or model_has_sinks
         stateful = kwargs.pop("stateful", None)  # stateful model only if it is converted with stateful=True
         self.stateful = model_has_sinks

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -46,7 +46,14 @@ from .configuration import (
     get_default_int4_config,
 )
 from .modeling import _TOKENIZER_FOR_DOC, INPUTS_DOCSTRING, MODEL_START_DOCSTRING, OVModel
-from .utils import ONNX_WEIGHTS_NAME, OV_TO_NP_TYPE, OV_XML_FILE_NAME, STR_TO_OV_TYPE, get_export_transformers_version
+from .utils import (
+    ONNX_WEIGHTS_NAME,
+    OV_TO_NP_TYPE,
+    OV_XML_FILE_NAME,
+    STR_TO_OV_TYPE,
+    get_export_transformers_version,
+    model_has_dynamic_inputs,
+)
 
 
 if TYPE_CHECKING:
@@ -120,7 +127,7 @@ class OVBaseDecoderModel(OVModel):
             model,
             config,
             device=device,
-            dynamic_shapes=False,
+            dynamic_shapes=False if not compile_only else model_has_dynamic_inputs(model),
             ov_config=ov_config,
             model_save_dir=model_save_dir,
             quantization_config=quantization_config,

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -110,10 +110,12 @@ class OVBaseDecoderModel(OVModel):
 
         compile_only = kwargs.get("compile_only", False)
         enable_compilation = kwargs.get("compile", True)
-        kwargs["compile"] = False or compile_only # avoid extra compilation in the base class
+        kwargs["compile"] = False or compile_only  # avoid extra compilation in the base class
         if compile_only and not enable_compilation:
-            raise ValueError("`compile_only` mode does not support disabling compilation."
-                             "Please provide `compile=True` if you want to use `compile_only=True` or set `compile_only=False`")
+            raise ValueError(
+                "`compile_only` mode does not support disabling compilation."
+                "Please provide `compile=True` if you want to use `compile_only=True` or set `compile_only=False`"
+            )
 
         super().__init__(
             model,
@@ -178,7 +180,7 @@ class OVBaseDecoderModel(OVModel):
 
         if use_cache ^ self.use_cache:
             raise_error(self.use_cache, use_cache, "use_cache")
-        
+
         if self.compile_only:
             self.request = self.model.create_infer_request()
 
@@ -233,7 +235,9 @@ class OVBaseDecoderModel(OVModel):
         """
 
         if self.compile_only:
-            logger.warning("`compile_only` does not support model saving on disk, you already should have preconverted model")
+            logger.warning(
+                "`compile_only` does not support model saving on disk, you already should have preconverted model"
+            )
             return
         model_to_save = self.model if self._pkv_precision == Type.f32 else self._original_model
         dst_path = os.path.join(save_directory, OV_XML_FILE_NAME)
@@ -275,8 +279,10 @@ class OVBaseDecoderModel(OVModel):
 
         compile_only = kwargs.pop("compile_only", False)
         if compile_only:
-            logger.warning("`compile_only` mode will be disabled because it does not support model export."
-                            "Please provide openvino model obtained using optimum-cli or saved on disk using `save_pretrained`")
+            logger.warning(
+                "`compile_only` mode will be disabled because it does not support model export."
+                "Please provide openvino model obtained using optimum-cli or saved on disk using `save_pretrained`"
+            )
             compile_only = False
 
         if task is None:
@@ -339,9 +345,8 @@ class OVBaseDecoderModel(OVModel):
         height: int = None,
         width: int = None,
     ):
-        
         if self.compile_only:
-            logger.warning("model reshaping does not supported in `compile_only` mode")
+            logger.warning("model reshaping does not support `compile_only` mode")
             return model
 
         if height is not None:

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -145,7 +145,7 @@ class OVBaseDecoderModel(OVModel):
         self._first_iter_beam_search = False
         self._second_iter_beam_search = False
         self.update_pkv_precision()
-        if self.is_dynamic and not self.compile_only:
+        if self.is_dynamic and not self._compile_only:
             self.model = self._reshape(self.model, -1, -1)
         is_stateful_supported = ensure_stateful_is_available(warn=False)
 
@@ -182,14 +182,14 @@ class OVBaseDecoderModel(OVModel):
         if use_cache ^ self.use_cache:
             raise_error(self.use_cache, use_cache, "use_cache")
 
-        if self.compile_only:
+        if self._compile_only:
             self.request = self.model.create_infer_request()
 
-        if not self.compile_only and enable_compilation:
+        if not self._compile_only and enable_compilation:
             self.compile()
 
     def update_pkv_precision(self, force_fp32=False):
-        if not self.use_cache or self.stateful or self.compile_only:
+        if not self.use_cache or self.stateful or self._compile_only:
             return
 
         pkv_precision = Type.f32
@@ -235,7 +235,7 @@ class OVBaseDecoderModel(OVModel):
                 The directory where to save the model files.
         """
 
-        if self.compile_only:
+        if self._compile_only:
             raise ValueError(
                 "`save_pretrained()` is not supported with `compile_only` mode, please intialize model without this option"
             )
@@ -345,7 +345,7 @@ class OVBaseDecoderModel(OVModel):
         height: int = None,
         width: int = None,
     ):
-        if self.compile_only:
+        if self._compile_only:
             raise ValueError(
                 "`reshape()` is not supported with `compile_only` mode, please intialize model without this option"
             )
@@ -388,7 +388,7 @@ class OVBaseDecoderModel(OVModel):
 
     def compile(self):
         if self.request is None:
-            if self.compile_only:
+            if self._compile_only:
                 self.request = self.model.create_infer_request()
             super().compile()
             self.request = self.request.create_infer_request()

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -237,10 +237,7 @@ class OVBaseDecoderModel(OVModel):
         """
 
         if self.compile_only:
-            logger.warning(
-                "`compile_only` does not support model saving on disk, you already should have preconverted model"
-            )
-            return
+            raise ValueError("`save_pretrained()` is not supported in `compile_only` mode, please intialize model without this option")
         model_to_save = self.model if self._pkv_precision == Type.f32 else self._original_model
         dst_path = os.path.join(save_directory, OV_XML_FILE_NAME)
         openvino.save_model(model_to_save, dst_path, compress_to_fp16=False)
@@ -348,8 +345,7 @@ class OVBaseDecoderModel(OVModel):
         width: int = None,
     ):
         if self.compile_only:
-            logger.warning("model reshaping does not support `compile_only` mode")
-            return model
+            raise ValueError("`reshape()` is not supported in `compile_only` mode, please intialize model without this option")
 
         if height is not None:
             logger.warning(f"`height` set to `{height}` will be ignored during reshaping operation.")
@@ -858,10 +854,7 @@ class OVModelForCausalLM(OVBaseDecoderModel, GenerationMixin):
                 )
 
             if compile_only:
-                logger.warning(
-                    "Quantization is not available for `compile_only` mode, quantization config will be ignored"
-                )
-                return causal_model
+                raise ValueError("quantization is not supported in `compile_only` mode, please intialize model without this option")
 
             from optimum.intel.openvino.quantization import OVQuantizer
 

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -177,10 +177,7 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
                 The directory where to save the model files
         """
         if self.compile_only:
-            logger.warning(
-                "`compile_only` does not support model saving on disk, you already should have preconverted model"
-            )
-            return
+            raise ValueError("`save_pretrained()` is not supported in `compile_only` mode, please intialize model without this option")
 
         save_directory = Path(save_directory)
 

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -314,7 +314,7 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
             vae_ov_conifg = {**ov_config}
             if "GPU" in device.upper() and "INFERENCE_PRECISION_HINT" not in vae_ov_conifg:
                 vae_ov_conifg["INFERENCE_PRECISION_HINT"] = "f32"
-            unet = cls._compile_model(unet_path, device, ov_config, True, Path(model_save_dir) / "unet")
+            unet = cls._compile_model(unet_path, device, ov_config, Path(model_save_dir) / "unet")
             for key, value in components.items():
                 components[key] = (
                     cls._compile_model(

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -650,7 +650,7 @@ class OVModelPart:
             for inputs in self.model.inputs
         }
         self.ov_config = ov_config or {**self.parent_model.ov_config}
-        self._compile_only = parent_model.compile_only
+        self._compile_only = parent_model._compile_only
         self.request = None if not self._compile_only else self.model
         self._model_name = model_name
         self._model_dir = Path(model_dir or parent_model._model_save_dir)

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -342,9 +342,8 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
             pass
 
     def to(self, device: str):
-        if self.compile_only:
-            logger.warning("`to()` does not support in `compile_only` mode")
-            return self
+        if self.compile_only and isinstance(device, str):
+            raise ValueError("`to()` is not supported in `compile_only` mode, please intialize model without this option")
 
         if isinstance(device, str):
             self._device = device.upper()
@@ -449,8 +448,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
                 The sequence length.
         """
         if self.compile_only:
-            logger.warning("`reshape()` does not supported in `compile_only` mode")
-            return self
+            raise ValueError("`reshape()` is not supported in `compile_only` mode, please intialize model without this option")
         super().reshape(batch_size, sequence_length)
         self.clear_requests()
         return self
@@ -465,8 +463,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
 
     def clear_requests(self):
         if self.compile_only:
-            logger.warning("`clear_requests()` does not supported in `compile_only` mode")
-            return self
+            raise ValueError("`clear_requests()` is not supported in `compile_only` mode, please intialize model without this option")
         self.encoder.request = None
         self.decoder.request = None
         if self.use_cache:

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -494,12 +494,12 @@ class OVEncoder:
     def __init__(self, model: openvino.runtime.Model, parent_model: OVModelForSeq2SeqLM):
         self.model = model
         self.parent_model = parent_model
-        self.comple_only = parent_model.compile_only
+        self._comple_only = parent_model._compile_only
         self.input_names = {key.get_any_name(): idx for idx, key in enumerate(self.model.inputs)}
         self.input_dtypes = {key.get_any_name(): key.get_element_type().get_type_name() for key in self.model.inputs}
         self.output_dtypes = {key.get_any_name(): key.get_element_type().get_type_name() for key in self.model.outputs}
         self.main_input_name = self.parent_model.main_input_name or "input_ids"
-        self.request = None if not self.comple_only else self.model
+        self.request = None if not self._comple_only else self.model
 
     @property
     def _device(self):
@@ -582,7 +582,7 @@ class OVDecoder:
     def __init__(self, model: openvino.runtime.Model, parent_model: OVModelForSeq2SeqLM):
         self.model = model
         self.parent_model = parent_model
-        self._compile_only = parent_model.compile_only
+        self._compile_only = parent_model._compile_only
         self.input_names = {key.get_any_name(): idx for idx, key in enumerate(self.model.inputs)}
         self.input_dtypes = {key.get_any_name(): key.get_element_type().get_type_name() for key in self.model.inputs}
         self.key_value_input_names = [key for key in self.input_names if "key_values" in key]

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -343,7 +343,9 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
 
     def to(self, device: str):
         if self.compile_only and isinstance(device, str):
-            raise ValueError("`to()` is not supported in `compile_only` mode, please intialize model without this option")
+            raise ValueError(
+                "`to()` is not supported with `compile_only` mode, please intialize model without this option"
+            )
 
         if isinstance(device, str):
             self._device = device.upper()
@@ -448,7 +450,9 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
                 The sequence length.
         """
         if self.compile_only:
-            raise ValueError("`reshape()` is not supported in `compile_only` mode, please intialize model without this option")
+            raise ValueError(
+                "`reshape()` is not supported with `compile_only` mode, please intialize model without this option"
+            )
         super().reshape(batch_size, sequence_length)
         self.clear_requests()
         return self
@@ -463,7 +467,9 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
 
     def clear_requests(self):
         if self.compile_only:
-            raise ValueError("`clear_requests()` is not supported in `compile_only` mode, please intialize model without this option")
+            raise ValueError(
+                "`clear_requests()` is not supported with `compile_only` mode, please intialize model without this option"
+            )
         self.encoder.request = None
         self.decoder.request = None
         if self.use_cache:

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -342,7 +342,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
             pass
 
     def to(self, device: str):
-        if self.compile_only and isinstance(device, str):
+        if self._compile_only and isinstance(device, str):
             raise ValueError(
                 "`to()` is not supported with `compile_only` mode, please intialize model without this option"
             )
@@ -449,7 +449,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
             sequence_length (`int`):
                 The sequence length.
         """
-        if self.compile_only:
+        if self._compile_only:
             raise ValueError(
                 "`reshape()` is not supported with `compile_only` mode, please intialize model without this option"
             )
@@ -466,7 +466,7 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
         return self
 
     def clear_requests(self):
-        if self.compile_only:
+        if self._compile_only:
             raise ValueError(
                 "`clear_requests()` is not supported with `compile_only` mode, please intialize model without this option"
             )
@@ -582,7 +582,7 @@ class OVDecoder:
     def __init__(self, model: openvino.runtime.Model, parent_model: OVModelForSeq2SeqLM):
         self.model = model
         self.parent_model = parent_model
-        self.compile_only = parent_model.compile_only
+        self._compile_only = parent_model.compile_only
         self.input_names = {key.get_any_name(): idx for idx, key in enumerate(self.model.inputs)}
         self.input_dtypes = {key.get_any_name(): key.get_element_type().get_type_name() for key in self.model.inputs}
         self.key_value_input_names = [key for key in self.input_names if "key_values" in key]
@@ -598,7 +598,7 @@ class OVDecoder:
             self.use_past = False
             self.num_pkv = 4
 
-        self.request = None if not self.compile_only else self.model.create_infer_request()
+        self.request = None if not self._compile_only else self.model.create_infer_request()
 
     @property
     def _device(self) -> str:

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -271,6 +271,10 @@ class OVQuantizer(OptimumQuantizer):
                 ov_config.quantization_config = OVQuantizationConfig()
 
         if isinstance(self.model, OVBaseModel):
+            if self.model.compile_only:
+                raise ValueError(
+                    "Quantization for `compile_only` model is not supported. Please load model with `compile_only=False`"
+                )
             self._quantize_ovbasemodel(
                 ov_config,
                 save_directory,

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -271,7 +271,7 @@ class OVQuantizer(OptimumQuantizer):
                 ov_config.quantization_config = OVQuantizationConfig()
 
         if isinstance(self.model, OVBaseModel):
-            if self.model.compile_only:
+            if self.model._compile_only:
                 raise ValueError(
                     "Quantization for `compile_only` model is not supported. Please load model with `compile_only=False`"
                 )

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -23,8 +23,9 @@ from typing import Tuple, Type, Union
 import numpy as np
 import torch
 from huggingface_hub import model_info
-from openvino.runtime import Core, properties
+from openvino.runtime import Core, Model, properties
 from openvino.runtime import Type as OVType
+from packaging.version import Version
 from transformers import AutoTokenizer, CLIPTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 from transformers.onnx.utils import ParameterFormat, compute_serialized_parameters_size
 
@@ -201,3 +202,17 @@ def _print_compiled_model_properties(compiled_model):
             logger.info(f"  {device}: {Core().get_property(device, 'FULL_DEVICE_NAME')}")
     except Exception:
         logger.error("[error] Get FULL_DEVICE_NAME failed")
+
+
+def get_export_transformers_version(model, config):
+    version_str = None
+
+    if isinstance(model, Model):
+        if "optimum" in model.rt_info:
+            version_str = model.rt_info["optimum"]["transformers_version"].value
+    if version_str is None:
+        version_str = getattr(config, "transformers_version", "0.0.0")
+
+    version_str = version_str or "0.0.0"
+
+    return Version(version_str)

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -216,3 +216,12 @@ def get_export_transformers_version(model, config):
     version_str = version_str or "0.0.0"
 
     return Version(version_str)
+
+
+def model_has_dynamic_inputs(model):
+    is_dynamic = False
+    for input in model.inputs:
+        is_dynamic = input.get_partial_shape().is_dynamic
+        if is_dynamic:
+            return is_dynamic
+    return is_dynamic

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -156,10 +156,6 @@ class OVModelIntegrationTest(unittest.TestCase):
         current_num_blobs = len(list(manual_openvino_cache_dir.glob("*.blob")))
         # compile_only get model from cache
         self.assertGreaterEqual(current_num_blobs, num_blobs)
-        device = compile_only_model._device
-        # to() method can not change device for compile only
-        compile_only_model.to("TEST")
-        self.assertEqual(compile_only_model._device, device)
         self.assertIsInstance(compile_only_model.model, ov.runtime.CompiledModel)
         self.assertIsInstance(compile_only_model.request, ov.runtime.CompiledModel)
         outputs = compile_only_model(**tokens)
@@ -204,10 +200,6 @@ class OVModelIntegrationTest(unittest.TestCase):
             self.assertEqual(model.use_cache, use_cache)
 
             compile_only_model = OVModelForCausalLM.from_pretrained(tmpdirname, compile_only=True, use_cache=use_cache)
-            device = compile_only_model._device
-            # to() method can not change device for compile only
-            compile_only_model.to("TEST")
-            self.assertEqual(compile_only_model._device, device)
             self.assertIsInstance(compile_only_model.model, ov.runtime.CompiledModel)
             self.assertIsInstance(compile_only_model.request, ov.runtime.InferRequest)
             outputs = compile_only_model(**tokens)
@@ -242,10 +234,6 @@ class OVModelIntegrationTest(unittest.TestCase):
             model = OVModelForSeq2SeqLM.from_pretrained(tmpdirname, device="cpu")
             # compile only
             compile_only_model = OVModelForSeq2SeqLM.from_pretrained(tmpdirname, compile_only=True)
-            device = compile_only_model._device
-            # to() method can not change device for compile only
-            compile_only_model.to("TEST")
-            self.assertEqual(compile_only_model._device, device)
             self.assertIsInstance(compile_only_model.encoder.model, ov.runtime.CompiledModel)
             self.assertIsInstance(compile_only_model.decoder.model, ov.runtime.CompiledModel)
             self.assertIsInstance(compile_only_model.decoder_with_past.model, ov.runtime.CompiledModel)
@@ -294,10 +282,6 @@ class OVModelIntegrationTest(unittest.TestCase):
                 self.assertIn(OV_XML_FILE_NAME.replace(".xml", ".bin"), folder_contents)
 
             compile_only_pipeline = OVStableDiffusionPipeline.from_pretrained(tmpdirname, compile_only=True)
-            device = compile_only_pipeline._device
-            # to() method can not change device for compile only
-            compile_only_pipeline.to("TEST")
-            self.assertEqual(compile_only_pipeline._device, device)
             self.assertIsInstance(compile_only_pipeline.unet.model, ov.runtime.CompiledModel)
             self.assertIsInstance(compile_only_pipeline.text_encoder.model, ov.runtime.CompiledModel)
             self.assertIsInstance(compile_only_pipeline.vae_encoder.model, ov.runtime.CompiledModel)

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -155,7 +155,7 @@ class OVModelIntegrationTest(unittest.TestCase):
         self.assertTrue(manual_openvino_cache_dir.is_dir())
         current_num_blobs = len(list(manual_openvino_cache_dir.glob("*.blob")))
         # compile_only get model from cache
-        self.assertEqual(num_blobs, current_num_blobs)
+        self.assertGreaterEqual(current_num_blobs, num_blobs)
         device = compile_only_model._device
         # to() method can not change device for compile only
         compile_only_model.to("TEST")

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Dict
 
 import numpy as np
+import openvino as ov
 import pytest
 import requests
 import timm
@@ -139,11 +140,31 @@ class OVModelIntegrationTest(unittest.TestCase):
         ov_config = {"CACHE_DIR": str(manual_openvino_cache_dir), "PERFORMANCE_HINT": "THROUGHPUT"}
         loaded_model = OVModelForSequenceClassification.from_pretrained(self.OV_MODEL_ID, ov_config=ov_config)
         self.assertTrue(manual_openvino_cache_dir.is_dir())
-        self.assertGreaterEqual(len(list(manual_openvino_cache_dir.glob("*.blob"))), 1)
+        num_blobs = len(list(manual_openvino_cache_dir.glob("*.blob")))
+        self.assertGreaterEqual(num_blobs, 1)
         if is_openvino_version("<", "2023.3"):
             self.assertEqual(loaded_model.request.get_property("PERFORMANCE_HINT").name, "THROUGHPUT")
         else:
             self.assertEqual(loaded_model.request.get_property("PERFORMANCE_HINT"), "THROUGHPUT")
+
+        # Test compile only
+
+        compile_only_model = OVModelForSequenceClassification.from_pretrained(
+            self.OV_MODEL_ID, ov_config=ov_config, compile_only=True
+        )
+        self.assertTrue(manual_openvino_cache_dir.is_dir())
+        current_num_blobs = len(list(manual_openvino_cache_dir.glob("*.blob")))
+        # compile_only get model from cache
+        self.assertEqual(num_blobs, current_num_blobs)
+        device = compile_only_model._device
+        # to() method can not change device for compile only
+        compile_only_model.to("TEST")
+        self.assertEqual(compile_only_model._device, device)
+        self.assertIsInstance(compile_only_model.model, ov.runtime.CompiledModel)
+        self.assertIsInstance(compile_only_model.request, ov.runtime.CompiledModel)
+        outputs = compile_only_model(**tokens)
+        self.assertTrue(torch.equal(loaded_model_outputs.logits, outputs.logits))
+        del compile_only_model
 
         with tempfile.TemporaryDirectory() as tmpdirname:
             loaded_model.save_pretrained(tmpdirname)
@@ -182,6 +203,17 @@ class OVModelIntegrationTest(unittest.TestCase):
             model = OVModelForCausalLM.from_pretrained(tmpdirname, use_cache=use_cache)
             self.assertEqual(model.use_cache, use_cache)
 
+            compile_only_model = OVModelForCausalLM.from_pretrained(tmpdirname, compile_only=True, use_cache=use_cache)
+            device = compile_only_model._device
+            # to() method can not change device for compile only
+            compile_only_model.to("TEST")
+            self.assertEqual(compile_only_model._device, device)
+            self.assertIsInstance(compile_only_model.model, ov.runtime.CompiledModel)
+            self.assertIsInstance(compile_only_model.request, ov.runtime.InferRequest)
+            outputs = compile_only_model(**tokens)
+            self.assertTrue(torch.equal(loaded_model_outputs.logits, outputs.logits))
+            del compile_only_model
+
         outputs = model(**tokens)
         self.assertTrue(torch.equal(loaded_model_outputs.logits, outputs.logits))
         del loaded_model
@@ -208,6 +240,18 @@ class OVModelIntegrationTest(unittest.TestCase):
             self.assertTrue(OV_DECODER_NAME in folder_contents)
             self.assertTrue(OV_DECODER_WITH_PAST_NAME in folder_contents)
             model = OVModelForSeq2SeqLM.from_pretrained(tmpdirname, device="cpu")
+            # compile only
+            compile_only_model = OVModelForSeq2SeqLM.from_pretrained(tmpdirname, compile_only=True)
+            device = compile_only_model._device
+            # to() method can not change device for compile only
+            compile_only_model.to("TEST")
+            self.assertEqual(compile_only_model._device, device)
+            self.assertIsInstance(compile_only_model.encoder.model, ov.runtime.CompiledModel)
+            self.assertIsInstance(compile_only_model.decoder.model, ov.runtime.CompiledModel)
+            self.assertIsInstance(compile_only_model.decoder_with_past.model, ov.runtime.CompiledModel)
+            outputs = compile_only_model.generate(**tokens)
+            self.assertTrue(torch.equal(loaded_model_outputs, outputs))
+            del compile_only_model
 
         outputs = model.generate(**tokens)
         self.assertTrue(torch.equal(loaded_model_outputs, outputs))
@@ -248,6 +292,21 @@ class OVModelIntegrationTest(unittest.TestCase):
                 folder_contents = os.listdir(os.path.join(tmpdirname, subfoler))
                 self.assertIn(OV_XML_FILE_NAME, folder_contents)
                 self.assertIn(OV_XML_FILE_NAME.replace(".xml", ".bin"), folder_contents)
+
+            compile_only_pipeline = OVStableDiffusionPipeline.from_pretrained(tmpdirname, compile_only=True)
+            device = compile_only_pipeline._device
+            # to() method can not change device for compile only
+            compile_only_pipeline.to("TEST")
+            self.assertEqual(compile_only_pipeline._device, device)
+            self.assertIsInstance(compile_only_pipeline.unet.model, ov.runtime.CompiledModel)
+            self.assertIsInstance(compile_only_pipeline.text_encoder.model, ov.runtime.CompiledModel)
+            self.assertIsInstance(compile_only_pipeline.vae_encoder.model, ov.runtime.CompiledModel)
+            self.assertIsInstance(compile_only_pipeline.vae_decoder.model, ov.runtime.CompiledModel)
+            np.random.seed(0)
+            outputs = compile_only_pipeline(**inputs).images
+            self.assertTrue(np.array_equal(pipeline_outputs, outputs))
+            del compile_only_pipeline
+
         np.random.seed(0)
         outputs = pipeline(**inputs).images
         self.assertTrue(np.array_equal(pipeline_outputs, outputs))


### PR DESCRIPTION
# What does this PR do?
this PR introduces inference mode for OpenVINO models using only device execution graph representation (compiled_model).
OpenVINO uses 2 models representation:
* Graph representation (Intermediate Representation) - device-agnostic, used for applying optimizations using openvino transformations and nncf, provides access to internal operations and modifications (changing input\output precision and reshaping), nonexecutable (does not have inference capabilities  need to run compile_model for moving to Compiled model format)
* Exeсtable representation (Compiled Model) - device-specific representation used for inference (obtained as result of IR compilation on specific device).

Both models sharing weights, but may have some difference (e.g. when device apply some additional own optimizations and does not preserve mapping between IR weights and compiled model, some weights and shapes can be also calculated on the first inference step - e.g. decompression of int4 constants) 

Besides that openvino support caching compiled model for speedup next loading on the same device. In this case we do not need to use Graph model representation as compiled model will be restored from cache. Experiments shows that it may reduce peak memory consumption:

default scenario for phi3-mini with caching
![image-2024-07-12-01-35-42-179](https://github.com/user-attachments/assets/4f33ae18-cdf3-46dd-8ddc-54d577ba2f45)

 phi3-mini with caching and compile_only=True
![image-2024-07-12-01-34-10-049](https://github.com/user-attachments/assets/9b8045f0-3967-4b3a-b2bc-5c7ed8fd77f2)


The idea of this PR to allow users get benifit of usage cached compiled model moving in special mode (I named it `compile_only`, as we do not permit other possible actions that possible to do with model (quantization, device changing, reshaping) except compilation) with acceptance possible limitations. Motivation of these changes that default scenario is very flexible and more suitable for experiments, while in deployment scenario (when all experiments already done before) memory constrains can be more strict.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

