### PR TITLE
fix stateful seq2seq model inference perfomance

### DIFF
--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -668,7 +668,7 @@ class OVDecoder:
         logits = torch.from_numpy(self.request.get_tensor("logits").data).to(self.device)
         self._past_length += input_ids.shape[1]
 
-        out_past_key_values = ()
+        out_past_key_values = ((),)
 
         if not self.stateful:
             # Tuple of length equal to : number of layer * number of past_key_value per decoder layer (2 corresponds to the


### PR DESCRIPTION
# What does this PR do?

due to empty tuple used for initialization past_key_values , it was treated as None later and as the result model works without past path activated


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

