### PR TITLE
[OV] Add int4 config for Llama-3.1-8b model id aliases

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -238,6 +238,15 @@ _DEFAULT_4BIT_CONFIGS = {
     },
 }
 
+# Add configs for model id aliases
+# The list below contains pairs of model ids: config for the second model id will be copied from the first model id.
+model_id_aliases = [
+    ("meta-llama/Meta-Llama-3.1-8B-Instruct", "meta-llama/Llama-3.1-8B-Instruct"),
+    ("meta-llama/Meta-Llama-3.1-8B", "meta-llama/Llama-3.1-8B"),
+]
+for m_id_1, m_id_2 in model_id_aliases:
+    _DEFAULT_4BIT_CONFIGS[m_id_2] = _DEFAULT_4BIT_CONFIGS[m_id_1]
+
 _DEFAULT_4BIT_CONFIG = {
     "bits": 4,
     "ratio": 1.0,


### PR DESCRIPTION
# What does this PR do?

https://huggingface.co/meta-llama/Meta-Llama-3.1-8B redirects to https://huggingface.co/meta-llama/Llama-3.1-8B . Thus these two model ids represent the same model. But the default int4 configs is set only for Meta-Llama-3.1-8B. That's why when export is run for Llama-3.1-8B, default int4 config is not applied.

In this PR this issue is fixed by adding a list of model id pairs that represent the same model.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

