### PR TITLE
disable kv cache compression for fp vlm

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -100,9 +100,15 @@ def _set_runtime_options(
     for model_name in models_and_export_configs.keys():
         _, sub_export_config = models_and_export_configs[model_name]
         sub_export_config.runtime_options = {}
-        if "diffusers" in library_name or "text-generation" in task:
+        if (
+            "diffusers" in library_name
+            or "text-generation" in task
+            or ("image-text-to-text" in task and model_name == "language_model")
+        ):
             sub_export_config.runtime_options["ACTIVATIONS_SCALE_FACTOR"] = "8.0"
-        if not quantized_model and "text-generation" in task:
+        if not quantized_model and (
+            "text-generation" in task or ("image-text-to-text" in task and model_name == "language_model")
+        ):
             sub_export_config.runtime_options["KV_CACHE_PRECISION"] = "f16"
 
 

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -134,6 +134,14 @@ class ExportModelTest(unittest.TestCase):
                     self.assertTrue(ov_model.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"]))
                     self.assertTrue(ov_model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
 
+                if task == "image-text-to-text":
+                    self.assertTrue(
+                        ov_model.language_model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"])
+                    )
+                    self.assertTrue(
+                        ov_model.language_model.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
+                    )
+
                 if library_name == "diffusers":
                     self.assertTrue(
                         ov_model.vae_encoder.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes issue with failed minicpmv with ov nightly. starting from 2024.6 openvino will use kv cache compression by default enabled, that may impact model accuracy, but identify when it should be disabled can not be predicted on runtime level, so we proposed addition of specific hint for such models (by our agreement it should be done for noncompressed models only) - extended this approach to handle language models as part visual language models


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

