### PR TITLE
minicpm fix for bf16

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -95,6 +95,7 @@ from .model_patcher import (
     LlavaImageEmbeddingModelPatcher,
     LlavaQwen2ImageEmbeddingsModelPatcher,
     MiniCPM3Patcher,
+    MiniCPMModelPatcher,
     MiniCPMVImageEmbeddingsModelPatcher,
     MiniCPMVResamplerModelPatcher,
     MistralModelPatcher,
@@ -220,6 +221,11 @@ class MiniCPMOpenVINOConfig(TextDecoderWithPositionIdsOnnxConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, MistralDummyPastKeyValuesGenerator)
     DUMMY_PKV_GENERATOR_CLASS = MistralDummyPastKeyValuesGenerator
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
+    ) -> "ModelPatcher":
+        return MiniCPMModelPatcher(self, model, model_kwargs=model_kwargs)
 
 
 class OVMiniCPM3DummyPastKeyValuesGenerator(MistralDummyPastKeyValuesGenerator):

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -3905,3 +3905,18 @@ class SanaTextEncoderModelPatcher(ModelPatcher):
             for layer in self._model.layers:
                 if hasattr(layer.self_attn, "_orig_forward"):
                     layer.self_attn.forward = layer.self_attn._orig_forward
+
+
+class MiniCPMModelPatcher(DecoderModelPatcher):
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: Union["PreTrainedModel", "TFPreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        for layer in model.model.layers:
+            if hasattr(layer, "scale_depth"):
+                layer.self_attn.o_proj.to(torch.float32)
+                layer.mlp.down_proj.to(torch.float32)
+
+        super().__init__(config, model, model_kwargs)


### PR DESCRIPTION
# What does this PR do?
 
avoid extra weight decompression in minicom model that breaks weight compression  to int8/int4


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

