### PR TITLE
Relax OpenVINO dependency version

### DIFF
--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -37,6 +37,7 @@ jobs:
 
       - name: Setup environment
         run: |
+          pip install --upgrade pip
           pip uninstall -y doc-builder
           cd doc-builder
           git pull origin main

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]
 
 EXTRAS_REQUIRE = {
     "nncf": ["nncf>=2.11.0"],
-    "openvino": ["nncf>=2.11.0", "openvino==2024.5.0", "openvino-tokenizers==2024.5.0"],
+    "openvino": ["nncf>=2.11.0", "openvino>=2024.5.0", "openvino-tokenizers>=2024.5.0"],
     "neural-compressor": ["neural-compressor[pt]>3.0", "accelerate", "transformers<4.46"],
     "ipex": ["intel-extension-for-pytorch", "transformers>=4.39,<4.45"],
     "diffusers": ["diffusers"],


### PR DESCRIPTION
This PR enables installing optimum[openvino] in an environment where you already have a nightly version of OpenVINO installed. Currently running `pip install optimum[openvino]` in such an environment uninstalls the existing OpenVINO and that is usually not expected/desired. 
Since nightly versions have to be explicitly installed by providing the index url, there's no chance someone will accidentally end up with a nightly version. Once a new OpenVINO version has been released it will have been validated.

I also wanted to relax the lower version but would also like to add a test that the lower bound version does still work. I can do that in a future PR. That's more important for the upcoming LTS release.