### PR TITLE
Add default int4 config for DeepSeek-R1-Distill-Llama-8B

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -210,6 +210,14 @@ _DEFAULT_4BIT_CONFIGS = {
         "quant_method": OVQuantizationMethod.AWQ,
         "scale_estimation": True,
     },
+    "deepseek-ai/DeepSeek-R1-Distill-Llama-8B": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "ratio": 0.8,
+        "dataset": "wikitext2",
+        "quant_method": OVQuantizationMethod.AWQ,
+    },
 }
 
 _DEFAULT_4BIT_CONFIG = {


### PR DESCRIPTION
# What does this PR do?

As in the description. For me locally this config results in 80.94 WWB similarity.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

