### PR TITLE
Add default int4 configs for Phi-4-mini-instruct and Qwen2.5-7B-Instruct

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -89,6 +89,15 @@ _DEFAULT_4BIT_CONFIGS = {
     "pansophic/rocket-3B": {"bits": 4, "sym": True, "group_size": 128, "ratio": 0.8},
     "THUDM/chatglm2-6b": {"bits": 4, "sym": True, "group_size": 128, "ratio": 0.72},
     "Qwen/Qwen-7B-Chat": {"bits": 4, "sym": True, "group_size": 128, "ratio": 0.6},
+    "Qwen/Qwen2.5-7B-Instruct": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 128,
+        "ratio": 1.0,
+        "dataset": "wikitext2",
+        "quant_method": OVQuantizationMethod.AWQ,
+        "scale_estimation": True,
+    },
     "openlm-research/open_llama_3b": {"bits": 4, "sym": False, "group_size": 64, "all_layers": True},
     "openlm-research/open_llama_3b_v2": {
         "bits": 4,
@@ -202,6 +211,15 @@ _DEFAULT_4BIT_CONFIGS = {
         "scale_estimation": True,
     },
     "microsoft/Phi-3.5-mini-instruct": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "ratio": 1.0,
+        "dataset": "wikitext2",
+        "quant_method": OVQuantizationMethod.AWQ,
+        "scale_estimation": True,
+    },
+    "microsoft/Phi-4-mini-instruct": {
         "bits": 4,
         "sym": False,
         "group_size": 64,


### PR DESCRIPTION
# What does this PR do?

WWB (English) similarity:
- Phi-4-mini-instruct: 88.16%
- Qwen2.5-7B-Instruct: 91.60% 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

