### PR TITLE
Introduce support for `mxfp4` data type for OV weight compression

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -70,9 +70,9 @@ def parse_args_openvino(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--weight-format",
         type=str,
-        choices=["fp32", "fp16", "int8", "int4", "int4_sym_g128", "int4_asym_g128", "int4_sym_g64", "int4_asym_g64"],
+        choices=["fp32", "fp16", "int8", "int4", "mxfp4_e2m1", "int4_sym_g128", "int4_asym_g128", "int4_sym_g64", "int4_asym_g64"],
         default=None,
-        help="he weight format of the exported model.",
+        help="The weight format of the exported model.",
     )
     optional_group.add_argument(
         "--library",
@@ -255,12 +255,11 @@ class OVExportCommand(BaseOptimumCLICommand):
         elif self.args.weight_format in {"fp16", "fp32"}:
             ov_config = OVConfig(dtype=self.args.weight_format)
         else:
-            is_int8 = self.args.weight_format == "int8"
-
-            # For int4 quantization if no parameter is provided, then use the default config if exist
-            if no_compression_parameter_provided(self.args) and not is_int8:
+            # For int4 quantization if no parameter is provided, then use the default config if exists
+            if no_compression_parameter_provided(self.args) and self.args.weight_format == "int4":
                 quantization_config = get_default_int4_config(self.args.model)
             else:
+                is_int8 = self.args.weight_format == "int8"
                 quantization_config = {
                     "bits": 8 if is_int8 else 4,
                     "ratio": 1 if is_int8 else (self.args.ratio or _DEFAULT_4BIT_CONFIG["ratio"]),
@@ -272,6 +271,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                     "quant_method": "awq" if self.args.awq else "default",
                     "sensitivity_metric": self.args.sensitivity_metric,
                     "scale_estimation": self.args.scale_estimation,
+                    "dtype": "int" if "int" in self.args.weight_format else self.args.weight_format,
                 }
 
             if quantization_config.get("dataset", None) is not None:

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -70,7 +70,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--weight-format",
         type=str,
-        choices=["fp32", "fp16", "int8", "int4", "mxfp4_e2m1"],
+        choices=["fp32", "fp16", "int8", "int4", "mxfp4"],
         default=None,
         help="The weight format of the exported model.",
     )

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -70,7 +70,17 @@ def parse_args_openvino(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--weight-format",
         type=str,
-        choices=["fp32", "fp16", "int8", "int4", "mxfp4_e2m1", "int4_sym_g128", "int4_asym_g128", "int4_sym_g64", "int4_asym_g64"],
+        choices=[
+            "fp32",
+            "fp16",
+            "int8",
+            "int4",
+            "mxfp4_e2m1",
+            "int4_sym_g128",
+            "int4_asym_g128",
+            "int4_sym_g64",
+            "int4_asym_g64",
+        ],
         default=None,
         help="The weight format of the exported model.",
     )

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -70,17 +70,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--weight-format",
         type=str,
-        choices=[
-            "fp32",
-            "fp16",
-            "int8",
-            "int4",
-            "mxfp4_e2m1",
-            "int4_sym_g128",
-            "int4_asym_g128",
-            "int4_sym_g64",
-            "int4_asym_g64",
-        ],
+        choices=["fp32", "fp16", "int8", "int4", "mxfp4_e2m1"],
         default=None,
         help="The weight format of the exported model.",
     )
@@ -281,18 +271,11 @@ class OVExportCommand(BaseOptimumCLICommand):
                     "quant_method": "awq" if self.args.awq else "default",
                     "sensitivity_metric": self.args.sensitivity_metric,
                     "scale_estimation": self.args.scale_estimation,
-                    "dtype": "int" if "int" in self.args.weight_format else self.args.weight_format,
+                    "weight_format": self.args.weight_format,
                 }
 
             if quantization_config.get("dataset", None) is not None:
                 quantization_config["trust_remote_code"] = self.args.trust_remote_code
-
-            if self.args.weight_format in {"int4_sym_g128", "int4_asym_g128", "int4_sym_g64", "int4_asym_g64"}:
-                logger.warning(
-                    f"--weight-format {self.args.weight_format} is deprecated, possible choices are fp32, fp16, int8, int4"
-                )
-                quantization_config["sym"] = "asym" not in self.args.weight_format
-                quantization_config["group_size"] = 128 if "128" in self.args.weight_format else 64
             ov_config = OVConfig(quantization_config=quantization_config)
 
         quantization_config = ov_config.quantization_config if ov_config else None

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -390,8 +390,6 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 raise ValueError("`all_layers` parameters is not supported for 8-bit quantization")
             if self.sensitivity_metric:
                 raise ValueError("`sensitivity_metric` parameters is not supported for 8-bit quantization")
-            if self.dataset:
-                raise ValueError("`dataset` parameters is not supported for 8-bit quantization")
             if self.quant_method == OVQuantizationMethod.AWQ:
                 raise ValueError("AWQ algorithm is not support for 8-bit quantization")
             if self.scale_estimation:

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -386,6 +386,16 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 raise ValueError(
                     f"For 8-bit quantization, `group_size` is expected to be set to -1, but was set to {self.group_size}"
                 )
+            if self.all_layers:
+                raise ValueError("`all_layers` parameters is not supported for 8-bit quantization")
+            if self.sensitivity_metric:
+                raise ValueError("`sensitivity_metric` parameters is not supported for 8-bit quantization")
+            if self.dataset:
+                raise ValueError("`dataset` parameters is not supported for 8-bit quantization")
+            if self.quant_method == OVQuantizationMethod.AWQ:
+                raise ValueError("AWQ algorithm is not support for 8-bit quantization")
+            if self.scale_estimation:
+                raise ValueError("Scale Estimation algorithm is not support for 8-bit quantization.")
 
         if self.tokenizer is not None and not isinstance(self.tokenizer, str):
             raise ValueError(f"Tokenizer is expected to be a string, but found {self.tokenizer}")
@@ -396,6 +406,15 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             raise ValueError(
                 f"Weight format must be one of the following: ['int4', 'int8', 'mxfp4'], but found: {self.weight_format}."
             )
+        if self.weight_format == "mxfp4":
+            if self.bits != 4:
+                raise ValueError(
+                    "When applying weight compression with 'mxfp4' weight format the `bits` parameters must be set to 4"
+                )
+            if self.quant_method == OVQuantizationMethod.AWQ:
+                raise ValueError("AWQ algorithm is not support for 'mxfp4' weight format")
+            if self.scale_estimation:
+                raise ValueError("Scale Estimation algorithm is not support for 'mxfp4' weight format")
 
 
 @dataclass

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -313,7 +313,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             Indicates whether to apply a scale estimation algorithm that minimizes the L2 error between the original and
             compressed layers. Providing a dataset is required to run scale estimation.
         weight_format (`str`, defaults to 'int'):
-            Data format weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4_e2m1'].
+            Data format weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4'].
     """
 
     def __init__(
@@ -392,9 +392,9 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
 
         if self.weight_format is None:
             self.weight_format = "int4" if self.bits == 4 else "int8"
-        if self.weight_format not in ["int4", "int8", "mxfp4_e2m1"]:
+        if self.weight_format not in ["int4", "int8", "mxfp4"]:
             raise ValueError(
-                f"Weight format must be one of the following: ['int4', 'int8', 'mxfp4_e2m1'], but found: {self.weight_format}."
+                f"Weight format must be one of the following: ['int4', 'int8', 'mxfp4'], but found: {self.weight_format}."
             )
 
 

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -313,7 +313,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             Indicates whether to apply a scale estimation algorithm that minimizes the L2 error between the original and
             compressed layers. Providing a dataset is required to run scale estimation.
         weight_format (`str`, defaults to 'int'):
-            Data type to compress weights to. Possible values: ['int4', 'int8', 'mxfp4_e2m1'].
+            Data format weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4_e2m1'].
     """
 
     def __init__(
@@ -394,7 +394,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             self.weight_format = "int4" if self.bits == 4 else "int8"
         if self.weight_format not in ["int4", "int8", "mxfp4_e2m1"]:
             raise ValueError(
-                f"Data type must be on of the following: ['int4', 'int8', 'mxfp4_e2m1'], but found: {self.weight_format}."
+                f"Weight format must be one of the following: ['int4', 'int8', 'mxfp4_e2m1'], but found: {self.weight_format}."
             )
 
 

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -509,7 +509,7 @@ class OVConfig(BaseConfig):
             if isinstance(self.quantization_config, OVWeightQuantizationConfig):
                 self.dtype = self.quantization_config.weight_format
             else:
-                self.dtype = f"int{quantization_config.bits}"
+                self.dtype = "int8"
         else:
             self.dtype = dtype
 

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -387,13 +387,17 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                     f"For 8-bit quantization, `group_size` is expected to be set to -1, but was set to {self.group_size}"
                 )
             if self.all_layers:
-                raise ValueError("`all_layers` parameters is not supported for 8-bit quantization")
+                raise ValueError("The `all_layers` parameter is not supported for 8-bit quantization")
             if self.sensitivity_metric:
-                raise ValueError("`sensitivity_metric` parameters is not supported for 8-bit quantization")
+                raise ValueError("The `sensitivity_metric` parameter is not supported for 8-bit quantization")
             if self.quant_method == OVQuantizationMethod.AWQ:
-                raise ValueError("AWQ algorithm is not support for 8-bit quantization")
+                raise ValueError(
+                    "The AWQ algorithm is not supported for 8-bit quantization and got `quant_method='awq'`, please update accordingly"
+                )
             if self.scale_estimation:
-                raise ValueError("Scale Estimation algorithm is not support for 8-bit quantization.")
+                raise ValueError(
+                    "The Scale Estimation algorithm is not supported for 8-bit quantization and got `scale_estimation=True`, please set `scale_estimation=False`"
+                )
 
         if self.tokenizer is not None and not isinstance(self.tokenizer, str):
             raise ValueError(f"Tokenizer is expected to be a string, but found {self.tokenizer}")
@@ -407,12 +411,12 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         if self.weight_format == "mxfp4":
             if self.bits != 4:
                 raise ValueError(
-                    "When applying weight compression with 'mxfp4' weight format the `bits` parameters must be set to 4"
+                    f"When applying weight compression with 'mxfp4' weight format the `bits` parameters must be set to 4, but found {self.bits}"
                 )
             if self.quant_method == OVQuantizationMethod.AWQ:
-                raise ValueError("AWQ algorithm is not support for 'mxfp4' weight format")
+                raise ValueError("The AWQ algorithm is not supported for 'mxfp4' weight format")
             if self.scale_estimation:
-                raise ValueError("Scale Estimation algorithm is not support for 'mxfp4' weight format")
+                raise ValueError("The Scale Estimation algorithm is not supported for 'mxfp4' weight format")
 
 
 @dataclass
@@ -505,7 +509,7 @@ class OVConfig(BaseConfig):
             if isinstance(self.quantization_config, OVWeightQuantizationConfig):
                 self.dtype = self.quantization_config.weight_format
             else:
-                self.dtype = "int8"
+                self.dtype = f"int{quantization_config.bits}"
         else:
             self.dtype = dtype
 

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -811,7 +811,7 @@ def _weight_only_quantization(
     if isinstance(config.sensitivity_metric, str):
         sensitivity_metric = getattr(SensitivityMetric, config.sensitivity_metric.upper())
 
-    if config.weight_format == "mxfp4_e2m1":
+    if config.weight_format == "mxfp4":
         mode = CompressWeightsMode.E2M1
     else:
         if config.bits == 8:

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -811,10 +811,15 @@ def _weight_only_quantization(
     if isinstance(config.sensitivity_metric, str):
         sensitivity_metric = getattr(SensitivityMetric, config.sensitivity_metric.upper())
 
-    if config.bits == 8:
-        mode = CompressWeightsMode.INT8_SYM if config.sym else CompressWeightsMode.INT8_ASYM
+    if config.dtype == "int":
+        if config.bits == 8:
+            mode = CompressWeightsMode.INT8_SYM if config.sym else CompressWeightsMode.INT8_ASYM
+        else:
+            mode = CompressWeightsMode.INT4_SYM if config.sym else CompressWeightsMode.INT4_ASYM
+    elif config.dtype == "mxfp4_e2m1":
+        mode = CompressWeightsMode.E2M1
     else:
-        mode = CompressWeightsMode.INT4_SYM if config.sym else CompressWeightsMode.INT4_ASYM
+        raise ValueError(f"Not supported weights data type: {config.dtype}.")
 
     return nncf.compress_weights(
         model,

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -811,15 +811,13 @@ def _weight_only_quantization(
     if isinstance(config.sensitivity_metric, str):
         sensitivity_metric = getattr(SensitivityMetric, config.sensitivity_metric.upper())
 
-    if config.dtype == "int":
+    if config.weight_format == "mxfp4_e2m1":
+        mode = CompressWeightsMode.E2M1
+    else:
         if config.bits == 8:
             mode = CompressWeightsMode.INT8_SYM if config.sym else CompressWeightsMode.INT8_ASYM
         else:
             mode = CompressWeightsMode.INT4_SYM if config.sym else CompressWeightsMode.INT4_ASYM
-    elif config.dtype == "mxfp4_e2m1":
-        mode = CompressWeightsMode.E2M1
-    else:
-        raise ValueError(f"Not supported weights data type: {config.dtype}.")
 
     return nncf.compress_weights(
         model,

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -94,24 +94,19 @@ class OVCLIExportTestCase(unittest.TestCase):
         ("text-generation-with-past", "opt125m", "int4_sym_g64", {"int8": 4, "int4": 72}),
         ("text-generation-with-past", "opt125m", "int4_asym_g64", {"int8": 4, "int4": 144}),
         ("text-generation-with-past", "opt125m", "mxfp4_e2m1", {"int8": 4, "f4e2m1": 72, "f8e8m0": 72}),
-        (
-            "text-generation-with-past",
-            "llama_awq",
-            "int4 --ratio 1.0 --sym --group-size 8 --all-layers",
-            {"int4": 16}
-        ),
+        ("text-generation-with-past", "llama_awq", "int4 --ratio 1.0 --sym --group-size 8 --all-layers", {"int4": 16}),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --awq --dataset wikitext2 --num-samples 100 "
             "--sensitivity-metric max_activation_variance",
-            {"int8": 4, "int4": 14}
+            {"int8": 4, "int4": 14},
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --scale-estimation --dataset wikitext2 --num-samples 100 ",
-            {"int8": 4, "int4": 14}
+            {"int8": 4, "int4": 14},
         ),
     ]
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -89,31 +89,29 @@ class OVCLIExportTestCase(unittest.TestCase):
     )
 
     TEST_4BIT_CONFIGURATONS = [
-        ("text-generation-with-past", "opt125m", "int4_sym_g128", 4, 72),
-        ("text-generation-with-past", "opt125m", "int4_asym_g128", 4, 144),
-        ("text-generation-with-past", "opt125m", "int4_sym_g64", 4, 72),
-        ("text-generation-with-past", "opt125m", "int4_asym_g64", 4, 144),
+        ("text-generation-with-past", "opt125m", "int4_sym_g128", {"int8": 4, "int4": 72}),
+        ("text-generation-with-past", "opt125m", "int4_asym_g128", {"int8": 4, "int4": 144}),
+        ("text-generation-with-past", "opt125m", "int4_sym_g64", {"int8": 4, "int4": 72}),
+        ("text-generation-with-past", "opt125m", "int4_asym_g64", {"int8": 4, "int4": 144}),
+        ("text-generation-with-past", "opt125m", "mxfp4_e2m1", {"int8": 4, "f4e2m1": 72, "f8e8m0": 72}),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 8 --all-layers",
-            0,
-            16,
+            {"int4": 16}
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --awq --dataset wikitext2 --num-samples 100 "
             "--sensitivity-metric max_activation_variance",
-            4,
-            14,
+            {"int8": 4, "int4": 14}
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --scale-estimation --dataset wikitext2 --num-samples 100 ",
-            4,
-            14,
+            {"int8": 4, "int4": 14}
         ),
     ]
 
@@ -219,8 +217,8 @@ class OVCLIExportTestCase(unittest.TestCase):
 
             expected_int8 = _ARCHITECTURES_TO_EXPECTED_INT8[model_type]
             for i, model in enumerate(models):
-                _, num_int8, _ = get_num_quantized_nodes(model)
-                self.assertEqual(expected_int8[i], num_int8)
+                _, num_weight_nodes = get_num_quantized_nodes(model)
+                self.assertEqual(expected_int8[i], num_weight_nodes["int8"])
 
     @parameterized.expand(SUPPORTED_SD_HYBRID_ARCHITECTURES)
     def test_exporters_cli_hybrid_quantization(self, model_type: str, exp_num_fq: int, exp_num_int8: int):
@@ -231,12 +229,12 @@ class OVCLIExportTestCase(unittest.TestCase):
                 check=True,
             )
             model = eval(_HEAD_TO_AUTOMODELS[model_type.replace("-refiner", "")]).from_pretrained(tmpdir)
-            num_fq, num_int8, _ = get_num_quantized_nodes(model.unet)
-            self.assertEqual(exp_num_int8, num_int8)
+            num_fq, num_weight_nodes = get_num_quantized_nodes(model.unet)
+            self.assertEqual(exp_num_int8, num_weight_nodes["int8"])
             self.assertEqual(exp_num_fq, num_fq)
 
     @parameterized.expand(TEST_4BIT_CONFIGURATONS)
-    def test_exporters_cli_int4(self, task: str, model_type: str, option: str, expected_int8: int, expected_int4: int):
+    def test_exporters_cli_int4(self, task: str, model_type: str, option: str, expected_num_weight_nodes: dict):
         with TemporaryDirectory() as tmpdir:
             result = subprocess.run(
                 f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} --task {task} --weight-format {option} {tmpdir}",
@@ -251,9 +249,9 @@ class OVCLIExportTestCase(unittest.TestCase):
                 else _HEAD_TO_AUTOMODELS[model_type.replace("-refiner", "")]
             ).from_pretrained(tmpdir, **model_kwargs)
 
-            _, num_int8, num_int4 = get_num_quantized_nodes(model)
-            self.assertEqual(expected_int8, num_int8)
-            self.assertEqual(expected_int4, num_int4)
+            _, num_weight_nodes = get_num_quantized_nodes(model)
+            expected_num_weight_nodes.update({k: 0 for k in set(num_weight_nodes) - set(expected_num_weight_nodes)})
+            self.assertEqual(expected_num_weight_nodes, num_weight_nodes)
             self.assertTrue("--awq" not in option or b"Applying AWQ" in result.stdout)
             self.assertTrue("--scale-estimation" not in option or b"Applying Scale Estimation" in result.stdout)
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -89,10 +89,8 @@ class OVCLIExportTestCase(unittest.TestCase):
     )
 
     TEST_4BIT_CONFIGURATONS = [
-        ("text-generation-with-past", "opt125m", "int4_sym_g128", {"int8": 4, "int4": 72}),
-        ("text-generation-with-past", "opt125m", "int4_asym_g128", {"int8": 4, "int4": 144}),
-        ("text-generation-with-past", "opt125m", "int4_sym_g64", {"int8": 4, "int4": 72}),
-        ("text-generation-with-past", "opt125m", "int4_asym_g64", {"int8": 4, "int4": 144}),
+        ("text-generation-with-past", "opt125m", "int4 --sym --group-size 128", {"int8": 4, "int4": 72}),
+        ("text-generation-with-past", "opt125m", "int4 --group-size 64", {"int8": 4, "int4": 144}),
         ("text-generation-with-past", "opt125m", "mxfp4_e2m1", {"int8": 4, "f4e2m1": 72, "f8e8m0": 72}),
         ("text-generation-with-past", "llama_awq", "int4 --ratio 1.0 --sym --group-size 8 --all-layers", {"int4": 16}),
         (

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -91,7 +91,7 @@ class OVCLIExportTestCase(unittest.TestCase):
     TEST_4BIT_CONFIGURATONS = [
         ("text-generation-with-past", "opt125m", "int4 --sym --group-size 128", {"int8": 4, "int4": 72}),
         ("text-generation-with-past", "opt125m", "int4 --group-size 64", {"int8": 4, "int4": 144}),
-        ("text-generation-with-past", "opt125m", "mxfp4_e2m1", {"int8": 4, "f4e2m1": 72, "f8e8m0": 72}),
+        ("text-generation-with-past", "opt125m", "mxfp4", {"int8": 4, "f4e2m1": 72, "f8e8m0": 72}),
         ("text-generation-with-past", "llama_awq", "int4 --ratio 1.0 --sym --group-size 8 --all-layers", {"int4": 16}),
         (
             "text-generation-with-past",

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -792,7 +792,7 @@ class OVQuantizationConfigTest(unittest.TestCase):
                 quant_method=OVQuantizationMethod.DEFAULT,
             ),
         ),
-        (OVWeightQuantizationConfig(dataset=["hello world", "i'm alive"]),),
+        (OVWeightQuantizationConfig(bits=4, dataset=["hello world", "i'm alive"]),),
         (
             OVQuantizationConfig(
                 ignored_scope={"names": ["op_name"]},
@@ -835,7 +835,7 @@ class OVQuantizationConfigTest(unittest.TestCase):
         (dict(num_samples=100), OVWeightQuantizationConfig, "Can't determine type of OV quantization config"),
         (dict(abc="def"), OVWeightQuantizationConfig, "Can't determine type of OV quantization config"),
         (
-            dict(bits=8, fast_bias_correction=True, dataset="wikitext2"),
+            dict(bits=4, fast_bias_correction=True, dataset="wikitext2"),
             OVWeightQuantizationConfig,
             "Can't determine type of OV quantization config",
         ),
@@ -857,7 +857,7 @@ class OVQuantizationConfigTest(unittest.TestCase):
         (dict(abc="def", weight_only=False), OVQuantizationConfig, None),
         (dict(abc="def", weight_only=True), OVWeightQuantizationConfig, None),
         (
-            dict(bits=8, fast_bias_correction=True, dataset="wikitext2", weight_only=True),
+            dict(bits=4, fast_bias_correction=True, dataset="wikitext2", weight_only=True),
             OVWeightQuantizationConfig,
             None,
         ),

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -187,17 +187,12 @@ class OVWeightCompressionTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES_STATEFUL_WITH_EXPECTED_8BIT_COMPRESSED_MATMULS = ((OVModelForCausalLM, "gpt2", 44, 44),)
 
     LOAD_IN_4_BITS_SCOPE = (
-        (
-            OVModelForCausalLM,
-            "gpt2",
-            dict(bits=4, sym=False, group_size=-1, ratio=0.8),
-            {"int4": 30, "int8": 14}
-        ),
+        (OVModelForCausalLM, "gpt2", dict(bits=4, sym=False, group_size=-1, ratio=0.8), {"int4": 30, "int8": 14}),
         (
             OVModelForCausalLM,
             "gpt2",
             dict(bits=4, dtype="mxfp4_e2m1", group_size=32),
-            {"f4e2m1": 20, 'f8e8m0': 20, "int8": 4}
+            {"f4e2m1": 20, "f8e8m0": 20, "int8": 4},
         ),
         (
             OVModelForCausalLM,
@@ -208,13 +203,13 @@ class OVWeightCompressionTest(unittest.TestCase):
                 group_size=32,
                 ignored_scope={"names": ["__module.model.transformer.h.2.mlp.c_fc/aten::addmm/MatMul"]},
             ),
-            {"int4": 38, "int8": 4}
+            {"int4": 38, "int8": 4},
         ),
         (
             OVModelForCausalLM,
             "gpt2",
             dict(bits=4, sym=False, group_size=-1, ratio=0.8, all_layers=True),
-            {"int4": 26, "int8": 18}
+            {"int4": 26, "int8": 18},
         ),
         (
             OVModelForCausalLM,
@@ -227,7 +222,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 sensitivity_metric="mean_activation_magnitude",
                 dataset="c4",
             ),
-            {"int4": 25, "int8": 14}
+            {"int4": 25, "int8": 14},
         ),
         (
             OVModelForCausalLM,
@@ -240,7 +235,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 sensitivity_metric="mean_activation_magnitude",
                 dataset=["one two, " * i for i in range(10)],
             ),
-            {"int4": 25, "int8": 14}
+            {"int4": 25, "int8": 14},
         ),
         (
             OVModelForCausalLM,
@@ -255,7 +250,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 quant_method=QuantizationMethod.AWQ,
                 scale_estimation=True,
             ),
-            {"int4": 12, "int8": 8}
+            {"int4": 12, "int8": 8},
         ),
         (
             OVModelForCausalLM,
@@ -269,7 +264,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 dataset="c4",
                 quant_method="awq",
             ),
-            {"int4": 12, "int8": 8}
+            {"int4": 12, "int8": 8},
         ),
     )
 
@@ -618,7 +613,9 @@ class OVWeightCompressionTest(unittest.TestCase):
                         compress_weights_patch.assert_called_with(unittest.mock.ANY, **compression_params)
 
     @parameterized.expand(LOAD_IN_4_BITS_SCOPE)
-    def test_ovmodel_4bit_dynamic_with_config(self, model_cls, model_name, quantization_config, expected_num_weight_nodes):
+    def test_ovmodel_4bit_dynamic_with_config(
+        self, model_cls, model_name, quantization_config, expected_num_weight_nodes
+    ):
         model_id = MODEL_NAMES[model_name]
         with tempfile.TemporaryDirectory() as tmp_dir:
             group_size = quantization_config.pop("group_size", 32)

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -191,7 +191,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         (
             OVModelForCausalLM,
             "gpt2",
-            dict(bits=4, weight_format="mxfp4_e2m1", group_size=32),
+            dict(bits=4, weight_format="mxfp4", group_size=32),
             {"f4e2m1": 20, "f8e8m0": 20, "int8": 4},
         ),
         (

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -191,7 +191,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         (
             OVModelForCausalLM,
             "gpt2",
-            dict(bits=4, dtype="mxfp4_e2m1", group_size=32),
+            dict(bits=4, weight_format="mxfp4_e2m1", group_size=32),
             {"f4e2m1": 20, "f8e8m0": 20, "int8": 4},
         ),
         (
@@ -512,8 +512,7 @@ class OVWeightCompressionTest(unittest.TestCase):
 
             openvino_config = OVConfig.from_pretrained(tmp_dir)
             self.assertEqual(openvino_config.quantization_config.bits, 4)
-            dtype = "int4" if quantization_config.dtype != "mxfp4_e2m1" else "mxfp4_e2m1"
-            self.assertEqual(openvino_config.dtype, dtype)
+            self.assertEqual(openvino_config.dtype, quantization_config.weight_format)
 
     @parameterized.expand(((OVModelForCausalLM, "gpt2"),))
     def test_ovmodel_stateful_load_with_compressed_weights(self, model_cls, model_type):
@@ -637,8 +636,7 @@ class OVWeightCompressionTest(unittest.TestCase):
 
             openvino_config = OVConfig.from_pretrained(tmp_dir)
             self.assertEqual(openvino_config.quantization_config.bits, 4)
-            dtype = "int4" if quantization_config.dtype != "mxfp4_e2m1" else "mxfp4_e2m1"
-            self.assertEqual(openvino_config.dtype, dtype)
+            self.assertEqual(openvino_config.dtype, quantization_config.weight_format)
 
 
 class OVQuantizerQATest(unittest.TestCase):

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -167,14 +167,23 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
 
 def get_num_quantized_nodes(ov_model):
     num_fake_quantize = 0
-    num_int8 = 0
-    num_int4 = 0
+    num_weight_nodes = {
+        "int8": 0,
+        "int4": 0,
+        "f4e2m1": 0,
+        "f8e8m0": 0,
+    }
     for elem in ov_model.model.get_ops():
         if "FakeQuantize" in elem.name:
             num_fake_quantize += 1
         for i in range(elem.get_output_size()):
-            if elem.get_output_element_type(i).get_type_name() in ["i8", "u8"]:
-                num_int8 += 1
-            if elem.get_output_element_type(i).get_type_name() in ["i4", "u4"]:
-                num_int4 += 1
-    return num_fake_quantize, num_int8, num_int4
+            type_name = elem.get_output_element_type(i).get_type_name()
+            if type_name in ["i8", "u8"]:
+                num_weight_nodes["int8"] += 1
+            if type_name in ["i4", "u4"]:
+                num_weight_nodes["int4"] += 1
+            if type_name == "f4e2m1":
+                num_weight_nodes["f4e2m1"] += 1
+            if type_name == "f8e8m0":
+                num_weight_nodes["f8e8m0"] += 1
+    return num_fake_quantize, num_weight_nodes


### PR DESCRIPTION
# What does this PR do?

- Added a new possible value for `--weight-format` CLI argument: `mxfp4`.
- Added `weight_format` parameter to `OVWeightQuantizationConfig` with three possible values: `int4`, `int8` and `mxfp4`. The latter is used for compression with mxfp4 `E2M1` mode.
- Added a couple of tests for compression with the new data type. Had to add quite a bit of logic to extend test infrastructure to work with data types other than int4/int8.
- Deprecate `"int4_sym_g128", "int4_asym_g128", "int4_sym_g64", "int4_asym_g64"` values for `--weight-format` CLI argument, as planned before.

### Example Usage

Optimum CLI:
```
optimum-cli export openvino -m facebook/opt-125m --task text-generation-with-past --weight-format mxfp4 ./tmp
```

Optimum Python API:
```
model = OVModelForCausalLM.from_pretrained(
    model_id="facebook/opt-125m",
    export=True,
    quantization_config=OVWeightQuantizationConfig(bits=4, weight_format="mxfp4"),
)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

