### PR TITLE
fix updated broken checking nondefault parameters

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -692,7 +692,7 @@ def export_from_model(
             # some model configs may have issues with loading without parameters initialization
             try:
                 misplaced_generation_parameters = model.config._get_non_default_generation_parameters()
-            except KeyError:
+            except (KeyError, TypeError):
                 misplaced_generation_parameters = {}
             if isinstance(model, GenerationMixin) and len(misplaced_generation_parameters) > 0:
                 logger.warning(

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -139,7 +139,7 @@ class OVBaseModel(OptimizedModel):
                 # some model configs may have issues with loading without parameters initialization
                 try:
                     misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
-                except KeyError:
+                except (KeyError, TypeError):
                     misplaced_generation_parameters = {}
                 if len(misplaced_generation_parameters) > 0:
                     logger.warning(

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -87,7 +87,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             # some model configs may have issues with loading without parameters initialization
             try:
                 misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
-            except KeyError:
+            except (KeyError, TypeError):
                 misplaced_generation_parameters = {}
             if len(misplaced_generation_parameters) > 0:
                 logger.warning(


### PR DESCRIPTION
# What does this PR do?
Recent changes in internvl2 models replaces error which models failed on checking non-default parameters with different error type on some models from this family:

```
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\optimum\exporters\openvino\convert.py", line 694, in export_from_model
    misplaced_generation_parameters = model.config._get_non_default_generation_parameters()
  File "C:\hostedtoolcache\windows\Python\3.9.13\x64\lib\site-packages\transformers\configuration_utils.py", line 1041, in _get_non_default_generation_parameters
    default_config = self.__class__()
  File "C:\Users\runneradmin\.cache\huggingface\modules\transformers_modules\OpenGVLab\InternVL2-1B\e426377ee3f7e84f1110e4c258ea49c00d9ee44d\configuration_internvl_chat.py", line 49, in __init__
    if llm_config.get('architectures')[0] == 'LlamaForCausalLM':
TypeError: 'NoneType' object is not subscriptable
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

