### PR TITLE
Restore SDPA in Gemma2 models for transformers > 4.45

### DIFF
--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -865,7 +865,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
 
         # starting from transformers 4.45.0 gemma2 uses eager attention by default, while ov - sdpa
         if model_arch == "gemma2" and is_transformers_version(">=", "4.45.0"):
-            model_kwargs["attn_implemenation"] = "sdpa"
+            model_kwargs["attn_implementation"] = "sdpa"
 
         ov_model = OVModelForCausalLM.from_pretrained(model_id, export=True, ov_config=F32_CONFIG, **model_kwargs)
         self.assertIsInstance(ov_model.config, PretrainedConfig)

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1101,7 +1101,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
 
         # starting from transformers 4.45.0 gemma2 uses eager attention by default, while ov - sdpa
         if model_arch == "gemma2" and is_transformers_version(">=", "4.45.0"):
-            model_kwargs["attn_implemenation"] = "sdpa"
+            model_kwargs["attn_implementation"] = "sdpa"
         # Qwen tokenizer does not support padding, chatglm, glm4 testing models produce nan that incompatible with beam search
         if model_arch in ["qwen", "chatglm", "glm4"]:
             return

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -863,6 +863,10 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         if model_arch in self.REMOTE_CODE_MODELS:
             model_kwargs = {"trust_remote_code": True}
 
+        # starting from transformers 4.45.0 gemma2 uses eager attention by default, while ov - sdpa
+        if model_arch == "gemma2" and is_transformers_version(">=", "4.45.0"):
+            model_kwargs["attn_implemenation"] = "sdpa"
+
         ov_model = OVModelForCausalLM.from_pretrained(model_id, export=True, ov_config=F32_CONFIG, **model_kwargs)
         self.assertIsInstance(ov_model.config, PretrainedConfig)
         self.assertTrue(ov_model.use_cache)
@@ -1094,6 +1098,10 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
                 "config": AutoConfig.from_pretrained(model_id, trust_remote_code=True),
                 "trust_remote_code": True,
             }
+
+        # starting from transformers 4.45.0 gemma2 uses eager attention by default, while ov - sdpa
+        if model_arch == "gemma2" and is_transformers_version(">=", "4.45.0"):
+            model_kwargs["attn_implemenation"] = "sdpa"
         # Qwen tokenizer does not support padding, chatglm, glm4 testing models produce nan that incompatible with beam search
         if model_arch in ["qwen", "chatglm", "glm4"]:
             return


### PR DESCRIPTION
# What does this PR do?
transformers 4.45 introduces perf regression for gemma2 models due to switching default realization from sdpa to eager in this commit:
https://github.com/huggingface/transformers/commit/975b988bfe6e7ebb47390cd9a1556c6888804883

benchmarking results for CPU:

| model |  precision | input prompt len | 2sd token latency (ms) without sdpa | 2nd token latency (ms) with sdpa |
----------|---------------|-----------------------|-------------------------------------------------|---------------------------------------|
|  gemma-2-2b  | FP16 | 32 | 37.9 | 26.7|
| gemma-2-2b | FP16 | 1024 | 106.7 | 27.3|
| gemma-2-9b | FP16 | 32 | 112.4 | 82.3 |
| gemma-2-9b | FP16 | 1024 | 310.2 | 83.7 |
|  gemma-2-2b  | INT8 | 32 | 31.9 | 20.9|
| gemma-2-2b | INT8 | 1024 | 111.3 | 21.3|
| gemma-2-9b | INT8 | 32 | 82.9 | 53.4 |
| gemma-2-9b | INT8 | 1024 | 301.9 | 55.5 |

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

