### PR TITLE
Skip test_aware_training_quantization test

### DIFF
--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1104,9 +1104,7 @@ class OVTrainerTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS = (("albert", 61, 39),)
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_QUANTIZED_MATMULS)
-    @unittest.skipIf(
-        is_transformers_version(">=", "4.46"), reason="OVTrainer is not compatible with transformers>=v4.46"
-    )
+    @unittest.skip(reason="Not supported on hosts running pre-commit jobs since OpenVINO 2025.0 relase.")
     def test_aware_training_quantization(self, model_name, expected_fake_nodes, expected_int8_nodes):
         model_id = MODEL_NAMES[model_name]
         model = AutoModelForSequenceClassification.from_pretrained(model_id, attn_implementation="eager")


### PR DESCRIPTION
# What does this PR do?

`tests/openvino/test_quantization.py::OVTrainerTest::test_aware_training_quantization_0_albert` test fails in pre-commit tests since OpenVINO 2025.0 release with the following error:
```
RuntimeError: Exception from src/inference/src/cpp/infer_request.cpp:223:
Exception from src/plugins/intel_cpu/src/node.cpp:797:
[CPU] Subgraph node with name '/albert/encoder/albert_layer_groups.5/albert_layers.0/attention/AlbertForSequenceClassification/AlbertModel[albert]/AlbertTransformer[encoder]/ModuleList[albert_layer_groups]/AlbertLayerGroup[5]/ModuleList[albert_layers]/AlbertLayer[0]/AlbertAttention[attention]/matmul_1|OUTPUT/FakeQuantize' Exception from src/plugins/intel_cpu/src/transformations/snippets/x64/op/brgemm_utils.cpp:47:
ov::intel_cpu::brgemm_utils: Unsupported hardware configuration: int8 is supported only on vnni platforms
```

Seems like the hosts running pre-commits on github do not support VNNI instructions. The whole quantization aware training logic is planned to be deprecated soon so it was decided to skip this test.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

