### PR TITLE
fix autotp linear check

### DIFF
--- a/optimum/exporters/ipex/modeling_utils.py
+++ b/optimum/exporters/ipex/modeling_utils.py
@@ -664,9 +664,9 @@ class _IPEXLlamaAttention(_IPEXAttention):
         if use_bias:
             concat_bias = torch.concat(bias_list, 0).contiguous()
             self.concat_linear.bias = nn.Parameter(concat_bias)
-        self.q_slice = self.q_proj.out_features
-        self.k_slice = self.q_slice + self.k_proj.out_features
-        self.v_slice = self.k_slice + self.v_proj.out_features
+        self.q_slice = self.q_proj.weight.shape[0]
+        self.k_slice = self.q_slice + self.k_proj.weight.shape[0]
+        self.v_slice = self.k_slice + self.v_proj.weight.shape[0]
         if self.module_device.type == "cpu":
             if module.o_proj.__class__.__name__ not in ["LinearAllreduce"]:
                 self.mha_linear_add = LinearAdd(module.o_proj)


### PR DESCRIPTION
If the original model is a deepspeed auto TP model, the linear will be [LinearLayer](https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/module_inject/layers.py#L124) which don't have `out_features`, so we can use `weight.shape[0]` which has the same value as `out_features`.