### PR TITLE
Reduce img size in dummy_inputs for FLUX

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1804,12 +1804,12 @@ class DummyFluxTransformerInputGenerator(DummyVisionInputGenerator):
         normalized_config: NormalizedVisionConfig,
         batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
         num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
-        width: int = DEFAULT_DUMMY_SHAPES["width"],
-        height: int = DEFAULT_DUMMY_SHAPES["height"],
+        width: int = DEFAULT_DUMMY_SHAPES["width"] // 4,
+        height: int = DEFAULT_DUMMY_SHAPES["height"] // 4,
         **kwargs,
     ):
         # Reduce img shape by 4 for FLUX to reduce memory usage on conversion
-        super().__init__(task, normalized_config, batch_size, num_channels, width // 4, height // 4, **kwargs)
+        super().__init__(task, normalized_config, batch_size, num_channels, width, height, **kwargs)
         if getattr(normalized_config, "in_channels", None):
             self.num_channels = normalized_config.in_channels // 4
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1808,7 +1808,8 @@ class DummyFluxTransformerInputGenerator(DummyVisionInputGenerator):
         height: int = DEFAULT_DUMMY_SHAPES["height"],
         **kwargs,
     ):
-        super().__init__(task, normalized_config, batch_size, num_channels, width, height, **kwargs)
+        # Reduce img shape by 4 for FLUX to reduce memory usage on conversion
+        super().__init__(task, normalized_config, batch_size, num_channels, width // 4, height // 4, **kwargs)
         if getattr(normalized_config, "in_channels", None):
             self.num_channels = normalized_config.in_channels // 4
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1806,9 +1806,9 @@ class DummyFluxTransformerInputGenerator(DummyVisionInputGenerator):
         num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
         width: int = DEFAULT_DUMMY_SHAPES["width"] // 4,
         height: int = DEFAULT_DUMMY_SHAPES["height"] // 4,
+        # Reduce img shape by 4 for FLUX to reduce memory usage on conversion
         **kwargs,
     ):
-        # Reduce img shape by 4 for FLUX to reduce memory usage on conversion
         super().__init__(task, normalized_config, batch_size, num_channels, width, height, **kwargs)
         if getattr(normalized_config, "in_channels", None):
             self.num_channels = normalized_config.in_channels // 4


### PR DESCRIPTION
# What does this PR do?

In addition to #1064 this change further reduce memory usage for FLUX conversion

| Before (with #1064 change) | After |
| ------- | ------ |
| ~33Gb ![image](https://github.com/user-attachments/assets/87bd5823-5f07-4ee2-8482-18b9803274e3) | ~13Gb ![image](https://github.com/user-attachments/assets/3d280957-236d-4c37-b175-7ac54433671f) |


Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

