### PR TITLE
fix timestep export shapes in sd3 and flux and tests with diffusers 0.32

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1806,7 +1806,7 @@ class DummyUnetTimestepInputGenerator(DummyTimestepInputGenerator):
 
 @register_in_tasks_manager("unet", *["semantic-segmentation"], library_name="diffusers")
 @register_in_tasks_manager("unet-2d-condition", *["semantic-segmentation"], library_name="diffusers")
-class UnetOpenVINOConfig(UNetOnnxConfig):
+class UNetOpenVINOConfig(UNetOnnxConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (
         DummyUnetVisionInputGenerator,
         DummyUnetTimestepInputGenerator,
@@ -1821,10 +1821,10 @@ class UnetOpenVINOConfig(UNetOnnxConfig):
 
 @register_in_tasks_manager("sd3-transformer", *["semantic-segmentation"], library_name="diffusers")
 @register_in_tasks_manager("sd3-transformer-2d", *["semantic-segmentation"], library_name="diffusers")
-class SD3TransformerOpenVINOConfig(UNetOnnxConfig):
+class SD3TransformerOpenVINOConfig(UNetOpenVINOConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (
         (DummyTransformerTimestpsInputGenerator,)
-        + UNetOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES
+        + UNetOpenVINOConfig.DUMMY_INPUT_GENERATOR_CLASSES
         + (PooledProjectionsDummyInputGenerator,)
     )
     NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -218,8 +218,8 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
                         ),
                     )
                 else:
-                    packed_height = height // pipeline.vae_scale_factor
-                    packed_width = width // pipeline.vae_scale_factor
+                    packed_height = height // pipeline.vae_scale_factor // 2
+                    packed_width = width // pipeline.vae_scale_factor // 2
                     channels = pipeline.transformer.config.in_channels
                     self.assertEqual(outputs.shape, (batch_size, packed_height * packed_width, channels))
 
@@ -426,7 +426,7 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
             height=height, width=width, batch_size=batch_size, channel=channel, input_type=input_type
         )
 
-        if "flux" == model_type:
+        if model_type in ["flux", "stable-diffusion-3"]:
             inputs["height"] = height
             inputs["width"] = width
 
@@ -529,8 +529,8 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
                             ),
                         )
                     else:
-                        packed_height = height // pipeline.vae_scale_factor
-                        packed_width = width // pipeline.vae_scale_factor
+                        packed_height = height // pipeline.vae_scale_factor // 2
+                        packed_width = width // pipeline.vae_scale_factor // 2
                         channels = pipeline.transformer.config.in_channels
                         self.assertEqual(outputs.shape, (batch_size, packed_height * packed_width, channels))
 
@@ -780,8 +780,8 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
                             ),
                         )
                     else:
-                        packed_height = height // pipeline.vae_scale_factor
-                        packed_width = width // pipeline.vae_scale_factor
+                        packed_height = height // pipeline.vae_scale_factor // 2
+                        packed_width = width // pipeline.vae_scale_factor // 2
                         channels = pipeline.transformer.config.in_channels
                         self.assertEqual(outputs.shape, (batch_size, packed_height * packed_width, channels))
 


### PR DESCRIPTION
# What does this PR do?

Fixes issues observed in precommit ci after diffusers 0.32.0 release
Fixes timestep shape for exporting flux and sd3


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

