### PR TITLE
support any input resolution in stable diffusion models

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1785,21 +1785,19 @@ class DummyTransformerTimestpsInputGenerator(DummyTimestepInputGenerator):
 
 class DummyUnetVisionInputGenerator(DummyVisionInputGenerator):
     def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
-        print("HERE")
-        
-        if not input_name in ["sample", "latent_sample"]:
+        if input_name not in ["sample", "latent_sample"]:
             return super().generate(input_name, framework, int_dtype, float_dtype)
         # add height and width discount for enable any resolution generation
         return self.random_float_tensor(
-                shape=[self.batch_size, self.num_channels, self.height - 1 , self.width - 1],
-                framework=framework,
-                dtype=float_dtype,
-            )
+            shape=[self.batch_size, self.num_channels, self.height - 1, self.width - 1],
+            framework=framework,
+            dtype=float_dtype,
+        )
 
 
 @register_in_tasks_manager("unet", *["semantic-segmentation"], library_name="diffusers")
 class UnetOpenVINOConfig(UNetOnnxConfig):
-    DUMMY_INPUT_GENERATOR_CLASSES = (DummyUnetVisionInputGenerator, ) + UNetOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[1:]
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyUnetVisionInputGenerator,) + UNetOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[1:]
 
 
 @register_in_tasks_manager("sd3-transformer", *["semantic-segmentation"], library_name="diffusers")

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1783,6 +1783,25 @@ class DummyTransformerTimestpsInputGenerator(DummyTimestepInputGenerator):
         return super().generate(input_name, framework, int_dtype, float_dtype)
 
 
+class DummyUnetVisionInputGenerator(DummyVisionInputGenerator):
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        print("HERE")
+        
+        if not input_name in ["sample", "latent_sample"]:
+            return super().generate(input_name, framework, int_dtype, float_dtype)
+        # add height and width discount for enable any resolution generation
+        return self.random_float_tensor(
+                shape=[self.batch_size, self.num_channels, self.height - 1 , self.width - 1],
+                framework=framework,
+                dtype=float_dtype,
+            )
+
+
+@register_in_tasks_manager("unet", *["semantic-segmentation"], library_name="diffusers")
+class UnetOpenVINOConfig(UNetOnnxConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyUnetVisionInputGenerator, ) + UNetOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[1:]
+
+
 @register_in_tasks_manager("sd3-transformer", *["semantic-segmentation"], library_name="diffusers")
 class SD3TransformerOpenVINOConfig(UNetOnnxConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -143,7 +143,7 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
             diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
 
             np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
-        
+
         # test on inputs nondivisible on 64
         height, width, batch_size = 96, 96, 1
 
@@ -154,7 +154,6 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
             diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
 
             np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
-
 
     @parameterized.expand(CALLBACK_SUPPORT_ARCHITECTURES)
     @require_diffusers
@@ -802,7 +801,7 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
             diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
 
             np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
-        
+
         # test generation when input resolution nondevisible on 64
         height, width, batch_size = 96, 96, 1
         inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
@@ -814,7 +813,6 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
             diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
 
             np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
-
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     @require_diffusers

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -143,6 +143,18 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
             diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
 
             np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
+        
+        # test on inputs nondivisible on 64
+        height, width, batch_size = 96, 96, 1
+
+        for output_type in ["latent", "np", "pt"]:
+            inputs["output_type"] = output_type
+
+            ov_output = ov_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+
+            np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
+
 
     @parameterized.expand(CALLBACK_SUPPORT_ARCHITECTURES)
     @require_diffusers
@@ -541,6 +553,20 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
 
             np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
 
+        # test generation when input resolution nondevisible on 64
+        height, width, batch_size = 96, 96, 1
+
+        inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size, model_type=model_arch)
+
+        for output_type in ["latent", "np", "pt"]:
+            print(output_type)
+            inputs["output_type"] = output_type
+
+            ov_output = ov_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+
+            np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     @require_diffusers
     def test_image_reproducibility(self, model_arch: str):
@@ -776,6 +802,19 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
             diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
 
             np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
+        
+        # test generation when input resolution nondevisible on 64
+        height, width, batch_size = 96, 96, 1
+        inputs = self.generate_inputs(height=height, width=width, batch_size=batch_size)
+
+        for output_type in ["latent", "np", "pt"]:
+            inputs["output_type"] = output_type
+
+            ov_output = ov_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+            diffusers_output = diffusers_pipeline(**inputs, generator=get_generator("pt", SEED)).images
+
+            np.testing.assert_allclose(ov_output, diffusers_output, atol=6e-3, rtol=1e-2)
+
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     @require_diffusers


### PR DESCRIPTION
# What does this PR do?

due to UNet architecture limitations, original stable diffusion pipeline implementation requires that input was always divisible on 64 (https://github.com/CompVis/stable-diffusion/issues/60#issuecomment-1240294667). In diffusers-based pipelines this issue was fixed and model can generate if input resolution nondivisible to 64 too (adjusting sizes between unet blocks), but during tracing we still note that openvino model preserve behaviour with requirement divisibility to 64 (because path with adjusting data resolution is not activated during tracing). This PR fixes this limitation