### PR TITLE
[OV] Add verbosity to a failed test

### DIFF
--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -176,10 +176,13 @@ class OVStableDiffusionImg2ImgPipelineTest(OVStableDiffusionPipelineBaseTest):
         inputs["prompt"] = "A painting of a squirrel eating a burger"
         inputs["image"] = floats_tensor((batch_size, 3, height, width), rng=random.Random(SEED))
         np.random.seed(0)
-        output = pipeline(**inputs).images[0, -3:, -3:, -1]
+        output = pipeline(**inputs).images[0, -3:, -3:, -1].flatten()
         # https://github.com/huggingface/diffusers/blob/v0.17.1/tests/pipelines/stable_diffusion/test_onnx_stable_diffusion_img2img.py#L71
         expected_slice = np.array([0.69643, 0.58484, 0.50314, 0.58760, 0.55368, 0.59643, 0.51529, 0.41217, 0.49087])
-        self.assertTrue(np.allclose(output.flatten(), expected_slice, atol=1e-1))
+        self.assertTrue(
+            np.allclose(output, expected_slice, atol=1e-1),
+            msg=f"Max difference: {np.abs(output - expected_slice).max()}. Actual value: {output}",
+        )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     @pytest.mark.run_slow


### PR DESCRIPTION
# What does this PR do?

The test `tests/openvino/test_diffusion.py::OVStableDiffusionImg2ImgPipelineTest::test_compare_diffusers_pipeline_0_stable_diffusion` fails from time to time. I was not able to reproduce the fail locally. In this PR some fail info is added to help fix the test in the future.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

