### PR TITLE
Add GPTQ support

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -158,6 +158,16 @@ def parse_args_openvino(parser: "ArgumentParser"):
         ),
     )
     optional_group.add_argument(
+        "--gptq",
+        action="store_true",
+        default=None,
+        help=(
+            "Indicates whether to apply GPTQ algorithm that optimizes compressed weights in a layer-wise fashion to "
+            "minimize the difference between activations of a compressed and original layer. Please note, that "
+            "applying GPTQ takes additional memory and time."
+        ),
+    )
+    optional_group.add_argument(
         "--sensitivity-metric",
         type=str,
         default=None,
@@ -203,6 +213,8 @@ def no_compression_parameter_provided(args):
                 args.dataset,
                 args.num_samples,
                 args.awq,
+                args.scale_estimation,
+                args.gptq,
                 args.sensitivity_metric,
             )
         )
@@ -272,6 +284,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                     "quant_method": "awq" if self.args.awq else "default",
                     "sensitivity_metric": self.args.sensitivity_metric,
                     "scale_estimation": self.args.scale_estimation,
+                    "gptq": self.args.gptq,
                     "weight_format": self.args.weight_format,
                 }
 

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -338,6 +338,9 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             compressed layers. Providing a dataset is required to run scale estimation.
         weight_format (`str`, defaults to 'int'):
             Data format weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4'].
+        qptq (`bool`, *optional*):
+            Whether to apply GPTQ algorithm. GPTQ optimizes compressed weights in a layer-wise fashion to minimize the
+            difference between activations of a compressed and original layer. Dataset is required to run GPTQ.
     """
 
     def __init__(
@@ -356,6 +359,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         quant_method: Union[str, OVQuantizationMethod] = OVQuantizationMethod.DEFAULT,
         scale_estimation: bool = None,
         weight_format: Optional[str] = None,
+        gptq: bool = None,
         **kwargs,
     ):
         super().__init__(bits=bits, sym=sym, ignored_scope=ignored_scope, num_samples=num_samples)
@@ -369,6 +373,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         self.quant_method = OVQuantizationMethod(quant_method) if isinstance(quant_method, str) else quant_method
         self.scale_estimation = scale_estimation
         self.weight_format = weight_format
+        self.gptq = gptq
         self.post_init()
 
     def post_init(self):
@@ -422,6 +427,10 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 raise ValueError(
                     "The Scale Estimation algorithm is not supported for 8-bit quantization and got `scale_estimation=True`, please set `scale_estimation=False`"
                 )
+            if self.gptq:
+                raise ValueError(
+                    "The GPTQ algorithm is not supported for 8-bit quantization and got `gptq=True`, please set `gptq=False`"
+                )
 
         if self.tokenizer is not None and not isinstance(self.tokenizer, str):
             raise ValueError(f"Tokenizer is expected to be a string, but found {self.tokenizer}")
@@ -441,6 +450,8 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 raise ValueError("The AWQ algorithm is not supported for 'mxfp4' weight format")
             if self.scale_estimation:
                 raise ValueError("The Scale Estimation algorithm is not supported for 'mxfp4' weight format")
+            if self.gptq:
+                raise ValueError("The GPTQ algorithm is not supported for 'mxfp4' weight format")
 
 
 @dataclass

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -835,6 +835,7 @@ def _weight_only_quantization(
         dataset=dataset,
         subset_size=config.num_samples if config.num_samples else 128,
         scale_estimation=config.scale_estimation,
+        gptq=config.gptq,
     )
 
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -110,6 +110,12 @@ class OVCLIExportTestCase(unittest.TestCase):
             "int4 --ratio 1.0 --sym --group-size 16 --scale-estimation --dataset wikitext2 --num-samples 100 ",
             {"int8": 4, "int4": 14},
         ),
+        (
+            "text-generation-with-past",
+            "llama_awq",
+            "int4 --ratio 1.0 --sym --group-size 16 --gptq --dataset wikitext2 --num-samples 100 ",
+            {"int8": 4, "int4": 14},
+        ),
     ]
 
     def _openvino_export(self, model_name: str, task: str):
@@ -247,6 +253,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             self.assertEqual(expected_num_weight_nodes, num_weight_nodes)
             self.assertTrue("--awq" not in option or b"Applying AWQ" in result.stdout)
             self.assertTrue("--scale-estimation" not in option or b"Applying Scale Estimation" in result.stdout)
+            self.assertTrue("--gptq" not in option or b"Applying GPTQ" in result.stdout)
 
     def test_exporters_cli_int4_with_local_model_and_default_config(self):
         with TemporaryDirectory() as tmpdir:

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -601,6 +601,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                     "awq": None,
                     "subset_size": 128,
                     "scale_estimation": None,
+                    "gptq": None,
                 }
                 compress_weights_patch.assert_called_with(
                     unittest.mock.ANY,
@@ -648,6 +649,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                     "awq": None,
                     "subset_size": 128,
                     "scale_estimation": None,
+                    "gptq": None,
                 }
                 compress_weights_patch.assert_called_with(unittest.mock.ANY, **compression_params)
 


### PR DESCRIPTION
# What does this PR do?

Add support for NNCF weights compression with GPTQ. 

Usage:
```
quantization_config = OVWeightQuantizationConfig(bits=4, dataset="wikitext2", gptq=True)
ov_config = OVConfig(quantization_config=quantization_config)
model = OVModelFromCausalLM.from_pretrained(model_id, export=True, ov_config=ov_config)
```

```
optimum-cli export openvino --task text-generation-with-past -m <model_id> --weight-format int4 --dataset wikitext2 --gptq ./model
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

