### PR TITLE
Fix type error for path usage

### DIFF
--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -241,7 +241,7 @@ def deduce_diffusers_dtype(model_name_or_path, **loading_kwargs):
         else:
             from diffusers import DiffusionPipeline
 
-            path = DiffusionPipeline.download(model_name_or_path, **loading_kwargs)
+            path = Path(DiffusionPipeline.download(model_name_or_path, **loading_kwargs))
         model_part_name = None
         if (path / "transformer").is_dir():
             model_part_name = "transformer"


### PR DESCRIPTION
# What does this PR do?

fixing bug found during internal validation:
```
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/optimum/exporters/openvino/__main__.py", line 341, in main_export
    dtype = deduce_diffusers_dtype(
  File "/opt/hostedtoolcache/Python/3.10.15/x64/lib/python3.10/site-packages/optimum/exporters/openvino/utils.py", line 246, in deduce_diffusers_dtype
    if (path / "transformer").is_dir():
TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

