### PR TITLE
PTQ support for OVModelForMaskedLM

### DIFF
--- a/docs/source/openvino/optimization.mdx
+++ b/docs/source/openvino/optimization.mdx
@@ -325,6 +325,64 @@ Click on a ✅ to copy the command/code for the corresponding optimization case.
                 </button>
             </td>
         </tr>
+        <tr>
+            <td style="text-align: center; vertical-align: middle;">fill-mask<br>(OVModelForMaskedLM)</td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('optimum-cli export openvino -m FacebookAI/roberta-base --weight-format int8 ./save_dir')">
+                    ✅
+                </button>
+            </td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('OVModelForMaskedLM.from_pretrained(\'FacebookAI/roberta-base\', quantization_config=OVWeightQuantizationConfig(bits=8)).save_pretrained(\'save_dir\')')">
+                    ✅
+                </button>
+            </td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('optimum-cli export openvino -m FacebookAI/roberta-base --weight-format int4 --dataset wikitext2 ./save_dir')">
+                    ✅
+                </button>
+            </td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('OVModelForMaskedLM.from_pretrained(\'FacebookAI/roberta-base\', quantization_config=OVWeightQuantizationConfig(bits=4, dataset=\'wikitext2\')).save_pretrained(\'save_dir\')')">
+                    ✅
+                </button>
+            </td>
+            <td style="text-align: center; vertical-align: middle;">–</td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('OVModelForMaskedLM.from_pretrained(\'FacebookAI/roberta-base\', quantization_config=OVWeightQuantizationConfig(bits=4, quant_method=\'hybrid\', dataset=\'wikitext2\')).save_pretrained(\'save_dir\')')">
+                    ✅
+                </button>
+            </td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('optimum-cli export openvino -m FacebookAI/roberta-base --quant-mode int8 --dataset wikitext2 ./save_dir')">
+                    ✅
+                </button>
+            </td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('OVModelForMaskedLM.from_pretrained(\'FacebookAI/roberta-base\', quantization_config=OVQuantizationConfig(bits=8, dataset=\'wikitext2\')).save_pretrained(\'save_dir\')')">
+                    ✅
+                </button>
+            </td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('optimum-cli export openvino -m FacebookAI/roberta-base --quant-mode nf4_f8e4m3 --dataset wikitext2 ./save_dir')">
+                    ✅
+                </button>
+            </td>
+            <td style="text-align: center; vertical-align: middle;">
+                <button
+                    onclick="navigator.clipboard.writeText('OVModelForMaskedLM.from_pretrained(\'FacebookAI/roberta-base\', quantization_config=OVMixedQuantizationConfig(OVWeightQuantizationConfig(bits=4, dtype=\'nf4\'), OVQuantizationConfig(dtype=\'f8e4m3\', dataset=\'wikitext2\'))).save_pretrained(\'save_dir\')')">
+                    ✅
+                </button>
+            </td>
+        </tr>
     </tbody>
 </table>
 

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -448,7 +448,8 @@ class OVExportCommand(BaseOptimumCLICommand):
         elif (
             quantize_with_dataset
             and (
-                task.startswith("text-generation")
+                task == "fill-mask"
+                or task.startswith("text-generation")
                 or task.startswith("automatic-speech-recognition")
                 or task.startswith("feature-extraction")
             )
@@ -474,6 +475,10 @@ class OVExportCommand(BaseOptimumCLICommand):
                 from ...intel import OVSentenceTransformer
 
                 model_cls = OVSentenceTransformer
+            elif task == "fill-mask":
+                from ...intel import OVModelForMaskedLM
+
+                model_cls = OVModelForMaskedLM
             else:
                 raise NotImplementedError(
                     f"Unable to find a matching model class for the task={task} and library_name={library_name}."

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -829,7 +829,8 @@ class OVCalibrationDatasetBuilder:
 
             self.model.request = InferRequestWrapper(
                 self.model.request,
-                calibration_data,  # inference_result_mock=inference_result_mock,
+                calibration_data,
+                inference_result_mock=inference_result_mock,
             )
 
             if isinstance(self.model, OVSentenceTransformer):

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -17,6 +17,7 @@ import inspect
 import logging
 import os
 from collections import UserDict, deque
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 
@@ -265,6 +266,7 @@ class OVCalibrationDatasetBuilder:
         from optimum.intel import (
             OVModelForCausalLM,
             OVModelForFeatureExtraction,
+            OVModelForMaskedLM,
             OVModelForVisualCausalLM,
             OVSentenceTransformer,
         )
@@ -326,7 +328,7 @@ class OVCalibrationDatasetBuilder:
                 )
 
             return self.build_from_dataset(config, dataset)
-        elif isinstance(self.model, (OVModelForFeatureExtraction, OVSentenceTransformer)):
+        elif isinstance(self.model, (OVModelForFeatureExtraction, OVSentenceTransformer, OVModelForMaskedLM)):
             if isinstance(config.dataset, str):
                 dataset = self.load_dataset(
                     PREDEFINED_LANGUAGE_DATASETS[config.dataset]["path"],
@@ -443,7 +445,12 @@ class OVCalibrationDatasetBuilder:
         Returns:
             A calibration dataset as an instance of `OVCalibrationDataset` containing an `nncf.Dataset` for each model component.
         """
-        from optimum.intel import OVModelForFeatureExtraction, OVModelForVisualCausalLM, OVSentenceTransformer
+        from optimum.intel import (
+            OVModelForFeatureExtraction,
+            OVModelForMaskedLM,
+            OVModelForVisualCausalLM,
+            OVSentenceTransformer,
+        )
         from optimum.intel.openvino.modeling_decoder import OVBaseDecoderModel
         from optimum.intel.openvino.modeling_seq2seq import _OVModelForWhisper
 
@@ -458,7 +465,13 @@ class OVCalibrationDatasetBuilder:
 
         if isinstance(
             self.model,
-            (OVModelForVisualCausalLM, _OVModelForWhisper, OVModelForFeatureExtraction, OVSentenceTransformer),
+            (
+                OVModelForVisualCausalLM,
+                _OVModelForWhisper,
+                OVModelForFeatureExtraction,
+                OVModelForMaskedLM,
+                OVSentenceTransformer,
+            ),
         ) or (is_diffusers_available() and isinstance(self.model, OVDiffusionPipeline)):
             # Prepare from raw dataset avoiding dataloader creation
             if batch_size != 1 or data_collator is not None or remove_unused_columns:
@@ -472,8 +485,8 @@ class OVCalibrationDatasetBuilder:
                 return self._prepare_speech_to_text_calibration_data(quantization_config, dataset)
             elif is_diffusers_available() and isinstance(self.model, OVDiffusionPipeline):
                 return self._prepare_diffusion_calibration_data(quantization_config, dataset)
-            elif isinstance(self.model, (OVModelForFeatureExtraction, OVSentenceTransformer)):
-                return self._prepare_feature_extraction_calibration_data(quantization_config, dataset)
+            elif isinstance(self.model, (OVModelForFeatureExtraction, OVSentenceTransformer, OVModelForMaskedLM)):
+                return self._prepare_text_encoder_model_calibration_data(quantization_config, dataset)
             else:
                 raise RuntimeError("Unsupported model type for calibration dataset collection.")
         else:
@@ -784,39 +797,54 @@ class OVCalibrationDatasetBuilder:
         else:
             self.model._progress_bar_config["disable"] = disable
 
-    def _prepare_feature_extraction_calibration_data(
+    def _prepare_text_encoder_model_calibration_data(
         self,
         quantization_config: OVQuantizationConfigBase,
         dataset: "Dataset",
         seq_len: int = 128,
     ) -> OVCalibrationDataset:
-        from optimum.intel import OVModelForFeatureExtraction, OVSentenceTransformer
+        """
+        Prepares calibration data for text-encoder-like models.
+        Supports OVModelForFeatureExtraction, OVModelForMaskedLM and OVSentenceTransformer.
+        """
+        from optimum.intel import OVModelForFeatureExtraction, OVModelForMaskedLM, OVSentenceTransformer
 
         self.model.compile()
 
         num_samples = quantization_config.num_samples or 128
         calibration_data = []
         try:
-            self.model.request = InferRequestWrapper(
-                self.model.request,
-                calibration_data,
-                inference_result_mock={
-                    "last_hidden_state": np.empty((1,), np.float32),
-                    "token_embeddings": np.empty((1,), np.float32),
-                    "sentence_embedding": np.empty((1,), np.float32),
-                },
-            )
-
+            inference_result_mock = {}
             if isinstance(self.model, OVModelForFeatureExtraction):
-                tokenizer = AutoTokenizer.from_pretrained(
-                    quantization_config.tokenizer, trust_remote_code=quantization_config.trust_remote_code
-                )
+                inference_result_mock["last_hidden_state"] = np.empty((1,), np.float32)
+            elif isinstance(self.model, OVModelForMaskedLM):
+                inference_result_mock["logits"] = np.empty((1,), np.float32)
             elif isinstance(self.model, OVSentenceTransformer):
-                tokenizer = self.model.tokenizer
+                inference_result_mock["token_embeddings"] = np.empty((1,), np.float32)
+                inference_result_mock["sentence_embedding"] = np.empty((1,), np.float32)
             else:
                 raise RuntimeError(
                     f"Unsupported model type {type(self.model).__name__} for calibration dataset collection."
                 )
+
+            self.model.request = InferRequestWrapper(
+                self.model.request,
+                calibration_data,  # inference_result_mock=inference_result_mock,
+            )
+
+            if isinstance(self.model, OVSentenceTransformer):
+                tokenizer = self.model.tokenizer
+            else:
+                tokenizer = AutoTokenizer.from_pretrained(
+                    quantization_config.tokenizer, trust_remote_code=quantization_config.trust_remote_code
+                )
+
+            seq_len = min(seq_len, self.model.config.max_position_embeddings or seq_len)
+
+            random_positions = None
+            if isinstance(self.model, OVModelForMaskedLM):
+                with numpy_seed(self.seed):
+                    random_positions = np.random.randint(0, seq_len, num_samples)
 
             pbar = tqdm(total=num_samples, desc="Collecting calibration data")
             for item in dataset:
@@ -824,7 +852,11 @@ class OVCalibrationDatasetBuilder:
                 if inputs["input_ids"].shape[1] < seq_len:
                     continue
 
-                self.model(**inputs) if isinstance(self.model, OVModelForFeatureExtraction) else self.model(inputs)
+                if isinstance(self.model, OVModelForMaskedLM):
+                    # Replace a random token with a mask token
+                    inputs["input_ids"][0, random_positions[len(calibration_data)]] = tokenizer.mask_token_id
+
+                self.model(inputs) if isinstance(self.model, OVSentenceTransformer) else self.model(**inputs)
 
                 pbar.update(min(num_samples, len(calibration_data)) - pbar.n)
                 if len(calibration_data) >= num_samples:
@@ -1612,3 +1644,16 @@ def _remove_f16_kv_cache_precision_flag(model: openvino.Model) -> openvino.Model
 def _add_nncf_version_flag(model: openvino.Model) -> openvino.Model:
     model.set_rt_info(_nncf_version, ["optimum", "nncf_version"])
     return model
+
+
+@contextmanager
+def numpy_seed(seed: int):
+    """
+    Context manager to set the numpy random seed.
+    """
+    old_state = np.random.get_state()
+    np.random.seed(seed)
+    try:
+        yield
+    finally:
+        np.random.set_state(old_state)

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -840,7 +840,9 @@ class OVCalibrationDatasetBuilder:
                     quantization_config.tokenizer, trust_remote_code=quantization_config.trust_remote_code
                 )
 
-            seq_len = min(seq_len, self.model.config.max_position_embeddings or seq_len)
+            max_position_embeddings = getattr(self.model.config, "max_position_embeddings", None)
+            if max_position_embeddings is not None and max_position_embeddings > 0:
+                seq_len = min(seq_len, max_position_embeddings)
 
             random_positions = None
             if isinstance(self.model, OVModelForMaskedLM):

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -348,6 +348,30 @@ class OVCLIExportTestCase(unittest.TestCase):
                 {"int8": 15},
             ],
         ),
+        (
+            "fill-mask",
+            "roberta",
+            "int8",
+            "--dataset wikitext2 --num-samples 1",
+            [
+                32,
+            ],
+            [
+                {"int8": 34},
+            ],
+        ),
+        (
+            "fill-mask",
+            "xlm_roberta",
+            "int8",
+            "--library sentence_transformers --dataset c4 --num-samples 1",
+            [
+                14,
+            ],
+            [
+                {"int8": 16},
+            ],
+        ),
     ]
 
     TEST_4BIT_CONFIGURATIONS = [

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -338,6 +338,36 @@ class OVQuantizerTest(unittest.TestCase):
                 {"int8": 15},
             ],
         ),
+        (
+            OVModelForMaskedLM,
+            "roberta",
+            OVQuantizationConfig(
+                dtype="int8",
+                dataset="wikitext2",
+                num_samples=1,
+            ),
+            [
+                32,
+            ],
+            [
+                {"int8": 34},
+            ],
+        ),
+        (
+            OVModelForMaskedLM,
+            "xlm_roberta",
+            OVQuantizationConfig(
+                dtype="int8",
+                dataset="c4",
+                num_samples=1,
+            ),
+            [
+                14,
+            ],
+            [
+                {"int8": 16},
+            ],
+        ),
     ]
 
     @staticmethod
@@ -495,11 +525,11 @@ class OVQuantizerTest(unittest.TestCase):
 
                 input_features = torch.randn((1, ov_model.config.num_mel_bins, 3000), dtype=torch.float32)
                 ov_model.generate(input_features)
-            elif model_cls in (OVModelForCausalLM, OVModelForFeatureExtraction):
+            elif model_cls in (OVModelForCausalLM, OVModelForFeatureExtraction, OVModelForMaskedLM):
                 tokenizer = AutoTokenizer.from_pretrained(model_id)
                 if tokenizer.pad_token is None:
                     tokenizer.pad_token = tokenizer.eos_token
-                tokens = tokenizer("This is a sample input", return_tensors="pt")
+                tokens = tokenizer("This is a sample <mask>", return_tensors="pt")
                 ov_model(**tokens)
             elif model_cls in (
                 OVStableDiffusionPipeline,


### PR DESCRIPTION
# What does this PR do?

Add support for full quantization of fill-mask pipelines (OVModelForMaskedLM).

| Model ID                                       | INT8 WC Similarity | INT8 PTQ Similarity | INT8 WC Speedup | INT8 PTQ Speedup |
|------------------------------------------------|--------------------|---------------------|------------------|-------------------|
| FacebookAI/roberta-base                        | 80.86%             | 69.00%              | 1.56x            | 1.67x             |
| FacebookAI/roberta-large                       | 82.22%             | 68.50%              | 1.77x            | 2.16x             |
| FacebookAI/xlm-roberta-base                    | 72.06%             | 56.08%              | 1.38x            | 1.36x             |
| FacebookAI/xlm-roberta-large                   | 74.32%             | 59.26%              | 1.70x            | 1.94x             |
| emilyalsentzer/Bio_ClinicalBERT                | 84.08%             | 66.32%              | 1.50x            | 1.62x             |
| google-bert/bert-base-cased                    | 90.24%             | 79.02%              | 1.52x            | 1.67x             |
| google-bert/bert-base-chinese                  | 86.14%             | 52.72%              | 1.51x            | 1.67x             |
| google-bert/bert-base-multilingual-cased       | 86.14%             | 65.34%              | 1.44x            | 1.45x             |
| google-bert/bert-base-multilingual-uncased     | 86.86%             | 69.98%              | 1.41x            | 1.43x             |
| google-bert/bert-large-uncased                 | 89.96%             | 70.44%              | 1.78x            | 2.19x             |
| microsoft/infoxlm-large                        | 0.00%              | 0.00%               | 1.71x            | 1.94x             |
| neuralmind/bert-base-portuguese-cased          | 83.36%             | 55.32%              | 1.50x            | 1.64x             |

WC stands for Weight Compression. "wikitext2" dataset with `num_samples=128` was used during PTQ calibration.

Similarity was measured on a set of 1000 prompts generated the similar way as calibration data is generated, but on a "c4" dataset.  A model was inferred on each prompt resulting in top-5 token predictions. These tokens were used to computed accuracy against tokens predicted by OV FP32 model. Order matters. I will add the code to the ticket once all models are supported.

`microsoft/infoxlm-large` is problematic and thus has 0% accuracy. PyTorch model fails during inference through `transformers.pipeline`, OV model returns garbage. A separate investigation is needed for it.

Similarity evaluation is just a rough sketch of model accuracy and does not precisely reflect model quality. A more thorough evaluation will be performed once enablement is done.

Ticket 165770

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

