### PR TITLE
restore original model_index.json after save_pretrained call

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -259,6 +259,26 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
 
         self._save_openvino_config(save_directory)
 
+    def _save_config(self, save_directory):
+        """
+        Saves a model configuration into a directory, so that it can be re-loaded using the
+        [`from_pretrained`] class method.
+        """
+        model_dir = (
+            self.model_save_dir
+            if not isinstance(self.model_save_dir, TemporaryDirectory)
+            else self.model_save_dir.name
+        )
+        save_dir = Path(save_directory)
+        original_config = Path(model_dir) / self.config_name
+        if original_config.exists():
+            if not save_dir.exists():
+                save_dir.mkdir(parents=True)
+
+            shutil.copy(original_config, save_dir)
+        else:
+            self.config.save_pretrained(save_dir)
+
     @classmethod
     def _from_pretrained(
         cls,


### PR DESCRIPTION
# What does this PR do?

due to registration ov diffusion pipeline components in pipeline config, their classes appears in model_index.json
after OVDiffusionPipeline.save_pretrained().
```
>>from optimum.intel.openvino import OVDiffusionPipeline

>>pipe = OVPipelineForText2Image.from_pretrained("hf-internal-testing/tiny-stable-diffusion-pipe-variants-right-format")
>>pipe.config
FrozenDict([('vae', ('optimum.intel.openvino.modeling_diffusion', 'OVModelVae')), ('text_encoder', ('optimum.intel.openvino.modeling_diffusion', 'OVModelTextEncoder')), ('tokenizer', ('transformers', 'CLIPTokenizer')), ('unet', ('optimum.intel.openvino.modeling_diffusion', 'OVModelUnet')), ('scheduler', ('diffusers', 'DDIMScheduler')), ('safety_checker', (None, None)), ('feature_extractor', ('transformers', 'CLIPFeatureExtractor')), ('image_encoder', (None, None)), ('requires_safety_checker', True), ('_name_or_path', '/tmp/tmpxgc_1oo1')]
```
That may bring some inconvinience:
- misalignment between optimum-cli result (cli tool preserves original model_index.json) and save_pretrained results
- impossibility store original and ov pipeline in the same local directory or hub repository. if ov pipeline will be saved vi save_pretrained after original pipeline, you will not able to use original pipeline (model index json will contains wrong class names):

```
from diffusers import DiffusionPipeline
from optimum.intel.openvino import OVDiffusionPipeline

save_dir = "common_repo"
model_id = "hf-internal-testing/tiny-stable-diffusion-pipe-variants-right-format"
pipe = DiffusionPipeline.from_pretrained(model_id)
pipe.save_pretrained(save_dir)

ov_pipe = OVDiffusionPipeline.from_pretrained(model_id)
ov_pipe.save_pretrained(save_dir)

# try to load original pipeline again
pipe_from_local_dir = DiffusionPipeline.from_pretrained(save_dir)
```
raises error:
```
diffusers/utils/import_utils.py", line 846, in __getattr__
    raise AttributeError(f"module {self.__name__} has no attribute {name}")
AttributeError: module diffusers has no attribute OVStableDiffusionPipeline
```



