### PR TITLE
fix issue with imposibility remove uncompressed model in tmp after compression

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -24,10 +24,6 @@ from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
 from transformers.utils import is_torch_available
 
 from openvino.runtime import Core, save_model
-
-
-# create core globally before openvino tokenizers import necessary to prevent errors with failed extension loading
-core = Core()
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig
 from optimum.exporters.onnx.constants import SDPA_ARCHS_ONNX_EXPORT_NOT_SUPPORTED
@@ -57,6 +53,8 @@ if is_torch_available():
 
 logger = logging.getLogger(__name__)
 
+# create core globally before openvino tokenizers import necessary to prevent errors with failed extension loading
+core = Core()
 
 
 def infer_task(

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -14,7 +14,6 @@
 
 import gc
 import logging
-
 import warnings
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
@@ -24,7 +23,8 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
 from transformers.utils import is_torch_available
 
-from openvino.runtime import Core, Type, save_model
+from openvino.runtime import Core, save_model
+
 
 # create core globally before openvino tokenizers import necessary to prevent errors with failed extension loading
 core = Core()

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -14,9 +14,8 @@
 
 import gc
 import logging
-import operator
+
 import warnings
-from functools import reduce
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Union
 
@@ -26,6 +25,9 @@ from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase
 from transformers.utils import is_torch_available
 
 from openvino.runtime import Core, Type, save_model
+
+# create core globally before openvino tokenizers import necessary to prevent errors with failed extension loading
+core = Core()
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig
 from optimum.exporters.onnx.constants import SDPA_ARCHS_ONNX_EXPORT_NOT_SUPPORTED
@@ -390,7 +392,7 @@ def main_export(
         model_name_or_path, subfolder=subfolder, trust_remote_code=trust_remote_code
     )
 
-    submodel_paths = export_from_model(
+    submodel_paths, model_sizes = export_from_model(
         model=model,
         output=output,
         task=task,
@@ -403,6 +405,7 @@ def main_export(
         device=device,
         trust_remote_code=trust_remote_code,
         patch_16bit_model=patch_16bit,
+        return_model_sizes=True,
         **kwargs_shapes,
     )
 
@@ -413,17 +416,10 @@ def main_export(
     del model
     gc.collect()
 
-    core = Core()
-    for submodel_path in submodel_paths:
+    for submodel_path, num_parameters in zip(submodel_paths, model_sizes):
         submodel_path = Path(output) / submodel_path
-        submodel = core.read_model(submodel_path)
-
         quantization_config = None
         if ov_config is None:
-            num_parameters = 0
-            for op in submodel.get_ops():
-                if op.get_type_name() == "Constant" and op.get_element_type() in [Type.f16, Type.f32, Type.bf16]:
-                    num_parameters += reduce(operator.mul, op.shape, 1)
             if num_parameters >= _MAX_UNCOMPRESSED_SIZE:
                 if is_nncf_available():
                     quantization_config = {"bits": 8, "sym": False}
@@ -439,6 +435,8 @@ def main_export(
         if quantization_config is None:
             continue
 
+        submodel = core.read_model(submodel_path)
+
         if not is_nncf_available():
             raise ImportError("Quantization of the weights requires nncf, please install it with `pip install nncf`")
 
@@ -449,7 +447,7 @@ def main_export(
         compressed_submodel_path = submodel_path.parent / f"{submodel_path.stem}_compressed.xml"
         save_model(submodel, compressed_submodel_path, compress_to_fp16=False)
         del submodel
-
+        gc.collect()
         submodel_path.unlink()
         submodel_path.with_suffix(".bin").unlink()
         compressed_submodel_path.rename(submodel_path)

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -58,6 +58,7 @@ if is_torch_available():
 logger = logging.getLogger(__name__)
 
 
+
 def infer_task(
     task,
     model_name_or_path,
@@ -435,12 +436,12 @@ def main_export(
         if quantization_config is None:
             continue
 
-        submodel = core.read_model(submodel_path)
-
         if not is_nncf_available():
             raise ImportError("Quantization of the weights requires nncf, please install it with `pip install nncf`")
 
         from optimum.intel.openvino.quantization import _weight_only_quantization
+
+        submodel = core.read_model(submodel_path)
 
         _weight_only_quantization(submodel, quantization_config)
 

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -60,9 +60,9 @@ from .utils import (
     OV_XML_FILE_NAME,
     _get_input_info,
     _get_open_clip_submodels_fn_and_export_configs,
+    calculate_model_size,
     clear_class_registry,
     remove_none_from_dummy_inputs,
-    calculate_model_size
 )
 
 
@@ -451,7 +451,7 @@ def export_pytorch(
         model_size = None
 
         if return_model_size:
-           model_size = calculate_model_size(ov_model)
+            model_size = calculate_model_size(ov_model)
         _save_model(
             ov_model,
             output,

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -155,7 +155,7 @@ def export(
             stateful=stateful,
             patch_16bit_model=patch_16bit_model,
             library_name=library_name,
-            return_model_size=return_model_size
+            return_model_size=return_model_size,
         )
 
     elif is_tf_available() and issubclass(type(model), TFPreTrainedModel):
@@ -166,7 +166,15 @@ def export(
             raise RuntimeError("`tf2onnx` does not support export on CUDA device.")
         if input_shapes is not None:
             logger.info("`input_shapes` argument is not supported by the Tensorflow ONNX export and will be ignored.")
-        return export_tensorflow(model, config, opset, output, ov_config=ov_config, return_model_size=return_model_size, library_name=library_name)
+        return export_tensorflow(
+            model,
+            config,
+            opset,
+            output,
+            ov_config=ov_config,
+            return_model_size=return_model_size,
+            library_name=library_name,
+        )
 
     else:
         raise RuntimeError(
@@ -181,7 +189,7 @@ def export_tensorflow(
     output: Path,
     ov_config: Optional["OVConfig"] = None,
     library_name: Optional[str] = None,
-    return_model_size: bool = False
+    return_model_size: bool = False,
 ):
     """
     Export the TensorFlow model to OpenVINO format.
@@ -228,7 +236,7 @@ def export_pytorch_via_onnx(
     model_kwargs: Optional[Dict[str, Any]] = None,
     ov_config: Optional["OVConfig"] = None,
     library_name: Optional[str] = None,
-    return_model_size: bool = False
+    return_model_size: bool = False,
 ):
     """
     Exports a PyTorch model to an OpenVINO Intermediate Representation via ONNX export.
@@ -272,7 +280,6 @@ def export_pytorch_via_onnx(
 
     library_name = _infer_library_from_model_or_model_class(model=model, library_name=library_name)
 
-
     model_size = None
     if return_model_size:
         model_size = calculate_model_size(ov_model)
@@ -300,7 +307,7 @@ def export_pytorch(
     stateful: bool = False,
     patch_16bit_model: bool = False,
     library_name: Optional[str] = None,
-    return_model_size: bool = False
+    return_model_size: bool = False,
 ) -> Tuple[List[str], List[str]]:
     """
     Exports a PyTorch model to an OpenVINO Intermediate Representation.
@@ -434,7 +441,7 @@ def export_pytorch(
                 model_kwargs,
                 ov_config=ov_config,
                 library_name=library_name,
-                return_model_size=return_model_size
+                return_model_size=return_model_size,
             )
 
         ov_model.validate_nodes_and_infer_types()  # TODO: remove as unnecessary validation?
@@ -487,7 +494,7 @@ def export_models(
     stateful: bool = True,
     patch_16bit_model: bool = False,
     library_name: Optional[str] = None,
-    return_model_sizes:bool = False
+    return_model_sizes: bool = False,
 ) -> Tuple[List[List[str]], List[List[str]]]:
     """
     Export the models to OpenVINO IR format
@@ -529,19 +536,19 @@ def export_models(
         output_path = output_dir / output_name
         output_path.parent.mkdir(parents=True, exist_ok=True)
         model_outputs = export(
-                model=submodel,
-                config=sub_export_config,
-                output=output_path,
-                opset=opset,
-                device=device,
-                input_shapes=input_shapes,
-                model_kwargs=model_kwargs,
-                ov_config=ov_config,
-                stateful=stateful[i] if isinstance(stateful, (list, tuple)) else stateful,
-                patch_16bit_model=patch_16bit_model,
-                library_name=library_name,
-                return_model_size=return_model_sizes,
-            )
+            model=submodel,
+            config=sub_export_config,
+            output=output_path,
+            opset=opset,
+            device=device,
+            input_shapes=input_shapes,
+            model_kwargs=model_kwargs,
+            ov_config=ov_config,
+            stateful=stateful[i] if isinstance(stateful, (list, tuple)) else stateful,
+            patch_16bit_model=patch_16bit_model,
+            library_name=library_name,
+            return_model_size=return_model_sizes,
+        )
         outputs.append(model_outputs if not return_model_sizes else model_outputs[:-1])
         if return_model_sizes:
             model_sizes.append(model_outputs[-1])
@@ -743,7 +750,7 @@ def export_from_model(
         model_kwargs=model_kwargs,
         patch_16bit_model=patch_16bit_model,
         library_name=library_name,
-        return_model_sizes=return_model_sizes
+        return_model_sizes=return_model_sizes,
     )
 
     if not return_model_sizes:

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -13,14 +13,14 @@
 #  limitations under the License.
 
 import inspect
-from collections import namedtuple
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import operator
+from collections import namedtuple
 from functools import reduce
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from transformers.utils import is_torch_available
 
-from openvino.runtime import Dimension, PartialShape, Symbol, Model, Type
+from openvino.runtime import Dimension, Model, PartialShape, Symbol, Type
 from openvino.runtime.utils.types import get_element_type
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -16,7 +16,7 @@ import logging
 import os
 import warnings
 from pathlib import Path
-from tempfile import TemporaryDirectory, gettempdir
+from tempfile import gettempdir
 from typing import Dict, Optional, Union
 
 import openvino
@@ -41,6 +41,7 @@ from .utils import (
     ONNX_WEIGHTS_NAME,
     OV_TO_PT_TYPE,
     OV_XML_FILE_NAME,
+    TemporaryDirectory,
     _print_compiled_model_properties,
     model_has_dynamic_inputs,
 )
@@ -570,7 +571,7 @@ class OVBaseModel(OptimizedModel):
             kwargs (`Dict`, *optional*):
                 kwargs will be passed to the model during initialization
         """
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(ignore_cleanup_errors=True)
         save_dir_path = Path(save_dir.name)
         # This attribute is needed to keep one reference on the temporary directory, since garbage collecting
         # would end-up removing the directory containing the underlying OpenVINO model
@@ -628,7 +629,7 @@ class OVBaseModel(OptimizedModel):
         stateful: bool = False,
         **kwargs,
     ):
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(ignore_cleanup_errors=True)
         save_dir_path = Path(save_dir.name)
         compile_only = kwargs.pop("compile_only", False)
         if compile_only:

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -15,7 +15,6 @@
 import logging
 import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Dict, Optional, Union
 
 import openvino
@@ -36,6 +35,7 @@ from .utils import (
     OV_DECODER_NAME,
     OV_DECODER_WITH_PAST_NAME,
     OV_ENCODER_NAME,
+    TemporaryDirectory,
 )
 
 
@@ -337,7 +337,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             kwargs (`Dict`, *optional*):
                 kwargs will be passed to the model during initialization
         """
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(ignore_cleanup_errors=True)
         save_dir_path = Path(save_dir.name)
 
         # This attribute is needed to keep one reference on the temporary directory, since garbage collecting

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -331,7 +331,7 @@ class OVBaseDecoderModel(OVModel):
             config, "original_max_position_embeddings", config.max_position_embeddings
         ):
             config.max_position_embeddings = config.original_max_position_embeddings
-
+        config.save_pretrained(save_dir_path)
         return cls._from_pretrained(
             model_id=save_dir_path,
             config=config,

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -15,7 +15,6 @@ import copy
 import logging
 import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
@@ -50,6 +49,7 @@ from .utils import (
     ONNX_WEIGHTS_NAME,
     OV_XML_FILE_NAME,
     STR_TO_OV_TYPE,
+    TemporaryDirectory,
     get_export_transformers_version,
     model_has_dynamic_inputs,
 )

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -276,7 +276,7 @@ class OVBaseDecoderModel(OVModel):
         quantization_config: Optional[Union[OVWeightQuantizationConfig, Dict]] = None,
         **kwargs,
     ):
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(ignore_cleanup_errors=True)
         save_dir_path = Path(save_dir.name)
         # This attribute is needed to keep one reference on the temporary directory, since garbage collecting
         # would end-up removing the directory containing the underlying OpenVINO model

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -18,7 +18,6 @@ import os
 import shutil
 from copy import deepcopy
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Any, Dict, List, Optional, Union
 
 import numpy as np
@@ -60,7 +59,8 @@ from ...exporters.openvino import main_export
 from .configuration import OVConfig, OVQuantizationMethod, OVWeightQuantizationConfig
 from .loaders import OVTextualInversionLoaderMixin
 from .modeling_base import OVBaseModel, OVModelPart
-from .utils import ONNX_WEIGHTS_NAME, OV_TO_NP_TYPE, OV_XML_FILE_NAME
+from .utils import ONNX_WEIGHTS_NAME, OV_TO_NP_TYPE, OV_XML_FILE_NAME, TemporaryDirectory,
+
 
 
 core = Core()
@@ -368,7 +368,7 @@ class OVStableDiffusionPipelineBase(OVBaseModel, OVTextualInversionLoaderMixin):
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(ignore_cleanup_errors=True)
         save_dir_path = Path(save_dir.name)
 
         # If load_in_8bit and quantization_config not specified then ov_config is set to None and will be set by default in convert depending on the model size

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -59,8 +59,7 @@ from ...exporters.openvino import main_export
 from .configuration import OVConfig, OVQuantizationMethod, OVWeightQuantizationConfig
 from .loaders import OVTextualInversionLoaderMixin
 from .modeling_base import OVBaseModel, OVModelPart
-from .utils import ONNX_WEIGHTS_NAME, OV_TO_NP_TYPE, OV_XML_FILE_NAME, TemporaryDirectory,
-
+from .utils import ONNX_WEIGHTS_NAME, OV_TO_NP_TYPE, OV_XML_FILE_NAME, TemporaryDirectory
 
 
 core = Core()

--- a/optimum/intel/openvino/modeling_open_clip.py
+++ b/optimum/intel/openvino/modeling_open_clip.py
@@ -16,7 +16,6 @@ import json
 import logging
 import os
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Dict, Optional, Union
 
 import numpy as np
@@ -39,6 +38,7 @@ from ...exporters.openvino import main_export
 from ..utils.modeling_utils import _find_files_matching_pattern, _OpenClipForZeroShotImageClassification
 from .configuration import OVConfig, OVWeightQuantizationConfig
 from .modeling import MODEL_START_DOCSTRING, OVModel
+from .utils import TemporaryDirectory
 
 
 logger = logging.getLogger(__name__)
@@ -237,7 +237,7 @@ class OVModelOpenCLIPText(OVModelOpenCLIPBase):
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(ignore_cleanup_errors=True)
         save_dir_path = Path(save_dir.name)
         # This attribute is needed to keep one reference on the temporary directory, since garbage collecting
         # would end-up removing the directory containing the underlying OpenVINO model
@@ -362,7 +362,7 @@ class OVModelOpenCLIPVisual(OVModelOpenCLIPBase):
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(ignore_cleanup_errors=True)
         save_dir_path = Path(save_dir.name)
         # This attribute is needed to keep one reference on the temporary directory, since garbage collecting
         # would end-up removing the directory containing the underlying OpenVINO model

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -2,7 +2,6 @@ import logging
 import os
 import warnings
 from pathlib import Path
-from tempfile import TemporaryDirectory
 from typing import Dict, Optional, Tuple, Union
 
 import numpy as np
@@ -19,6 +18,7 @@ from ...exporters.openvino.stateful import ensure_stateful_is_available
 from .configuration import OVConfig, OVWeightQuantizationConfig
 from .modeling_base import OVBaseModel, OVModelPart
 from .modeling_decoder import CausalLMOutputWithPast, OVModelForCausalLM
+from .utils import TemporaryDirectory
 
 
 logger = logging.getLogger(__name__)
@@ -481,7 +481,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
                 "Please provide openvino model obtained using optimum-cli or saved on disk using `save_pretrained`"
             )
             compile_only = False
-        save_dir = TemporaryDirectory()
+        save_dir = TemporaryDirectory(ignore_cleanup_errors=True)
         save_dir_path = Path(save_dir.name)
 
         # This attribute is needed to keep one reference on the temporary directory, since garbage collecting

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -555,7 +555,7 @@ class OVQuantizer(OptimumQuantizer):
         if not save_onnx_model:
             export_kwargs = {"stateful": stateful}
 
-        (_, _, is_onnx), _ = export_fn(model=model, config=onnx_config, output=model_path, opset=opset, **export_kwargs)
+        _, _, is_onnx = export_fn(model=model, config=onnx_config, output=model_path, opset=opset, **export_kwargs)
         if is_onnx:
             # Load and save the compressed model
             model = core.read_model(onnx_path)

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -555,7 +555,7 @@ class OVQuantizer(OptimumQuantizer):
         if not save_onnx_model:
             export_kwargs = {"stateful": stateful}
 
-        _, _, is_onnx = export_fn(model=model, config=onnx_config, output=model_path, opset=opset, **export_kwargs)
+        (_, _, is_onnx), _ = export_fn(model=model, config=onnx_config, output=model_path, opset=opset, **export_kwargs)
         if is_onnx:
             # Load and save the compressed model
             model = core.read_model(onnx_path)

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -16,7 +16,7 @@
 import json
 import logging
 import os
-import shutil
+import stat
 import warnings
 import weakref
 from glob import glob
@@ -234,6 +234,194 @@ def model_has_dynamic_inputs(model):
     return is_dynamic
 
 
+# adopted from https://github.com/python/cpython/blob/3.12/Lib/shutil.py for compatibility with python<3.10
+def _rmtree(path, ignore_errors=False, onerror=None, *, onexc=None, dir_fd=None):
+    """Recursively delete a directory tree.
+
+    If dir_fd is not None, it should be a file descriptor open to a directory;
+    path will then be relative to that directory.
+    dir_fd may not be implemented on your platform.
+    If it is unavailable, using it will raise a NotImplementedError.
+
+    If ignore_errors is set, errors are ignored; otherwise, if onexc or
+    onerror is set, it is called to handle the error with arguments (func,
+    path, exc_info) where func is platform and implementation dependent;
+    path is the argument to that function that caused it to fail; and
+    the value of exc_info describes the exception. For onexc it is the
+    exception instance, and for onerror it is a tuple as returned by
+    sys.exc_info().  If ignore_errors is false and both onexc and
+    onerror are None, the exception is reraised.
+
+    onerror is deprecated and only remains for backwards compatibility.
+    If both onerror and onexc are set, onerror is ignored and onexc is used.
+    """
+    _use_fd_functions = (
+        {os.open, os.stat, os.unlink, os.rmdir} <= os.supports_dir_fd
+        and os.scandir in os.supports_fd
+        and os.stat in os.supports_follow_symlinks
+    )
+
+    if hasattr(os.stat_result, "st_file_attributes"):
+
+        def _rmtree_islink(path):
+            try:
+                st = os.lstat(path)
+                return stat.S_ISLNK(st.st_mode) or (
+                    st.st_file_attributes & stat.FILE_ATTRIBUTE_REPARSE_POINT
+                    and st.st_reparse_tag == stat.IO_REPARSE_TAG_MOUNT_POINT
+                )
+            except OSError:
+                return False
+
+    else:
+
+        def _rmtree_islink(path):
+            return os.path.islink(path)
+
+    def _rmtree_safe_fd(stack, onexc):
+        # Each stack item has four elements:
+        # * func: The first operation to perform: os.lstat, os.close or os.rmdir.
+        #   Walking a directory starts with an os.lstat() to detect symlinks; in
+        #   this case, func is updated before subsequent operations and passed to
+        #   onexc() if an error occurs.
+        # * dirfd: Open file descriptor, or None if we're processing the top-level
+        #   directory given to rmtree() and the user didn't supply dir_fd.
+        # * path: Path of file to operate upon. This is passed to onexc() if an
+        #   error occurs.
+        # * orig_entry: os.DirEntry, or None if we're processing the top-level
+        #   directory given to rmtree(). We used the cached stat() of the entry to
+        #   save a call to os.lstat() when walking subdirectories.
+        func, dirfd, path, orig_entry = stack.pop()
+        name = path if orig_entry is None else orig_entry.name
+        try:
+            if func is os.close:
+                os.close(dirfd)
+                return
+            if func is os.rmdir:
+                os.rmdir(name, dir_fd=dirfd)
+                return
+
+            # Note: To guard against symlink races, we use the standard
+            # lstat()/open()/fstat() trick.
+            assert func is os.lstat
+            if orig_entry is None:
+                orig_st = os.lstat(name, dir_fd=dirfd)
+            else:
+                orig_st = orig_entry.stat(follow_symlinks=False)
+
+            func = os.open  # For error reporting.
+            topfd = os.open(name, os.O_RDONLY | os.O_NONBLOCK, dir_fd=dirfd)
+
+            func = os.path.islink  # For error reporting.
+            try:
+                if not os.path.samestat(orig_st, os.fstat(topfd)):
+                    # Symlinks to directories are forbidden, see GH-46010.
+                    raise OSError("Cannot call rmtree on a symbolic link")
+                stack.append((os.rmdir, dirfd, path, orig_entry))
+            finally:
+                stack.append((os.close, topfd, path, orig_entry))
+
+            func = os.scandir  # For error reporting.
+            with os.scandir(topfd) as scandir_it:
+                entries = list(scandir_it)
+            for entry in entries:
+                fullname = os.path.join(path, entry.name)
+                try:
+                    if entry.is_dir(follow_symlinks=False):
+                        # Traverse into sub-directory.
+                        stack.append((os.lstat, topfd, fullname, entry))
+                        continue
+                except OSError:
+                    pass
+                try:
+                    os.unlink(entry.name, dir_fd=topfd)
+                except OSError as err:
+                    onexc(os.unlink, fullname, err)
+        except OSError as err:
+            err.filename = path
+            onexc(func, path, err)
+
+    def _rmtree_unsafe(path, onexc):
+        def onerror(err):
+            onexc(os.scandir, err.filename, err)
+
+        results = os.walk(path, topdown=False, onerror=onerror, followlinks=os._walk_symlinks_as_files)
+        for dirpath, dirnames, filenames in results:
+            for name in dirnames:
+                fullname = os.path.join(dirpath, name)
+                try:
+                    os.rmdir(fullname)
+                except OSError as err:
+                    onexc(os.rmdir, fullname, err)
+            for name in filenames:
+                fullname = os.path.join(dirpath, name)
+                try:
+                    os.unlink(fullname)
+                except OSError as err:
+                    onexc(os.unlink, fullname, err)
+        try:
+            os.rmdir(path)
+        except OSError as err:
+            onexc(os.rmdir, path, err)
+
+    if ignore_errors:
+
+        def onexc(*args):
+            pass
+
+    elif onerror is None and onexc is None:
+
+        def onexc(*args):
+            raise
+
+    elif onexc is None:
+        if onerror is None:
+
+            def onexc(*args):
+                raise
+
+        else:
+            # delegate to onerror
+            def onexc(*args):
+                func, path, exc = args
+                if exc is None:
+                    exc_info = None, None, None
+                else:
+                    exc_info = type(exc), exc, exc.__traceback__
+                return onerror(func, path, exc_info)
+
+    if _use_fd_functions:
+        # While the unsafe rmtree works fine on bytes, the fd based does not.
+        if isinstance(path, bytes):
+            path = os.fsdecode(path)
+        stack = [(os.lstat, dir_fd, path, None)]
+        try:
+            while stack:
+                _rmtree_safe_fd(stack, onexc)
+        finally:
+            # Close any file descriptors still on the stack.
+            while stack:
+                func, fd, path, entry = stack.pop()
+                if func is not os.close:
+                    continue
+                try:
+                    os.close(fd)
+                except OSError as err:
+                    onexc(os.close, path, err)
+    else:
+        if dir_fd is not None:
+            raise NotImplementedError("dir_fd unavailable on this platform")
+        try:
+            if _rmtree_islink(path):
+                # symlinks to directories are forbidden, see bug #1669
+                raise OSError("Cannot call rmtree on a symbolic link")
+        except OSError as err:
+            onexc(os.path.islink, path, err)
+            # can't continue even if onexc hook returns
+            return
+        return _rmtree_unsafe(path, onexc)
+
+
 # copied https://github.com/python/cpython/blob/3.12/Lib/tempfile.py
 # to add behaviour that available only for python3.10+ for older python version
 class TemporaryDirectory(OrigTemporaryDirectory):
@@ -311,7 +499,7 @@ class TemporaryDirectory(OrigTemporaryDirectory):
                 if not ignore_errors:
                     raise
 
-        shutil.rmtree(name, onexc=onexc)
+        _rmtree(name, onexc=onexc)
 
     def cleanup(self):
         if self._finalizer.detach() or os.path.exists(self.name):

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -425,7 +425,7 @@ def _rmtree(path, ignore_errors=False, onerror=None, *, onexc=None, dir_fd=None)
 # copied https://github.com/python/cpython/blob/3.12/Lib/tempfile.py
 # to add behaviour that available only for python3.10+ for older python version
 class TemporaryDirectory(OrigTemporaryDirectory):
-    def __init__(self, suffix=None, prefix=None, dir=None, ignore_cleanup_errors=False, *, delete=True):
+    def __init__(self, suffix=None, prefix=None, dir=None, ignore_cleanup_errors=True, *, delete=True):
         super().__init__(suffix=suffix, prefix=prefix, dir=dir)
         self._ignore_cleanup_errors = ignore_cleanup_errors
         self._delete = delete

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,15 @@
 import os
 import re
 import subprocess
+from pathlib import Path
 
 from setuptools import find_namespace_packages, setup
 
 
 # Ensure we match the version set in optimum/intel/version.py
+filepath = Path(__file__).parent / "optimum/intel/version.py"
 try:
-    filepath = "optimum/intel/version.py"
-    with open(filepath) as version_file:
+    with filepath.open() as version_file:
         (__version__,) = re.findall('__version__ = "(.*)"', version_file.read())
     if __version__.endswith(".dev0"):
         dev_version_id = ""
@@ -20,7 +21,7 @@ try:
                 .decode()
             )
             dev_version_id = "+" + dev_version_id
-        except subprocess.CalledProcessError:
+        except (subprocess.CalledProcessError, FileNotFoundError):
             pass
         __version__ = __version__ + dev_version_id
 except Exception as error:

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -13,7 +13,6 @@
 #  limitations under the License.
 
 import random
-import tempfile
 import unittest
 from typing import Dict
 
@@ -47,6 +46,7 @@ from optimum.intel.openvino.modeling_diffusion import (
     OVModelVaeDecoder,
     OVModelVaeEncoder,
 )
+from optimum.intel.openvino.utils import TemporaryDirectory
 from optimum.intel.utils.import_utils import is_diffusers_version
 from optimum.utils.import_utils import is_onnxruntime_available
 
@@ -428,7 +428,7 @@ class OVtableDiffusionXLPipelineTest(unittest.TestCase):
             num_images_per_prompt=num_images_per_prompt,
             generator=np.random.RandomState(SEED),
         )
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             pipeline.save_pretrained(tmp_dir)
             pipeline = self.MODEL_CLASS.from_pretrained(tmp_dir)
         ov_outputs_2 = pipeline(
@@ -470,7 +470,7 @@ class OVStableDiffusionXLImg2ImgPipelineTest(unittest.TestCase):
         model_id = "hf-internal-testing/tiny-stable-diffusion-xl-pipe"
         pipeline = self.MODEL_CLASS.from_pretrained(model_id, ov_config=F32_CONFIG)
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             pipeline.save_pretrained(tmp_dir)
             pipeline = self.MODEL_CLASS.from_pretrained(tmp_dir, ov_config=F32_CONFIG)
 

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -15,7 +15,6 @@
 
 import unittest
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 import torch
 from parameterized import parameterized
@@ -46,6 +45,7 @@ from optimum.intel import (
     OVStableDiffusionXLPipeline,
 )
 from optimum.intel.openvino.modeling_base import OVBaseModel
+from optimum.intel.openvino.utils import TemporaryDirectory
 from optimum.intel.utils.import_utils import _transformers_version
 from optimum.utils.save_utils import maybe_load_preprocessors
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -14,7 +14,6 @@
 import subprocess
 import unittest
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from parameterized import parameterized
 from transformers import AutoModelForCausalLM
@@ -44,7 +43,7 @@ from optimum.intel import (  # noqa
     OVStableDiffusionXLPipeline,
 )
 from optimum.intel.openvino.configuration import _DEFAULT_4BIT_CONFIGS
-from optimum.intel.openvino.utils import _HEAD_TO_AUTOMODELS
+from optimum.intel.openvino.utils import _HEAD_TO_AUTOMODELS, TemporaryDirectory
 from optimum.intel.utils.import_utils import (
     compare_versions,
     is_openvino_tokenizers_available,

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -14,7 +14,6 @@
 
 import gc
 import os
-import tempfile
 import time
 import unittest
 from pathlib import Path
@@ -94,7 +93,7 @@ from optimum.intel.openvino.modeling_visual_language import (
     OVModelWithEmbedForCausalLM,
     OVVisionEmbedding,
 )
-from optimum.intel.openvino.utils import _print_compiled_model_properties
+from optimum.intel.openvino.utils import TemporaryDirectory, _print_compiled_model_properties
 from optimum.intel.pipelines import pipeline as optimum_pipeline
 from optimum.intel.utils.import_utils import is_openvino_version, is_transformers_version
 from optimum.intel.utils.modeling_utils import _find_files_matching_pattern
@@ -171,7 +170,7 @@ class OVModelIntegrationTest(unittest.TestCase):
         self.assertTrue(torch.equal(loaded_model_outputs.logits, outputs.logits))
         del compile_only_model
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             loaded_model.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(OV_XML_FILE_NAME in folder_contents)
@@ -200,7 +199,7 @@ class OVModelIntegrationTest(unittest.TestCase):
         self.assertEqual(loaded_model.request.get_compiled_model().get_property("PERFORMANCE_HINT"), "LATENCY")
         loaded_model_outputs = loaded_model(**tokens)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             loaded_model.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(OV_XML_FILE_NAME in folder_contents)
@@ -234,7 +233,7 @@ class OVModelIntegrationTest(unittest.TestCase):
 
         loaded_model_outputs = loaded_model.generate(**tokens)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             loaded_model.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(OV_ENCODER_NAME in folder_contents)
@@ -274,7 +273,7 @@ class OVModelIntegrationTest(unittest.TestCase):
         }
         pipeline_outputs = loaded_pipeline(**inputs, generator=np.random.RandomState(SEED)).images
         self.assertEqual(pipeline_outputs.shape, (batch_size, height, width, 3))
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             loaded_pipeline.save_pretrained(tmpdirname)
             pipeline = OVStableDiffusionPipeline.from_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
@@ -318,7 +317,7 @@ class OVModelIntegrationTest(unittest.TestCase):
     def test_infer_export_when_loading(self):
         model_id = MODEL_NAMES["phi"]
         model = AutoModelForCausalLM.from_pretrained(model_id)
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             model.save_pretrained(Path(tmpdirname) / "original")
             # Load original model and convert
             model = OVModelForCausalLM.from_pretrained(Path(tmpdirname) / "original")
@@ -340,7 +339,7 @@ class OVModelIntegrationTest(unittest.TestCase):
 
         # local model
         api = HfApi()
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             for revision in ("main", "ov", "itrex"):
                 local_dir = Path(tmpdirname) / revision
                 api.snapshot_download(repo_id=model_id, local_dir=local_dir, revision=revision)
@@ -359,7 +358,7 @@ class OVModelIntegrationTest(unittest.TestCase):
 
         # local model
         api = HfApi()
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             local_dir = Path(tmpdirname) / "model"
             api.snapshot_download(repo_id=model_id, local_dir=local_dir)
             ov_files = _find_files_matching_pattern(local_dir, pattern=pattern)
@@ -376,7 +375,7 @@ class PipelineTest(unittest.TestCase):
         self.assertIsInstance(ov_exported_pipe.model, OVBaseModel)
         self.assertIsInstance(ov_pipe.model, OVBaseModel)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             ov_exported_pipe.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(OV_XML_FILE_NAME in folder_contents)
@@ -396,7 +395,7 @@ class PipelineTest(unittest.TestCase):
         self.assertIsInstance(ov_exported_pipe.model, OVBaseModel)
         self.assertIsInstance(ov_pipe.model, OVBaseModel)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             ov_exported_pipe.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(OV_DECODER_WITH_PAST_NAME in folder_contents)
@@ -712,7 +711,7 @@ class OVModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         from Sentence Transformers then an appropriate exception raises.
         """
         model_id = MODEL_NAMES[model_arch]
-        with tempfile.TemporaryDirectory() as tmp_dir:
+        with TemporaryDirectory() as tmp_dir:
             save_dir = str(tmp_dir)
             OVSentenceTransformer.from_pretrained(model_id, export=True).save_pretrained(save_dir)
             with self.assertRaises(Exception) as context:
@@ -1346,7 +1345,7 @@ class OVModelForImageClassificationIntegrationTest(unittest.TestCase):
     @parameterized.expand(TIMM_MODELS)
     def test_timm_save_and_infer(self, model_id):
         ov_model = OVModelForImageClassification.from_pretrained(model_id, export=True)
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             model_save_path = os.path.join(tmpdirname, "timm_ov_model")
             ov_model.save_pretrained(model_save_path)
             model = OVModelForImageClassification.from_pretrained(model_save_path)
@@ -2215,7 +2214,7 @@ class OVModelForOpenCLIPZeroShortImageClassificationTest(unittest.TestCase):
 
         loaded_model_outputs = loaded_model(tokens, processed_image)
 
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             loaded_model.save_pretrained(tmpdirname)
             folder_contents = os.listdir(tmpdirname)
             self.assertTrue(loaded_model.text_model._xml_model_name in folder_contents)

--- a/tests/openvino/test_modeling_sentence_transformers.py
+++ b/tests/openvino/test_modeling_sentence_transformers.py
@@ -14,7 +14,6 @@
 
 import gc
 import os
-import tempfile
 import unittest
 
 import numpy as np
@@ -26,6 +25,7 @@ from transformers import (
 )
 
 from optimum.intel import OVSentenceTransformer
+from optimum.intel.openvino.utils import TemporaryDirectory
 
 
 SEED = 42
@@ -65,7 +65,7 @@ class OVModelForSTFeatureExtractionIntegrationTest(unittest.TestCase):
     def test_sentence_transformers_save_and_infer(self, model_arch):
         model_id = MODEL_NAMES[model_arch]
         ov_model = OVSentenceTransformer.from_pretrained(model_id, export=True, ov_config=F32_CONFIG)
-        with tempfile.TemporaryDirectory() as tmpdirname:
+        with TemporaryDirectory() as tmpdirname:
             model_save_path = os.path.join(tmpdirname, "sentence_transformers_ov_model")
             ov_model.save_pretrained(model_save_path)
             model = OVSentenceTransformer.from_pretrained(model_save_path)

--- a/tests/openvino/test_training_examples.py
+++ b/tests/openvino/test_training_examples.py
@@ -25,7 +25,7 @@ import torch
 import torch.cuda
 from parameterized import parameterized
 
-from optimum.intel.openvino.utils import OV_XML_FILE_NAME
+from optimum.intel.openvino.utils import OV_XML_FILE_NAME, TemporaryDirectory
 
 
 PROJECT_ROOT = Path(__file__).parents[2]
@@ -165,7 +165,7 @@ class OVTrainingExampleTest(unittest.TestCase):
             self.skipTest("No enough cuda devices.")
 
         self.env[CUDA_VISIBLE_DEVICES] = ",".join(map(str, self.available_cuda_device_ids[:2]))
-        with tempfile.TemporaryDirectory() as output_dir:
+        with TemporaryDirectory() as output_dir:
             args = [sys.executable, desc.filename, *desc.get_args_with_output_dir(output_dir)]
             proc = subprocess.Popen(
                 args=args,
@@ -182,7 +182,7 @@ class OVTrainingExampleTest(unittest.TestCase):
             self.skipTest("No enough cuda devices.")
 
         self.env[CUDA_VISIBLE_DEVICES] = ",".join(map(str, self.available_cuda_device_ids[:2]))
-        with tempfile.TemporaryDirectory() as output_dir:
+        with TemporaryDirectory() as output_dir:
             args = [
                 "torchrun",
                 "--rdzv_backend=c10d",


### PR DESCRIPTION
# What does this PR do?

Fixes # https://github.com/openvinotoolkit/openvino/issues/26844

Reworked conversion part and weight compression after it for avoiding tmp directory lock on windows and unnecessary reading model.

Added handler for tmp dir that allow ignore permission errors (natively added in python3.10, for forward-porting to <3.10, we can remove it after removing python3.9 support)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

