### PR TITLE
Disable graph check while tracing

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -429,9 +429,9 @@ def export_pytorch(
 
             patcher.patched_forward = ts_patched_forward
 
-            decoder_kwargs = {}
+            ts_decoder_kwargs = {}
             if library_name == "diffusers" and is_openvino_version(">=", "2025.0"):
-                decoder_kwargs["trace_kwargs"] = {"check_trace": False}
+                ts_decoder_kwargs["trace_kwargs"] = {"check_trace": False}
 
             with patcher:
                 if patch_16bit_model:
@@ -440,9 +440,9 @@ def export_pytorch(
                     __make_16bit_traceable(model)
                 check_dummy_inputs_are_allowed(model, dummy_inputs)
                 input_info = _get_input_info(model, config, dummy_inputs)
-                decoder = TorchScriptPythonDecoder(model, example_input=dummy_inputs, **decoder_kwargs)
+                ts_decoder = TorchScriptPythonDecoder(model, example_input=dummy_inputs, **ts_decoder_kwargs)
                 ov_model = convert_model(
-                    decoder,
+                    ts_decoder,
                     example_input=dummy_inputs,
                     input=[(item.shape, item.type) for item in input_info],
                 )

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -45,9 +45,9 @@ from optimum.intel.utils.import_utils import (
     _transformers_version,
     compare_versions,
     is_openvino_tokenizers_version,
+    is_openvino_version,
     is_tokenizers_version,
     is_transformers_version,
-    is_openvino_version,
 )
 from optimum.utils import DEFAULT_DUMMY_SHAPES, is_diffusers_available
 

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -23,7 +23,6 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Un
 from transformers.generation import GenerationMixin
 from transformers.utils import is_tf_available, is_torch_available
 
-from openvino.frontend.pytorch.ts_decoder import TorchScriptPythonDecoder
 from openvino.runtime import Model, save_model
 from openvino.runtime.exceptions import OVTypeError
 from openvino.tools.ovc import convert_model
@@ -367,6 +366,7 @@ def export_pytorch(
     import torch
     from torch.utils._pytree import tree_map
 
+    from openvino.frontend.pytorch.ts_decoder import TorchScriptPythonDecoder
     from optimum.exporters.utils import check_dummy_inputs_are_allowed
 
     logger.info(f"Using framework PyTorch: {torch.__version__}")


### PR DESCRIPTION
# What does this PR do?
This is alternative to #1064. It will only work with `openvino>=2025.0` (https://github.com/openvinotoolkit/openvino/pull/28328)
By disabling checking graph after trace we reduce memory usage in diffusers.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

