### PR TITLE
fix gptj export for transformers>4.49

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -23,6 +23,7 @@ from transformers.utils import is_tf_available
 from optimum.exporters.onnx.base import ConfigBehavior
 from optimum.exporters.onnx.config import OnnxConfig, TextDecoderOnnxConfig, TextDecoderWithPositionIdsOnnxConfig
 from optimum.exporters.onnx.model_configs import (
+    BloomOnnxConfig,
     CLIPOnnxConfig,
     CLIPTextOnnxConfig,
     CLIPTextWithProjectionOnnxConfig,
@@ -71,6 +72,7 @@ from .model_patcher import (
     AquilaModelPatcher,
     ArcticModelPatcher,
     BaichuanModelPatcher,
+    BloomModelPatcher,
     ChatGLMModelPatcher,
     CodeGenModelPatcher,
     CommonImageEmbeddingsModelPatcher,
@@ -905,6 +907,25 @@ class GPTJOpenVINOConfig(GPTJOnnxConfig):
         self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
     ) -> "ModelPatcher":
         return GptJModelPatcher(self, model, model_kwargs=model_kwargs)
+
+
+@register_in_tasks_manager(
+    "bloom",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text-classification",
+        "token-classification",
+    ],
+    library_name="transformers",
+)
+class BloomOpenVINOConfig(BloomOnnxConfig):
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
+    ) -> "ModelPatcher":
+        return BloomModelPatcher(self, model, model_kwargs=model_kwargs)
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -23,6 +23,8 @@ from transformers.utils import is_tf_available
 from optimum.exporters.onnx.base import ConfigBehavior
 from optimum.exporters.onnx.config import OnnxConfig, TextDecoderOnnxConfig, TextDecoderWithPositionIdsOnnxConfig
 from optimum.exporters.onnx.model_configs import (
+    BlenderbotOnnxConfig,
+    BlenderbotSmallOnnxConfig,
     BloomOnnxConfig,
     CLIPOnnxConfig,
     CLIPTextOnnxConfig,
@@ -37,8 +39,10 @@ from optimum.exporters.onnx.model_configs import (
     GPTNeoXOnnxConfig,
     IBertOnnxConfig,
     LlamaOnnxConfig,
+    MarianOnnxConfig,
     MistralOnnxConfig,
     MPTOnnxConfig,
+    PegasusOnnxConfig,
     PhiOnnxConfig,
     T5OnnxConfig,
     UNetOnnxConfig,
@@ -72,6 +76,8 @@ from .model_patcher import (
     AquilaModelPatcher,
     ArcticModelPatcher,
     BaichuanModelPatcher,
+    BlenderbotModelPatcher,
+    BlenderbotSmallModelPatcher,
     BloomModelPatcher,
     ChatGLMModelPatcher,
     CodeGenModelPatcher,
@@ -101,6 +107,7 @@ from .model_patcher import (
     LlavaImageEmbeddingModelPatcher,
     LlavaNextVideoImageEmbeddingModelPatcher,
     LlavaQwen2ImageEmbeddingsModelPatcher,
+    MarianModelPatcher,
     MiniCPM3Patcher,
     MiniCPMModelPatcher,
     MiniCPMVImageEmbeddingsModelPatcher,
@@ -108,6 +115,7 @@ from .model_patcher import (
     MistralModelPatcher,
     MixtralModelPatcher,
     MPTModelPatcher,
+    PegasusModelPatcher,
     PersimmonModelPatcher,
     Phi3ModelPatcher,
     Phi3VisionImageEmbeddingsPatcher,
@@ -3302,3 +3310,79 @@ class Idefics3OpenVINOConfig(BaseVLMOpenVINOConfig):
 @register_in_tasks_manager("smolvlm", *["image-text-to-text", "video-text-to-text"], library_name="transformers")
 class SmolVLMOpenVINOConfig(Idefics3OpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "4.50.0"
+
+
+@register_in_tasks_manager(
+    "blenderbot",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text2text-generation",
+        "text2text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class BlenderbotOpenVINOConfig(BlenderbotOnnxConfig):
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
+    ) -> "ModelPatcher":
+        return BlenderbotModelPatcher(self, model, model_kwargs=model_kwargs)
+
+
+@register_in_tasks_manager(
+    "blenderbot-small",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text2text-generation",
+        "text2text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class BlenderbotSmallOpenVINOConfig(BlenderbotSmallOnnxConfig):
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
+    ) -> "ModelPatcher":
+        return BlenderbotSmallModelPatcher(self, model, model_kwargs=model_kwargs)
+
+
+@register_in_tasks_manager(
+    "pegasus",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text2text-generation",
+        "text2text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class PegasusOpenVINOConfig(PegasusOnnxConfig):
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
+    ) -> "ModelPatcher":
+        return PegasusModelPatcher(self, model, model_kwargs=model_kwargs)
+
+
+@register_in_tasks_manager(
+    "marian",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text2text-generation",
+        "text2text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class MarianOpenVINOConfig(MarianOnnxConfig):
+    def patch_model_for_export(
+        self, model: Union["PreTrainedModel", "TFPreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None
+    ) -> "ModelPatcher":
+        return MarianModelPatcher(self, model, model_kwargs=model_kwargs)

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -2953,6 +2953,7 @@ class GptNeoxJapaneseModelPatcher(DecoderModelPatcher):
         unpatch_update_causal_mask(self._model, "gpt_neox_japanese")
 
 
+# Adopted from https://github.com/huggingface/optimum/blob/main/optimum/bettertransformer/models/attention.py#L721
 def _bloom_attn_forward(
     self,
     hidden_states: torch.Tensor,
@@ -5127,8 +5128,6 @@ def _blenderbot_attn_forward(
         past_key_value = (key_states, value_states)
 
     query_states = self._shape(query_states, tgt_len, bsz)
-    key_states = key_states
-    value_states = value_states
 
     attn_output = torch.nn.functional.scaled_dot_product_attention(
         query_states,

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -67,9 +67,9 @@ from transformers.utils import http_user_agent
 from utils_tests import (
     MODEL_NAMES,
     TEST_IMAGE_URL,
+    get_num_sdpa,
     mock_torch_cuda_is_available,
     patch_awq_for_inference,
-    get_num_sdpa,
 )
 
 from optimum.exporters.openvino.model_patcher import patch_update_causal_mask
@@ -1156,7 +1156,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "baichuan2-13b": 2,
         "gpt_bigcode": 5,
         "blenderbot": 2,
-        "blenderbot_small": 2,
+        "blenderbot-small": 2,
         "bloom": 5,
         "chatglm": 2,
         "codegen": 5,
@@ -1168,18 +1168,18 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "llama": 2,
         "marian": 2,
         "minicpm": 4,
-        "mistral": 2,
-        "mixtral": 2,
+        "mistral": 2 if is_transformers_version(">=", "4.40.0") else 0,
+        "mixtral": 2 if is_transformers_version(">=", "4.40.0") else 0,
         "mpt": 5,
         "opt": 5,
         "pegasus": 2,
         "qwen": 2,
-        "phi": 2,
+        "phi": 2 if is_transformers_version(">=", "4.40.0") else 0,
         "internlm2": 4,
         "falcon": 2,
         "falcon-40b": 2,
         "persimmon": 2,
-        "biogpt": 5,
+        "biogpt": 5 if is_transformers_version(">=", "4.45.0") else 0,
         "aquila": 2,
         "aquila2": 2,
         "xverse": 2,
@@ -1202,14 +1202,14 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "granite": 6,
         "granite-moe": 6,
         "glm": 28,
-        "mistral_nemo": 8,
+        "mistral-nemo": 8,
         "minicpm3": 6,
         "phi3-moe": 2,
         "deepseek": 2,
         "opt_gptq": 12,
         "mixtral_awq": 2,
         "gemma3-text": 2,
-        "glm4": 2 
+        "glm4": 2,
     }
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1150,7 +1150,67 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "deepseek",
     )
 
-    EXPECTED_NUM_SDPA = {}
+    EXPECTED_NUM_SDPA = {
+        "bart": 2,
+        "baichuan2": 2,
+        "baichuan2-13b": 2,
+        "gpt_bigcode": 5,
+        "blenderbot": 2,
+        "blenderbot_small": 2,
+        "bloom": 5,
+        "chatglm": 2,
+        "codegen": 5,
+        "codegen2": 2,
+        "gpt2": 5,
+        "gptj": 5,
+        "gpt_neo": 4,
+        "gpt_neox": 5,
+        "llama": 2,
+        "marian": 2,
+        "minicpm": 4,
+        "mistral": 2,
+        "mixtral": 2,
+        "mpt": 5,
+        "opt": 5,
+        "pegasus": 2,
+        "qwen": 2,
+        "phi": 2,
+        "internlm2": 4,
+        "falcon": 2,
+        "falcon-40b": 2,
+        "persimmon": 2,
+        "biogpt": 5,
+        "aquila": 2,
+        "aquila2": 2,
+        "xverse": 2,
+        "internlm": 2,
+        "jais": 2,
+        "chatglm4": 6,
+        "decilm": 4,
+        "gemma": 1,
+        "olmo": 2,
+        "stablelm": 2,
+        "starcoder2": 2,
+        "dbrx": 2,
+        "cohere": 2,
+        "qwen2": 2,
+        "qwen2-moe": 4,
+        "arctic": 4,
+        "phi3": 2,
+        "gemma2": 4,
+        "exaone": 8,
+        "granite": 6,
+        "granite-moe": 6,
+        "glm": 28,
+        "mistral_nemo": 8,
+        "minicpm3": 6,
+        "phi3-moe": 2,
+        "deepseek": 2,
+        "opt_gptq": 12,
+        "mixtral_awq": 2,
+        "gemma3-text": 2,
+        "glm4": 2 
+    }
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):
@@ -2169,12 +2229,12 @@ class OVModelForPix2StructIntegrationTest(unittest.TestCase):
     GENERATION_LENGTH = 100
     SPEEDUP_CACHE = 1.1
 
-    # IMAGE = Image.open(
-    #     requests.get(
-    #         "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/ai2d-demo.jpg",
-    #         stream=True,
-    #     ).raw
-    # )
+    IMAGE = Image.open(
+        requests.get(
+            "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/ai2d-demo.jpg",
+            stream=True,
+        ).raw
+    )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -329,3 +329,12 @@ def check_compression_state_per_model(
     # Check fake nodes
     if expected_num_fake_nodes_per_model is not None:
         test_case.assertEqual(expected_num_fake_nodes_per_model, actual_num_fake_nodes_per_model)
+
+
+def get_num_sdpa(model):
+    ov_model = model if isinstance(model, ov.Model) else model.model
+    num_sdpa = 0
+    for op in ov_model.get_ops():
+        if op.type_info.name == "ScaledDotProductAttention":
+            num_sdpa += 1
+    return num_sdpa


### PR DESCRIPTION
# What does this PR do?

BetterTransformers is not applicable for transformers>=4.49, however not all of supported by it models have sdpa attention by default in transformers library now. In our case, usage eager attention instead of sdpa for this case, may lead to significant perf degradations and inability to apply PagedAttention later.

For avoid this:
* restored sdpa for models where it was covered by BetterTransformers (bloom, blenderbot, blenderbot-small, gptj, pegasus, marian)
* added checking number of SDPA operations after model export in tests


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

