### PR TITLE
Add $ to the end of filename regex patterns

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -439,7 +439,7 @@ class OVBaseModel(OptimizedModel):
 
             ov_files = _find_files_matching_pattern(
                 model_dir,
-                pattern=r"(.*)?openvino(.*)?\_model.xml",
+                pattern=r"(.*)?openvino(.*)?\_model.xml$",
                 subfolder=subfolder,
                 use_auth_token=token,
                 revision=revision,

--- a/optimum/intel/openvino/modeling_open_clip.py
+++ b/optimum/intel/openvino/modeling_open_clip.py
@@ -152,7 +152,7 @@ class OVModelOpenCLIPBase(OVModel):
 
             ov_files = _find_files_matching_pattern(
                 model_dir,
-                pattern=r"(.*)?openvino(.*)?\_model\_(.*)?.xml",
+                pattern=r"(.*)?openvino(.*)?\_model\_(.*)?.xml$",
                 subfolder=subfolder,
                 use_auth_token=token,
                 revision=revision,

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -339,7 +339,7 @@ class OVModelIntegrationTest(unittest.TestCase):
 
     def test_find_files_matching_pattern(self):
         model_id = "echarlaix/tiny-random-PhiForCausalLM"
-        pattern = r"(.*)?openvino(.*)?\_model.xml"
+        pattern = r"(.*)?openvino(.*)?\_model.xml$"
         # hub model
         for revision in ("main", "ov", "itrex"):
             ov_files = _find_files_matching_pattern(
@@ -360,7 +360,7 @@ class OVModelIntegrationTest(unittest.TestCase):
 
     @parameterized.expand(("stable-diffusion", "stable-diffusion-openvino"))
     def test_find_files_matching_pattern_sd(self, model_arch):
-        pattern = r"(.*)?openvino(.*)?\_model.xml"
+        pattern = r"(.*)?openvino(.*)?\_model.xml$"
         model_id = MODEL_NAMES[model_arch]
         # hub model
         ov_files = _find_files_matching_pattern(model_id, pattern=pattern)
@@ -373,6 +373,23 @@ class OVModelIntegrationTest(unittest.TestCase):
             api.snapshot_download(repo_id=model_id, local_dir=local_dir)
             ov_files = _find_files_matching_pattern(local_dir, pattern=pattern)
             self.assertTrue(len(ov_files) > 0 if "openvino" in model_id else len(ov_files) == 0)
+
+    @parameterized.expand(("", "openvino"))
+    def test_find_files_matching_pattern_with_config_in_root(self, subfolder):
+        # Notably, the model has a config.json file in the root directory and not in the subfolder
+        model_id = "sentence-transformers-testing/stsb-bert-tiny-openvino"
+        pattern = r"(.*)?openvino(.*)?\_model.xml$"
+        # hub model
+        ov_files = _find_files_matching_pattern(model_id, pattern=pattern, subfolder=subfolder)
+        self.assertTrue(len(ov_files) == 1 if subfolder == "openvino" else len(ov_files) == 0)
+
+        # local model
+        api = HfApi()
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            local_dir = Path(tmpdirname) / "model"
+            api.snapshot_download(repo_id=model_id, local_dir=local_dir)
+            ov_files = _find_files_matching_pattern(local_dir, pattern=pattern, subfolder=subfolder)
+            self.assertTrue(len(ov_files) == 1 if subfolder == "openvino" else len(ov_files) == 0)
 
 
 class PipelineTest(unittest.TestCase):


### PR DESCRIPTION
# What does this PR do?
* Add $ to the end of filename regex patterns
* add an unrelated test for a model with modeling files in a subfolder and configuration files in the root. This passes on main, but failed on 1.19.0. As expected, if `subfolder="openvino"`, then the OV files can be seen, if `subfolder=""`, then they are not.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

---

- Tom Aarsen