### PR TITLE
add name_or_path into model

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -74,6 +74,7 @@ class OVBaseModel(OptimizedModel):
         **kwargs,
     ):
         self.config = config
+        self.name_or_path = getattr(config, "name_or_path", None)
         self.model_save_dir = model_save_dir
         self._device = device.upper()
         self.is_dynamic = dynamic_shapes


### PR DESCRIPTION
# What does this PR do?
transformers.PretrainedModel init method initilaizes this field, while optimum not.

We see compatibility issue in llama-index due to that:

https://github.com/run-llama/llama_index/commit/f037de8d0471b37f9c4069ebef5dfb329633d2c6
AttributeError: 'OVModelForCausalLM' object has no attribute 'name_or_path'
 

