### PR TITLE
Add _is_stateful property to OVBaseDecoderModel

### DIFF
--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -193,6 +193,10 @@ class OVBaseDecoderModel(OVModel):
         if not self._compile_only and enable_compilation:
             self.compile()
 
+    @property
+    def _is_stateful(self) -> bool:
+        return self.stateful
+
     def update_pkv_precision(self, force_fp32=False):
         if not self.use_cache or self.stateful or self._compile_only:
             return


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

Hello, when I try assisted generation with optimum-intel and openvino, it complains about

```
AttributeError: 'OVModelForCausalLM' object has no attribute '_is_stateful'. Did you mean: '_make_stateful'?
```

After adding this property to `OVBaseDecoderModel`, the error is gone, and assisted generation works.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

