### PR TITLE
Add new features from NNCF 2.14

### DIFF
--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -29,7 +29,7 @@ optimum-cli export openvino --model local_llama --task text-generation-with-past
 
 Check out the help for more options:
 
-```
+```text
 usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt,tf}] [--trust-remote-code]
                                    [--weight-format {fp32,fp16,int8,int4,mxfp4,nf4}]
                                    [--library {transformers,diffusers,timm,sentence_transformers,open_clip}]

--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -29,7 +29,7 @@ optimum-cli export openvino --model local_llama --task text-generation-with-past
 
 Check out the help for more options:
 
-```bash
+```
 usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt,tf}] [--trust-remote-code]
                                    [--weight-format {fp32,fp16,int8,int4,mxfp4,nf4}]
                                    [--library {transformers,diffusers,timm,sentence_transformers,open_clip}]
@@ -50,14 +50,14 @@ Required arguments:
 
 Optional arguments:
   --task TASK           The task to export the model for. If not specified, the task will be auto-inferred based on
-                        the model. Available tasks depend on the model, but are among: ['image-to-image', 'image-
-                        segmentation', 'inpainting', 'sentence-similarity', 'text-to-audio', 'image-to-text',
-                        'automatic-speech-recognition', 'token-classification', 'text-to-image', 'audio-
-                        classification', 'feature-extraction', 'semantic-segmentation', 'masked-im', 'audio-xvector',
+                        the model. Available tasks depend on the model, but are among: ['image-to-image',
+                        'image-segmentation', 'inpainting', 'sentence-similarity', 'text-to-audio', 'image-to-text',
+                        'automatic-speech-recognition', 'token-classification', 'text-to-image', 'audio-classification',
+                        'feature-extraction', 'semantic-segmentation', 'masked-im', 'audio-xvector',
                         'audio-frame-classification', 'text2text-generation', 'multiple-choice', 'depth-estimation',
                         'image-classification', 'fill-mask', 'zero-shot-object-detection', 'object-detection',
                         'question-answering', 'zero-shot-image-classification', 'mask-generation', 'text-generation',
-                        'text-classification']. For decoder models, use `xxx-with-past` to export the model using past
+                        'text-classification']. For decoder models, use 'xxx-with-past' to export the model using past
                         key values in the decoder.
   --framework {pt,tf}   The framework to use for the export. If not provided, will attempt to use the local
                         checkpoint's original framework or what is available in the environment.

--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -92,8 +92,8 @@ Optional arguments:
                         typical non-fixed zero point.
   --dataset DATASET     The dataset used for data-aware compression or quantization with NNCF. For language models you
                         can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the dataset will
-                        be collected from model's generations. For diffusion models -- on of
-                        ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit'].For
+                        be collected from model's generations. For diffusion models it should be on of
+                        ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit']. For
                         visual language models the dataset must be set to 'contextual'.
   --all-layers          Whether embeddings and last MatMul layers should be compressed to INT4. If not provided an
                         weight compression is applied, they are compressed to INT8.

--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -34,9 +34,10 @@ usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt,
                                    [--weight-format {fp32,fp16,int8,int4,mxfp4,nf4}]
                                    [--library {transformers,diffusers,timm,sentence_transformers,open_clip}]
                                    [--cache_dir CACHE_DIR] [--pad-token-id PAD_TOKEN_ID] [--ratio RATIO] [--sym]
-                                   [--group-size GROUP_SIZE] [--dataset DATASET] [--all-layers] [--awq]
-                                   [--scale-estimation] [--gptq] [--sensitivity-metric SENSITIVITY_METRIC]
-                                   [--num-samples NUM_SAMPLES] [--disable-stateful] [--disable-convert-tokenizer]
+                                   [--group-size GROUP_SIZE] [--backup-precision {none,int8_sym,int8_asym}]
+                                   [--dataset DATASET] [--all-layers] [--awq] [--scale-estimation] [--gptq] [--lora]
+                                   [--sensitivity-metric SENSITIVITY_METRIC] [--num-samples NUM_SAMPLES]
+                                   [--disable-stateful] [--disable-convert-tokenizer]
                                    output
 
 optional arguments:
@@ -49,15 +50,15 @@ Required arguments:
 
 Optional arguments:
   --task TASK           The task to export the model for. If not specified, the task will be auto-inferred based on
-                        the model. Available tasks depend on the model, but are among: ['fill-mask', 'masked-im',
-                        'audio-classification', 'automatic-speech-recognition', 'text-to-audio', 'image-text-to-text',
-                        'depth-estimation', 'image-to-image', 'text-generation', 'text-to-image', 'mask-generation',
-                        'audio-frame-classification', 'sentence-similarity', 'image-classification', 'multiple-
-                        choice', 'text-classification', 'text2text-generation', 'token-classification', 'feature-
-                        extraction', 'zero-shot-image-classification', 'zero-shot-object-detection', 'object-
-                        detection', 'inpainting', 'question-answering', 'semantic-segmentation', 'image-segmentation',
-                        'audio-xvector', 'image-to-text']. For decoder models, use `xxx-with-past` to export the model
-                        using past key values in the decoder.
+                        the model. Available tasks depend on the model, but are among: ['image-to-image', 'image-
+                        segmentation', 'inpainting', 'sentence-similarity', 'text-to-audio', 'image-to-text',
+                        'automatic-speech-recognition', 'token-classification', 'text-to-image', 'audio-
+                        classification', 'feature-extraction', 'semantic-segmentation', 'masked-im', 'audio-xvector',
+                        'audio-frame-classification', 'text2text-generation', 'multiple-choice', 'depth-estimation',
+                        'image-classification', 'fill-mask', 'zero-shot-object-detection', 'object-detection',
+                        'question-answering', 'zero-shot-image-classification', 'mask-generation', 'text-generation',
+                        'text-classification']. For decoder models, use `xxx-with-past` to export the model using past
+                        key values in the decoder.
   --framework {pt,tf}   The framework to use for the export. If not provided, will attempt to use the local
                         checkpoint's original framework or what is available in the environment.
   --trust-remote-code   Allows to use custom code for the modeling hosted in the model repository. This option should
@@ -82,10 +83,18 @@ Optional arguments:
   --group-size GROUP_SIZE
                         The group size to use for quantization. Recommended value is 128 and -1 uses per-column
                         quantization.
-  --dataset DATASET     The dataset used for data-aware compression or quantization with NNCF. You can use the one
-                        from the list ['wikitext2','c4','c4-new'] for language models or
-                        ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit'] for
-                        diffusion models.
+  --backup-precision {none,int8_sym,int8_asym}
+                        Defines a backup precision for mixed-precision weight compression. Only valid for int4 weight
+                        format. If not provided, backup precision is int8_asym. 'none' stands for original floating-
+                        point precision of the model weights, in this case weights are retained in their original
+                        precision without any quantization. 'int8_sym' stands for 8-bit integer symmetric quantization
+                        without zero point. 'int8_asym' stands for 8-bit integer asymmetric quantization with a
+                        typical non-fixed zero point.
+  --dataset DATASET     The dataset used for data-aware compression or quantization with NNCF. For language models you
+                        can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the dataset will
+                        be collected from model's generations. For diffusion models -- on of
+                        ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit'].For
+                        visual language models the dataset must be set to 'contextual'.
   --all-layers          Whether embeddings and last MatMul layers should be compressed to INT4. If not provided an
                         weight compression is applied, they are compressed to INT8.
   --awq                 Whether to apply AWQ algorithm. AWQ improves generation quality of INT4-compressed LLMs, but
@@ -98,6 +107,9 @@ Optional arguments:
   --gptq                Indicates whether to apply GPTQ algorithm that optimizes compressed weights in a layer-wise
                         fashion to minimize the difference between activations of a compressed and original layer.
                         Please note, that applying GPTQ takes additional memory and time.
+  --lora                Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm mitigates
+                        quantization noise introduced during weight compression by leveraging low-rank adaptation.
+                        Please note, that applying LoRA algorithm takes additional memory and time.
   --sensitivity-metric SENSITIVITY_METRIC
                         The sensitivity metric for assigning quantization precision to layers. It can be one of the
                         following: ['weight_quantization_error', 'hessian_input_activation',

--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -35,9 +35,9 @@ usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt,
                                    [--library {transformers,diffusers,timm,sentence_transformers,open_clip}]
                                    [--cache_dir CACHE_DIR] [--pad-token-id PAD_TOKEN_ID] [--ratio RATIO] [--sym]
                                    [--group-size GROUP_SIZE] [--backup-precision {none,int8_sym,int8_asym}]
-                                   [--dataset DATASET] [--all-layers] [--awq] [--scale-estimation] [--gptq] [--lora]
-                                   [--sensitivity-metric SENSITIVITY_METRIC] [--num-samples NUM_SAMPLES]
-                                   [--disable-stateful] [--disable-convert-tokenizer]
+                                   [--dataset DATASET] [--all-layers] [--awq] [--scale-estimation] [--gptq]
+                                   [--lora-correction] [--sensitivity-metric SENSITIVITY_METRIC]
+                                   [--num-samples NUM_SAMPLES] [--disable-stateful] [--disable-convert-tokenizer]
                                    output
 
 optional arguments:
@@ -107,9 +107,9 @@ Optional arguments:
   --gptq                Indicates whether to apply GPTQ algorithm that optimizes compressed weights in a layer-wise
                         fashion to minimize the difference between activations of a compressed and original layer.
                         Please note, that applying GPTQ takes additional memory and time.
-  --lora                Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm mitigates
+  --lora-correction     Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm mitigates
                         quantization noise introduced during weight compression by leveraging low-rank adaptation.
-                        Please note, that applying LoRA algorithm takes additional memory and time.
+                        Please note, that applying LoRA Correction algorithm takes additional memory and time.
   --sensitivity-metric SENSITIVITY_METRIC
                         The sensitivity metric for assigning quantization precision to layers. It can be one of the
                         following: ['weight_quantization_error', 'hessian_input_activation',

--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -88,8 +88,8 @@ Optional arguments:
                         format. If not provided, backup precision is int8_asym. 'none' stands for original floating-
                         point precision of the model weights, in this case weights are retained in their original
                         precision without any quantization. 'int8_sym' stands for 8-bit integer symmetric quantization
-                        without zero point. 'int8_asym' stands for 8-bit integer asymmetric quantization with a
-                        typical non-fixed zero point.
+                        without zero point. 'int8_asym' stands for 8-bit integer asymmetric quantization with zero
+                        points per each quantization group.
   --dataset DATASET     The dataset used for data-aware compression or quantization with NNCF. For language models you
                         can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the dataset will
                         be collected from model's generations. For diffusion models it should be on of
@@ -107,9 +107,10 @@ Optional arguments:
   --gptq                Indicates whether to apply GPTQ algorithm that optimizes compressed weights in a layer-wise
                         fashion to minimize the difference between activations of a compressed and original layer.
                         Please note, that applying GPTQ takes additional memory and time.
-  --lora-correction     Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm mitigates
-                        quantization noise introduced during weight compression by leveraging low-rank adaptation.
-                        Please note, that applying LoRA Correction algorithm takes additional memory and time.
+  --lora-correction     Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm introduces
+                        low-rank adaptation layers in the model that can recover accuracy after weight compression at
+                        some cost of inference latency. Please note, that applying LoRA Correction algorithm takes
+                        additional memory and time.
   --sensitivity-metric SENSITIVITY_METRIC
                         The sensitivity metric for assigning quantization precision to layers. It can be one of the
                         following: ['weight_quantization_error', 'hessian_input_activation',

--- a/docs/source/openvino/optimization.mdx
+++ b/docs/source/openvino/optimization.mdx
@@ -101,6 +101,7 @@ Quality of 4-bit weight compressed model can further be improved by employing on
 * **AWQ** which stands for Activation Aware Quantization is an algorithm that tunes model weights for more accurate 4-bit compression. It slightly improves generation quality of compressed LLMs, but requires significant additional time and memory for tuning weights on a calibration dataset. Please note that it is possible that there will be no matching patterns in the model to apply AWQ, in such case it will be skipped.
 * **Scale Estimation** is a method that tunes quantization scales to minimize the `L2` error between the original and compressed layers. Providing a dataset is required to run scale estimation. Using this method also incurs additional time and memory overhead.
 * **GPTQ** optimizes compressed weights in a layer-wise fashion to minimize the difference between activations of a compressed and original layer.
+* **LoRA** mitigates quantization noise introduced during weight compression by leveraging low-rank adaptation.
 
 Data-aware algorithms can be applied together or separately. For that, provide corresponding arguments to the 4-bit `OVWeightQuantizationConfig` together with a dataset. For example:
 ```python
@@ -114,6 +115,8 @@ quantization_config = OVWeightQuantizationConfig(
     dataset="wikitext2"
 )
 ```
+
+Note: GPTQ and LoRA algorithms can't be applied simultaneously.
 
 ### Static quantization
 

--- a/docs/source/openvino/optimization.mdx
+++ b/docs/source/openvino/optimization.mdx
@@ -101,7 +101,7 @@ Quality of 4-bit weight compressed model can further be improved by employing on
 * **AWQ** which stands for Activation Aware Quantization is an algorithm that tunes model weights for more accurate 4-bit compression. It slightly improves generation quality of compressed LLMs, but requires significant additional time and memory for tuning weights on a calibration dataset. Please note that it is possible that there will be no matching patterns in the model to apply AWQ, in such case it will be skipped.
 * **Scale Estimation** is a method that tunes quantization scales to minimize the `L2` error between the original and compressed layers. Providing a dataset is required to run scale estimation. Using this method also incurs additional time and memory overhead.
 * **GPTQ** optimizes compressed weights in a layer-wise fashion to minimize the difference between activations of a compressed and original layer.
-* **LoRA** mitigates quantization noise introduced during weight compression by leveraging low-rank adaptation.
+* **LoRA Correction** mitigates quantization noise introduced during weight compression by leveraging low-rank adaptation.
 
 Data-aware algorithms can be applied together or separately. For that, provide corresponding arguments to the 4-bit `OVWeightQuantizationConfig` together with a dataset. For example:
 ```python
@@ -116,7 +116,7 @@ quantization_config = OVWeightQuantizationConfig(
 )
 ```
 
-Note: GPTQ and LoRA algorithms can't be applied simultaneously.
+Note: GPTQ and LoRA Correction algorithms can't be applied simultaneously.
 
 ### Static quantization
 

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -138,8 +138,8 @@ def parse_args_openvino(parser: "ArgumentParser"):
             "The dataset used for data-aware compression or quantization with NNCF. "
             "For language models you can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the "
             "dataset will be collected from model's generations. "
-            "For diffusion models -- on of ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS',"
-            "'laion/filtered-wit']."
+            "For diffusion models it should be on of ['conceptual_captions',"
+            "'laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit']. "
             "For visual language models the dataset must be set to 'contextual'."
         ),
     )

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -168,6 +168,16 @@ def parse_args_openvino(parser: "ArgumentParser"):
         ),
     )
     optional_group.add_argument(
+        "--lora",
+        action="store_true",
+        default=None,
+        help=(
+            "Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm mitigates quantization "
+            "noise introduced during weight compression by leveraging low-rank adaptation. Please note, that applying "
+            "LoRA algorithm takes additional memory and time."
+        ),
+    )
+    optional_group.add_argument(
         "--sensitivity-metric",
         type=str,
         default=None,
@@ -215,6 +225,7 @@ def no_compression_parameter_provided(args):
                 args.awq,
                 args.scale_estimation,
                 args.gptq,
+                args.lora,
                 args.sensitivity_metric,
             )
         )
@@ -287,6 +298,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                     "sensitivity_metric": self.args.sensitivity_metric,
                     "scale_estimation": self.args.scale_estimation,
                     "gptq": self.args.gptq,
+                    "lora": self.args.lora,
                     "weight_format": self.args.weight_format,
                 }
 

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -136,9 +136,9 @@ def parse_args_openvino(parser: "ArgumentParser"):
         default=None,
         help=(
             "The dataset used for data-aware compression or quantization with NNCF. "
-            "For language models you can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the"
+            "For language models you can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the "
             "dataset will be collected from model's generations. "
-            "For diffusion models on of ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS',"
+            "For diffusion models -- on of ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS',"
             "'laion/filtered-wit']."
             "For visual language models the dataset must be set to 'contextual'."
         ),
@@ -159,7 +159,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
         help=(
             "Whether to apply AWQ algorithm. AWQ improves generation quality of INT4-compressed LLMs, but requires "
             "additional time for tuning weights on a calibration dataset. To run AWQ, please also provide a dataset "
-            "argument. Note: it's possible that there will be no matching patterns in the model to apply AWQ, in such "
+            "argument. Note: it is possible that there will be no matching patterns in the model to apply AWQ, in such "
             "case it will be skipped."
         ),
     )
@@ -198,7 +198,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
         type=str,
         default=None,
         help=(
-            "The sensitivity metric for assigning quantization precision to layers. Can be one of the following: "
+            "The sensitivity metric for assigning quantization precision to layers. It can be one of the following: "
             "['weight_quantization_error', 'hessian_input_activation', 'mean_activation_variance', "
             "'max_activation_variance', 'mean_activation_magnitude']."
         ),
@@ -217,7 +217,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
             "In stateful models all kv-cache inputs and outputs are hidden in the model and are not exposed as model inputs and outputs. "
             "If --disable-stateful option is used, it may result in sub-optimal inference performance. "
             "Use it when you intentionally want to use a stateless model, for example, to be compatible with existing "
-            "OpenVINO native inference code that expects kv-cache inputs and outputs in the model."
+            "OpenVINO native inference code that expects KV-cache inputs and outputs in the model."
         ),
     )
     optional_group.add_argument(

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -118,6 +118,19 @@ def parse_args_openvino(parser: "ArgumentParser"):
         help=("The group size to use for quantization. Recommended value is 128 and -1 uses per-column quantization."),
     )
     optional_group.add_argument(
+        "--backup-precision",
+        type=str,
+        choices=["none", "int8_sym", "int8_asym"],
+        default=None,
+        help=(
+            "Defines a backup precision for mixed-precision weight compression. Only valid for int4 weight format. "
+            "If not provided, backup precision is int8_asym. 'none' stands for original floating-point precision of "
+            "the model weights, in this case weights are retained in their original precision without any "
+            "quantization. 'int8_sym' stands for 8-bit integer symmetric quantization without zero point. 'int8_asym' "
+            "stands for 8-bit integer asymmetric quantization with a typical non-fixed zero point."
+        ),
+    )
+    optional_group.add_argument(
         "--dataset",
         type=str,
         default=None,
@@ -227,6 +240,7 @@ def no_compression_parameter_provided(args):
                 args.gptq,
                 args.lora,
                 args.sensitivity_metric,
+                args.backup_precision,
             )
         )
     )
@@ -300,6 +314,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                     "gptq": self.args.gptq,
                     "lora": self.args.lora,
                     "weight_format": self.args.weight_format,
+                    "backup_precision": self.args.backup_precision,
                 }
 
             if quantization_config.get("dataset", None) is not None:

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -184,13 +184,13 @@ def parse_args_openvino(parser: "ArgumentParser"):
         ),
     )
     optional_group.add_argument(
-        "--lora",
+        "--lora-correction",
         action="store_true",
         default=None,
         help=(
             "Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm mitigates quantization "
             "noise introduced during weight compression by leveraging low-rank adaptation. Please note, that applying "
-            "LoRA algorithm takes additional memory and time."
+            "LoRA Correction algorithm takes additional memory and time."
         ),
     )
     optional_group.add_argument(
@@ -241,7 +241,7 @@ def no_compression_parameter_provided(args):
                 args.awq,
                 args.scale_estimation,
                 args.gptq,
-                args.lora,
+                args.lora_correction,
                 args.sensitivity_metric,
                 args.backup_precision,
             )
@@ -315,7 +315,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                     "sensitivity_metric": self.args.sensitivity_metric,
                     "scale_estimation": self.args.scale_estimation,
                     "gptq": self.args.gptq,
-                    "lora": self.args.lora,
+                    "lora_correction": self.args.lora_correction,
                     "weight_format": self.args.weight_format,
                     "backup_precision": self.args.backup_precision,
                 }

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -127,7 +127,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
             "If not provided, backup precision is int8_asym. 'none' stands for original floating-point precision of "
             "the model weights, in this case weights are retained in their original precision without any "
             "quantization. 'int8_sym' stands for 8-bit integer symmetric quantization without zero point. 'int8_asym' "
-            "stands for 8-bit integer asymmetric quantization with a typical non-fixed zero point."
+            "stands for 8-bit integer asymmetric quantization with zero points per each quantization group."
         ),
     )
     optional_group.add_argument(
@@ -188,9 +188,9 @@ def parse_args_openvino(parser: "ArgumentParser"):
         action="store_true",
         default=None,
         help=(
-            "Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm mitigates quantization "
-            "noise introduced during weight compression by leveraging low-rank adaptation. Please note, that applying "
-            "LoRA Correction algorithm takes additional memory and time."
+            "Indicates whether to apply LoRA Correction algorithm. When enabled, this algorithm introduces low-rank "
+            "adaptation layers in the model that can recover accuracy after weight compression at some cost of "
+            "inference latency. Please note, that applying LoRA Correction algorithm takes additional memory and time."
         ),
     )
     optional_group.add_argument(

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -136,8 +136,11 @@ def parse_args_openvino(parser: "ArgumentParser"):
         default=None,
         help=(
             "The dataset used for data-aware compression or quantization with NNCF. "
-            "You can use the one from the list ['wikitext2','c4','c4-new'] for language models "
-            "or ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit'] for diffusion models."
+            "For language models you can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the"
+            "dataset will be collected from model's generations. "
+            "For diffusion models on of ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS',"
+            "'laion/filtered-wit']."
+            "For visual language models the dataset must be set to 'contextual'."
         ),
     )
     optional_group.add_argument(

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -314,9 +314,12 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 - A path to a *directory* containing vocabulary files required by the tokenizer, for instance saved
                     using the [`~PreTrainedTokenizer.save_pretrained`] method, e.g., `./my_model_directory/`.
         dataset (`str or List[str]`, *optional*):
-            The dataset used for data-aware compression with NNCF. For language models you can provide your own dataset
-            in a list of strings or just use the one from the list ['wikitext2','c4','c4-new']. For diffusion models it
-            must be one of ['conceptual_captions', 'laion/220k-GPT4Vision-captions-from-LIVIS', 'laion/filtered-wit'].
+            The dataset used for data-aware compression with NNCF.
+            - For language models you can provide your own dataset in a list of strings or just use one from the list
+                ['auto', 'wikitext2','c4','c4-new']. With 'auto' the dataset will be collected from model's generations.
+            - For diffusion models the dataset must be one of ['conceptual_captions',
+                'laion/220k-GPT4Vision-captions-from-LIVIS', 'laion/filtered-wit'].
+            - For visual language models the dataset must be set to 'contextual'.
             Alternatively, you can provide data objects via `calibration_dataset` argument of `OVQuantizer.quantize()`
             method.
         ratio (`float`, defaults to 1.0):
@@ -423,7 +426,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 f"If you wish to provide a custom dataset, please use the `OVQuantizer` instead."
             )
         if self.dataset is not None and isinstance(self.dataset, str):
-            lm_datasets = ["wikitext2", "c4", "c4-new"]
+            lm_datasets = ["wikitext2", "c4", "c4-new", "auto"]
             visual_lm_datasets = list(PREDEFINED_VISUAL_LM_DATASETS.keys())
             stable_diffusion_datasets = list(PREDEFINED_SD_DATASETS.keys())
             if self.dataset not in lm_datasets + visual_lm_datasets + stable_diffusion_datasets:

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -359,7 +359,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 - A string, the *model id* of a predefined processor hosted inside a model repo on huggingface.co.
                 - A path to a *directory* containing files required by the processor, for instance saved
                     using the [`~AutoProcessor.save_pretrained`] method, e.g., `./my_model_directory/`.
-        lora (`bool`, *optional*):
+        lora_correction (`bool`, *optional*):
             If True, apply LoRA Correction algorithm. When enabled, this algorithm mitigates quantization noise
             introduced during weight compression by leveraging low-rank adaptation. It calculates low-rank matrices via
             singular value decomposition (SVD) on the difference between the original and quantized weights. These
@@ -390,7 +390,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         weight_format: Optional[str] = None,
         gptq: bool = None,
         processor: Optional[str] = None,
-        lora: bool = None,
+        lora_correction: bool = None,
         backup_precision: Optional[str] = None,
         **kwargs,
     ):
@@ -407,7 +407,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         self.weight_format = weight_format
         self.gptq = gptq
         self.processor = processor
-        self.lora = lora
+        self.lora_correction = lora_correction
         self.backup_precision = backup_precision
         self.post_init()
 
@@ -464,9 +464,9 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 raise ValueError(
                     "The GPTQ algorithm is not supported for 8-bit quantization and got `gptq=True`, please set `gptq=False`"
                 )
-            if self.lora:
+            if self.lora_correction:
                 raise ValueError(
-                    "The LoRA algorithm is not supported for 8-bit quantization and got `lora=True`, please set `lora=False`"
+                    "The LoRA Correction algorithm is not supported for 8-bit quantization and got `lora_correction=True`, please set `lora_correction=False`"
                 )
             if self.backup_precision is not None:
                 raise ValueError(
@@ -503,10 +503,10 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                     raise ValueError("The Scale Estimation algorithm is not supported for 'mxpf4' weight format")
                 if self.gptq:
                     raise ValueError("The GPTQ algorithm is not supported for 'mxfp4' weight format")
-                if self.lora:
-                    raise ValueError("The LoRA algorithm is not supported for 'mxfp4' weight format")
-        if self.gptq and self.lora:
-            raise ValueError("The GPTQ and LoRA algorithms can't be applied simultaneously")
+                if self.lora_correction:
+                    raise ValueError("The LoRA Correction algorithm is not supported for 'mxfp4' weight format")
+        if self.gptq and self.lora_correction:
+            raise ValueError("The GPTQ and LoRA Correction algorithms can't be applied simultaneously")
 
 
 @dataclass

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -360,16 +360,17 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 - A path to a *directory* containing files required by the processor, for instance saved
                     using the [`~AutoProcessor.save_pretrained`] method, e.g., `./my_model_directory/`.
         lora_correction (`bool`, *optional*):
-            If True, apply LoRA Correction algorithm. When enabled, this algorithm mitigates quantization noise
-            introduced during weight compression by leveraging low-rank adaptation. It calculates low-rank matrices via
-            singular value decomposition (SVD) on the difference between the original and quantized weights. These
-            matrices are iteratively refined by solving a system of linear equations to improve accuracy.
+            If True, apply LoRA Correction algorithm. When enabled, this algorithm introduces low-rank adaptation
+            layers in the model that can recover accuracy after weight compression at some cost of inference latency.
+            It calculates low-rank matrices via singular value decomposition (SVD) on the difference between the
+            original and quantized weights. These matrices are iteratively refined by solving a system of linear
+            equations to improve accuracy.
         backup_precision (`str`, defaults to None):
             Defines a backup precision for mixed-precision weight compression.
             - "none" stands for original floating-point precision of the model weights, in this case weights are
                 retained in their original precision without any quantization.
             - "int8_sym" stands for 8-bit integer symmetric quantization without zero point.
-            - "int8_asym" stands for 8-bit integer asymmetric quantization with a typical non-fixed zero point.
+            - "int8_asym" stands for 8-bit integer asymmetric quantization with zero points per each quantization group.
     """
 
     def __init__(

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -948,7 +948,7 @@ def _weight_only_quantization(
         subset_size=config.num_samples if config.num_samples else 128,
         scale_estimation=config.scale_estimation,
         gptq=config.gptq,
-        lora_correction=config.lora,
+        lora_correction=config.lora_correction,
         backup_mode=None if config.backup_precision is None else nncf.BackupMode(config.backup_precision),
     )
 

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -734,7 +734,11 @@ class OVQuantizer(OptimumQuantizer):
         nsamples = quantization_config.num_samples if quantization_config.num_samples else 128
         config_dataset = quantization_config.dataset
         if isinstance(config_dataset, str):
-            calibration_dataset = get_dataset(config_dataset, tokenizer, seqlen=32, nsamples=nsamples)
+            if config_dataset == "auto":
+                generated_data = nncf.data.generate_text_data(self.model, tokenizer, dataset_size=nsamples)
+                calibration_dataset = [tokenizer(text, return_tensors="pt") for text in generated_data]
+            else:
+                calibration_dataset = get_dataset(config_dataset, tokenizer, seqlen=32, nsamples=nsamples)
         elif isinstance(config_dataset, list) and all(isinstance(it, str) for it in config_dataset):
             calibration_dataset = [tokenizer(text, return_tensors="pt") for text in config_dataset[:nsamples]]
         else:

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -453,20 +453,13 @@ class OVQuantizer(OptimumQuantizer):
         if calibration_dataset is None:
             raise ValueError("Calibration dataset is required to run quantization.")
 
-        # TODO: remove after update to NNCF 2.14
-        model_type = nncf.ModelType(quantization_config.model_type)
-        ignored_scope = quantization_config.get_ignored_scope_instance()
-        if model_type == nncf.ModelType.TRANSFORMER:
-            ignored_scope.types += ["GroupNormalization"]
-            ignored_scope.validate = False
-
         # Actual model quantization
         quantized_model = nncf.quantize(
             self.model.model,
             calibration_dataset,
             subset_size=quantization_config.num_samples,
-            ignored_scope=ignored_scope,
-            model_type=model_type,
+            ignored_scope=quantization_config.get_ignored_scope_instance(),
+            model_type=nncf.ModelType(quantization_config.model_type),
             preset=nncf.QuantizationPreset.PERFORMANCE if quantization_config.sym else nncf.QuantizationPreset.MIXED,
             fast_bias_correction=quantization_config.fast_bias_correction,
             advanced_parameters=nncf.AdvancedQuantizationParameters(
@@ -951,6 +944,7 @@ def _weight_only_quantization(
         subset_size=config.num_samples if config.num_samples else 128,
         scale_estimation=config.scale_estimation,
         gptq=config.gptq,
+        lora_correction=config.lora,
     )
 
 
@@ -1026,10 +1020,6 @@ def _hybrid_quantization(
 
     ptq_ignored_scope = quantization_config.get_ignored_scope_instance()
     ptq_ignored_scope.names += ops_to_compress
-
-    # TODO: remove after update to NNCF 2.14
-    ptq_ignored_scope.types += ["GroupNormalization"]
-    ptq_ignored_scope.validate = False
 
     subset_size = quantization_config.num_samples if quantization_config.num_samples else 200
     quantized_model = nncf.quantize(

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -905,7 +905,6 @@ def _weight_only_quantization(
         config = OVWeightQuantizationConfig.from_dict(quantization_config)
 
     dataset = None
-    print(quantization_config.dataset, calibration_dataset)
     if calibration_dataset is not None:
         if is_datasets_available() and isinstance(calibration_dataset, Dataset):
             raise ValueError(

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -905,6 +905,7 @@ def _weight_only_quantization(
         config = OVWeightQuantizationConfig.from_dict(quantization_config)
 
     dataset = None
+    print(quantization_config.dataset, calibration_dataset)
     if calibration_dataset is not None:
         if is_datasets_available() and isinstance(calibration_dataset, Dataset):
             raise ValueError(
@@ -945,6 +946,7 @@ def _weight_only_quantization(
         scale_estimation=config.scale_estimation,
         gptq=config.gptq,
         lora_correction=config.lora,
+        backup_mode=None if config.backup_precision is None else nncf.BackupMode(config.backup_precision),
     )
 
 

--- a/setup.py
+++ b/setup.py
@@ -61,8 +61,8 @@ TESTS_REQUIRE = [
 QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]
 
 EXTRAS_REQUIRE = {
-    "nncf": ["nncf>=2.11.0"],
-    "openvino": ["nncf>=2.11.0", "openvino>=2024.5.0", "openvino-tokenizers>=2024.5.0"],
+    "nncf": ["nncf>=2.14.0"],
+    "openvino": ["nncf>=2.14.0", "openvino>=2024.5.0", "openvino-tokenizers>=2024.5.0"],
     "neural-compressor": ["neural-compressor[pt]>3.0", "accelerate", "transformers<4.46"],
     "ipex": ["intel-extension-for-pytorch", "transformers>=4.39,<4.45"],
     "diffusers": ["diffusers"],

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -131,6 +131,12 @@ class OVCLIExportTestCase(unittest.TestCase):
             "int4 --ratio 1.0 --sym --group-size 16 --gptq --dataset wikitext2 --num-samples 100 ",
             {"int8": 4, "int4": 14},
         ),
+        (
+            "text-generation-with-past",
+            "llama_awq",
+            "int4 --ratio 1.0 --sym --group-size 16 --lora --dataset wikitext2 --num-samples 1",
+            {"int8": 4, "int4": 14},
+        ),
     ]
 
     if is_transformers_version(">=", "4.40.0"):
@@ -317,6 +323,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             self.assertTrue("--awq" not in option or b"Applying AWQ" in result.stdout)
             self.assertTrue("--scale-estimation" not in option or b"Applying Scale Estimation" in result.stdout)
             self.assertTrue("--gptq" not in option or b"Applying GPTQ" in result.stdout)
+            self.assertTrue("--lora" not in option or b"with correction of low-rank adapters" in result.stdout)
 
     def test_exporters_cli_int4_with_local_model_and_default_config(self):
         with TemporaryDirectory() as tmpdir:

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -134,7 +134,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         (
             "text-generation-with-past",
             "llama_awq",
-            "int4 --ratio 1.0 --sym --group-size 16 --lora --dataset auto --num-samples 16",
+            "int4 --ratio 1.0 --sym --group-size 16 --lora-correction --dataset auto --num-samples 16",
             {"int8": 60, "int4": 14},
         ),
         ("text-generation-with-past", "llama_awq", "int4 --group-size 16 --backup-precision none", {"int4": 28}),
@@ -324,7 +324,9 @@ class OVCLIExportTestCase(unittest.TestCase):
             self.assertTrue("--awq" not in option or b"Applying AWQ" in result.stdout)
             self.assertTrue("--scale-estimation" not in option or b"Applying Scale Estimation" in result.stdout)
             self.assertTrue("--gptq" not in option or b"Applying GPTQ" in result.stdout)
-            self.assertTrue("--lora" not in option or b"with correction of low-rank adapters" in result.stdout)
+            self.assertTrue(
+                "--lora-correction" not in option or b"with correction of low-rank adapters" in result.stdout
+            )
 
     def test_exporters_cli_int4_with_local_model_and_default_config(self):
         with TemporaryDirectory() as tmpdir:

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -134,7 +134,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         (
             "text-generation-with-past",
             "llama_awq",
-            "int4 --ratio 1.0 --sym --group-size 16 --lora --dataset wikitext2 --num-samples 1",
+            "int4 --ratio 1.0 --sym --group-size 16 --lora --dataset auto --num-samples 16",
             {"int8": 60, "int4": 14},
         ),
         ("text-generation-with-past", "llama_awq", "int4 --group-size 16 --backup-precision none", {"int4": 28}),

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -135,8 +135,9 @@ class OVCLIExportTestCase(unittest.TestCase):
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --lora --dataset wikitext2 --num-samples 1",
-            {"int8": 4, "int4": 14},
+            {"int8": 60, "int4": 14},
         ),
+        ("text-generation-with-past", "llama_awq", "int4 --group-size 16 --backup-precision none", {"int4": 28}),
     ]
 
     if is_transformers_version(">=", "4.40.0"):

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -312,11 +312,19 @@ class OVWeightCompressionTest(unittest.TestCase):
             False,
             dict(
                 bits=4,
+                group_size=16,
                 num_samples=1,
                 dataset="c4",
                 lora=True,
             ),
-            {"int4": 12, "int8": 8},
+            {"int4": 28, "int8": 60},
+        ),
+        (
+            OVModelForCausalLM,
+            "llama_awq",
+            False,
+            dict(bits=4, backup_precision="none", group_size=16),
+            {"int4": 28},
         ),
     ]
 
@@ -762,6 +770,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                     "subset_size": 128,
                     "scale_estimation": None,
                     "gptq": None,
+                    "lora": None,
                 }
                 compress_weights_patch.assert_called_with(
                     unittest.mock.ANY,
@@ -810,6 +819,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                     "subset_size": 128,
                     "scale_estimation": None,
                     "gptq": None,
+                    "lora": None,
                 }
                 compress_weights_patch.assert_called_with(unittest.mock.ANY, **compression_params)
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -306,6 +306,18 @@ class OVWeightCompressionTest(unittest.TestCase):
             ),
             {"int4": 12, "int8": 8},
         ),
+        (
+            OVModelForCausalLM,
+            "llama_awq",
+            False,
+            dict(
+                bits=4,
+                num_samples=1,
+                dataset="c4",
+                lora=True,
+            ),
+            {"int4": 12, "int8": 8},
+        ),
     ]
 
     if is_transformers_version(">=", "4.40.0"):
@@ -685,6 +697,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 quantization_config.scale_estimation or False, wc_rt_info["scale_estimation"].value == "True"
             )
             self.assertEqual(quantization_config.gptq or False, wc_rt_info["gptq"].value == "True")
+            self.assertEqual(quantization_config.lora or False, wc_rt_info["lora_correction"].value == "True")
 
             openvino_config = OVConfig.from_pretrained(tmp_dir)
             self.assertEqual(openvino_config.quantization_config.bits, 4)

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -313,8 +313,8 @@ class OVWeightCompressionTest(unittest.TestCase):
             dict(
                 bits=4,
                 group_size=16,
-                num_samples=1,
-                dataset="c4",
+                num_samples=16,
+                dataset="auto",
                 lora=True,
             ),
             {"int4": 28, "int8": 60},

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -315,7 +315,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 group_size=16,
                 num_samples=16,
                 dataset="auto",
-                lora=True,
+                lora_correction=True,
             ),
             {"int4": 28, "int8": 60},
         ),
@@ -705,7 +705,9 @@ class OVWeightCompressionTest(unittest.TestCase):
                 quantization_config.scale_estimation or False, wc_rt_info["scale_estimation"].value == "True"
             )
             self.assertEqual(quantization_config.gptq or False, wc_rt_info["gptq"].value == "True")
-            self.assertEqual(quantization_config.lora or False, wc_rt_info["lora_correction"].value == "True")
+            self.assertEqual(
+                quantization_config.lora_correction or False, wc_rt_info["lora_correction"].value == "True"
+            )
 
             openvino_config = OVConfig.from_pretrained(tmp_dir)
             self.assertEqual(openvino_config.quantization_config.bits, 4)

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -770,7 +770,8 @@ class OVWeightCompressionTest(unittest.TestCase):
                     "subset_size": 128,
                     "scale_estimation": None,
                     "gptq": None,
-                    "lora": None,
+                    "lora_correction": None,
+                    "backup_mode": None,
                 }
                 compress_weights_patch.assert_called_with(
                     unittest.mock.ANY,
@@ -819,7 +820,8 @@ class OVWeightCompressionTest(unittest.TestCase):
                     "subset_size": 128,
                     "scale_estimation": None,
                     "gptq": None,
-                    "lora": None,
+                    "lora_correction": None,
+                    "backup_mode": None,
                 }
                 compress_weights_patch.assert_called_with(unittest.mock.ANY, **compression_params)
 


### PR DESCRIPTION
# What does this PR do?

Changes:
- Added API for running weights compression with LoRA Correction algorithm. Usage: `optimum-cli export openvino ... --lora-correction`, or `OVWeightQuantizationConfig(..., lora_correction=True)`
- Added API for selecting weights compression backup precision. Usage: `optimum-cli export openvino ... --backup-precision <none|int8_sym|int8_asym>` or `OVWeightQuantizationConfig(..., backup_precision=<"none"|"int8_sym"|"int8_asym">)`.
- Added an "auto" dataset option for compressing `OVModelForCausalLM`. In this case `num_samples` strings are generated according to https://github.com/openvinotoolkit/nncf/blob/release_v2140/nncf/data/generators.py#L23 . Usage: `optimum-cli export openvino ... --dataset auto` or 
`OVWeightQuantizationConfig(..., dataset="auto")`.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

