### PR TITLE
fix import bug when ipex is available but sentence_transformers is no…

### DIFF
--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -51,6 +51,7 @@ except OptionalDependencyNotAvailable:
         "IPEXModel",
     ]
 else:
+    _import_structure["utils.dummy_ipex_objects"] = []
     _import_structure["ipex"] = [
         "IPEXModelForCausalLM",
         "IPEXModelForSequenceClassification",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ EXTRAS_REQUIRE = {
     "nncf": ["nncf>=2.14.0"],
     "openvino": ["nncf>=2.14.0", "openvino>=2024.5.0", "openvino-tokenizers>=2024.5.0"],
     "neural-compressor": ["neural-compressor[pt]>3.0", "accelerate", "transformers<4.46"],
-    "ipex": ["intel-extension-for-pytorch>=2.4", "transformers>4.45,<4.47"],
+    "ipex": ["intel-extension-for-pytorch>=2.4", "transformers>4.45,<4.47", "accelerate"],
     "diffusers": ["diffusers"],
     "quality": QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,


### PR DESCRIPTION
fix import bug when ipex is available but sentence_transformers is not; 
add `accelerate` dependency to run with XPU