### PR TITLE
Fix test for transformers 4.36

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -1,6 +1,7 @@
 name: OpenVINO - Test
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -46,9 +47,9 @@ jobs:
           pip install .[openvino,openvino-tokenizers,diffusers,tests] transformers[testing]
 
       - if: ${{ matrix.transformers-version != 'latest' }}
-        name: Downgrade Transformers and Accelerate
+        name: Install specific dependencies and versions required for older transformers
         run: |
-          pip install transformers==${{ matrix.transformers-version }} accelerate==0.* peft==0.13.*
+          pip install transformers==${{ matrix.transformers-version }} accelerate==0.* peft==0.13.* diffusers==0.30.* transformers_stream_generator
 
       - if: ${{ matrix.test-pattern == '*modeling*' }}
         name: Uninstall NNCF

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -46,8 +46,8 @@ jobs:
           pip uninstall -y nncf
 
       - if: ${{ matrix.transformers-version != 'latest' }}
-        name: Downgrade Transformers and Accelerate
-        run: pip install transformers==${{ matrix.transformers-version }} accelerate==0.* peft==0.13.*
+        name: Install specific dependencies and versions required for older transformers
+        run: pip install transformers==${{ matrix.transformers-version }} accelerate==0.* peft==0.13.*, diffusers==0.30.* transformers_stream_generator
 
       - name: Pip freeze
         run: pip freeze

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -106,8 +106,8 @@ class OVQuantizerTest(unittest.TestCase):
                 weight_only=False,
                 smooth_quant_alpha=0.95,
             ),
-            (14, 22, 21) if is_transformers_version("<=", "4.36.0") else (14, 22, 25),
-            (14, 21, 17) if is_transformers_version("<=", "4.36.0") else (14, 22, 18),
+            (14, 22, 21) if is_transformers_version("<=", "4.42.4") else (14, 22, 25),
+            (14, 21, 17) if is_transformers_version("<=", "4.42.4") else (14, 22, 18),
         ),
     ]
 


### PR DESCRIPTION
Instead of https://github.com/huggingface/optimum-intel/pull/1063

When fixing the test for 4.37 I tried with 4.36 and tests passed with that too, so we can support this a little longer.

Also added workflow_dispatch trigger to OpenVINO test. This makes it easier to test these kinds of changes in a branch in a fork. workflow_dispatch only works if it is also in main, so without having this in main you always have to add it to the main branch of your fork first. If there's a reason not to have it, I'll remove it.

@AlexKoff88 