### PR TITLE
Allow loading local models in a subfolder (with config in root)

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -512,7 +512,7 @@ class OVBaseModel(OptimizedModel):
         # locates a file in a local folder and repo, downloads and cache it if necessary.
         model_path = Path(model_path)
         if model_path.is_dir():
-            model_cache_path = model_path / file_name
+            model_cache_path = model_path / subfolder / file_name
         else:
             file_name = Path(file_name)
             if file_name.suffix != ".onnx":

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -324,6 +324,20 @@ class OVModelIntegrationTest(unittest.TestCase):
         self.assertIsInstance(model.config, PretrainedConfig)
         self.assertTrue(model.stateful)
 
+    @parameterized.expand(("", "openvino"))
+    def test_loading_with_config_in_root(self, subfolder):
+        # config.json file in the root directory and not in the subfolder
+        model_id = "sentence-transformers-testing/stsb-bert-tiny-openvino"
+        export = subfolder == ""
+        # hub model
+        OVModelForFeatureExtraction.from_pretrained(model_id, subfolder=subfolder, export=export)
+        # local model
+        api = HfApi()
+        with tempfile.TemporaryDirectory() as tmpdirname:
+            local_dir = Path(tmpdirname) / "model"
+            api.snapshot_download(repo_id=model_id, local_dir=local_dir)
+            OVModelForFeatureExtraction.from_pretrained(local_dir, subfolder=subfolder, export=export)
+
     def test_infer_export_when_loading(self):
         model_id = MODEL_NAMES["phi"]
         model = AutoModelForCausalLM.from_pretrained(model_id)


### PR DESCRIPTION
# What does this PR do?
* Allow loading local models in a subfolder, also when the configuration is in root

Note: This PR depends on https://github.com/huggingface/optimum/pull/2044 to be merged & released, and would require increasing the `optimum` version in the dependencies. I'm not sure how the `optimum` vs `optimum-...` dependencies are handled, so I'm not sure if this is a viable PR.

You can consider this a sister-PR to https://github.com/huggingface/optimum/pull/2044 - the changes were also inspired from it. 

## What didn't work before?

```python
import tempfile
from pathlib import Path

from huggingface_hub import HfApi
from optimum.intel import OVModelForFeatureExtraction

model_id = "sentence-transformers-testing/stsb-bert-tiny-openvino"

# hub model
ov_model = OVModelForFeatureExtraction.from_pretrained(model_id, subfolder="openvino", file_name="openvino_model.xml")
print("Hub model:", ov_model)

# local model
api = HfApi()
with tempfile.TemporaryDirectory() as tmpdirname:
    local_dir = Path(tmpdirname) / "model"
    api.snapshot_download(repo_id=model_id, local_dir=local_dir)

    ov_model = OVModelForFeatureExtraction.from_pretrained(local_dir, subfolder="openvino", file_name="openvino_model.xml")
    print("Remote model:", ov_model)

```
The second model from this snippet would not be loaded, because the `subfolder` was not being inserted between the model path and the filename. https://github.com/huggingface/optimum/pull/2044 fixes the same issue but for ONNX.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

cc @echarlaix 

- Tom Aarsen