### PR TITLE
Constrain autoawq package version

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -54,7 +54,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.test-pattern == '*modeling*'}}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq "autoawq<0.28" --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq "autoawq<0.2.8" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - if: ${{ matrix.test-pattern == '*modeling*' }}
         name: Uninstall NNCF

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -54,7 +54,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.test-pattern == '*modeling*'}}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq autoawq --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq autoawq<0.28 --extra-index-url https://download.pytorch.org/whl/cpu
 
       - if: ${{ matrix.test-pattern == '*modeling*' }}
         name: Uninstall NNCF

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -54,7 +54,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.test-pattern == '*modeling*'}}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq autoawq<0.28 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq "autoawq<0.28" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - if: ${{ matrix.test-pattern == '*modeling*' }}
         name: Uninstall NNCF

--- a/.github/workflows/test_openvino_full.yml
+++ b/.github/workflows/test_openvino_full.yml
@@ -81,7 +81,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.os != 'windows-2019' }}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq "autoawq<0.28" --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq "autoawq<0.2.8" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Pip freeze
         run: pip freeze

--- a/.github/workflows/test_openvino_full.yml
+++ b/.github/workflows/test_openvino_full.yml
@@ -81,7 +81,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.os != 'windows-2019' }}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq autoawq --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq autoawq<0.28 --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Pip freeze
         run: pip freeze

--- a/.github/workflows/test_openvino_full.yml
+++ b/.github/workflows/test_openvino_full.yml
@@ -81,7 +81,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.os != 'windows-2019' }}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq autoawq<0.28 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq "autoawq<0.28" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Pip freeze
         run: pip freeze

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -52,7 +52,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.os != 'windows-2019' }}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq "autoawq<0.28" --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq "autoawq<0.2.8" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Pip freeze
         run: pip freeze

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -52,7 +52,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.os != 'windows-2019' }}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq autoawq<0.28 --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq "autoawq<0.28" --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Pip freeze
         run: pip freeze

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -52,7 +52,7 @@ jobs:
       - if: ${{ matrix.transformers-version == 'latest' && matrix.os != 'windows-2019' }}
         name: Install auto-gptq, autoawq
         run: |
-          pip install auto-gptq autoawq --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install auto-gptq autoawq<0.28 --extra-index-url https://download.pytorch.org/whl/cpu
 
       - name: Pip freeze
         run: pip freeze


### PR DESCRIPTION
# What does this PR do?

Seems like `autoawq==0.2.8` is broken: https://github.com/huggingface/optimum-intel/actions/runs/12883232903/job/35917035242

Thanks to @eaidova for quick investigation


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

