### PR TITLE
use Tensor.numpy() instead np.array(Tensor)

### DIFF
--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -174,9 +174,9 @@ class OVModelForSequenceClassification(OVModel):
 
         np_inputs = isinstance(input_ids, np.ndarray)
         if not np_inputs:
-            input_ids = np.array(input_ids)
-            attention_mask = np.array(attention_mask)
-            token_type_ids = np.array(token_type_ids) if token_type_ids is not None else token_type_ids
+            input_ids = input_ids.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy()
+            token_type_ids = token_type_ids.cpu().numpy() if token_type_ids is not None else token_type_ids
 
         inputs = {
             "input_ids": input_ids,
@@ -239,9 +239,9 @@ class OVModelForQuestionAnswering(OVModel):
 
         np_inputs = isinstance(input_ids, np.ndarray)
         if not np_inputs:
-            input_ids = np.array(input_ids)
-            attention_mask = np.array(attention_mask)
-            token_type_ids = np.array(token_type_ids) if token_type_ids is not None else token_type_ids
+            input_ids = input_ids.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy()
+            token_type_ids = token_type_ids.cpu().numpy() if token_type_ids is not None else token_type_ids
 
         inputs = {
             "input_ids": input_ids,
@@ -308,9 +308,9 @@ class OVModelForTokenClassification(OVModel):
 
         np_inputs = isinstance(input_ids, np.ndarray)
         if not np_inputs:
-            input_ids = np.array(input_ids)
-            attention_mask = np.array(attention_mask)
-            token_type_ids = np.array(token_type_ids) if token_type_ids is not None else token_type_ids
+            input_ids = input_ids.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy()
+            token_type_ids = token_type_ids.cpu().numpy() if token_type_ids is not None else token_type_ids
 
         inputs = {
             "input_ids": input_ids,
@@ -379,9 +379,9 @@ class OVModelForFeatureExtraction(OVModel):
 
         np_inputs = isinstance(input_ids, np.ndarray)
         if not np_inputs:
-            input_ids = np.array(input_ids)
-            attention_mask = np.array(attention_mask)
-            token_type_ids = np.array(token_type_ids) if token_type_ids is not None else token_type_ids
+            input_ids = input_ids.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy()
+            token_type_ids = token_type_ids.cpu().numpy() if token_type_ids is not None else token_type_ids
 
         inputs = {
             "input_ids": input_ids,
@@ -448,9 +448,9 @@ class OVModelForMaskedLM(OVModel):
 
         np_inputs = isinstance(input_ids, np.ndarray)
         if not np_inputs:
-            input_ids = np.array(input_ids)
-            attention_mask = np.array(attention_mask)
-            token_type_ids = np.array(token_type_ids) if token_type_ids is not None else token_type_ids
+            input_ids = input_ids.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy()
+            token_type_ids = token_type_ids.cpu().numpy() if token_type_ids is not None else token_type_ids
 
         inputs = {
             "input_ids": input_ids,
@@ -581,7 +581,7 @@ class OVModelForImageClassification(OVModel):
 
         np_inputs = isinstance(pixel_values, np.ndarray)
         if not np_inputs:
-            pixel_values = np.array(pixel_values)
+            pixel_values = pixel_values.cpu().numpy()
 
         inputs = {
             "pixel_values": pixel_values,
@@ -640,8 +640,8 @@ class OVModelForAudioClassification(OVModel):
 
         np_inputs = isinstance(input_values, np.ndarray)
         if not np_inputs:
-            input_values = np.array(input_values)
-            attention_mask = np.array(attention_mask) if attention_mask is not None else attention_mask
+            input_values = input_values.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy() if attention_mask is not None else attention_mask
 
         inputs = {
             "input_values": input_values,
@@ -711,8 +711,8 @@ class OVModelForCTC(OVModel):
     ):
         np_inputs = isinstance(input_values, np.ndarray)
         if not np_inputs:
-            input_values = np.array(input_values)
-            attention_mask = np.array(attention_mask) if attention_mask is not None else attention_mask
+            input_values = input_values.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy() if attention_mask is not None else attention_mask
 
         inputs = {
             "input_values": input_values,
@@ -791,8 +791,8 @@ class OVModelForAudioXVector(OVModel):
     ):
         np_inputs = isinstance(input_values, np.ndarray)
         if not np_inputs:
-            input_values = np.array(input_values)
-            attention_mask = np.array(attention_mask) if attention_mask is not None else attention_mask
+            input_values = input_values.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy() if attention_mask is not None else attention_mask
 
         inputs = {
             "input_values": input_values,
@@ -867,8 +867,8 @@ class OVModelForAudioFrameClassification(OVModel):
     ):
         np_inputs = isinstance(input_values, np.ndarray)
         if not np_inputs:
-            input_values = np.array(input_values)
-            attention_mask = np.array(attention_mask) if attention_mask is not None else attention_mask
+            input_values = input_values.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy() if attention_mask is not None else attention_mask
 
         inputs = {
             "input_values": input_values,
@@ -929,7 +929,7 @@ class OVModelForCustomTasks(OVModel):
         np_inputs = isinstance(next(iter(kwargs.values())), np.ndarray)
         inputs = {}
         for input_name in self.input_names:
-            inputs[input_name] = np.array(kwargs.pop(input_name)) if not np_inputs else kwargs.pop(input_name)
+            inputs[input_name] = kwargs.pop(input_name).cpu().numpy() if not np_inputs else kwargs.pop(input_name)
 
         outputs = self._inference(inputs)
         model_outputs = {}

--- a/optimum/intel/openvino/modeling_sentence_transformers.py
+++ b/optimum/intel/openvino/modeling_sentence_transformers.py
@@ -43,9 +43,9 @@ class OVSentenceTransformer(OVModel):
 
         np_inputs = isinstance(input_ids, np.ndarray)
         if not np_inputs:
-            input_ids = np.array(input_ids)
-            attention_mask = np.array(attention_mask)
-            token_type_ids = np.array(token_type_ids) if token_type_ids is not None else token_type_ids
+            input_ids = input_ids.cpu().numpy()
+            attention_mask = attention_mask.cpu().numpy()
+            token_type_ids = token_type_ids.cpu().numpy() if token_type_ids is not None else token_type_ids
 
         inputs = {
             "input_ids": input_ids,

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -150,7 +150,7 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
         # Add the attention_mask inputs when needed
         if "attention_mask" in self.input_names or "position_ids" in self.input_names:
             if attention_mask is not None:
-                attention_mask = np.array(attention_mask)
+                attention_mask = attention_mask.cpu().numpy()
             else:
                 attention_mask = np.ones((inputs_embeds.shape[0], inputs_embeds.shape[1] + past_len), dtype=int)
 
@@ -159,7 +159,7 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
 
         if "position_ids" in self.input_names:
             if position_ids is not None:
-                position_ids = np.array(position_ids)
+                position_ids = position_ids.cpu().numpy()
             else:
                 position_ids = np.cumsum(attention_mask, axis=1) - 1
                 position_ids[attention_mask == 0] = 1


### PR DESCRIPTION
# What does this PR do?

* numpy 2.0 produces deprecation warning when np.array(torch.tensor()) used  https://github.com/pytorch/pytorch/issues/136264
* in some cases usage model with pipelines assign input tensor on different device (e.g. on M1 MacOS, default device for pipeline in mps:0) that may lead to unexpected error inside with attempt to cast to array non-cpu offloaded tensor


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

