### PR TITLE
change ipex transformers limited verison in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ except Exception as error:
 INSTALL_REQUIRE = [
     "torch>=1.11",
     "optimum~=1.23",
-    "transformers>=4.36,<4.46",
+    "transformers>=4.36,<4.47",
     "datasets>=1.4.0",
     "sentencepiece",
     "setuptools",
@@ -62,9 +62,9 @@ QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]
 
 EXTRAS_REQUIRE = {
     "nncf": ["nncf>=2.11.0"],
-    "ipex": ["intel-extension-for-pytorch", "transformers>=4.39,<4.46"],
     "openvino": ["nncf>=2.11.0", "openvino==2024.5.0", "openvino-tokenizers==2024.5.0"],
     "neural-compressor": ["neural-compressor[pt]>3.0", "accelerate", "transformers<4.46"],
+    "ipex": ["intel-extension-for-pytorch", "transformers>=4.39,<4.46"],
     "diffusers": ["diffusers"],
     "quality": QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,

--- a/tests/neural_compressor/test_cli.py
+++ b/tests/neural_compressor/test_cli.py
@@ -12,7 +12,6 @@ class NeuralCoderAdaptorTest(unittest.TestCase):
         self.assertIsInstance(dynamic_api, str)
         self.assertIsInstance(static_api, str)
 
-    @unittest.skip(reason="INC is going to deprecate, skip this failed test")
     def test_cli(self):
         with tempfile.TemporaryDirectory() as tempdir:
             # TODO : enable

--- a/tests/neural_compressor/test_ipex.py
+++ b/tests/neural_compressor/test_ipex.py
@@ -53,7 +53,6 @@ class IPEXQuantizationTest(INCTestMixin):
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (("text-classification", "bert", 21),)
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS)
-    @unittest.skip(reason="INC is going to deprecate, skip this failed test")
     def test_ipex_static_quantization_with_smoothquant(self, task, model_arch, expected_quantized_matmuls):
         recipes = {"smooth_quant": True, "smooth_quant_args": {"alpha": 0.5}}
         num_samples = 10
@@ -81,5 +80,5 @@ class IPEXQuantizationTest(INCTestMixin):
                 is_static=True,
                 num_samples=num_samples,
                 load_inc_model=False,
-                load_ipex_model=True,
+                load_ipex_model=False,
             )


### PR DESCRIPTION
Jit is deprecated in IPEXModel, so we cannot use ipex model to load a jit model which is saved by INC