### PR TITLE
fix order of hidden states in text encoder

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -995,9 +995,9 @@ class OVPipelinePart(ConfigMixin):
 class OVModelTextEncoder(OVPipelinePart):
     def __init__(self, model: openvino.runtime.Model, parent_pipeline: OVDiffusionPipeline, model_name: str = ""):
         super().__init__(model, parent_pipeline, model_name)
-        self.hidden_states_output_names = sorted(
-            {name for out in self.model.outputs for name in out.names if name.startswith("hidden_states")}
-        )
+        self.hidden_states_output_names = {
+            name for out in self.model.outputs for name in out.names if name.startswith("hidden_states")
+        }
 
     def forward(
         self,

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -995,9 +995,9 @@ class OVPipelinePart(ConfigMixin):
 class OVModelTextEncoder(OVPipelinePart):
     def __init__(self, model: openvino.runtime.Model, parent_pipeline: OVDiffusionPipeline, model_name: str = ""):
         super().__init__(model, parent_pipeline, model_name)
-        self.hidden_states_output_names = {
+        self.hidden_states_output_names = [
             name for out in self.model.outputs for name in out.names if name.startswith("hidden_states")
-        }
+        ]
 
     def forward(
         self,


### PR DESCRIPTION
# What does this PR do?

using sorting breaks topological order of outputs, it keeps output names in alphabetical order, that is different from topological if model has > 10 layers (e.g. hiden_states.0, hidden_states.1, ..., hidden_states.9, hidden_states.10 we got hidden_states.0, hidden_tates.1, hidden_states.10, hidden_states.2, ...., hidden_states.9) that significantly impact model accuracy for sdxl.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

