### PR TITLE
set paged attn block size as a env parameter

### DIFF
--- a/optimum/exporters/ipex/cache_utils.py
+++ b/optimum/exporters/ipex/cache_utils.py
@@ -6,10 +6,6 @@ from intel_extension_for_pytorch.llm.modules import PagedAttention
 from transformers import Cache, PretrainedConfig
 
 
-# Recommend 16 on CPU and 64 on XPU.
-BLOCK_SIZE = int(os.environ.get("OI_PAGED_ATTN_BLOCK_SIZE", 16))
-
-
 class IPEXPagedCache(Cache):
     """
     A PagedCache that grows dynamically as more tokens are generated. everytime it grows block-size memory, vendor could set the pageCache memory layout.
@@ -49,7 +45,8 @@ class IPEXPagedCache(Cache):
         self.batch_size = batch_size
         # Used in `generate` to keep tally of how many tokens the cache has seen
         self._seen_tokens = torch.zeros([batch_size], dtype=torch.int32, device=device)
-        self.block_size = BLOCK_SIZE
+        default_block_size = 16 if device.type == "cpu" else 64
+        self.block_size = int(os.environ.get("OI_PAGED_ATTN_BLOCK_SIZE", str(default_block_size)))
         self.num_blocks = (max_cache_len // self.block_size + (max_cache_len % self.block_size != 0)) * batch_size
         self.block_tables = -1 * torch.ones([self.num_blocks], dtype=torch.int32, device=device).reshape(
             batch_size, -1

--- a/optimum/exporters/ipex/cache_utils.py
+++ b/optimum/exporters/ipex/cache_utils.py
@@ -5,6 +5,10 @@ from intel_extension_for_pytorch.llm.modules import PagedAttention
 from transformers import Cache, PretrainedConfig
 
 
+# May need to tune based on sequence length and different models but default to 16 currently.
+BLOCK_SIZE = 16
+
+
 class IPEXPagedCache(Cache):
     """
     A PagedCache that grows dynamically as more tokens are generated. everytime it grows block-size memory, vendor could set the pageCache memory layout.
@@ -44,7 +48,7 @@ class IPEXPagedCache(Cache):
         self.batch_size = batch_size
         # Used in `generate` to keep tally of how many tokens the cache has seen
         self._seen_tokens = torch.zeros([batch_size], dtype=torch.int32, device=device)
-        self.block_size = 64
+        self.block_size = BLOCK_SIZE
         self.num_blocks = (max_cache_len // self.block_size + (max_cache_len % self.block_size != 0)) * batch_size
         self.block_tables = -1 * torch.ones([self.num_blocks], dtype=torch.int32, device=device).reshape(
             batch_size, -1

--- a/optimum/exporters/ipex/cache_utils.py
+++ b/optimum/exporters/ipex/cache_utils.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional, Tuple
 
 import torch
@@ -5,8 +6,8 @@ from intel_extension_for_pytorch.llm.modules import PagedAttention
 from transformers import Cache, PretrainedConfig
 
 
-# May need to tune based on sequence length and different models but default to 16 currently.
-BLOCK_SIZE = 16
+# Recommend 16 on CPU and 64 on XPU.
+BLOCK_SIZE = int(os.environ.get("OI_PAGED_ATTN_BLOCK_SIZE", 16))
 
 
 class IPEXPagedCache(Cache):

--- a/optimum/exporters/ipex/modeling_utils.py
+++ b/optimum/exporters/ipex/modeling_utils.py
@@ -652,17 +652,19 @@ class _IPEXAttention(nn.Module):
                 is_causal=True,
             )
             self.use_sdpa = True
-        elif self.has_flash_attn(query) and past_len == 0:
+        elif self.has_flash_attn(query):
             attn_output = torch.empty_like(query)
             seq_len_tensor = torch.cat((input_lens.new_tensor([0]), input_lens.cumsum(-1).int()))
+            query_len_tensor = seq_len_tensor if past_len == 0 else torch.arange(seq_len_tensor.shape[0]).int()
+            query_max_len = input_lens.max() if past_len == 0 else 1
             PagedAttention.flash_attn_varlen_func(
                 attn_output,
                 query.contiguous() if query.device.type == "xpu" else query,
                 key_cache.contiguous() if key_cache.device.type == "xpu" else key_cache,
                 value_cache.contiguous() if value_cache.device.type == "xpu" else value_cache,
+                query_len_tensor,
                 seq_len_tensor,
-                seq_len_tensor,
-                input_lens.max(),
+                query_max_len,
                 input_lens.max(),
                 1.0 / math.sqrt(self.head_dim),
                 True,

--- a/optimum/exporters/ipex/modeling_utils.py
+++ b/optimum/exporters/ipex/modeling_utils.py
@@ -652,19 +652,17 @@ class _IPEXAttention(nn.Module):
                 is_causal=True,
             )
             self.use_sdpa = True
-        elif self.has_flash_attn(query):
+        elif self.has_flash_attn(query) and past_len == 0:
             attn_output = torch.empty_like(query)
             seq_len_tensor = torch.cat((input_lens.new_tensor([0]), input_lens.cumsum(-1).int()))
-            query_len_tensor = seq_len_tensor if past_len == 0 else torch.arange(seq_len_tensor.shape[0]).int()
-            query_max_len = input_lens.max() if past_len == 0 else 1
             PagedAttention.flash_attn_varlen_func(
                 attn_output,
                 query.contiguous() if query.device.type == "xpu" else query,
                 key_cache.contiguous() if key_cache.device.type == "xpu" else key_cache,
                 value_cache.contiguous() if value_cache.device.type == "xpu" else value_cache,
-                query_len_tensor,
                 seq_len_tensor,
-                query_max_len,
+                seq_len_tensor,
+                input_lens.max(),
                 input_lens.max(),
                 1.0 / math.sqrt(self.head_dim),
                 True,


### PR DESCRIPTION
Based on our latest tests, the #1065 has 20%+ speed-up for 1st token but will cause 2nd token latency regression, especially on short prompt input. We can set the block size as a ENV parameter and default to 16 to eliminate the 2nd latency regression mostly, and it also keeps most of the acceleration for 1st token. 

Overall, with #1065 and this PR, we got the following performance speed-up table:
input len: 512; output len: 128; bs: 2; num_beams: 2
```
|  speed-up   |   gpt2-xl   | llama3.1-8B |
|  1st token  |    1.37x    |    1.29x    |
|  2nd token  |    0.98x    |    0.97x    |
```