### PR TITLE
warm up do not work for compiled model

### DIFF
--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -240,11 +240,14 @@ class IPEXModel(OptimizedModel):
         self.compiled = True
 
     def _init_warmup(self):
-        inputs = prepare_jit_inputs(self.model, self.export_feature, False)
-        with torch.no_grad():
-            self.model(**inputs)
-            self.model(**inputs)
-        logger.info("Warm up end")
+        if self.compiled:
+            logger.info("Detected torch.compile is applied, please warm-up by your own case")
+        else:
+            inputs = prepare_jit_inputs(self.model, self.export_feature, False)
+            with torch.no_grad():
+                self.model(**inputs)
+                self.model(**inputs)
+            logger.info("Warm up end")
 
 
 class IPEXModelForSequenceClassification(IPEXModel):
@@ -400,10 +403,13 @@ class IPEXModelForCausalLM(IPEXModel, GenerationMixin):
         return result
 
     def _init_warmup(self):
-        inputs = prepare_jit_inputs(self.model, self.export_feature, False)
-        self.generate(input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"], max_new_tokens=4)
-        self.generate(input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"], max_new_tokens=4)
-        logger.info("Warm up end")
+        if self.compiled:
+            logger.info("Detected torch.compile is applied, please warm-up by your own case")
+        else:
+            inputs = prepare_jit_inputs(self.model, self.export_feature, False)
+            self.generate(input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"], max_new_tokens=4)
+            self.generate(input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"], max_new_tokens=4)
+            logger.info("Warm up end")
 
 
 class IPEXModelForSeq2SeqLM(IPEXModel, GenerationMixin):
@@ -478,10 +484,13 @@ class IPEXModelForSeq2SeqLM(IPEXModel, GenerationMixin):
         return "num_logits_to_keep" in set(inspect.signature(self.model.forward).parameters.keys())
 
     def _init_warmup(self):
-        inputs = prepare_jit_inputs(self.model, self.export_feature, False)
-        self.generate(input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"], max_new_tokens=4)
-        self.generate(input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"], max_new_tokens=4)
-        logger.info("Warm up end")
+        if self.compiled:
+            logger.info("Detected torch.compile is applied, please warm-up by your own case")
+        else:
+            inputs = prepare_jit_inputs(self.model, self.export_feature, False)
+            self.generate(input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"], max_new_tokens=4)
+            self.generate(input_ids=inputs["input_ids"], attention_mask=inputs["attention_mask"], max_new_tokens=4)
+            logger.info("Warm up end")
 
 
 def _ipex_crop_past_key_values(model, past_key_values, max_length):


### PR DESCRIPTION
The warm-up for models which applied torch.compile is not working because of different shapes.

The following codes can reproduce
```python
import time
import torch
from transformers import pipeline

model_id = "ProsusAI/finbert"
pipe = pipeline("sentiment-analysis", model=model_id)
pipe.model.forward = torch.compile(pipe.model.forward)

prompt_1 = "This was a masterpiece. Not completely faithful to the books, but enthralling from beginning to end. Might be my favorite of the three."
for i in range(4):
    start = time.time()
    output = pipe(prompt_1)
    end = time.time()
    print(f"time for epoch {i}: {(end-start):.3f} s")

prompt_2 = "I am not happy."
for i in range(4):
    start = time.time()
    output = pipe(prompt_2)
    end = time.time()
    print(f"time for epoch {i}: {(end-start):.3f} s")
```

Same issue also happens on cuda. I think it's an issue of torch.compile.
I suppose we can disable warm-up as most models applied torch.compile in IPEXModel, WDYT? @echarlaix 