### PR TITLE
Add a warning about OVTrainer deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,57 +157,6 @@ quantizer.quantize(ov_config=ov_config, calibration_dataset=calibration_dataset,
 optimized_model = OVModelForSequenceClassification.from_pretrained(save_dir)
 ```
 
-#### Quantization-aware training:
-
-Quantization aware training (QAT) is applied in order to simulate the effects of quantization during training, to alleviate its effects on the model’s accuracy. Here is an example on how to fine-tune a DistilBERT model on the sst-2 task while applying quantization aware training (QAT).
-
-```diff
-  import evaluate
-  import numpy as np
-  from datasets import load_dataset
-  from transformers import AutoModelForSequenceClassification, AutoTokenizer, TrainingArguments, default_data_collator
-- from transformers import Trainer
-+ from optimum.intel import OVConfig, OVModelForSequenceClassification, OVTrainer
-
-  model_id = "distilbert-base-uncased-finetuned-sst-2-english"
-  model = AutoModelForSequenceClassification.from_pretrained(model_id)
-  tokenizer = AutoTokenizer.from_pretrained(model_id)
-  dataset = load_dataset("glue", "sst2")
-  dataset = dataset.map(
-      lambda examples: tokenizer(examples["sentence"], padding=True, truncation=True, max_length=128), batched=True
-  )
-  metric = evaluate.load("glue", "sst2")
-  compute_metrics = lambda p: metric.compute(
-      predictions=np.argmax(p.predictions, axis=1), references=p.label_ids
-  )
-
-  # The directory where the quantized model will be saved
-  save_dir = "nncf_results"
-
-  # Load the default quantization configuration detailing the quantization we wish to apply
-+ ov_config = OVConfig()
-
-- trainer = Trainer(
-+ trainer = OVTrainer(
-      model=model,
-      args=TrainingArguments(save_dir, num_train_epochs=1.0, do_train=True, do_eval=True),
-      train_dataset=dataset["train"].select(range(300)),
-      eval_dataset=dataset["validation"],
-      compute_metrics=compute_metrics,
-      tokenizer=tokenizer,
-      data_collator=default_data_collator,
-+     ov_config=ov_config,
-+     task="text-classification",
-  )
-  train_result = trainer.train()
-  metrics = trainer.evaluate()
-  trainer.save_model()
-
-+ optimized_model = OVModelForSequenceClassification.from_pretrained(save_dir)
-```
-
-You can find more examples in the [documentation](https://huggingface.co/docs/optimum/intel/index).
-
 
 ## IPEX
 To load your IPEX model, you can just replace your `AutoModelForXxx` class with the corresponding `IPEXModelForXxx` class. You can set `export=True` to load a PyTorch checkpoint, export your model via TorchScript and apply IPEX optimizations : both operators optimization (replaced with customized IPEX operators) and graph-level optimization (like operators fusion) will be applied on your model.

--- a/docs/source/openvino/optimization.mdx
+++ b/docs/source/openvino/optimization.mdx
@@ -162,6 +162,8 @@ For more details, please refer to the corresponding NNCF [documentation](https:/
 
 Apart from optimizing a model after training like post-training quantization above, `optimum.openvino` also provides optimization methods during training, namely Quantization-Aware Training (QAT) and Joint Pruning, Quantization and Distillation (JPQD).
 
+> Note: Training-time optimization methods are deprecated and will be removed in optimum-intel v1.22.0.
+
 
 ### Quantization-Aware Training (QAT) 
 

--- a/docs/source/openvino/optimization.mdx
+++ b/docs/source/openvino/optimization.mdx
@@ -162,7 +162,11 @@ For more details, please refer to the corresponding NNCF [documentation](https:/
 
 Apart from optimizing a model after training like post-training quantization above, `optimum.openvino` also provides optimization methods during training, namely Quantization-Aware Training (QAT) and Joint Pruning, Quantization and Distillation (JPQD).
 
-> Note: Training-time optimization methods are deprecated and will be removed in optimum-intel v1.22.0.
+<Tip warning={true}>
+
+Training-time optimization methods are deprecated and will be removed in optimum-intel v1.22.0.
+
+</Tip>
 
 
 ### Quantization-Aware Training (QAT) 

--- a/optimum/intel/openvino/trainer.py
+++ b/optimum/intel/openvino/trainer.py
@@ -213,6 +213,10 @@ class OVTrainer(Trainer):
         ov_config: Optional[OVConfig] = None,
         task: Optional[str] = None,
     ):
+        logger.warning(
+            "Quantization aware training capabilities are deprecated and will be removed in optimum-intel v1.19.0. "
+        )
+
         self.neftune_noise_alpha = None
 
         super().__init__(

--- a/optimum/intel/openvino/trainer.py
+++ b/optimum/intel/openvino/trainer.py
@@ -214,7 +214,7 @@ class OVTrainer(Trainer):
         task: Optional[str] = None,
     ):
         logger.warning(
-            "Quantization aware training capabilities are deprecated and will be removed in optimum-intel v1.19.0. "
+            "OVTrainer is deprecated and will be removed in optimum-intel v1.22.0. "
         )
 
         self.neftune_noise_alpha = None

--- a/optimum/intel/openvino/trainer.py
+++ b/optimum/intel/openvino/trainer.py
@@ -213,9 +213,7 @@ class OVTrainer(Trainer):
         ov_config: Optional[OVConfig] = None,
         task: Optional[str] = None,
     ):
-        logger.warning(
-            "OVTrainer is deprecated and will be removed in optimum-intel v1.22.0. "
-        )
+        logger.warning("OVTrainer is deprecated and will be removed in optimum-intel v1.22.0.")
 
         self.neftune_noise_alpha = None
 


### PR DESCRIPTION
# What does this PR do?

OVTrainer was introduced for quantized/sparse fine-tuning of relatively small models, but most SotA transformers nowadays are much larger and finetuning them on client side is not feasible anymore. For such models weight compression is mainly applied now. So OVTrainer has not been popular for quite some time and at the same time has some testing burden connected with it. We've decided to deprecate it.

In this PR a warning about deprecation in the next release is added.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

