### PR TITLE
Install torchvision CPU in OpenVINO notebook tests

### DIFF
--- a/.github/workflows/test_openvino_notebooks.yml
+++ b/.github/workflows/test_openvino_notebooks.yml
@@ -39,7 +39,7 @@ jobs:
         # Install PyTorch CPU to prevent unnecessary downloading/installing of CUDA packages
         # ffmpeg, torchaudio and pillow are required for image classification and audio classification pipelines
         sudo apt-get install ffmpeg
-        pip install torch torchaudio --extra-index-url https://download.pytorch.org/whl/cpu
+        pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
         pip install -r notebooks/openvino/requirements.txt
         pip install .[tests,openvino] nbval
 


### PR DESCRIPTION
Currently torch CPU version is installed, but torchvision CUDA version (as dependency of timm, which is a dependency of optimum-intel[tests]). This leads to issues. This tiny PR fixes that.
Could also be fixed by using --extra-index-url everywhere, but this method is a bit safer and clearer.