### PR TITLE
disable long scale usage for exported phi3

### DIFF
--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -1549,6 +1549,12 @@ class Phi3ModelPatcher(DecoderModelPatcher):
     def __enter__(self):
         super().__enter__()
 
+        # currently, long RoPE can not be traced for long context support, disable it for avoid potential accuracy issues
+        if self._model.config.max_position_embeddings != getattr(
+            self._model.config, "original_max_position_embeddings", self._model.config.max_position_embeddings
+        ):
+            self._model.config.max_position_embeddings = self._model.config.original_max_position_embe
+
         if is_transformers_version(">=", "4.42.0"):
             self._model.model._orig_forward = self._model.model.forward
             self._model.model.forward = types.MethodType(phi3_442_forward, self._model.model)

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -331,6 +331,10 @@ class OVBaseDecoderModel(OVModel):
 
         config.is_decoder = True
         config.is_encoder_decoder = False
+        if config.model_type == "phi3" and config.max_position_embeddings != getattr(
+            config, "original_max_position_embeddings", config.max_position_embeddings
+        ):
+            config.max_position_embeddings = config.original_max_position_embeddings
         config.save_pretrained(save_dir_path)
         return cls._from_pretrained(
             model_id=save_dir_path,


### PR DESCRIPTION
# What does this PR do?
for phi3, phi3.5 due to torchscript (I guess onnx has the same issue) limitations we can not capture condition for switching between short and long context if it is applicable, as the result it may lead to issues when user passed larger prompt then original max position embeddings (can be visible in lm-evaluation-harness tool on wiki-text dataset, where max_position_embedding used for splitting text on chunks for long samples). This is workaround that limit max_position_embeddings for exported model. We are investigating proper fix for this issue (that makes model suitable for both long and short context)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

