### PR TITLE
Deprecate `compression_option` and `compression_ratio` OV export parameters

### DIFF
--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -16,7 +16,6 @@
 import unittest
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Optional
 
 import torch
 from parameterized import parameterized
@@ -76,7 +75,6 @@ class ExportModelTest(unittest.TestCase):
     def _openvino_export(
         self,
         model_type: str,
-        compression_option: Optional[str] = None,
         stateful: bool = True,
         patch_16bit_model: bool = False,
     ):
@@ -106,7 +104,6 @@ class ExportModelTest(unittest.TestCase):
                     output=Path(tmpdirname),
                     task=supported_task,
                     preprocessors=preprocessors,
-                    compression_option=compression_option,
                     stateful=stateful,
                 )
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -108,16 +108,12 @@ class OVCLIExportTestCase(unittest.TestCase):
         ),
     ]
 
-    def _openvino_export(
-        self, model_name: str, task: str, compression_option: str = None, compression_ratio: float = None
-    ):
+    def _openvino_export(self, model_name: str, task: str):
         with TemporaryDirectory() as tmpdir:
             main_export(
                 model_name_or_path=model_name,
                 output=tmpdir,
                 task=task,
-                compression_option=compression_option,
-                compression_ratio=compression_ratio,
             )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)


### PR DESCRIPTION
# What does this PR do?

`compression_option` and `compression_ratio` parameters are no longer used and to be deprecated since v1.17


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

