### PR TITLE
updated OVPipelinePart to have separate ov_config

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -741,6 +741,7 @@ class OVPipelinePart(ConfigMixin):
         self.model_name = model_name
         self.parent_pipeline = parent_pipeline
         self.request = None if not parent_pipeline._compile_only else self.model
+        self.ov_config = parent_pipeline.ov_config
 
         if isinstance(parent_pipeline.model_save_dir, TemporaryDirectory):
             self.model_save_dir = Path(parent_pipeline.model_save_dir.name) / self.model_name
@@ -763,10 +764,6 @@ class OVPipelinePart(ConfigMixin):
     @property
     def device(self) -> torch.device:
         return self.parent_pipeline.device
-
-    @property
-    def ov_config(self) -> OVConfig:
-        return self.parent_pipeline.ov_config
 
     @property
     def dtype(self) -> torch.dtype:


### PR DESCRIPTION
# What does this PR do?

VAE decoders of some Stable Diffusion models are needed to be run in f32 due to accuracy issue as below.
https://github.com/huggingface/optimum-intel/blob/f7b5b547c167cb6a9f20fa77d493ee2dde3c3034/optimum/intel/openvino/modeling_diffusion.py#L988-L991

In https://github.com/huggingface/optimum-intel/pull/889, `ov_config` was updated to be shared among all models, and it made all models to run in f32.
https://github.com/huggingface/optimum-intel/blob/f7b5b547c167cb6a9f20fa77d493ee2dde3c3034/optimum/intel/openvino/modeling_diffusion.py#L768-L769
So, this PR updates `OVPipelinePart` to have separate `ov_config` to resolve this issue.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

