### PR TITLE
update setting activation scale for diffusers

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -46,7 +46,6 @@ from optimum.intel.utils.import_utils import (
     _torch_version,
     _transformers_version,
     compare_versions,
-    is_diffusers_version,
     is_openvino_tokenizers_version,
     is_openvino_version,
     is_tokenizers_version,

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -63,7 +63,7 @@ from optimum.utils import (
 )
 
 from ...exporters.openvino import main_export
-from ..utils.import_utils import is_diffusers_version
+from ..utils.import_utils import is_diffusers_version, is_openvino_version
 from .configuration import OVConfig, OVQuantizationMethod, OVWeightQuantizationConfig
 from .loaders import OVTextualInversionLoaderMixin
 from .modeling_base import OVBaseModel
@@ -75,6 +75,7 @@ from .utils import (
     _print_compiled_model_properties,
     model_has_dynamic_inputs,
     np_to_pt_generators,
+    check_scale_available,
 )
 
 
@@ -484,8 +485,15 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
             ov_config = kwargs.get("ov_config", {})
             device = kwargs.get("device", "CPU")
             vae_ov_conifg = {**ov_config}
-            if "GPU" in device.upper() and "INFERENCE_PRECISION_HINT" not in vae_ov_conifg:
-                vae_ov_conifg["INFERENCE_PRECISION_HINT"] = "f32"
+            if (
+                "GPU" in device.upper()
+                and "INFERENCE_PRECISION_HINT" not in vae_ov_conifg
+                and is_openvino_version("<=", "2025.0")
+            ):
+                vae_model_path = models["vae_decoder"]
+                required_upcast = check_scale_available(vae_model_path)
+                if required_upcast:
+                    vae_ov_conifg["INFERENCE_PRECISION_HINT"] = "f32"
             for name, path in models.items():
                 if name in kwargs:
                     models[name] = kwargs.pop(name)
@@ -1202,7 +1210,12 @@ class OVModelVaeEncoder(OVPipelinePart):
         return ModelOutput(**model_outputs)
 
     def _compile(self):
-        if "GPU" in self._device and "INFERENCE_PRECISION_HINT" not in self.ov_config:
+        if (
+            "GPU" in self._device
+            and "INFERENCE_PRECISION_HINT" not in self.ov_config
+            and is_openvino_version("<", "2025.0")
+            and check_scale_available(self.model)
+        ):
             self.ov_config.update({"INFERENCE_PRECISION_HINT": "f32"})
         super()._compile()
 
@@ -1241,7 +1254,12 @@ class OVModelVaeDecoder(OVPipelinePart):
         return ModelOutput(**model_outputs)
 
     def _compile(self):
-        if "GPU" in self._device and "INFERENCE_PRECISION_HINT" not in self.ov_config:
+        if (
+            "GPU" in self._device
+            and "INFERENCE_PRECISION_HINT" not in self.ov_config
+            and is_openvino_version("<", "2025.0")
+            and check_scale_available(self.model)
+        ):
             self.ov_config.update({"INFERENCE_PRECISION_HINT": "f32"})
         super()._compile()
 

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -73,9 +73,9 @@ from .utils import (
     OV_XML_FILE_NAME,
     TemporaryDirectory,
     _print_compiled_model_properties,
+    check_scale_available,
     model_has_dynamic_inputs,
     np_to_pt_generators,
-    check_scale_available,
 )
 
 

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -565,3 +565,21 @@ class TemporaryDirectory(OrigTemporaryDirectory):
     def cleanup(self):
         if self._finalizer.detach() or os.path.exists(self.name):
             self._rmtree(self.name, ignore_errors=self._ignore_cleanup_errors)
+
+
+def check_scale_available(model: Union[Model, str, Path]):
+    if isinstance(model, Model):
+        return model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
+    if not Path(model).exists():
+        return False
+    import xml.etree.ElementTree as ET
+
+    tree = ET.parse(model)
+    root = tree.getroot()
+    rt_info = root.find("rt_info")
+    if rt_info is None:
+        return False
+    runtime_options = rt_info.find("runtime_options")
+    if runtime_options is None:
+        return False
+    return runtime_options.find("ACTIVATIONS_SCALE_FACTOR") is not None

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -75,6 +75,13 @@ class ExportModelTest(unittest.TestCase):
         "llava": OVModelForVisualCausalLM,
     }
 
+    EXPECTED_DIFFUSERS_SCALE_FACTORS = {
+        "stable-diffusion-xl": {"vae_encoder": "128.0", "vae_decoder": "128.0"},
+        "stable-diffusion-3": {"text_encoder_3": "8.0"},
+        "flux": {"text_encoder_2": "8.0", "transformer": "8.0", "vae_encoder": "8.0", "vae_decoder": "8.0"},
+        "stable-diffusion-xl-refiner": {"vae_encoder": "128.0", "vae_decoder": "128.0"},
+    }
+
     if is_transformers_version(">=", "4.45"):
         SUPPORTED_ARCHITECTURES.update({"stable-diffusion-3": OVStableDiffusion3Pipeline, "flux": OVFluxPipeline})
 
@@ -143,32 +150,33 @@ class ExportModelTest(unittest.TestCase):
                     )
 
                 if library_name == "diffusers":
-                    self.assertTrue(
-                        ov_model.vae_encoder.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
-                    )
-                    self.assertTrue(
-                        ov_model.vae_decoder.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
-                    )
-                    if hasattr(ov_model, "text_encoder") and ov_model.text_encoder:
-                        self.assertTrue(
-                            ov_model.text_encoder.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
-                        )
-                    if hasattr(ov_model, "text_encoder_2") and ov_model.text_encoder_2:
-                        self.assertTrue(
-                            ov_model.text_encoder_2.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
-                        )
-                    if hasattr(ov_model, "text_encoder_3") and ov_model.text_encoder_3:
-                        self.assertTrue(
-                            ov_model.text_encoder_3.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
-                        )
-                    if hasattr(ov_model, "unet") and ov_model.unet:
-                        self.assertTrue(
-                            ov_model.unet.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
-                        )
-                    if hasattr(ov_model, "transformer") and ov_model.transformer:
-                        self.assertTrue(
-                            ov_model.transformer.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
-                        )
+                    expected_scale_factors = self.EXPECTED_DIFFUSERS_SCALE_FACTORS.get(model_type, {})
+                    components = [
+                        "unet",
+                        "transformer",
+                        "text_encoder",
+                        "text_encoder_2",
+                        "text_encoder_3",
+                        "vae_encoder",
+                        "vae_decoder",
+                    ]
+                    for component in components:
+                        component_model = getattr(ov_model, component, None)
+                        if component_model is None:
+                            continue
+                        component_scale = expected_scale_factors.get(component)
+                        if component_scale is not None:
+                            self.assertTrue(
+                                component_model.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
+                            )
+                            self.assertEqual(
+                                component_model.model.get_rt_info()["runtime_options"]["ACTIVATIONS_SCALE_FACTOR"],
+                                component_scale,
+                            )
+                        else:
+                            self.assertFalse(
+                                component_model.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
+                            )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_export(self, model_type: str):


### PR DESCRIPTION
# What does this PR do?

some diffusion models suffer from execution in fp16 due to activations overflow, previously, to fix this issue we changed inference precision to f32 in runtime which may significantly affect performance. 
In 2025.0, openvino will provide a more accurate mechanism to inform plugins about such possible overflows. However, this may still affect model perf if it will be set everywhere where there is no need. 

This PR introduced approach for setting activation scale only for specific pipeline components based on models analysis result


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

