### PR TITLE
Introduce OVCalibrationDatasetBuilder (part 1/2)

### DIFF
--- a/notebooks/openvino/stable_diffusion_hybrid_quantization.ipynb
+++ b/notebooks/openvino/stable_diffusion_hybrid_quantization.ipynb
@@ -168,8 +168,7 @@
     "    return {\"prompt\": example[\"caption\"]}\n",
     "\n",
     "NUM_SAMPLES = 200\n",
-    "dataset = dataset.take(NUM_SAMPLES)\n",
-    "calibration_dataset = dataset.map(lambda x: preprocess_fn(x), remove_columns=dataset.column_names)"
+    "prompts = [example[\"caption\"] for example in dataset.take(NUM_SAMPLES)]"
    ]
   },
   {
@@ -1038,8 +1037,7 @@
     "quantization_config = OVWeightQuantizationConfig(bits=8, num_samples=NUM_SAMPLES, quant_method=OVQuantizationMethod.HYBRID)\n",
     "quantizer = OVQuantizer(int8_pipe)\n",
     "quantizer.quantize(\n",
-    "    ov_config=OVConfig(quantization_config=quantization_config),\n",
-    "    calibration_dataset=calibration_dataset,\n",
+    "    ov_config=OVConfig(quantization_config=quantization_config, dataset=prompts),\n",
     "    save_directory=int8_model_path\n",
     ")"
    ]

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -80,7 +80,7 @@ except OptionalDependencyNotAvailable:
     _import_structure["utils.dummy_openvino_and_nncf_objects"].extend(
         [
             "OVQuantizer",
-            "CalibrationDataset",
+            "OVCalibrationDataset",
             "OVQuantizationConfig",
             "OVWeightQuantizationConfig",
             "OVDynamicQuantizationConfig",
@@ -91,7 +91,7 @@ else:
     _import_structure["openvino"].extend(
         [
             "OVQuantizer",
-            "CalibrationDataset",
+            "OVCalibrationDataset",
             "OVQuantizationConfig",
             "OVWeightQuantizationConfig",
             "OVDynamicQuantizationConfig",
@@ -264,7 +264,7 @@ if TYPE_CHECKING:
             raise OptionalDependencyNotAvailable()
     except OptionalDependencyNotAvailable:
         from .utils.dummy_openvino_and_nncf_objects import (
-            CalibrationDataset,
+            OVCalibrationDataset,
             OVDynamicQuantizationConfig,
             OVMixedQuantizationConfig,
             OVQuantizationConfig,
@@ -273,7 +273,7 @@ if TYPE_CHECKING:
         )
     else:
         from .openvino import (
-            CalibrationDataset,
+            OVCalibrationDataset,
             OVDynamicQuantizationConfig,
             OVMixedQuantizationConfig,
             OVQuantizationConfig,

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -80,6 +80,7 @@ except OptionalDependencyNotAvailable:
     _import_structure["utils.dummy_openvino_and_nncf_objects"].extend(
         [
             "OVQuantizer",
+            "CalibrationDataset",
             "OVQuantizationConfig",
             "OVWeightQuantizationConfig",
             "OVDynamicQuantizationConfig",
@@ -90,6 +91,7 @@ else:
     _import_structure["openvino"].extend(
         [
             "OVQuantizer",
+            "CalibrationDataset",
             "OVQuantizationConfig",
             "OVWeightQuantizationConfig",
             "OVDynamicQuantizationConfig",
@@ -262,6 +264,7 @@ if TYPE_CHECKING:
             raise OptionalDependencyNotAvailable()
     except OptionalDependencyNotAvailable:
         from .utils.dummy_openvino_and_nncf_objects import (
+            CalibrationDataset,
             OVDynamicQuantizationConfig,
             OVMixedQuantizationConfig,
             OVQuantizationConfig,
@@ -270,6 +273,7 @@ if TYPE_CHECKING:
         )
     else:
         from .openvino import (
+            CalibrationDataset,
             OVDynamicQuantizationConfig,
             OVMixedQuantizationConfig,
             OVQuantizationConfig,

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -47,7 +47,7 @@ if is_nncf_available():
 
     patch_torch_operators()
 
-    from .quantization import OVQuantizer
+    from .quantization import CalibrationDataset, OVQuantizer
 
 
 from .configuration import (

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -47,7 +47,7 @@ if is_nncf_available():
 
     patch_torch_operators()
 
-    from .quantization import CalibrationDataset, OVQuantizer
+    from .quantization import OVCalibrationDataset, OVQuantizer
 
 
 from .configuration import (

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -549,7 +549,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 )
 
         if self.dataset is not None and not (
-            self.quant_method == OVQuantizationMethod.AWQ
+            self.quant_method in [OVQuantizationMethod.AWQ, OVQuantizationMethod.HYBRID]
             or self.scale_estimation
             or self.gptq
             or self.lora_correction

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -1913,7 +1913,7 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
 
     def _set_2d_pos_cache(self, max_size):
         pos_embed = torch.from_numpy(self._get_2d_sincos_pos_embed(self.embed_dim, max_size)).float()
-        self._pos_embed = pos_embed
+        self._pos_embeds = pos_embed
 
     def _adjust_pos_cache(self, tgt_sizes):
         max_h = torch.max(tgt_sizes[:, 0])

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -601,7 +601,8 @@ class OVCalibrationDatasetBuilder:
         self, config: OVQuantizationConfigBase, dataset: "Dataset"
     ) -> OVCalibrationDataset:
         """
-        Prepares calibration data for VLM pipelines. Currently, collects data only for a language model component.
+        Prepares calibration data for VLM pipelines.
+        Currently, collects data only for a language model component.
         """
         processor = AutoProcessor.from_pretrained(config.processor, trust_remote_code=config.trust_remote_code)
         try:
@@ -873,7 +874,7 @@ class OVQuantizer(OptimumQuantizer):
             ):
                 logger.warning(
                     "Assuming `caption` column should be used for calibration. This behavior will be deprecated in "
-                    "optimum-intel v1.25. Please filter the required columns before passing the dataset."
+                    "optimum-intel v1.25. Please filter out the unnecessary columns before passing the dataset."
                 )
                 calibration_dataset = calibration_dataset.select_columns(["caption"])
 
@@ -974,15 +975,6 @@ class OVQuantizer(OptimumQuantizer):
 
             if calibration_dataset is None:
                 raise ValueError("Calibration dataset is required to run data-aware quantization.")
-            if (
-                not (
-                    is_diffusers_available()
-                    and isinstance(self.model, OVDiffusionPipeline)
-                    or isinstance(self.model, _OVModelForWhisper)
-                )
-                and "model" not in calibration_dataset
-            ):
-                raise RuntimeError("Calibration datasets should contain a key 'model' with a dataset.")
 
             if (
                 isinstance(quantization_config, OVWeightQuantizationConfig)

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -141,9 +141,13 @@ _HEAD_TO_AUTOMODELS = {
 LANGUAGE_DATASETS = ["wikitext2", "c4", "c4-new", "auto"]
 
 PREDEFINED_SD_DATASETS = {
-    "conceptual_captions": {"split": "train", "inputs": {"prompt": "caption"}},
-    "laion/220k-GPT4Vision-captions-from-LIVIS": {"split": "train", "inputs": {"prompt": "caption"}},
-    "laion/filtered-wit": {"split": "train", "inputs": {"prompt": "caption"}},
+    "conceptual_captions": {"split": "train", "prompt_column_name": "caption", "streaming": True},
+    "laion/220k-GPT4Vision-captions-from-LIVIS": {
+        "split": "train",
+        "prompt_column_name": "caption",
+        "streaming": True,
+    },
+    "laion/filtered-wit": {"split": "train", "prompt_column_name": "caption", "streaming": True},
 }
 
 PREDEFINED_VISUAL_LM_DATASETS = {
@@ -151,6 +155,7 @@ PREDEFINED_VISUAL_LM_DATASETS = {
         "id": "ucla-contextual/contextual_test",
         "split": "test",
         "inputs": {"image_url": "image_url", "instruction": "instruction"},
+        "streaming": True,
     }
 }
 

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -164,7 +164,7 @@ PREDEFINED_SPEECH_TO_TEXT_DATASETS = {
         "id": "openslr/librispeech_asr",
         "name": "clean",
         "split": "validation",
-        "inputs": {"audio": ("audio", "array"), "sampling_rate": ("audio", "sampling_rate")},
+        "streaming": True,
     }
 }
 

--- a/optimum/intel/utils/dummy_openvino_and_nncf_objects.py
+++ b/optimum/intel/utils/dummy_openvino_and_nncf_objects.py
@@ -26,6 +26,13 @@ class OVQuantizer(metaclass=DummyObject):
         requires_backends(cls, ["openvino", "nncf"])
 
 
+class CalibrationDataset(metaclass=DummyObject):
+    _backends = ["openvino", "nncf"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["openvino", "nncf"])
+
+
 class OVWeightQuantizationConfig(metaclass=DummyObject):
     _backends = ["openvino", "nncf"]
 

--- a/optimum/intel/utils/dummy_openvino_and_nncf_objects.py
+++ b/optimum/intel/utils/dummy_openvino_and_nncf_objects.py
@@ -26,7 +26,7 @@ class OVQuantizer(metaclass=DummyObject):
         requires_backends(cls, ["openvino", "nncf"])
 
 
-class CalibrationDataset(metaclass=DummyObject):
+class OVCalibrationDataset(metaclass=DummyObject):
     _backends = ["openvino", "nncf"]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
# What does this PR do?

This is the first part of the changes introduced in #1191.

This is a preparation PR for the introduction of `OVPipelineQuantizationConfig` which purpose is to contain inside of it multiple quantization configs per pipeline model.

### Changes:
- Introduce a `OVCalibrationDataset` class representing _Dict[str, nncf.Dataset]_. The reasoning behind is that most recent model pipelines contain many ov.Model components and not a single _model.model_ as it was before. To quantize such pipelines in a data-aware fashion we need a dataset per ov submodel. This is what `OVCalibrationDataset` represents.
- Moved calibration dataset collection logic into a newly added `OVCalibrationDatasetBuilder` class. It is not exposed to users and is instantiated only inside _OVQuantizer_. The class supports the following methods:
  - `load_dataset(...)` -- basically does the same as the current _OVQuantizer.get_calibation_dataset()_ method.
  - `build_from_dataset_name(dataset, ...) -> OVCalibrationDataset` -- builds nncf calibration dataset from an instance of _datasets.Dataset_.
  - `build_from_dataset_name(dataset_name, ...) -> OVCalibrationDataset` -- builds calibration dataset by first calling _load_dataset()_ method and then _build_from_dataset()_ method. 
  - `build_from_quantization_config(q_config) -> OVCalibrationDataset` -- builds calibration dataset from just a quantization config, using _q_config.dataset_ field and others. Relies on _build_from_dataset_name()_.

### Deprecations:
All changes are backward compatible. However some deprecation warnings (until v1.25) are added to avoid some rare corner case API scenarios which I believe should be avoided:
- Providing _calibration_dataset_ to `OVQuantizer.quantize()` as a list. Currently this is only supported for a list of prompts for hybrid quantization of diffusion models. The list is better to be provided via `quantization_config.dataset` field as it is done for causal models quantization.
- Deprecate `remove_unused_columns` argument for `OVQuantizer.quantize()` because it relies on the fact that `model.forward()` is used for inference. However we can't always guarantee that. For example there is `model.generate()` method. In general I believe the user should remove the unnecessary columns themselves if they provide a `datasets.Dataset` instance which is already a quite advanced usage scenario.
- Currently all columns except `caption` column are removed from a `datasets.Dataset` instance in case of a hybrid quantization. I haven't found usages like this, I believe it is not currently used, but added a deprecation warning anyway.

### Future plans:
In one of the next PRs an `OVPipelineQuantizationConfig` will be introduced. The changes implemented here will be helpful when implementing support for this type of config.

For the further future (past v1.25) I would consider to change `OVQuantizer.get_calibration_dataset` signature. I believe it would be better for it to return _OVCalibrationDataset_ instance from either _datasets.Dataset_ instance or a dataset name as input. This way _OVQuantizer.quantize()_ will accept fully ready _OVCalibrationDataset_ instance and _batch_size_ and _data_collator_ arguments can be removed. For example in the future it could look like this:
```
calibration_dataset: OVCalibrationDataset = ov_quantizer.get_calibration_dataset(
  ov_config,
  dataset_name,
  ...,
  batch_size,
  data_collator,
)
ov_quantizer.quantize(calibration_dataset, ov_config)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

