### PR TITLE
fix misplaced configs saving

### DIFF
--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -294,8 +294,8 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
                 dst_path = save_path / OV_XML_FILE_NAME
                 dst_path.parent.mkdir(parents=True, exist_ok=True)
                 openvino.save_model(model.model, dst_path, compress_to_fp16=False)
-                model_dir = model.config.get("_name_or_path", None) or model.model_save_dir
-                config_path = Path(model_dir) / CONFIG_NAME
+                model_dir = self.config.get("_name_or_path", None) or model.model_save_dir
+                config_path = Path(model_dir) / save_path.name / CONFIG_NAME
                 if config_path.is_file():
                     config_save_path = save_path / CONFIG_NAME
                     shutil.copyfile(config_path, config_save_path)

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -294,7 +294,11 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
                 dst_path = save_path / OV_XML_FILE_NAME
                 dst_path.parent.mkdir(parents=True, exist_ok=True)
                 openvino.save_model(model.model, dst_path, compress_to_fp16=False)
-                model_dir = self.config.get("_name_or_path", None) or model.model_save_dir
+                model_dir = (
+                    self.model_save_dir
+                    if not isinstance(self.model_save_dir, TemporaryDirectory)
+                    else self.model_save_dir.name
+                )
                 config_path = Path(model_dir) / save_path.name / CONFIG_NAME
                 if config_path.is_file():
                     config_save_path = save_path / CONFIG_NAME

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -359,6 +359,13 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
                     self.assertTrue(model_lib in ["diffusers", "transformers"])
                     self.assertFalse(model_class.startswith("OV"))
             loaded_pipeline = self.OVMODEL_CLASS.from_pretrained(tmpdirname)
+            for component in ["text_encoder", "unet", "vae_encoder", "vae_decoder"]:
+                config = getattr(getattr(ov_pipeline, component), "config", None)
+                if config is not None:
+                    loaded_config = getattr(getattr(loaded_pipeline, component), "config")
+                    self.assertDictEqual(
+                        config, loaded_config, f"Expected config:\n{config}\nLoaded config:|n{loaded_config}"
+                    )
             self.assertTrue(loaded_pipeline.safety_checker is not None)
             self.assertIsInstance(loaded_pipeline.safety_checker, StableDiffusionSafetyChecker)
             del loaded_pipeline


### PR DESCRIPTION
# What does this PR do?

during diffusion pipeline loading, `_name_or_path` field overridden only for main pipeline config, while its components still contains paths for original pipeline. As te result, ioriginal config loaded using diffusers pytorch pipeline and saved on disk for ov diffusers pipeline are different (e.g. for too old models where config does not contains some important fields) it may lead to incorrect loading.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

