### PR TITLE
restore cache_position input in whisper

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -3032,6 +3032,11 @@ class WhisperOpenVINOConfig(WhisperOnnxConfig):
         common_inputs = super().inputs
         if getattr(self, "stateful", False) and self._behavior == ConfigBehavior.DECODER:
             common_inputs["decoder_input_ids"] = {0: "batch_size", 1: "decoder_sequence_length"}
+
+        if self._behavior is not ConfigBehavior.ENCODER and self.use_past_in_inputs:
+            if is_transformers_version(">=", "4.43.0"):
+                # since https://github.com/huggingface/transformers/pull/31166
+                common_inputs["cache_position"] = {0: "decoder_sequence_length"}
         return common_inputs
 
 


### PR DESCRIPTION
# What does this PR do?
cache_position input was removed in optimum for whisper after this commit https://github.com/huggingface/optimum/commit/414afab57943eb6629181ff9a351a73c4eeb879e

 our internal optimizations and transformations rely on having this input in model, so restore it for openvino config

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

