### PR TITLE
relax requirement for patch size and config for llava preprocessor

### DIFF
--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -295,6 +295,14 @@ def save_preprocessors(
         if is_transformers_version(">=", "4.45") and model_type == "phi3-v" and len(preprocessors) > 1:
             if not hasattr(preprocessors[1], "chat_template"):
                 preprocessors[1].chat_template = getattr(preprocessors[0], "chat_template", None)
+        if (
+            is_transformers_version(">=", "4.45")
+            and model_type in ["llava", "llava-next"]
+            and preprocessors is not None
+        ):
+            if getattr(preprocessors[1], "patch_size", None) is None:
+                preprocessors[1].patch_size = config.vision_config.patch_size
+                preprocessors[1].vision_feature_select_strategy = config.vision_feature_select_strategy
         for processor in preprocessors:
             try:
                 processor.save_pretrained(output)

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -1021,7 +1021,7 @@ class _OVLlavaForCausalLM(OVModelForVisualCausalLM):
             else:
                 prompt = text
 
-        if getattr(processor, "patch_size", None) is None:
+        if is_transformers_version(">", "4.47") and getattr(processor, "patch_size", None) is None:
             if (
                 getattr(config, "vision_config", None) is not None
                 and getattr(config.vision_config, "patch_size", None) is not None

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -1021,7 +1021,7 @@ class _OVLlavaForCausalLM(OVModelForVisualCausalLM):
             else:
                 prompt = text
 
-        if is_transformers_version(">", "4.47") and getattr(processor, "patch_size", None) is None:
+        if is_transformers_version(">", "4.47.99") and getattr(processor, "patch_size", None) is None:
             if (
                 getattr(config, "vision_config", None) is not None
                 and getattr(config.vision_config, "patch_size", None) is not None


### PR DESCRIPTION
# What does this PR do?

* add processor configuration parameters on export stage if missed
* check and require config only for transformers>=4.48 (previous versions supports image preprocessing without patch_size)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

