### PR TITLE
ignore gpt neo for better transformer only for transformers>=4.45

### DIFF
--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -45,7 +45,13 @@ if TYPE_CHECKING:
         from transformers.modeling_tf_utils import TFPreTrainedModel
 
 
-BETTERTRANSFORMER_IGNORE = ("codegen", "gpt_neo")
+BETTERTRANSFORMER_IGNORE = [
+    "codegen",
+]
+
+# in transformers 4.45 gpt_neo has SDPA
+if is_transformers_version(">=", "4.44.99"):
+    BETTERTRANSFORMER_IGNORE.append("gpt_neo")
 
 
 def patch_model_with_bettertransformer(model):


### PR DESCRIPTION
# What does this PR do?

we still need to apply bettertransformer for old transformers for gpt_neo where sdpa attention is not available yet 

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

