### PR TITLE
fix reshaping unet if timestep is 0d tensor

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -657,7 +657,8 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
         for inputs in model.inputs:
             shapes[inputs] = inputs.get_partial_shape()
             if inputs.get_any_name() == "timestep":
-                shapes[inputs][0] = 1
+                if shapes[inputs].rank == 1:
+                    shapes[inputs][0] = 1
             elif inputs.get_any_name() == "sample":
                 in_channels = self.unet.config.get("in_channels", None)
                 if in_channels is None:


### PR DESCRIPTION
# What does this PR do?
during testing models I found issue with reshaping unet in diffusion pipeline. Issue connected that reshaping expect to have 1d tensor (torch.tensor([5])), while in some cases it represented as 0d tensor (torch.tensor(5)), in this case reshaping failed with

```
  File "/home/ea/work/py311/lib/python3.11/site-packages/optimum/intel/openvino/modeling_diffusion.py", line 661, in _reshape_unet
    shapes[inputs][0] = 1
    ~~~~~~~~~~~~~~^^^
RuntimeError: Exception from src/core/src/shape_util.cpp:65:
Accessing out-of-range dimension
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

