### PR TITLE
disable warning about tokenizers version for ov tokenizers >= 2024.5

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -55,6 +55,9 @@ if is_torch_available():
 
 logger = logging.getLogger(__name__)
 
+# init core before import openvino tokenizers to prevent failed attempt loading extension
+core = Core()
+
 
 def infer_task(
     task,
@@ -413,7 +416,6 @@ def main_export(
     del model
     gc.collect()
 
-    core = Core()
     for submodel_path in submodel_paths:
         submodel_path = Path(output) / submodel_path
         submodel = core.read_model(submodel_path)

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -41,6 +41,7 @@ from optimum.intel.utils.import_utils import (
     _torch_version,
     _transformers_version,
     compare_versions,
+    is_openvino_tokenizers_version,
     is_tokenizers_version,
     is_transformers_version,
 )
@@ -734,9 +735,9 @@ def export_tokenizer(
     except ModuleNotFoundError:
         return
 
-    if is_tokenizers_version(">", "0.19"):
+    if is_tokenizers_version(">", "0.19") and is_openvino_tokenizers_version("<", "2024.5.0.0"):
         logger.warning(
-            "Exporting tokenizers to OpenVINO is not supported for tokenizers version > 0.19. "
+            "Exporting tokenizers to OpenVINO is not supported for tokenizers version > 0.19 and openvino version <= 2024.4. "
             "Please downgrade to tokenizers version <= 0.19 to export tokenizers to OpenVINO."
         )
 

--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -382,6 +382,24 @@ def is_openvino_version(operation: str, version: str):
     return compare_versions(parse(_openvino_version), operation, version)
 
 
+def is_openvino_tokenizers_version(operation: str, version: str):
+    if not is_openvino_available():
+        return False
+    if not is_openvino_tokenizers_available():
+        return False
+    import openvino_tokenizers
+
+    tokenizers_version = openvino_tokenizers.__version__
+
+    if tokenizers_version == "0.0.0.0":
+        try:
+            tokenizers_version = importlib_metadata.version("openvino_tokenizers") or tokenizers_version
+        except importlib_metadata.PackageNotFoundError:
+            pass
+
+    return compare_versions(parse(tokenizers_version), operation, version)
+
+
 def is_diffusers_version(operation: str, version: str):
     """
     Compare the current diffusers version to a given reference with an operation.

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -153,7 +153,7 @@ class OVCLIExportTestCase(unittest.TestCase):
     def test_exporters_cli_tokenizers(self, task: str, model_type: str):
         with TemporaryDirectory() as tmpdir:
             output = subprocess.check_output(
-                f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} --task {task} {tmpdir}",
+                f"TRANSFORMERS_VERBOSITY=debug optimum-cli export openvino --model {MODEL_NAMES[model_type]} --task {task} {tmpdir}",
                 shell=True,
                 stderr=subprocess.STDOUT,
             ).decode()


### PR DESCRIPTION
# What does this PR do?
* remove confusing warning if it is inapplicable, you can see that these tests are passed with nightly

* increase verbosity level for ov tokenizers tests
After these changes  https://github.com/huggingface/optimum/pull/2047 default loglevel in optimum-cli become warning, that breaks openvino tokenizers tests from text_export_cli,py. they capture output and try to find message visible in info level that does not appear anymore.

@apaniukov fyi



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

