### PR TITLE
add saving safety_checker

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -715,6 +715,9 @@ def export_from_model(
         tokenizer_3 = getattr(model, "tokenizer_3", None)
         if tokenizer_3 is not None:
             tokenizer_3.save_pretrained(output.joinpath("tokenizer_3"))
+        safety_checker = getattr(model, "safety_checker", None)
+        if safety_checker is not None:
+            safety_checker.save_pretrained(output.joinpath("safety_checker"))
 
         model.save_config(output)
 

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -424,15 +424,12 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
                     module = getattr(pipelines, module_name)
                 else:
                     module = importlib.import_module(module_name)
-                logger.warn(module)
                 class_obj = getattr(module, module_class)
                 load_method = getattr(class_obj, "from_pretrained")
                 # Check if the module is in a subdirectory
                 if (model_save_path / name).is_dir():
-                    logger.warn(name)
                     submodels[name] = load_method(model_save_path / name)
                 else:
-                    logger.warn(name)
                     submodels[name] = load_method(model_save_path)
 
         models = {
@@ -454,10 +451,8 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
         if (quantization_config is None or quantization_config.dataset is None) and not compile_only:
             for name, path in models.items():
                 if name in kwargs:
-                    logger.warn(name)
                     models[name] = kwargs.pop(name)
                 else:
-                    logger.warn(name)
                     models[name] = cls.load_model(path, quantization_config) if path.is_file() else None
         elif compile_only:
             ov_config = kwargs.get("ov_config", {})

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -295,6 +295,8 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
             self.tokenizer_3.save_pretrained(save_directory / "tokenizer_3")
         if self.feature_extractor is not None:
             self.feature_extractor.save_pretrained(save_directory / "feature_extractor")
+        if getattr(self, "safety_checker", None) is not None:
+            self.safety_checker.save_pretrained(save_directory / "safety_checker")
 
         self._save_openvino_config(save_directory)
 
@@ -422,12 +424,15 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
                     module = getattr(pipelines, module_name)
                 else:
                     module = importlib.import_module(module_name)
+                logger.warn(module)
                 class_obj = getattr(module, module_class)
                 load_method = getattr(class_obj, "from_pretrained")
                 # Check if the module is in a subdirectory
                 if (model_save_path / name).is_dir():
+                    logger.warn(name)
                     submodels[name] = load_method(model_save_path / name)
                 else:
+                    logger.warn(name)
                     submodels[name] = load_method(model_save_path)
 
         models = {
@@ -449,8 +454,10 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
         if (quantization_config is None or quantization_config.dataset is None) and not compile_only:
             for name, path in models.items():
                 if name in kwargs:
+                    logger.warn(name)
                     models[name] = kwargs.pop(name)
                 else:
+                    logger.warn(name)
                     models[name] = cls.load_model(path, quantization_config) if path.is_file() else None
         elif compile_only:
             ov_config = kwargs.get("ov_config", {})


### PR DESCRIPTION
# What does this PR do?

safety_checker is part of pipeline for sd and sdxl models family. In case, if we provide already converted model and model_index.json contains safety_checker object definition, pipeline loading failed in attempt to load model for it:
OSError: Error no file named pytorch_model.bin, model.safetensors, tf_model.h5, model.ckpt.index or flax_model.msgpack found in directory

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

