### PR TITLE
Quantization support for CausalVisualLMs

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -329,11 +329,18 @@ class OVExportCommand(BaseOptimumCLICommand):
             model.save_pretrained(self.args.output)
             if not self.args.disable_convert_tokenizer:
                 maybe_convert_tokenizers(library_name, self.args.output, model, task=task)
-        elif task.startswith("text-generation") and quantize_with_dataset:
-            from optimum.intel import OVModelForCausalLM
+        elif (task.startswith("text-generation") or task == "image-text-to-text") and quantize_with_dataset:
+            if task.startswith("text-generation"):
+                from optimum.intel import OVModelForCausalLM
 
-            # To quantize a text-generation model with a dataset, an instantiated OVModelForCausalLM is required
-            model = OVModelForCausalLM.from_pretrained(
+                model_cls = OVModelForCausalLM
+            else:
+                from optimum.intel import OVModelForVisualCausalLM
+
+                model_cls = OVModelForVisualCausalLM
+
+            # To quantize a model with a dataset, an instance of a model class is required
+            model = model_cls.from_pretrained(
                 self.args.model,
                 export=True,
                 quantization_config=quantization_config,

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -727,14 +727,14 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
 
     @staticmethod
     @abstractmethod
-    def assemble_input(
+    def preprocess_inputs(
         processor,
         instruction: str,
         image: Optional[Image] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
     ):
         """
-        Assemble a model input from an instruction and an image.
+        Preprocess input instruction and an image.
         """
 
 
@@ -907,7 +907,7 @@ class _OVLlavaForCausalLM(OVModelForVisualCausalLM):
         return attention_mask, position_ids
 
     @staticmethod
-    def assemble_input(
+    def preprocess_inputs(
         processor,
         instruction: str,
         image: Optional[Image] = None,
@@ -1433,7 +1433,7 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
         return vllm_embedding, attention_mask, position_ids
 
     @staticmethod
-    def assemble_input(
+    def preprocess_inputs(
         processor,
         instruction: str,
         image: Optional[Image] = None,
@@ -1618,7 +1618,7 @@ class _OVNanoLlavaForCausalLM(OVModelForVisualCausalLM):
         return new_input_embeds, attention_mask, position_ids
 
     @staticmethod
-    def assemble_input(
+    def preprocess_inputs(
         processor,
         instruction: str,
         image: Optional[Image] = None,

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -729,7 +729,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
     @abstractmethod
     def preprocess_inputs(
         processor,
-        instruction: str,
+        text: str,
         image: Optional[Image] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
     ):
@@ -909,13 +909,13 @@ class _OVLlavaForCausalLM(OVModelForVisualCausalLM):
     @staticmethod
     def preprocess_inputs(
         processor,
-        instruction: str,
+        text: str,
         image: Optional[Image] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
     ):
         if image is None:
             raise ValueError("Image is required.")
-        chat_template = [{"role": "user", "content": [{"type": "text", "text": instruction}, {"type": "image"}]}]
+        chat_template = [{"role": "user", "content": [{"type": "text", "text": text}, {"type": "image"}]}]
         prompt = processor.apply_chat_template(chat_template, add_generation_prompt=True)
         inputs = processor(images=image, text=prompt, return_tensors="pt")
         return inputs
@@ -1435,13 +1435,13 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
     @staticmethod
     def preprocess_inputs(
         processor,
-        instruction: str,
+        text: str,
         image: Optional[Image] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
     ):
         if image is None:
             raise ValueError("Image is required.")
-        prompt = f"<|im_start|>user\n(<image>./</image>)\n{instruction}<|im_end|>\n<|im_start|>assistant\n"
+        prompt = f"<|im_start|>user\n(<image>./</image>)\n{text}<|im_end|>\n<|im_start|>assistant\n"
         inputs = processor([prompt], [image], return_tensors="pt")
         return inputs
 
@@ -1620,13 +1620,13 @@ class _OVNanoLlavaForCausalLM(OVModelForVisualCausalLM):
     @staticmethod
     def preprocess_inputs(
         processor,
-        instruction: str,
+        text: str,
         image: Optional[Image] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
     ):
         if tokenizer is None:
             raise ValueError("Tokenizer is required.")
-        messages = [{"role": "user", "content": f"<image>\n{instruction}"}]
+        messages = [{"role": "user", "content": f"<image>\n{text}"}]
         text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
         text_chunks = [tokenizer(chunk).input_ids for chunk in text.split("<image>")]
         input_ids = torch.tensor(text_chunks[0] + [-200] + text_chunks[1], dtype=torch.long).unsqueeze(0)

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 import os
 import warnings
@@ -499,7 +500,11 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
         )
 
         if to_quantize:
-            OVQuantizer(model).quantize(ov_config=OVConfig(quantization_config=quantization_config))
+            quantization_config_copy = copy.deepcopy(quantization_config)
+            quantization_config_copy.tokenizer = quantization_config.tokenizer or model_id
+            potential_processor_id = config.mm_vision_tower if isinstance(model, _OVNanoLlavaForCausalLM) else model_id
+            quantization_config_copy.processor = quantization_config.processor or potential_processor_id
+            OVQuantizer(model).quantize(ov_config=OVConfig(quantization_config=quantization_config_copy))
 
         return model
 

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -783,7 +783,7 @@ class OVQuantizer(OptimumQuantizer):
             image = Image.open(requests.get(image_url, stream=True).raw)
 
             try:
-                inputs = self.model.assemble_input(processor, instruction, image, tokenizer)
+                inputs = self.model.preprocess_inputs(processor, instruction, image, tokenizer)
             except ValueError as value_error:
                 if "Tokenizer is required." in str(value_error) and tokenizer_error is not None:
                     raise tokenizer_error

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -776,9 +776,7 @@ class OVQuantizer(OptimumQuantizer):
             image = Image.open(requests.get(image_url, stream=True).raw)
 
             instruction = item[dataset_metadata["inputs"]["instruction"]]
-            chat_template = [{"role": "user", "content": [{"type": "text", "text": instruction}, {"type": "image"}]}]
-            prompt = processor.apply_chat_template(chat_template, add_generation_prompt=True)
-            inputs = processor(images=image, text=prompt, return_tensors="pt")
+            inputs = self.model.assemble_input(processor, instruction, image)
             input_ids = inputs.input_ids
             if input_ids.size(1) > max_tokens:
                 continue

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -757,6 +757,12 @@ class OVQuantizer(OptimumQuantizer):
                 "You have entered a string value for dataset. You can only choose between"
                 f"{list(PREDEFINED_VISUAL_LM_DATASETS.keys())}, but the {dataset_name} was found"
             )
+        if config.processor is None:
+            raise ValueError(
+                "`processor` must be specified in order to run data-aware weight compression. "
+                "Please provide it as a model id, or a path to a directory containing all the required "
+                "configuration files."
+            )
 
         dataset_metadata = PREDEFINED_VISUAL_LM_DATASETS[dataset_name]
         dataset = datasets.load_dataset(dataset_metadata["name"], split=dataset_metadata["split"]).shuffle(seed=0)

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -135,6 +135,14 @@ PREDEFINED_SD_DATASETS = {
     "laion/filtered-wit": {"split": "train", "inputs": {"prompt": "caption"}},
 }
 
+PREDEFINED_VISUAL_LM_DATASETS = {
+    "contextual": {
+        "name": "ucla-contextual/contextual_test",
+        "split": "test",
+        "inputs": {"image_url": "image_url", "instruction": "instruction"},
+    }
+}
+
 
 NEED_CONVERT_TO_FAST_TOKENIZER: Tuple[Type[PreTrainedTokenizer]] = (CLIPTokenizer,)
 

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -116,6 +116,7 @@ _HEAD_TO_AUTOMODELS = {
     "token-classification": "OVModelForTokenClassification",
     "question-answering": "OVModelForQuestionAnswering",
     "image-classification": "OVModelForImageClassification",
+    "image-text-to-text": "OVModelForVisualCausalLM",
     "audio-classification": "OVModelForAudioClassification",
     "stable-diffusion": "OVStableDiffusionPipeline",
     "stable-diffusion-xl": "OVStableDiffusionXLPipeline",

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -134,19 +134,17 @@ class OVCLIExportTestCase(unittest.TestCase):
         TEST_4BIT_CONFIGURATIONS.extend(
             [
                 (
-                    (
-                        "image-text-to-text",
-                        "llava_next",
-                        'int4 --group-size 16 --ratio 0.9 --sensitivity-metric "mean_activation_magnitude" '
-                        "--dataset contextual --num-samples 1",
-                        {"int8": 8, "int4": 22},
-                    ),
+                    "image-text-to-text",
+                    "llava_next",
+                    'int4 --group-size 16 --ratio 0.9 --sensitivity-metric "mean_activation_magnitude" '
+                    "--dataset contextual --num-samples 1",
+                    {"int8": 8, "int4": 22},
                 ),
                 (
                     "image-text-to-text",
                     "nanollava",
                     'int4 --group-size 8 --ratio 0.9 --sensitivity-metric "mean_activation_variance" '
-                    "--dataset contextual -num-samples 1 --trust-remote-code",
+                    "--dataset contextual --num-samples 1 --trust-remote-code",
                     {"int8": 12, "int4": 18},
                 ),
             ]

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -313,7 +313,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                         group_size=16,
                         dataset="contextual",
                         ratio=0.8,
-                        sensitivity_metric="mean_activation_magnitude",
+                        sensitivity_metric="hessian_input_activation",
                         num_samples=1,
                         processor=MODEL_NAMES["llava_next"],
                     ),

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -296,23 +296,43 @@ class OVWeightCompressionTest(unittest.TestCase):
     ]
 
     if is_transformers_version(">=", "4.40.0"):
-        LOAD_IN_4_BITS_SCOPE.append(
-            (
-                OVModelForVisualCausalLM,
-                "llava_next",
-                False,
-                dict(
-                    bits=4,
-                    group_size=16,
-                    dataset="contextual",
-                    ratio=0.8,
-                    sensitivity_metric="mean_activation_magnitude",
-                    num_samples=1,
-                    processor=MODEL_NAMES["llava_next"],
+        LOAD_IN_4_BITS_SCOPE.extend(
+            [
+                (
+                    OVModelForVisualCausalLM,
+                    "llava_next",
+                    False,
+                    dict(
+                        bits=4,
+                        group_size=16,
+                        dataset="contextual",
+                        ratio=0.8,
+                        sensitivity_metric="mean_activation_magnitude",
+                        num_samples=1,
+                        processor=MODEL_NAMES["llava_next"],
+                    ),
+                    {"int4": 20, "int8": 10},
                 ),
-                {"int4": 20, "int8": 10},
-            )
+                (
+                    OVModelForVisualCausalLM,
+                    "nanollava",
+                    True,
+                    dict(
+                        bits=4,
+                        group_size=8,
+                        dataset="contextual",
+                        ratio=0.8,
+                        sensitivity_metric="mean_activation_magnitude",
+                        num_samples=1,
+                        processor=MODEL_NAMES["nanollava_vision_tower"],
+                        tokenizer=MODEL_NAMES["nanollava"],
+                        trust_remote_code=True,
+                    ),
+                    {"int4": 16, "int8": 14},
+                ),
+            ]
         )
+
     if is_transformers_version(">=", "4.45.0"):
         LOAD_IN_4_BITS_SCOPE.append(
             (
@@ -348,6 +368,9 @@ class OVWeightCompressionTest(unittest.TestCase):
         (OVModelOpenCLIPForZeroShotImageClassification, "open-clip", False),
         (OVModelForVisualCausalLM, "llava", False),
     ]
+
+    if is_transformers_version(">=", "4.40.0"):
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "nanollava", True))
 
     if is_transformers_version(">=", "4.45.0"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "minicpmv", True))

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -341,7 +341,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 True,
                 dict(
                     bits=4,
-                    group_size=-1,  # TODO: set to 32 after model is updated
+                    group_size=16,
                     dataset="contextual",
                     ratio=0.8,
                     sensitivity_metric="mean_activation_magnitude",
@@ -349,7 +349,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                     processor=MODEL_NAMES["minicpmv"],
                     trust_remote_code=True,
                 ),
-                {"int4": 24, "int8": 6},
+                {"int4": 22, "int8": 8},
             )
         )
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -192,7 +192,13 @@ class OVWeightCompressionTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES_STATEFUL_WITH_EXPECTED_8BIT_COMPRESSED_MATMULS = ((OVModelForCausalLM, "gpt2", 44, 44),)
 
     LOAD_IN_4_BITS_SCOPE = [
-        (OVModelForCausalLM, "gpt2", dict(bits=4, sym=False, group_size=-1, ratio=0.8), {"int4": 30, "int8": 14}),
+        (
+            OVModelForCausalLM,  # model cls
+            "gpt2",  # model name
+            False,  # trust remote code
+            dict(bits=4, sym=False, group_size=-1, ratio=0.8),  # quantization config
+            {"int4": 30, "int8": 14},  # reference number of low-precision nodes
+        ),
         (
             OVModelForCausalLM,
             "gpt2",

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -548,7 +548,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 # TODO: Check that AWQ was actually applied
                 pass
 
-            ov_model = model
+            ov_model = model.model
             if model_cls == OVModelForVisualCausalLM:
                 ov_model = model.lm_model
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -317,7 +317,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                         num_samples=1,
                         processor=MODEL_NAMES["llava_next"],
                     ),
-                    {"int4": 20, "int8": 10},
+                    {"int4": 24, "int8": 6},
                 ),
                 (
                     OVModelForVisualCausalLM,

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -97,6 +97,7 @@ MODEL_NAMES = {
     "mpnet": "hf-internal-testing/tiny-random-MPNetModel",
     "mt5": "stas/mt5-tiny-random",
     "nanollava": "katuni4ka/tiny-random-nanollava",
+    "nanollava_vision_tower": "katuni4ka/tiny-random-siglip",
     "nystromformer": "hf-internal-testing/tiny-random-NystromformerModel",
     "olmo": "katuni4ka/tiny-random-olmo-hf",
     "orion": "katuni4ka/tiny-random-orion",
@@ -180,6 +181,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "llava": (30, 18, 2),
     "llava_next": (30, 18, 2),
     "minicpmv": (30, 52, 2, 12),
+    "nanollava": (30, 30, 2),
 }
 
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -178,6 +178,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "stable-diffusion-3": (66, 42, 58, 30),
     "flux": (56, 24, 28, 64),
     "llava": (30, 18, 2),
+    "llava_next": (30, 18, 2),
 }
 
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -179,6 +179,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "flux": (56, 24, 28, 64),
     "llava": (30, 18, 2),
     "llava_next": (30, 18, 2),
+    "minicpmv": (30, 52, 2, 12),
 }
 
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import numpy as np
+import openvino as ov
 import torch
 
 
@@ -176,10 +177,11 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "open-clip": (20, 28),
     "stable-diffusion-3": (66, 42, 58, 30),
     "flux": (56, 24, 28, 64),
+    "llava": (30, 18, 2),
 }
 
 
-def get_num_quantized_nodes(ov_model):
+def get_num_quantized_nodes(model):
     num_fake_quantize = 0
     num_weight_nodes = {
         "int8": 0,
@@ -187,7 +189,8 @@ def get_num_quantized_nodes(ov_model):
         "f4e2m1": 0,
         "f8e8m0": 0,
     }
-    for elem in ov_model.model.get_ops():
+    ov_model = model if isinstance(model, ov.Model) else model.model
+    for elem in ov_model.get_ops():
         if "FakeQuantize" in elem.name:
             num_fake_quantize += 1
         for i in range(elem.get_output_size()):


### PR DESCRIPTION
# What does this PR do?

Add support for (data-aware) compression of CausalVisualLMs:
- LLaVa (e.g., `llava-hf/llava-v1.6-mistral-7b-hf`)
- NanoLLaVa (e.g, `qnguyen3/nanoLLaVA`)
- MiniCPMV (e.g., `openbmb/MiniCPM-V-2_6`)

When `quantization_config` is given, language model will be compressed according to it. Other model parts, including vision and text embeddings models are compressed to int8_asym.

Example:

optimum-cli
```shell
optimum-cli export openvino --task image-text-to-text -m llava-hf/llava-v1.6-mistral-7b-hf \
--weight-format int4 --dataset contextual --awq --num-samples 32 ./llava_int4_awq
```

Python API
```python
from pathlib import Path

import requests
from PIL import Image
from transformers import AutoConfig, AutoProcessor, AutoTokenizer, TextStreamer

from optimum.intel.openvino import OVModelForVisualCausalLM, OVWeightQuantizationConfig


models_parent_dir = Path("./models")
quantization_config = OVWeightQuantizationConfig(
    bits=4,
    quant_method=OVQuantizationMethod.AWQ,
    dataset="contextual",
    num_samples=32,
    trust_remote_code=False,
    processor=None,
    tokenizer=None,
)


compress = bool(1)
model_arch = "llava"
# model_arch = "nanollava"
# model_arch = "minicpmv"

trc = False
if model_arch == "llava":
    model_id = "llava-hf/llava-v1.6-mistral-7b-hf"
    model_path = models_parent_dir / "llava-v1.6-mistral-7b-hf/FP32"

    processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trc)
    tokenizer = None
elif model_arch == "nanollava":
    model_id = "qnguyen3/nanoLLaVA"
    model_path = models_parent_dir / "nanoLLaVA/FP32"
    trc = True

    config = AutoConfig.from_pretrained(model_id, trust_remote_code=trc)
    processor = AutoProcessor.from_pretrained(config.mm_vision_tower, trust_remote_code=trc)
    tokenizer = AutoTokenizer.from_pretrained(model_id, trsut_remote_code=trc)
elif model_arch == "minicpmv":
    model_id = "openbmb/MiniCPM-V-2_6"
    model_path = models_parent_dir / "MiniCPM-V-2_6/FP32"
    trc = True

    processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trc)
    tokenizer = None
else:
    raise Exception

quantization_config.trust_remote_code = trc

if not model_path.exists():
    OVModelForVisualCausalLM.from_pretrained(
        model_id, export=True, trust_remote_code=trc, load_in_8bit=False, compile=False
    ).save_pretrained(model_path)
    processor.save_pretrained(model_path)
    if tokenizer is not None:
        tokenizer.save_pretrained(model_path)

if compress:
    model = OVModelForVisualCausalLM.from_pretrained(
        model_path, trust_remote_code=trc, quantization_config=quantization_config
    )
    compressed_model_path = model_path / "../int4"
    model.save_pretrained(compressed_model_path)
    model = OVModelForVisualCausalLM.from_pretrained(compressed_model_path, trust_remote_code=trc)
else:
    model = OVModelForVisualCausalLM.from_pretrained(model_path, trust_remote_code=trc)

image_file = "http://images.cocodataset.org/val2017/000000039769.jpg"
raw_image = Image.open(requests.get(image_file, stream=True).raw)
inputs = model.preprocess_inputs(processor, "What are these?", raw_image, tokenizer=tokenizer)

if model_arch == "nanollava":
    streamer = TextStreamer(tokenizer, skip_prompt=True, skip_special_tokens=True)
    output_ids = model.generate(**inputs, max_new_tokens=128, use_cache=True, streamer=streamer)
else:
    output = model.generate(**inputs, max_new_tokens=10, do_sample=False)
    print(processor.decode(output[0], skip_special_tokens=True))
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

