### PR TITLE
avoid extra reshaping to max_model_lenght for unet

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -1025,6 +1025,9 @@ def get_diffusion_models_for_export_ext(
     is_lcm = pipeline.__class__.__name__.startswith("LatentConsistencyModel")
 
     if is_sd or is_sdxl or is_lcm:
+        tokenizer = pipeline.tokenizer_2 if is_sdxl else pipeline.tokenizer
+        model_max_length = getattr(tokenizer, "model_max_length", None)
+        pipeline.unet.config.model_max_length = model_max_length
         models_for_export = get_diffusion_models_for_export(pipeline, int_dtype, float_dtype, exporter)
         if is_sdxl and pipeline.vae.config.force_upcast:
             models_for_export["vae_encoder"][1].runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "128.0"}


### PR DESCRIPTION
# What does this PR do?

unet in stable diffusion pipelines always is saved with dynamic shapes during export and uses reshape to set max_model_lenght from tokenizer before starting inference. Suggestion is remove reshape every model loading and set max_model_len as default value for encoder_hidden_state during export if it is known


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

