### PR TITLE
Reset OV inference request after model quantization

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -384,22 +384,27 @@ class OVQuantizer(OptimumQuantizer):
                     sub_models = filter(lambda x: x, (getattr(self.model, name) for name in sub_model_names))
                     for sub_model in sub_models:
                         _weight_only_quantization(sub_model.model, quantization_config_copy)
+                        sub_model.request = None
 
                     # Apply hybrid quantization to UNet
                     self.model.unet.model = _hybrid_quantization(
                         self.model.unet.model, quantization_config, calibration_dataset
                     )
+                    self.model.unet.request = None
                 else:
                     # The model may be for example OVModelForImageClassification, OVModelForAudioClassification, etc.
                     self.model.model = _hybrid_quantization(self.model.model, quantization_config, calibration_dataset)
+                    self.model.request = None
             else:
                 if is_diffusers_available() and isinstance(self.model, OVStableDiffusionPipelineBase):
                     sub_model_names = ["vae_encoder", "vae_decoder", "text_encoder", "text_encoder_2", "unet"]
                     sub_models = filter(lambda x: x, (getattr(self.model, name) for name in sub_model_names))
                     for sub_model in sub_models:
                         _weight_only_quantization(sub_model.model, quantization_config)
+                        sub_model.request = None
                 else:
                     _weight_only_quantization(self.model.model, quantization_config, calibration_dataset)
+                    self.model.request = None
             if save_directory is not None:
                 self.model.save_pretrained(save_directory)
                 ov_config.save_pretrained(save_directory)
@@ -427,6 +432,7 @@ class OVQuantizer(OptimumQuantizer):
         )
 
         self.model.model = quantized_model
+        self.model.request = None
         if save_directory is not None:
             self.model.save_pretrained(save_directory)
             ov_config.save_pretrained(save_directory)

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -384,13 +384,12 @@ class OVQuantizer(OptimumQuantizer):
                     sub_models = filter(lambda x: x, (getattr(self.model, name) for name in sub_model_names))
                     for sub_model in sub_models:
                         _weight_only_quantization(sub_model.model, quantization_config_copy)
-                        sub_model.request = None
 
                     # Apply hybrid quantization to UNet
                     self.model.unet.model = _hybrid_quantization(
                         self.model.unet.model, quantization_config, calibration_dataset
                     )
-                    self.model.unet.request = None
+                    self.model.clear_requests()
                 else:
                     # The model may be for example OVModelForImageClassification, OVModelForAudioClassification, etc.
                     self.model.model = _hybrid_quantization(self.model.model, quantization_config, calibration_dataset)
@@ -401,7 +400,7 @@ class OVQuantizer(OptimumQuantizer):
                     sub_models = filter(lambda x: x, (getattr(self.model, name) for name in sub_model_names))
                     for sub_model in sub_models:
                         _weight_only_quantization(sub_model.model, quantization_config)
-                        sub_model.request = None
+                    self.model.clear_requests()
                 else:
                     _weight_only_quantization(self.model.model, quantization_config, calibration_dataset)
                     self.model.request = None


### PR DESCRIPTION
# What does this PR do?

Reset inference request after model is changed by quantization. Otherwise, after quantization call the non-quantized model is inferred.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

