### PR TITLE
disable flash_attn during export internvl2

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -87,6 +87,7 @@ from .model_patcher import (
     InputEmbeddingPatcher,
     InternLM2Patcher,
     InternLMModelPatcher,
+    InternVL2ChatLangModelPatcher,
     InternVLChatImageEmbeddingModelPatcher,
     JaisModelPatcher,
     LlamaModelPatcher,
@@ -1642,7 +1643,11 @@ class InternVLChatOpenVINOConfig(OnnxConfig):
         if behavior == InternVLChatConfigBehavior.LANGUAGE:
             model_type = self._orig_config.llm_config.model_type
             return get_vlm_text_generation_config(
-                model_type, self._orig_config.llm_config, self.int_dtype, self.float_dtype
+                model_type,
+                self._orig_config.llm_config,
+                self.int_dtype,
+                self.float_dtype,
+                InternVL2ChatLangModelPatcher,
             )
 
         if behavior == InternVLChatConfigBehavior.VISION_EMBEDDINGS:


### PR DESCRIPTION
# What does this PR do?
InternVL2 models forces flash attention if it is available in user environment that may breaks model export. In the same time, if flash attn disabled, it selects eager attention for some cases, that gives suboptimal perf on openvino side. Updated model patching for sdpa attention realization as main path

Fixes https://github.com/huggingface/optimum-intel/issues/1073


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

