### PR TITLE
Replace compvis safety checker model with a tiny version

### DIFF
--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -314,7 +314,7 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
         safety_checker = StableDiffusionSafetyChecker.from_pretrained(
-            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker"
+            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker", subfolder="safety_checker"
         )
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
@@ -655,7 +655,7 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
         safety_checker = StableDiffusionSafetyChecker.from_pretrained(
-            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker"
+            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker", subfolder="safety_checker"
         )
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
@@ -925,7 +925,7 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
         safety_checker = StableDiffusionSafetyChecker.from_pretrained(
-            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker"
+            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker", subfolder="safety_checker"
         )
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -313,7 +313,7 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
     @parameterized.expand(["stable-diffusion", "latent-consistency"])
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
-        safety_checker = StableDiffusionSafetyChecker.from_pretrained("CompVis/stable-diffusion-safety-checker")
+        safety_checker = StableDiffusionSafetyChecker.from_pretrained("katuni4ka/tiny-random-stable-diffusion-with-safety-checker")
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
         ov_pipeline = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
@@ -652,7 +652,7 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
     @parameterized.expand(["stable-diffusion", "latent-consistency"])
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
-        safety_checker = StableDiffusionSafetyChecker.from_pretrained("CompVis/stable-diffusion-safety-checker")
+        safety_checker = StableDiffusionSafetyChecker.from_pretrained("katuni4ka/tiny-random-stable-diffusion-with-safety-checker")
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
         ov_pipeline = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
@@ -920,7 +920,7 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
     @parameterized.expand(["stable-diffusion"])
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
-        safety_checker = StableDiffusionSafetyChecker.from_pretrained("CompVis/stable-diffusion-safety-checker")
+        safety_checker = StableDiffusionSafetyChecker.from_pretrained("katuni4ka/tiny-random-stable-diffusion-with-safety-checker")
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
         ov_pipeline = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -313,7 +313,9 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
     @parameterized.expand(["stable-diffusion", "latent-consistency"])
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
-        safety_checker = StableDiffusionSafetyChecker.from_pretrained("katuni4ka/tiny-random-stable-diffusion-with-safety-checker")
+        safety_checker = StableDiffusionSafetyChecker.from_pretrained(
+            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker"
+        )
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
         ov_pipeline = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
@@ -652,7 +654,9 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
     @parameterized.expand(["stable-diffusion", "latent-consistency"])
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
-        safety_checker = StableDiffusionSafetyChecker.from_pretrained("katuni4ka/tiny-random-stable-diffusion-with-safety-checker")
+        safety_checker = StableDiffusionSafetyChecker.from_pretrained(
+            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker"
+        )
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
         ov_pipeline = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
@@ -920,7 +924,9 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
     @parameterized.expand(["stable-diffusion"])
     @require_diffusers
     def test_safety_checker(self, model_arch: str):
-        safety_checker = StableDiffusionSafetyChecker.from_pretrained("katuni4ka/tiny-random-stable-diffusion-with-safety-checker")
+        safety_checker = StableDiffusionSafetyChecker.from_pretrained(
+            "katuni4ka/tiny-random-stable-diffusion-with-safety-checker"
+        )
 
         pipeline = self.AUTOMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)
         ov_pipeline = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES[model_arch], safety_checker=safety_checker)


### PR DESCRIPTION
# What does this PR do?

In this PR `CompVis/stable-diffusion-safety-checker` model is replaced with `katuni4ka/tiny-random-stable-diffusion-with-safety-checker/safety_checker`. This saves up about 2GB of model cache disk space.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

