### PR TITLE
fix config saving when check on misplaced args broken

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -663,7 +663,7 @@ def export_from_model(
             # some model configs may have issues with loading without parameters initialization
             try:
                 misplaced_generation_parameters = model.config._get_non_default_generation_parameters()
-            except Exception:
+            except KeyError:
                 misplaced_generation_parameters = {}
             if isinstance(model, GenerationMixin) and len(misplaced_generation_parameters) > 0:
                 logger.warning(

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -71,6 +71,7 @@ from .utils import (
     _get_open_clip_submodels_fn_and_export_configs,
     clear_class_registry,
     remove_none_from_dummy_inputs,
+    save_config,
 )
 
 
@@ -659,7 +660,11 @@ def export_from_model(
         files_subpaths = ["openvino_" + model_name + ".xml" for model_name in models_and_export_configs.keys()]
     elif library_name != "diffusers":
         if is_transformers_version(">=", "4.44.99"):
-            misplaced_generation_parameters = model.config._get_non_default_generation_parameters()
+            # some model configs may have issues with loading without parameters initialization
+            try:
+                misplaced_generation_parameters = model.config._get_non_default_generation_parameters()
+            except Exception:
+                misplaced_generation_parameters = {}
             if isinstance(model, GenerationMixin) and len(misplaced_generation_parameters) > 0:
                 logger.warning(
                     "Moving the following attributes in the config to the generation config: "
@@ -671,7 +676,7 @@ def export_from_model(
                     setattr(model.config, param_name, None)
 
         # Saving the model config and preprocessor as this is needed sometimes.
-        model.config.save_pretrained(output)
+        save_config(model.config, output)
         generation_config = getattr(model, "generation_config", None)
         if generation_config is not None:
             try:

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1444,7 +1444,7 @@ class InternVLChatConfigBehavior(str, enum.Enum):
 @register_in_tasks_manager("internvl-chat", *["image-text-to-text"], library_name="transformers")
 class InternVLChatOpenVINOConfig(OnnxConfig):
     SUPPORTED_BEHAVIORS = [model_type.value for model_type in InternVLChatConfigBehavior]
-    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)
 
     def __init__(

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -14,6 +14,7 @@
 
 import inspect
 from collections import namedtuple
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from transformers.utils import is_torch_available
@@ -209,3 +210,13 @@ def _get_open_clip_submodels_fn_and_export_configs(
 
 
 MULTI_MODAL_TEXT_GENERATION_MODELS = ["llava", "llava-next", "llava-qwen2", "internvl-chat", "minicpmv"]
+
+
+def save_config(config, save_dir):
+    try:
+        config.save_pretrained(save_dir)
+    except Exception:
+        save_dir = Path(save_dir)
+        save_dir.mkdir(exist_ok=True)
+        output_config_file = Path(save_dir / "config.json")
+        config.to_json_file(output_config_file, use_diff=True)

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -221,7 +221,7 @@ def save_config(config, save_dir):
         config.save_pretrained(save_dir)
     except Exception as exp:
         logger.warning(
-            f"Attempt to save config using standard API is failed with {exp}. It may be issue with model config, please check its correctness before usage."
+            f"Attempt to save config using standard API has failed with {exp}. There may be an issue with model config, please check its correctness before usage."
         )
         save_dir = Path(save_dir)
         save_dir.mkdir(exist_ok=True, parents=True)

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import inspect
+import logging
 from collections import namedtuple
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -24,6 +25,9 @@ from openvino.runtime.utils.types import get_element_type
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig
 from optimum.utils import is_diffusers_available
+
+
+logger = logging.getLogger(__name__)
 
 
 InputInfo = namedtuple("InputInfo", ["name", "shape", "type", "example"])
@@ -215,8 +219,11 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = ["llava", "llava-next", "llava-qwen2", "int
 def save_config(config, save_dir):
     try:
         config.save_pretrained(save_dir)
-    except Exception:
+    except Exception as exp:
+        logger.warning(
+            f"Attempt to save config using standard API is failed with {exp}. It may be issue with model config, please check its correctness before usage."
+        )
         save_dir = Path(save_dir)
-        save_dir.mkdir(exist_ok=True)
+        save_dir.mkdir(exist_ok=True, parents=True)
         output_config_file = Path(save_dir / "config.json")
         config.to_json_file(output_config_file, use_diff=True)

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -139,7 +139,7 @@ class OVBaseModel(OptimizedModel):
                 # some model configs may have issues with loading without parameters initialization
                 try:
                     misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
-                except Exception:
+                except KeyError:
                     misplaced_generation_parameters = {}
                 if len(misplaced_generation_parameters) > 0:
                     logger.warning(

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -136,7 +136,11 @@ class OVBaseModel(OptimizedModel):
             self.generation_config = generation_config or GenerationConfig.from_model_config(config)
 
             if is_transformers_version(">=", "4.44.99"):
-                misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
+                # some model configs may have issues with loading without parameters initialization
+                try:
+                    misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
+                except Exception:
+                    misplaced_generation_parameters = {}
                 if len(misplaced_generation_parameters) > 0:
                     logger.warning(
                         "Moving the following attributes in the config to the generation config: "

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -87,7 +87,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             # some model configs may have issues with loading without parameters initialization
             try:
                 misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
-            except Exception:
+            except KeyError:
                 misplaced_generation_parameters = {}
             if len(misplaced_generation_parameters) > 0:
                 logger.warning(

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -84,7 +84,11 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
         self.generation_config = generation_config or GenerationConfig.from_model_config(config)
 
         if is_transformers_version(">=", "4.44.99"):
-            misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
+            # some model configs may have issues with loading without parameters initialization
+            try:
+                misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
+            except Exception:
+                misplaced_generation_parameters = {}
             if len(misplaced_generation_parameters) > 0:
                 logger.warning(
                     "Moving the following attributes in the config to the generation config: "

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -1228,7 +1228,7 @@ class _OvInternVLForCausalLM(OVModelForVisualCausalLM):
 
     def preprocess_inputs(
         self,
-        text: str = "",
+        text: str,
         image: Optional[Image] = None,
         processor: Optional[AutoImageProcessor] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -24,8 +24,8 @@ from transformers.modeling_outputs import BaseModelOutputWithPooling
 
 from ...exporters.openvino import main_export
 from ...exporters.openvino.stateful import ensure_stateful_is_available, model_has_input_output_name
-from .. import OVQuantizer
 from ...exporters.openvino.utils import save_config
+from .. import OVQuantizer
 from .configuration import OVConfig, OVWeightQuantizationConfig
 from .modeling_base import OVBaseModel, OVModelPart
 from .modeling_decoder import CausalLMOutputWithPast, OVModelForCausalLM
@@ -915,10 +915,16 @@ class _OVLlavaForCausalLM(OVModelForVisualCausalLM):
         image: Optional[Image] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
     ):
-        if image is None:
-            raise ValueError("Image is required.")
-        chat_template = [{"role": "user", "content": [{"type": "text", "text": text}, {"type": "image"}]}]
-        prompt = processor.apply_chat_template(chat_template, add_generation_prompt=True)
+        if processor.chat_template is not None:
+            chat_prompt = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+            if image is not None:
+                chat_prompt[0]["content"].append({"type": "image"})
+            prompt = processor.apply_chat_template(chat_prompt, add_generation_prompt=True, tokenize=False)
+        else:
+            if image is not None and "<image>" not in text:
+                prompt = "<image>\n" + text
+            else:
+                prompt = text
         inputs = processor(images=image, text=prompt, return_tensors="pt")
         return inputs
 
@@ -1217,6 +1223,120 @@ class _OvInternVLForCausalLM(OVModelForVisualCausalLM):
         input_embeds = input_embeds.reshape(B, N, C)
         return input_embeds, attention_mask, position_ids
 
+    def preprocess_inputs(
+        self,
+        processor=None,
+        text: str = "",
+        image: Optional[Image] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+    ):
+        if tokenizer is None:
+            raise ValueError("Tokenizer is required.")
+        import torchvision.transforms as T
+        from torchvision.transforms.functional import InterpolationMode
+
+        IMG_START_TOKEN = "<img>"
+        IMG_END_TOKEN = "</img>"
+        IMG_CONTEXT_TOKEN = "<IMG_CONTEXT>"
+
+        IMAGENET_MEAN = (0.485, 0.456, 0.406)
+        IMAGENET_STD = (0.229, 0.224, 0.225)
+
+        def build_transform(input_size):
+            MEAN, STD = IMAGENET_MEAN, IMAGENET_STD
+            transform = T.Compose(
+                [
+                    T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
+                    T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
+                    T.ToTensor(),
+                    T.Normalize(mean=MEAN, std=STD),
+                ]
+            )
+            return transform
+
+        def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
+            best_ratio_diff = float("inf")
+            best_ratio = (1, 1)
+            area = width * height
+            for ratio in target_ratios:
+                target_aspect_ratio = ratio[0] / ratio[1]
+                ratio_diff = abs(aspect_ratio - target_aspect_ratio)
+                if ratio_diff < best_ratio_diff:
+                    best_ratio_diff = ratio_diff
+                    best_ratio = ratio
+                elif ratio_diff == best_ratio_diff:
+                    if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
+                        best_ratio = ratio
+            return best_ratio
+
+        def dynamic_preprocess(image, min_num=1, max_num=12, image_size=28, use_thumbnail=False):
+            orig_width, orig_height = image.size
+            aspect_ratio = orig_width / orig_height
+
+            # calculate the existing image aspect ratio
+            target_ratios = {
+                (i, j)
+                for n in range(min_num, max_num + 1)
+                for i in range(1, n + 1)
+                for j in range(1, n + 1)
+                if i * j <= max_num and i * j >= min_num
+            }
+            target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
+
+            # find the closest aspect ratio to the target
+            target_aspect_ratio = find_closest_aspect_ratio(
+                aspect_ratio, target_ratios, orig_width, orig_height, image_size
+            )
+
+            # calculate the target width and height
+            target_width = image_size * target_aspect_ratio[0]
+            target_height = image_size * target_aspect_ratio[1]
+            blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
+
+            # resize the image
+            resized_img = image.resize((target_width, target_height))
+            processed_images = []
+            for i in range(blocks):
+                box = (
+                    (i % (target_width // image_size)) * image_size,
+                    (i // (target_width // image_size)) * image_size,
+                    ((i % (target_width // image_size)) + 1) * image_size,
+                    ((i // (target_width // image_size)) + 1) * image_size,
+                )
+                # split the image
+                split_img = resized_img.crop(box)
+                processed_images.append(split_img)
+            assert len(processed_images) == blocks
+            if use_thumbnail and len(processed_images) != 1:
+                thumbnail_img = image.resize((image_size, image_size))
+                processed_images.append(thumbnail_img)
+            return processed_images
+
+        def load_image(image, input_size=448, max_num=12):
+            transform = build_transform(input_size=input_size)
+            images = dynamic_preprocess(image, image_size=input_size, use_thumbnail=True, max_num=max_num)
+            pixel_values = [transform(image) for image in images]
+            pixel_values = torch.stack(pixel_values)
+            return pixel_values
+
+        if image is not None:
+            if "<image>" not in text:
+                text = "<image>\n" + text
+            pixel_values = load_image(image, input_size=self.config.vision_config.image_size)
+            num_patches = pixel_values.shape[0]
+            num_image_token = int(
+                (self.config.vision_config.image_size // self.config.vision_config.patch_size) ** 2
+                * (self.config.downsample_ratio**2)
+            )
+            image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_image_token * num_patches + IMG_END_TOKEN
+            text = text.replace("<image>", image_tokens, 1)
+            text_inputs = tokenizer(text, return_tensors="pt")
+            inputs = dict(text_inputs)
+            inputs.update({"pixel_values": pixel_values})
+        else:
+            inputs = tokenizer(text, return_tensors="pt")
+        return inputs
+
 
 class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
     additional_parts = ["resampler"]
@@ -1443,9 +1563,15 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
         image: Optional[Image] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
     ):
-        if image is None:
-            raise ValueError("Image is required.")
-        prompt = f"<|im_start|>user\n(<image>./</image>)\n{text}<|im_end|>\n<|im_start|>assistant\n"
+        if processor.chat_template is not None:
+            messages = [{"role": "user", "content": text if image is None else "(<image>./</image>)\n" + text}]
+            prompt = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        else:
+            prompt = (
+                f"<|im_start|>user\n(<image>./</image>)\n{text}<|im_end|>\n<|im_start|>assistant\n"
+                if image is not None
+                else text
+            )
         inputs = processor([prompt], [image], return_tensors="pt")
         return inputs
 
@@ -1630,10 +1756,15 @@ class _OVNanoLlavaForCausalLM(OVModelForVisualCausalLM):
     ):
         if tokenizer is None:
             raise ValueError("Tokenizer is required.")
-        messages = [{"role": "user", "content": f"<image>\n{text}"}]
-        text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
-        text_chunks = [tokenizer(chunk).input_ids for chunk in text.split("<image>")]
-        input_ids = torch.tensor(text_chunks[0] + [-200] + text_chunks[1], dtype=torch.long).unsqueeze(0)
+        text_content = f"<image>\n{text}" if image is not None else text
+        messages = [{"role": "user", "content": text_content}]
+        if tokenizer.chat_template is not None:
+            text = tokenizer.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        if image is not None:
+            text_chunks = [tokenizer(chunk).input_ids for chunk in text.split("<image>")]
+            input_ids = torch.tensor(text_chunks[0] + [-200] + text_chunks[1], dtype=torch.long).unsqueeze(0)
+        else:
+            input_ids = tokenizer(text, return_tensors="pt").input_ids
         attention_mask = torch.ones_like(input_ids, dtype=torch.int64)
         result = {"input_ids": input_ids, "attention_mask": attention_mask}
         if image is not None:

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -25,6 +25,7 @@ from transformers.modeling_outputs import BaseModelOutputWithPooling
 from ...exporters.openvino import main_export
 from ...exporters.openvino.stateful import ensure_stateful_is_available, model_has_input_output_name
 from .. import OVQuantizer
+from ...exporters.openvino.utils import save_config
 from .configuration import OVConfig, OVWeightQuantizationConfig
 from .modeling_base import OVBaseModel, OVModelPart
 from .modeling_decoder import CausalLMOutputWithPast, OVModelForCausalLM
@@ -318,6 +319,13 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
             part_model = getattr(self, part, None)
             if part_model is not None:
                 part_model._compile()
+
+    def _save_config(self, save_directory):
+        """
+        Saves a model configuration into a directory, so that it can be re-loaded using the
+        [`from_pretrained`] class method.
+        """
+        save_config(self.config, save_directory)
 
     def _save_pretrained(self, save_directory: Union[str, Path]):
         """

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -784,7 +784,9 @@ class OVQuantizer(OptimumQuantizer):
             image = Image.open(requests.get(image_url, stream=True).raw)
 
             try:
-                inputs = self.model.preprocess_inputs(processor, instruction, image, tokenizer)
+                inputs = self.model.preprocess_inputs(
+                    text=instruction, image=image, processor=processor, tokenizer=tokenizer
+                )
             except ValueError as value_error:
                 if "Tokenizer is required." in str(value_error) and tokenizer_error is not None:
                     raise tokenizer_error

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -2071,7 +2071,6 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             )
             preprocessors = {"processor": processor, "tokenizer": tokenizer}
         elif model_arch == "internvl2":
-            config = AutoConfig.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
             tokenizer = AutoTokenizer.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1883,7 +1883,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
     if is_transformers_version(">=", "4.40.0"):
         SUPPORTED_ARCHITECTURES += ["llava_next", "nanollava"]
     if is_transformers_version(">=", "4.45.0"):
-        SUPPORTED_ARCHITECTURES += ["minicpmv", "nanollava", "internvl2"]
+        SUPPORTED_ARCHITECTURES += ["minicpmv", "internvl2"]
     TASK = "image-text-to-text"
     REMOTE_CODE_MODELS = ["internvl2", "minicpmv", "nanollava"]
 
@@ -1922,7 +1922,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             transformers_model.img_context_token_id = img_context_token_id
         if "nanollava" in model_arch:
             transformers_model.get_vision_tower().load_model()
-        inputs = self.gen_inputs(model_arch, prompt, self.IMAGE)
+        preprocessors = self.get_preprocessors(model_arch)
         set_seed(SEED)
         ov_model = OVModelForVisualCausalLM.from_pretrained(
             model_id, export=True, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
@@ -1934,6 +1934,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             self.assertTrue(hasattr(ov_model, additional_part))
             self.assertIsInstance(getattr(ov_model, additional_part), MODEL_PARTS_CLS_MAPPING[additional_part])
         self.assertIsInstance(ov_model.config, PretrainedConfig)
+        inputs = ov_model.preprocess_inputs(**preprocessors, text=prompt, image=self.IMAGE.resize((600, 600)))
         # pytorch minicpmv and internvl are not designed to be used via forward
         if model_arch not in ["minicpmv", "internvl2"]:
             set_seed(SEED)
@@ -1959,7 +1960,8 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
         set_seed(SEED)
         ov_outputs = ov_model.generate(**inputs, generation_config=gen_config)
         set_seed(SEED)
-        transformers_outputs = transformers_model.generate(**inputs, generation_config=gen_config)
+        with torch.no_grad():
+            transformers_outputs = transformers_model.generate(**inputs, generation_config=gen_config)
 
         # original minicpmv, internvl always skip input tokens in generation results, while transformers based approach provide them
         if model_arch in ["minicpmv", "internvl2"]:
@@ -2038,7 +2040,8 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
 
         tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
         question = "Describe image"
-        inputs = self.gen_inputs(model_arch, question, self.IMAGE)
+        preprocessors = self.get_preprocessors(model_arch)
+        inputs = model.preprocess_inputs(**preprocessors, text=question, image=self.IMAGE.resize((600, 600)))
         # General case
         outputs = model.generate(**inputs, max_new_tokens=10)
         outputs = tokenizer.batch_decode(outputs[:, inputs["input_ids"].shape[1] :], skip_special_tokens=True)
@@ -2046,7 +2049,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
 
         # No input image case
         question = "Hi, how are you?"
-        inputs = self.gen_inputs(model_arch, question, None)
+        inputs = model.preprocess_inputs(**preprocessors, text=question, image=None)
         outputs = model.generate(**inputs, max_new_tokens=10)
         # filter out original prompt becuase it may contains out of tokenizer tokens e.g. in nanollva text separator = -200
         outputs = outputs[:, inputs["input_ids"].shape[1] :]
@@ -2056,22 +2059,8 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
 
         gc.collect()
 
-    def gen_inputs(self, model_arch, base_text_prompt, image=None):
+    def get_preprocessors(self, model_arch):
         model_id = MODEL_NAMES[model_arch]
-        if "llava" in model_arch:
-            prompt = f"<image>\n {base_text_prompt}" if image is not None else base_text_prompt
-        elif "minicpmv" in model_arch:
-            prompt = (
-                "<|im_start|>user\n(<image>./</image>)\n {base_text_prompt}<|im_end|>\n<|im_start|>assistant\n"
-                if image is not None
-                else base_text_prompt
-            )
-        elif "internvl2" in model_arch:
-            prompt = (
-                "<|im_start|>user\n<image>\n {base_text_prompt}<|im_end|>\n<|im_start|>assistant\n"
-                if image is not None
-                else base_text_prompt
-            )
         if model_arch == "nanollava":
             config = AutoConfig.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
             processor = AutoProcessor.from_pretrained(
@@ -2080,134 +2069,19 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             tokenizer = AutoTokenizer.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
-            image_input = None
-            if image is not None:
-                image_input = processor(images=image, return_tensors="pt")["pixel_values"]
-                text_chunks = [tokenizer(chunk).input_ids for chunk in prompt.split("<image>")]
-
-                input_ids = torch.tensor(text_chunks[0] + [-200] + text_chunks[1], dtype=torch.long).unsqueeze(0)
-            else:
-                input_ids = tokenizer(prompt, return_tensors="pt").input_ids
-            attention_mask = torch.ones_like(input_ids, dtype=torch.int64)
-            inputs = {"input_ids": input_ids, "attention_mask": attention_mask, "images": image_input}
+            preprocessors = {"processor": processor, "tokenizer": tokenizer}
         elif model_arch == "internvl2":
             config = AutoConfig.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
             tokenizer = AutoTokenizer.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
-            inputs = self.internvl_input_transform(config, tokenizer, prompt, image)
+            preprocessors = {"processor": None, "tokenizer": tokenizer}
         else:
             processor = AutoProcessor.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
-            inputs = processor(
-                images=[image.resize((600, 600))] if image is not None else None, text=[prompt], return_tensors="pt"
-            )
-        return inputs
-
-    def internvl_input_transform(self, config, tokenizer, prompt, image=None):
-        import torchvision.transforms as T
-        from torchvision.transforms.functional import InterpolationMode
-
-        IMG_START_TOKEN = "<img>"
-        IMG_END_TOKEN = "</img>"
-        IMG_CONTEXT_TOKEN = "<IMG_CONTEXT>"
-
-        IMAGENET_MEAN = (0.485, 0.456, 0.406)
-        IMAGENET_STD = (0.229, 0.224, 0.225)
-
-        def build_transform(input_size):
-            MEAN, STD = IMAGENET_MEAN, IMAGENET_STD
-            transform = T.Compose(
-                [
-                    T.Lambda(lambda img: img.convert("RGB") if img.mode != "RGB" else img),
-                    T.Resize((input_size, input_size), interpolation=InterpolationMode.BICUBIC),
-                    T.ToTensor(),
-                    T.Normalize(mean=MEAN, std=STD),
-                ]
-            )
-            return transform
-
-        def find_closest_aspect_ratio(aspect_ratio, target_ratios, width, height, image_size):
-            best_ratio_diff = float("inf")
-            best_ratio = (1, 1)
-            area = width * height
-            for ratio in target_ratios:
-                target_aspect_ratio = ratio[0] / ratio[1]
-                ratio_diff = abs(aspect_ratio - target_aspect_ratio)
-                if ratio_diff < best_ratio_diff:
-                    best_ratio_diff = ratio_diff
-                    best_ratio = ratio
-                elif ratio_diff == best_ratio_diff:
-                    if area > 0.5 * image_size * image_size * ratio[0] * ratio[1]:
-                        best_ratio = ratio
-            return best_ratio
-
-        def dynamic_preprocess(image, min_num=1, max_num=12, image_size=28, use_thumbnail=False):
-            orig_width, orig_height = image.size
-            aspect_ratio = orig_width / orig_height
-
-            # calculate the existing image aspect ratio
-            target_ratios = {
-                (i, j)
-                for n in range(min_num, max_num + 1)
-                for i in range(1, n + 1)
-                for j in range(1, n + 1)
-                if i * j <= max_num and i * j >= min_num
-            }
-            target_ratios = sorted(target_ratios, key=lambda x: x[0] * x[1])
-
-            # find the closest aspect ratio to the target
-            target_aspect_ratio = find_closest_aspect_ratio(
-                aspect_ratio, target_ratios, orig_width, orig_height, image_size
-            )
-
-            # calculate the target width and height
-            target_width = image_size * target_aspect_ratio[0]
-            target_height = image_size * target_aspect_ratio[1]
-            blocks = target_aspect_ratio[0] * target_aspect_ratio[1]
-
-            # resize the image
-            resized_img = image.resize((target_width, target_height))
-            processed_images = []
-            for i in range(blocks):
-                box = (
-                    (i % (target_width // image_size)) * image_size,
-                    (i // (target_width // image_size)) * image_size,
-                    ((i % (target_width // image_size)) + 1) * image_size,
-                    ((i // (target_width // image_size)) + 1) * image_size,
-                )
-                # split the image
-                split_img = resized_img.crop(box)
-                processed_images.append(split_img)
-            assert len(processed_images) == blocks
-            if use_thumbnail and len(processed_images) != 1:
-                thumbnail_img = image.resize((image_size, image_size))
-                processed_images.append(thumbnail_img)
-            return processed_images
-
-        def load_image(image, input_size=448, max_num=12):
-            transform = build_transform(input_size=input_size)
-            images = dynamic_preprocess(image, image_size=input_size, use_thumbnail=True, max_num=max_num)
-            pixel_values = [transform(image) for image in images]
-            pixel_values = torch.stack(pixel_values)
-            return pixel_values
-
-        if image is not None:
-            pixel_values = load_image(image, input_size=config.vision_config.image_size)
-            num_patches = pixel_values.shape[0]
-            num_image_token = int(
-                (config.vision_config.image_size // config.vision_config.patch_size) ** 2
-                * (config.downsample_ratio**2)
-            )
-            image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_image_token * num_patches + IMG_END_TOKEN
-            prompt = prompt.replace("<image>", image_tokens, 1)
-            text_inputs = tokenizer(prompt, return_tensors="pt")
-            inputs = dict(text_inputs)
-            inputs.update({"pixel_values": pixel_values})
-        else:
-            inputs = tokenizer(prompt, return_tensors="pt")
-        return inputs
+            preprocessors = {"processor": processor, "tokenizer": None}
+        return preprocessors
 
 
 class OVModelForSpeechSeq2SeqIntegrationTest(unittest.TestCase):

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1935,7 +1935,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             self.assertIsInstance(getattr(ov_model, additional_part), MODEL_PARTS_CLS_MAPPING[additional_part])
         self.assertIsInstance(ov_model.config, PretrainedConfig)
         # pytorch minicpmv and internvl are not designed to be used via forward
-        if not model_arch in ["minicpmv", "internvl2"]:
+        if model_arch not in ["minicpmv", "internvl2"]:
             set_seed(SEED)
             ov_outputs = ov_model(**inputs)
             set_seed(SEED)

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1912,6 +1912,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
         transformers_model = self.get_transformer_model_class(model_arch).from_pretrained(
             model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
         )
+        transformers_model.eval()
         if "internvl2" in model_arch:
             tokenizer = AutoTokenizer.from_pretrained(
                 model_id, trast_remote_code=model_arch in self.REMOTE_CODE_MODELS
@@ -2072,7 +2073,6 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             tokenizer = AutoTokenizer.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
-<<<<<<< HEAD
             image_input = None
             if image is not None:
                 image_input = processor(images=image, return_tensors="pt")["pixel_values"]
@@ -2082,12 +2082,6 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             attention_mask = torch.ones_like(input_ids, dtype=torch.int64)
             inputs = {"input_ids": input_ids, "attention_mask": attention_mask, "images": image_input}
         elif model_arch == "internvl2":
-=======
-            inputs = processor(
-                images=[image.resize((600, 600))] if image is not None else None, text=[prompt], return_tensors="pt"
-            )
-        else:
->>>>>>> fix tests
             config = AutoConfig.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
             tokenizer = AutoTokenizer.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -71,6 +71,7 @@ MODEL_NAMES = {
     "ibert": "hf-internal-testing/tiny-random-ibert",
     "internlm": "katuni4ka/tiny-random-internlm",
     "internlm2": "katuni4ka/tiny-random-internlm2",
+    "internvl2": "katuni4ka/tiny-random-internvl2",
     "jais": "katuni4ka/tiny-random-jais",
     "levit": "hf-internal-testing/tiny-random-LevitModel",
     "longt5": "hf-internal-testing/tiny-random-longt5",


### PR DESCRIPTION
# What does this PR do?

some model configs does not expect be loaded without arguments that required for checking misplaced arguments  in 4.45 release (example https://huggingface.co/OpenGVLab/InternVL2-1B). This fix allows ignoring such cases for loading and saving config files

```
from pathlib import Path
import requests
from optimum.intel.openvino import OVModelForVisualCausalLM
from PIL import Image
from transformers import AutoTokenizer


model_id = "OpenGVLab/InternVL2-1B"
tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
model_path = Path(".models/InternVL2-1B/FP32")
if not model_path.exists():
    model = OVModelForVisualCausalLM.from_pretrained(model_id, trust_remote_code=True)
    model.save_pretrained(model_path)
    tokenizer.save_pretrained(model_path)
model = OVModelForVisualCausalLM.from_pretrained(model_path, trust_remote_code=True)


image_file = "http://images.cocodataset.org/val2017/000000039769.jpg"
raw_image = Image.open(requests.get(image_file, stream=True).raw).convert("RGB")

question = "Please describe the image shortly."
inputs = model.preprocess_inputs(
    tokenizer=tokenizer,
    image=raw_image,
    text=question,
)
generation_output = model.generate(**inputs, max_new_tokens=10)

print(tokenizer.batch_decode(generation_output[:, inputs["input_ids"].shape[1]:]))
```
## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

