### PR TITLE
support Zero-shot-Image-Classification

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -119,6 +119,7 @@ Here is the list of the supported architectures :
 - SEW
 - SEW-D
 - Segformer
+- SigLIP
 - SmolVLM(SmolVLM2)
 - SpeechT5 (text-to-speech)
 - SqueezeBert

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -191,6 +191,7 @@ else:
             "OVModelOpenCLIPVisual",
             "OVModelOpenCLIPText",
             "OVModelOpenCLIPForZeroShotImageClassification",
+            "OVModelForZeroShotImageClassification",
             "OVSamModel",
         ]
     )

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -357,6 +357,7 @@ if TYPE_CHECKING:
             OVModelForTokenClassification,
             OVModelForVision2Seq,
             OVModelForVisualCausalLM,
+            OVModelForZeroShotImageClassification,
             OVModelOpenCLIPForZeroShotImageClassification,
             OVModelOpenCLIPText,
             OVModelOpenCLIPVisual,

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -69,6 +69,7 @@ from .modeling import (
     OVModelForQuestionAnswering,
     OVModelForSequenceClassification,
     OVModelForTokenClassification,
+    OVModelForZeroShotImageClassification,
 )
 from .modeling_decoder import OVModelForCausalLM
 from .modeling_open_clip import (

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -971,7 +971,7 @@ class OVModelForZeroShotImageClassification(OVModel):
         inputs = {"input_ids": input_ids, "pixel_values": pixel_values}
         # Add the attention_mask when needed
         if "attention_mask" in self.input_names:
-            inputs["attention_mask"] = attention_mask
+            inputs["attention_mask"] = attention_mask if attention_mask is not None else np.ones_like(input_ids)
         outputs = self._inference(inputs)
         logits_per_image = (
             torch.from_numpy(outputs["logits_per_image"]).to(self.device)

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -129,6 +129,7 @@ _HEAD_TO_AUTOMODELS = {
     "question-answering": "OVModelForQuestionAnswering",
     "image-classification": "OVModelForImageClassification",
     "image-text-to-text": "OVModelForVisualCausalLM",
+    "zero-shot-image-classification": "OVModelForZeroShotImageClassification",
     "audio-classification": "OVModelForAudioClassification",
     "stable-diffusion": "OVStableDiffusionPipeline",
     "stable-diffusion-xl": "OVStableDiffusionXLPipeline",

--- a/optimum/intel/utils/dummy_openvino_objects.py
+++ b/optimum/intel/utils/dummy_openvino_objects.py
@@ -59,6 +59,17 @@ class OVModelOpenCLIPText(metaclass=DummyObject):
         requires_backends(cls, ["openvino"])
 
 
+class OVModelForZeroShotImageClassification(metaclass=DummyObject):
+    _backends = ["openvino"]
+
+    def __init__(self, *args, **kwargs):
+        requires_backends(self, ["openvino"])
+
+    @classmethod
+    def from_pretrained(cls, *args, **kwargs):
+        requires_backends(cls, ["openvino"])
+
+
 class OVModelForAudioFrameClassification(metaclass=DummyObject):
     _backends = ["openvino"]
 

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -44,6 +44,7 @@ from optimum.intel import (
     OVModelForTextToSpeechSeq2Seq,
     OVModelForTokenClassification,
     OVModelForVisualCausalLM,
+    OVModelForZeroShotImageClassification,
     OVSamModel,
     OVStableDiffusion3Pipeline,
     OVStableDiffusionPipeline,
@@ -78,6 +79,7 @@ class ExportModelTest(unittest.TestCase):
         "llava": OVModelForVisualCausalLM,
         "sam": OVSamModel,
         "speecht5": OVModelForTextToSpeechSeq2Seq,
+        "clip": OVModelForZeroShotImageClassification,
     }
 
     EXPECTED_DIFFUSERS_SCALE_FACTORS = {

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -45,6 +45,7 @@ from optimum.intel import (  # noqa
     OVModelForTextToSpeechSeq2Seq,
     OVModelForTokenClassification,
     OVModelForVisualCausalLM,
+    OVModelForZeroShotImageClassification,
     OVModelOpenCLIPForZeroShotImageClassification,
     OVModelOpenCLIPText,
     OVModelOpenCLIPVisual,
@@ -87,6 +88,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         ("image-to-image", "stable-diffusion-xl-refiner"),
         ("feature-extraction", "sam"),
         ("text-to-audio", "speecht5"),
+        ("zero-shot-image-classification", "clip"),
     ]
 
     if is_transformers_version(">=", "4.45"):
@@ -119,6 +121,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "ltx-video": 2 if is_tokenizers_version("<", "0.20.0") or is_openvino_version(">=", "2024.5") else 0,
         "sam": 0,  # no tokenizer
         "speecht5": 2,
+        "clip": 2 if is_tokenizers_version("<", "0.20.0") or is_openvino_version(">=", "2024.5") else 0,
     }
 
     TOKENIZER_CHAT_TEMPLATE_TESTS_MODELS = {

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -59,7 +59,6 @@ from transformers import (
     GenerationConfig,
     Pix2StructForConditionalGeneration,
     PretrainedConfig,
-    SamModel,
     pipeline,
     set_seed,
 )
@@ -3168,7 +3167,7 @@ class OVSamIntegrationTest(unittest.TestCase):
         ).convert("RGB")
         inputs = processor(IMAGE, input_points=input_points, return_tensors="pt")
 
-        transformers_model = SamModel.from_pretrained(model_id)
+        transformers_model = OVSamModel.from_pretrained(model_id)
 
         # test end-to-end inference
         ov_outputs = ov_model(**inputs)
@@ -3302,7 +3301,9 @@ class OVModelForTextToSpeechSeq2SeqIntegrationTest(unittest.TestCase):
 
 
 class OVModelForZeroShotImageClassificationIntegrationTest(unittest.TestCase):
-    SUPPORTED_ARCHITECTURES = ["clip", "siglip"]
+    SUPPORTED_ARCHITECTURES = ["clip"]
+    if is_transformers_version(">=", "4.45"):
+        SUPPORTED_ARCHITECTURES.append("siglip")
     TASK = "zero-shot-image-classification"
     IMAGE_URL = "http://images.cocodataset.org/val2017/000000039769.jpg"
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -39,6 +39,7 @@ MODEL_NAMES = {
     "blenderbot": "hf-internal-testing/tiny-random-BlenderbotModel",
     "bloom": "hf-internal-testing/tiny-random-BloomModel",
     "camembert": "hf-internal-testing/tiny-random-camembert",
+    "clip": "hf-tiny-model-private/tiny-random-CLIPModel",
     "convbert": "hf-internal-testing/tiny-random-ConvBertForSequenceClassification",
     "cohere": "hf-internal-testing/tiny-random-CohereForCausalLM",
     "chatglm": "katuni4ka/tiny-random-chatglm2",
@@ -154,6 +155,7 @@ MODEL_NAMES = {
     "stable-diffusion-3": "yujiepan/stable-diffusion-3-tiny-random",
     "stablelm": "hf-internal-testing/tiny-random-StableLmForCausalLM",
     "starcoder2": "hf-internal-testing/tiny-random-Starcoder2ForCausalLM",
+    "siglip": "katuni4ka/tiny-random-SiglipModel",
     "latent-consistency": "echarlaix/tiny-random-latent-consistency",
     "sew": "hf-internal-testing/tiny-random-SEWModel",
     "sew_d": "asapp/sew-d-tiny-100k-ft-ls100h",
@@ -223,6 +225,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "ltx-video": (34, 28, 28, 64),
     "sam": (102, 100),
     "speecht5": (28, 52, 10, 80),
+    "clip": (130,),
 }
 
 TEST_IMAGE_URL = "http://images.cocodataset.org/val2017/000000039769.jpg"


### PR DESCRIPTION
# What does this PR do?
Added inference class for zero-shot-classification models. Export part is standard and supported by optimum
```
from PIL import Image
import requests

from transformers import CLIPProcessor, CLIPModel
from optimum.intel.openvino import OVModelForZeroShotImageClassification

model = OVModelForZeroShotImageClassification.from_pretrained("openai/clip-vit-base-patch16")
processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch16")

url = "http://images.cocodataset.org/val2017/000000039769.jpg"
image = Image.open(requests.get(url, stream=True).raw)

inputs = processor(text=["a photo of a cat", "a photo of a dog"], images=image, return_tensors="pt", padding=True)

outputs = model(**inputs)
logits_per_image = outputs.logits_per_image # this is the image-text similarity score
probs = logits_per_image.softmax(dim=1) # we can take the softmax to get the label probabilities

print(probs)
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

