### PR TITLE
restore input format for stable diffusion and export configs mapping

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1812,6 +1812,12 @@ class UnetOpenVINOConfig(UNetOnnxConfig):
         DummyUnetTimestepInputGenerator,
     ) + UNetOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[2:]
 
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        common_inputs = super().inputs
+        common_inputs["timestep"] = {0: "batch_size"}
+        return common_inputs
+
 
 @register_in_tasks_manager("sd3-transformer", *["semantic-segmentation"], library_name="diffusers")
 @register_in_tasks_manager("sd3-transformer-2d", *["semantic-segmentation"], library_name="diffusers")

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1850,6 +1850,7 @@ class SD3TransformerOpenVINOConfig(UNetOnnxConfig):
 
 
 @register_in_tasks_manager("t5-encoder-model", *["feature-extraction"], library_name="diffusers")
+@register_in_tasks_manager("t5-encoder", *["feature-extraction"], library_name="diffusers")
 class T5EncoderOpenVINOConfig(CLIPTextOpenVINOConfig):
     pass
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1250,19 +1250,12 @@ class CLIPOpenVINOConfig(CLIPOnnxConfig):
 
 @register_in_tasks_manager("clip-text-model", *["feature-extraction"], library_name="transformers")
 @register_in_tasks_manager("clip-text-model", *["feature-extraction"], library_name="diffusers")
+@register_in_tasks_manager("clip-text", *["feature-extraction"], library_name="diffusers")
 class CLIPTextOpenVINOConfig(CLIPTextOnnxConfig):
     def patch_model_for_export(
         self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
     ) -> ModelPatcher:
         return ModelPatcher(self, model, model_kwargs=model_kwargs)
-
-    def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
-        dummy_inputs = super().generate_dummy_inputs(framework=framework, **kwargs)
-        # TODO: fix should be by casting inputs during inference and not export
-        if framework == "pt":
-            import torch
-            dummy_inputs["input_ids"] = dummy_inputs["input_ids"].to(dtype=torch.int32)
-        return dummy_inputs
 
 
 @register_in_tasks_manager("clip-text-with-projection", *["feature-extraction"], library_name="transformers")
@@ -1812,11 +1805,16 @@ class DummyUnetTimestepInputGenerator(DummyTimestepInputGenerator):
 
 
 @register_in_tasks_manager("unet", *["semantic-segmentation"], library_name="diffusers")
+@register_in_tasks_manager("unet-2d-condition", *["semantic-segmentation"], library_name="diffusers")
 class UnetOpenVINOConfig(UNetOnnxConfig):
-    DUMMY_INPUT_GENERATOR_CLASSES = (DummyUnetVisionInputGenerator, DummyUnetTimestepInputGenerator) + UNetOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[2:]
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        DummyUnetVisionInputGenerator,
+        DummyUnetTimestepInputGenerator,
+    ) + UNetOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES[2:]
 
 
 @register_in_tasks_manager("sd3-transformer", *["semantic-segmentation"], library_name="diffusers")
+@register_in_tasks_manager("sd3-transformer-2d", *["semantic-segmentation"], library_name="diffusers")
 class SD3TransformerOpenVINOConfig(UNetOnnxConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (
         (DummyTransformerTimestpsInputGenerator,)
@@ -1921,6 +1919,7 @@ class DummyFluxTextInputGenerator(DummySeq2SeqDecoderTextInputGenerator):
 
 
 @register_in_tasks_manager("flux-transformer", *["semantic-segmentation"], library_name="diffusers")
+@register_in_tasks_manager("flux-transformer-2d", *["semantic-segmentation"], library_name="diffusers")
 class FluxTransformerOpenVINOConfig(SD3TransformerOpenVINOConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (
         DummyTransformerTimestpsInputGenerator,


### PR DESCRIPTION
# What does this PR do?

changes on optimum side for support sd3 make export configs mapping incompatible with our registered configuration (we need own clip config for preserving SDPA in model) and changed sd timestep input format. That is not expected on our side and may causes errors in users's custom pipelines

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

