### PR TITLE
Correct get tensor name for stateful keys, values

### DIFF
--- a/optimum/exporters/openvino/stateful.py
+++ b/optimum/exporters/openvino/stateful.py
@@ -200,10 +200,10 @@ def patch_stateful(config: PretrainedConfig, ov_model: ov.Model):
     """
 
     key_value_input_names = [
-        key.get_any_name() for key in ov_model.inputs if any("key_values" in key_name for key_name in key.get_names())
+        key_name for key in ov_model.inputs for key_name in key.get_names() if "key_values" in key_name
     ]
     key_value_output_names = [
-        key.get_any_name() for key in ov_model.outputs if any("present" in key_name for key_name in key.get_names())
+        key_name for key in ov_model.outputs for key_name in key.get_names() if "present" in key_name
     ]
     not_kv_inputs = [
         input for input in ov_model.inputs if not any(name in key_value_input_names for name in input.get_names())


### PR DESCRIPTION
# Description
The changes change gets tensor names for stateful for key and values. If key or value pattern name found will be used  instead any names which can be different.

When pattern name found and used then OpenVINO will not use restore name path for keys, values when apply `StatefulToStateless`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

