### PR TITLE
make minicpm and internvl preprocessing compatible with orig models

### DIFF
--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -793,6 +793,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
         image: Optional[Image] = None,
         processor: Optional[AutoImageProcessor] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
     ):
         """
         Preprocess input instruction and an image.
@@ -969,6 +970,7 @@ class _OVLlavaForCausalLM(OVModelForVisualCausalLM):
         image: Optional[Image] = None,
         processor: Optional[AutoImageProcessor] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
     ):
         if processor is None:
             raise ValueError("Processor is required.")
@@ -1282,12 +1284,13 @@ class _OVInternVLForCausalLM(OVModelForVisualCausalLM):
         input_embeds = input_embeds.reshape(B, N, C)
         return input_embeds, attention_mask, position_ids
 
+    @staticmethod
     def preprocess_inputs(
-        self,
         text: str,
         image: Optional[Image] = None,
         processor: Optional[AutoImageProcessor] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
     ):
         if tokenizer is None:
             raise ValueError("Tokenizer is required.")
@@ -1379,13 +1382,15 @@ class _OVInternVLForCausalLM(OVModelForVisualCausalLM):
             return pixel_values
 
         if image is not None:
+            if config is None:
+                raise ValueError("Config is required.")
             if "<image>" not in text:
                 text = "<image>\n" + text
-            pixel_values = load_image(image, input_size=self.config.vision_config.image_size)
+            pixel_values = load_image(image, input_size=config.vision_config.image_size)
             num_patches = pixel_values.shape[0]
             num_image_token = int(
-                (self.config.vision_config.image_size // self.config.vision_config.patch_size) ** 2
-                * (self.config.downsample_ratio**2)
+                (config.vision_config.image_size // config.vision_config.patch_size) ** 2
+                * (config.downsample_ratio**2)
             )
             image_tokens = IMG_START_TOKEN + IMG_CONTEXT_TOKEN * num_image_token * num_patches + IMG_END_TOKEN
             text = text.replace("<image>", image_tokens, 1)
@@ -1660,6 +1665,7 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
         image: Optional[Image] = None,
         processor: Optional[AutoImageProcessor] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
     ):
         if processor is None:
             raise ValueError("Processor is required.")
@@ -1673,6 +1679,7 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
                 else text
             )
         inputs = processor([prompt], [image], return_tensors="pt")
+        inputs.pop("image_sizes", None)
         return inputs
 
 
@@ -1853,6 +1860,7 @@ class _OVNanoLlavaForCausalLM(OVModelForVisualCausalLM):
         image: Optional[Image] = None,
         processor: Optional[AutoImageProcessor] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
     ):
         if tokenizer is None:
             raise ValueError("Tokenizer is required.")
@@ -2012,6 +2020,7 @@ class _OVPhi3VisionForCausalLM(OVModelForVisualCausalLM):
         image: Optional[Image] = None,
         processor: Optional[AutoImageProcessor] = None,
         tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
     ):
         if processor is None:
             raise ValueError("Processor is required.")

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -785,7 +785,7 @@ class OVQuantizer(OptimumQuantizer):
 
             try:
                 inputs = self.model.preprocess_inputs(
-                    text=instruction, image=image, processor=processor, tokenizer=tokenizer
+                    text=instruction, image=image, processor=processor, tokenizer=tokenizer, config=self.model.config
                 )
             except ValueError as value_error:
                 if "Tokenizer is required." in str(value_error) and tokenizer_error is not None:

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -2165,10 +2165,11 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             )
             preprocessors = {"processor": processor, "tokenizer": tokenizer}
         elif model_arch == "internvl2":
+            config = AutoConfig.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
             tokenizer = AutoTokenizer.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
-            preprocessors = {"processor": None, "tokenizer": tokenizer}
+            preprocessors = {"processor": None, "tokenizer": tokenizer, "config": config}
         else:
             processor = AutoProcessor.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS


### PR DESCRIPTION
* minicpmv generate does not expect to see `image_sizes` input that generates by preprocessor
* make internvl preprocess input static to be able reuse it for pytorch model without model creation (it requires to slightly change preprocess_input signature to provide config)

# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

