### PR TITLE
fix model removal from tmp dir windows

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -445,11 +445,13 @@ def main_export(
         else:
             quantization_config = ov_config.quantization_config
         if quantization_config is None:
+            del submodel
+            gc.collect()
             continue
 
         if not is_nncf_available():
             raise ImportError("Quantization of the weights requires nncf, please install it with `pip install nncf`")
-
+ 
         from optimum.intel.openvino.quantization import _weight_only_quantization
 
         _weight_only_quantization(submodel, quantization_config)
@@ -457,6 +459,7 @@ def main_export(
         compressed_submodel_path = submodel_path.parent / f"{submodel_path.stem}_compressed.xml"
         save_model(submodel, compressed_submodel_path, compress_to_fp16=False)
         del submodel
+        gc.collect()
 
         submodel_path.unlink()
         submodel_path.with_suffix(".bin").unlink()

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -455,11 +455,10 @@ def main_export(
 
         from optimum.intel.openvino.quantization import _weight_only_quantization
 
-        compressed_submodel = _weight_only_quantization(submodel, quantization_config)
+        _weight_only_quantization(submodel, quantization_config)
 
         compressed_submodel_path = submodel_path.parent / f"{submodel_path.stem}_compressed.xml"
-        save_model(compressed_submodel, compressed_submodel_path, compress_to_fp16=False)
-        del compressed_submodel
+        save_model(submodel, compressed_submodel_path, compress_to_fp16=False)
         del submodel
         gc.collect()
 

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -118,6 +118,8 @@ def _save_model(
     if hasattr(config, "runtime_options"):
         model = _add_runtime_options_to_rt_info(model, config.runtime_options)
     save_model(model, path, compress_to_fp16)
+    del model
+    gc.collect()
 
 
 def export(
@@ -239,6 +241,7 @@ def export_tensorflow(
         config=config,
     )
     del ov_model
+    gc.collect()
     return input_names, output_names, True
 
 
@@ -303,6 +306,7 @@ def export_pytorch_via_onnx(
         config=config,
     )
     del ov_model
+    gc.collect()
     return input_names, output_names, True
 
 

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -21,7 +21,7 @@ import warnings
 import weakref
 from glob import glob
 from pathlib import Path
-from tempfile import TemporaryDirectory as OrigTemporaryDirectory
+from tempfile import TemporaryDirectory as OrigTemporaryDirectory, mkdtemp
 from typing import Tuple, Type, Union
 
 import numpy as np
@@ -472,7 +472,7 @@ def _rmtree(path, ignore_errors=False, onerror=None, *, onexc=None, dir_fd=None)
 # to add behaviour that available only for python3.10+ for older python version
 class TemporaryDirectory(OrigTemporaryDirectory):
     def __init__(self, suffix=None, prefix=None, dir=None, ignore_cleanup_errors=True, *, delete=True):
-        super().__init__(suffix=suffix, prefix=prefix, dir=dir)
+        self.name = mkdtemp(suffix, prefix, dir)
         self._ignore_cleanup_errors = ignore_cleanup_errors
         self._delete = delete
         self._finalizer = weakref.finalize(
@@ -485,13 +485,13 @@ class TemporaryDirectory(OrigTemporaryDirectory):
         )
 
     @classmethod
-    def _cleanup(cls, name, warn_message, ignore_errors=False, delete=True):
+    def _cleanup(cls, name, warn_message, ignore_errors=True, delete=True):
         if delete:
             cls._rmtree(name, ignore_errors=ignore_errors)
             warnings.warn(warn_message, ResourceWarning)
 
     @classmethod
-    def _rmtree(cls, name, ignore_errors=False, repeated=False):
+    def _rmtree(cls, name, ignore_errors=True, repeated=False):
         def _dont_follow_symlinks(func, path, *args):
             # Pass follow_symlinks=False, unless not supported on this platform.
             if func in os.supports_follow_symlinks:
@@ -545,7 +545,7 @@ class TemporaryDirectory(OrigTemporaryDirectory):
                 if not ignore_errors:
                     raise
 
-        _rmtree(name, onexc=onexc)
+        _rmtree(name, onexc=onexc, ignore_errors=ignore_errors)
 
     def cleanup(self):
         if self._finalizer.detach() or os.path.exists(self.name):

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -21,7 +21,8 @@ import warnings
 import weakref
 from glob import glob
 from pathlib import Path
-from tempfile import TemporaryDirectory as OrigTemporaryDirectory, mkdtemp
+from tempfile import TemporaryDirectory as OrigTemporaryDirectory
+from tempfile import mkdtemp
 from typing import Tuple, Type, Union
 
 import numpy as np


### PR DESCRIPTION
# What does this PR do?

Additional fixes for issue with removing model from tmp dir on Windows:
1. For python3.11+ cleanup stage called twice with ignore_cleanup_erros=True (in our tmp dir class) and ignore_cleanup_erros=False (comes from base tmp dir class) that may fail if we use model with api
2. For models that consist from several submodels where not all of them big enough for compression by default based on model size (e.g. vlm with small vision encoder and big llm part) added removal submodel after reading if compression will be not applied.

