### PR TITLE
use small model for testing textual inversion

### DIFF
--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -386,8 +386,8 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
         # for now we only test for stable-diffusion
         # this is very slow and costly to run right now
 
-        model_id = "runwayml/stable-diffusion-v1-5"
-        ti_id = "sd-concepts-library/cat-toy"
+        model_id = "hf-internal-testing/tiny-stable-diffusion-torch"
+        ti_id = "katuni4ka/textual_inversion_cat"
 
         inputs = self.generate_inputs()
         inputs["prompt"] = "A <cat-toy> backpack"
@@ -630,8 +630,8 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
         # for now we only test for stable-diffusion
         # this is very slow and costly to run right now
 
-        model_id = "runwayml/stable-diffusion-v1-5"
-        ti_id = "sd-concepts-library/cat-toy"
+        model_id = "hf-internal-testing/tiny-stable-diffusion-torch"
+        ti_id = "katuni4ka/textual_inversion_cat"
 
         inputs = self.generate_inputs(model_type="stable-diffusion")
         inputs["prompt"] = "A <cat-toy> backpack"
@@ -874,8 +874,8 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
         # for now we only test for stable-diffusion
         # this is very slow and costly to run right now
 
-        model_id = "runwayml/stable-diffusion-v1-5"
-        ti_id = "sd-concepts-library/cat-toy"
+        model_id = "hf-internal-testing/tiny-stable-diffusion-torch"
+        ti_id = "katuni4ka/textual_inversion_cat"
 
         inputs = self.generate_inputs()
         inputs["prompt"] = "A <cat-toy> backpack"

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -17,7 +17,6 @@ import unittest
 from pathlib import Path
 
 import numpy as np
-import pytest
 import torch
 from diffusers import (
     AutoPipelineForImage2Image,
@@ -28,7 +27,6 @@ from diffusers import (
 from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from diffusers.utils import load_image
 from parameterized import parameterized
-from transformers.testing_utils import slow
 from utils_tests import MODEL_NAMES, SEED
 
 from optimum.intel.openvino import (
@@ -379,13 +377,8 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
         self.assertEqual(ov_pipeline.height, height)
         self.assertEqual(ov_pipeline.width, width)
 
-    @pytest.mark.run_slow
-    @slow
     @require_diffusers
     def test_textual_inversion(self):
-        # for now we only test for stable-diffusion
-        # this is very slow and costly to run right now
-
         model_id = "hf-internal-testing/tiny-stable-diffusion-torch"
         ti_id = "katuni4ka/textual_inversion_cat"
 
@@ -623,13 +616,8 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
         self.assertEqual(ov_pipeline.height, height)
         self.assertEqual(ov_pipeline.width, width)
 
-    @pytest.mark.run_slow
-    @slow
     @require_diffusers
     def test_textual_inversion(self):
-        # for now we only test for stable-diffusion
-        # this is very slow and costly to run right now
-
         model_id = "hf-internal-testing/tiny-stable-diffusion-torch"
         ti_id = "katuni4ka/textual_inversion_cat"
 
@@ -867,13 +855,8 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
         self.assertEqual(ov_pipeline.height, height)
         self.assertEqual(ov_pipeline.width, width)
 
-    @pytest.mark.run_slow
-    @slow
     @require_diffusers
     def test_textual_inversion(self):
-        # for now we only test for stable-diffusion
-        # this is very slow and costly to run right now
-
         model_id = "hf-internal-testing/tiny-stable-diffusion-torch"
         ti_id = "katuni4ka/textual_inversion_cat"
 


### PR DESCRIPTION
# What does this PR do?

Current textual_inversion tests use runwayml/stable-diffusion-v1-5, that is more than 5GB in size and due to slowness and required amount of resources tests are executed only in slow tests scope. This PR propose to replace it with light-weight tiny model and adapter trained for it to speedup test and reduce required amount of memory for downloading test models

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

