### PR TITLE
Fix `peft`-`transformers` compatibility

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -48,12 +48,7 @@ jobs:
       - if: ${{ matrix.transformers-version != 'latest' }}
         name: Downgrade Transformers and Accelerate
         run: |
-          pip install transformers==${{ matrix.transformers-version }} accelerate==0.*
-
-      - if: ${{ matrix.transformers-version == '4.36.0' }}
-        name: Install peft==0.13
-        run: |
-          pip install peft==0.13.*  
+          pip install transformers==${{ matrix.transformers-version }} accelerate==0.* peft==0.13.*
 
       - if: ${{ matrix.test-pattern == '*modeling*' }}
         name: Uninstall NNCF

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -50,6 +50,11 @@ jobs:
         run: |
           pip install transformers==${{ matrix.transformers-version }} accelerate==0.*
 
+      - if: ${{ matrix.transformers-version == '4.36.0' }}
+        name: Downgrade Transformers and Accelerate
+        run: |
+          pip install peft==0.13.*  
+
       - if: ${{ matrix.test-pattern == '*modeling*' }}
         name: Uninstall NNCF
         run: |

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -51,7 +51,7 @@ jobs:
           pip install transformers==${{ matrix.transformers-version }} accelerate==0.*
 
       - if: ${{ matrix.transformers-version == '4.36.0' }}
-        name: Downgrade Transformers and Accelerate
+        name: Install peft==0.13
         run: |
           pip install peft==0.13.*  
 

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -47,12 +47,7 @@ jobs:
 
       - if: ${{ matrix.transformers-version != 'latest' }}
         name: Downgrade Transformers and Accelerate
-        run: pip install transformers==${{ matrix.transformers-version }} accelerate==0.*
-
-      - if: ${{ matrix.transformers-version == '4.36.0' }}
-        name: Install peft==0.13
-        run: |
-          pip install peft==0.13.*  
+        run: pip install transformers==${{ matrix.transformers-version }} accelerate==0.* peft==0.13.*
 
       - name: Pip freeze
         run: pip freeze

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -49,6 +49,11 @@ jobs:
         name: Downgrade Transformers and Accelerate
         run: pip install transformers==${{ matrix.transformers-version }} accelerate==0.*
 
+      - if: ${{ matrix.transformers-version == '4.36.0' }}
+        name: Downgrade Transformers and Accelerate
+        run: |
+          pip install peft==0.13.*  
+
       - name: Pip freeze
         run: pip freeze
 

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -50,7 +50,7 @@ jobs:
         run: pip install transformers==${{ matrix.transformers-version }} accelerate==0.*
 
       - if: ${{ matrix.transformers-version == '4.36.0' }}
-        name: Downgrade Transformers and Accelerate
+        name: Install peft==0.13
         run: |
           pip install peft==0.13.*  
 


### PR DESCRIPTION
# What does this PR do?

Install `peft==0.13.*` with `transformers==4.36.0`, because the newly released `peft==0.14` is not compatible with this transformers version.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

