### PR TITLE
Avoid use of deprecated openvino.runtime

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -25,7 +25,7 @@ from requests.exceptions import ConnectionError as RequestsConnectionError
 from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase, ProcessorMixin
 from transformers.utils import is_torch_available
 
-from openvino.runtime import Core, Type, save_model
+from openvino import Core, Type, save_model
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig
 from optimum.exporters.onnx.constants import SDPA_ARCHS_ONNX_EXPORT_NOT_SUPPORTED

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -25,8 +25,8 @@ from transformers.generation import GenerationMixin
 from transformers.models.speecht5.modeling_speecht5 import SpeechT5HifiGan
 from transformers.utils import is_tf_available, is_torch_available
 
-from openvino.runtime import Model, save_model
-from openvino.runtime.exceptions import OVTypeError
+from openvino import Model, save_model
+from openvino.exceptions import OVTypeError
 from openvino.tools.ovc import convert_model
 from optimum.exporters import TasksManager
 from optimum.exporters.utils import (

--- a/optimum/exporters/openvino/stateful.py
+++ b/optimum/exporters/openvino/stateful.py
@@ -19,7 +19,7 @@ import numpy as np
 from transformers import PretrainedConfig
 
 import openvino as ov
-from openvino.runtime import opset13
+from openvino import opset13
 from optimum.intel.utils.import_utils import _openvino_version, is_openvino_version, is_transformers_version
 
 from .utils import MULTI_MODAL_TEXT_GENERATION_MODELS

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -21,8 +21,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 from transformers import PretrainedConfig
 from transformers.utils import is_torch_available
 
-from openvino.runtime import Dimension, PartialShape, Symbol
-from openvino.runtime.utils.types import get_element_type
+from openvino import Dimension, PartialShape, Symbol
+from openvino.utils.types import get_element_type
 from optimum.exporters import TasksManager
 from optimum.exporters.onnx.base import OnnxConfig
 from optimum.intel.utils import is_transformers_version

--- a/optimum/intel/openvino/loaders.py
+++ b/optimum/intel/openvino/loaders.py
@@ -19,9 +19,9 @@ import openvino
 import torch
 from diffusers.loaders.textual_inversion import TextualInversionLoaderMixin, load_textual_inversion_state_dicts
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
-from openvino.runtime import Type
-from openvino.runtime import opset11 as ops
-from openvino.runtime.passes import Manager, Matcher, MatcherPass, WrapType
+from openvino import Type
+from openvino import opset11 as ops
+from openvino.passes import Manager, Matcher, MatcherPass, WrapType
 from transformers import PreTrainedTokenizer
 
 from .utils import TEXTUAL_INVERSION_EMBEDDING_KEYS
@@ -81,7 +81,7 @@ class OVTextualInversionLoaderMixin(TextualInversionLoaderMixin):
         pretrained_model_name_or_path: Union[str, List[str], Dict[str, torch.Tensor], List[Dict[str, torch.Tensor]]],
         token: Optional[Union[str, List[str]]] = None,
         tokenizer: Optional["PreTrainedTokenizer"] = None,  # noqa: F821
-        text_encoder: Optional["openvino.runtime.Model"] = None,  # noqa: F821
+        text_encoder: Optional["openvino.Model"] = None,  # noqa: F821
         **kwargs,
     ):
         if not hasattr(self, "tokenizer"):
@@ -97,9 +97,9 @@ class OVTextualInversionLoaderMixin(TextualInversionLoaderMixin):
             raise ValueError(
                 f"{self.__class__.__name__} requires `self.text_encoder` for calling `{self.load_textual_inversion.__name__}`"
             )
-        elif not isinstance(self.text_encoder.model, openvino.runtime.Model):
+        elif not isinstance(self.text_encoder.model, openvino.Model):
             raise ValueError(
-                f"{self.__class__.__name__} requires `self.text_encoder` of type `openvino.runtime.Model` for calling `{self.load_textual_inversion.__name__}`"
+                f"{self.__class__.__name__} requires `self.text_encoder` of type `openvino.Model` for calling `{self.load_textual_inversion.__name__}`"
             )
 
         # 1. Set correct tokenizer and text encoder

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -66,7 +66,7 @@ MODEL_START_DOCSTRING = r"""
     This model inherits from [`optimum.intel.openvino.modeling.OVBaseModel`]. Check the superclass documentation for the generic methods the
     library implements for all its model (such as downloading or saving)
     Parameters:
-        model (`openvino.runtime.Model`): is the main class used to run OpenVINO Runtime inference.
+        model (`openvino.Model`): is the main class used to run OpenVINO Runtime inference.
         config (`transformers.PretrainedConfig`): [PretrainedConfig](https://huggingface.co/docs/transformers/main_classes/configuration#transformers.PretrainedConfig)
             is the Model configuration class with all the parameters of the model.
             Initializing with a config file does not load the weights associated with the model, only the configuration.
@@ -119,7 +119,7 @@ class OVModel(OVBaseModel):
     base_model_prefix = "openvino_model"
     auto_model_class = AutoModel
 
-    def __init__(self, model: openvino.runtime.Model, config: transformers.PretrainedConfig = None, **kwargs):
+    def __init__(self, model: openvino.Model, config: transformers.PretrainedConfig = None, **kwargs):
         super().__init__(model, config, **kwargs)
         # Avoid warnings when creating a transformers pipeline
         AutoConfig.register(self.base_model_prefix, AutoConfig)

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -67,7 +67,7 @@ class OVBaseModel(OptimizedModel):
 
     def __init__(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
         dynamic_shapes: bool = True,
@@ -206,7 +206,7 @@ class OVBaseModel(OptimizedModel):
         return None
 
     @property
-    def ov_submodels(self) -> Dict[str, openvino.runtime.Model]:
+    def ov_submodels(self) -> Dict[str, openvino.Model]:
         return {submodel_name: getattr(self, submodel_name) for submodel_name in self._ov_submodel_names}
 
     @property
@@ -220,7 +220,7 @@ class OVBaseModel(OptimizedModel):
     def load_model(
         file_name: Union[str, Path],
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
-    ) -> openvino.runtime.Model:
+    ) -> openvino.Model:
         """
         Loads the model.
 
@@ -231,7 +231,7 @@ class OVBaseModel(OptimizedModel):
                 Quantization config to apply after model is loaded.
         """
 
-        def fix_op_names_duplicates(model: openvino.runtime.Model):
+        def fix_op_names_duplicates(model: openvino.Model):
             names = set()
             for op in model.get_ops():
                 friendly_name = op.get_friendly_name()
@@ -705,7 +705,7 @@ class OVBaseModel(OptimizedModel):
 
     def _reshape(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         batch_size: int,
         sequence_length: int,
         height: int = None,

--- a/optimum/intel/openvino/modeling_base_seq2seq.py
+++ b/optimum/intel/openvino/modeling_base_seq2seq.py
@@ -53,9 +53,9 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
 
     def __init__(
         self,
-        encoder: openvino.runtime.Model,
-        decoder: openvino.runtime.Model,
-        decoder_with_past: openvino.runtime.Model = None,
+        encoder: openvino.Model,
+        decoder: openvino.Model,
+        decoder_with_past: openvino.Model = None,
         config: PretrainedConfig = None,
         device: str = "CPU",
         dynamic_shapes: bool = True,
@@ -446,7 +446,7 @@ class OVBaseModelForSeq2SeqLM(OVBaseModel):
             **kwargs,
         )
 
-    def _reshape(self, model: openvino.runtime.Model, batch_size: int, sequence_length: int, is_decoder=True):
+    def _reshape(self, model: openvino.Model, batch_size: int, sequence_length: int, is_decoder=True):
         shapes = {}
         for inputs in model.inputs:
             shapes[inputs] = inputs.get_partial_shape()

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -103,7 +103,7 @@ TEXT_GENERATION_EXAMPLE = r"""
 class OVBaseDecoderModel(OVModel):
     def __init__(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
         dynamic_shapes: bool = True,
@@ -360,7 +360,7 @@ class OVBaseDecoderModel(OVModel):
 
     def _reshape(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         batch_size: int,
         sequence_length: int,
         height: int = None,

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -50,7 +50,7 @@ from huggingface_hub import snapshot_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from huggingface_hub.utils import validate_hf_hub_args
 from openvino._offline_transformations import compress_model_transformation
-from openvino.runtime import Core
+from openvino import Core
 from transformers import CLIPFeatureExtractor, CLIPTokenizer
 from transformers.modeling_outputs import ModelOutput
 from transformers.utils import http_user_agent
@@ -141,14 +141,14 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
     def __init__(
         self,
         scheduler: SchedulerMixin,
-        unet: Optional[openvino.runtime.Model] = None,
-        vae_decoder: Optional[openvino.runtime.Model] = None,
+        unet: Optional[openvino.Model] = None,
+        vae_decoder: Optional[openvino.Model] = None,
         # optional pipeline models
-        vae_encoder: Optional[openvino.runtime.Model] = None,
-        text_encoder: Optional[openvino.runtime.Model] = None,
-        text_encoder_2: Optional[openvino.runtime.Model] = None,
-        text_encoder_3: Optional[openvino.runtime.Model] = None,
-        transformer: Optional[openvino.runtime.Model] = None,
+        vae_encoder: Optional[openvino.Model] = None,
+        text_encoder: Optional[openvino.Model] = None,
+        text_encoder_2: Optional[openvino.Model] = None,
+        text_encoder_3: Optional[openvino.Model] = None,
+        transformer: Optional[openvino.Model] = None,
         # optional pipeline submodels
         tokenizer: Optional[CLIPTokenizer] = None,
         tokenizer_2: Optional[CLIPTokenizer] = None,
@@ -183,7 +183,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
                 )
 
             main_model = unet if unet is not None else transformer
-            if not isinstance(main_model, openvino.runtime.CompiledModel):
+            if not isinstance(main_model, openvino.CompiledModel):
                 raise ValueError("`compile_only` expect that already compiled model will be provided")
 
             model_is_dynamic = model_has_dynamic_inputs(main_model)
@@ -278,7 +278,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
             self.compile()
 
     @property
-    def ov_submodels(self) -> Dict[str, openvino.runtime.Model]:
+    def ov_submodels(self) -> Dict[str, openvino.Model]:
         return {name: getattr(getattr(self, name), "model") for name in self._ov_submodel_names}
 
     @property
@@ -709,7 +709,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
 
     def _reshape_unet(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         batch_size: int = -1,
         height: int = -1,
         width: int = -1,
@@ -757,7 +757,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
 
     def _reshape_transformer(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         batch_size: int = -1,
         height: int = -1,
         width: int = -1,
@@ -825,7 +825,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
         return model
 
     def _reshape_text_encoder(
-        self, model: openvino.runtime.Model, batch_size: int = -1, tokenizer_max_length: int = -1
+        self, model: openvino.Model, batch_size: int = -1, tokenizer_max_length: int = -1
     ):
         if batch_size != -1:
             shapes = {input_tensor: [batch_size, tokenizer_max_length] for input_tensor in model.inputs}
@@ -834,7 +834,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
 
     def _reshape_vae_encoder(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         batch_size: int = -1,
         height: int = -1,
         width: int = -1,
@@ -858,7 +858,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
 
     def _reshape_vae_decoder(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         height: int = -1,
         width: int = -1,
         num_images_per_prompt: int = -1,
@@ -1098,7 +1098,7 @@ class OVPipelinePart(ConfigMixin):
 
     def __init__(
         self,
-        model: openvino.runtime.Model,
+        model: openvino.Model,
         parent_pipeline: OVDiffusionPipeline,
         model_name: str = "",
     ):
@@ -1184,7 +1184,7 @@ class OVPipelinePart(ConfigMixin):
 
 
 class OVModelTextEncoder(OVPipelinePart):
-    def __init__(self, model: openvino.runtime.Model, parent_pipeline: OVDiffusionPipeline, model_name: str = ""):
+    def __init__(self, model: openvino.Model, parent_pipeline: OVDiffusionPipeline, model_name: str = ""):
         super().__init__(model, parent_pipeline, model_name)
         self.hidden_states_output_names = [
             name for out in self.model.outputs for name in out.names if name.startswith("hidden_states")

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -824,9 +824,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
         model.reshape(shapes)
         return model
 
-    def _reshape_text_encoder(
-        self, model: openvino.Model, batch_size: int = -1, tokenizer_max_length: int = -1
-    ):
+    def _reshape_text_encoder(self, model: openvino.Model, batch_size: int = -1, tokenizer_max_length: int = -1):
         if batch_size != -1:
             shapes = {input_tensor: [batch_size, tokenizer_max_length] for input_tensor in model.inputs}
             model.reshape(shapes)

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -49,8 +49,8 @@ from diffusers.utils.constants import CONFIG_NAME
 from huggingface_hub import snapshot_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from huggingface_hub.utils import validate_hf_hub_args
-from openvino._offline_transformations import compress_model_transformation
 from openvino import Core
+from openvino._offline_transformations import compress_model_transformation
 from transformers import CLIPFeatureExtractor, CLIPTokenizer
 from transformers.modeling_outputs import ModelOutput
 from transformers.utils import http_user_agent

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -22,7 +22,7 @@ import numpy as np
 import openvino
 import torch
 import transformers
-from openvino.runtime import Core
+from openvino import Core
 from transformers import (
     AutoConfig,
     AutoModelForSeq2SeqLM,
@@ -59,11 +59,11 @@ _TOKENIZER_FOR_DOC = "AutoTokenizer"
 
 INPUTS_DOCSTRING = r"""
     Arguments:
-        encoder (`openvino.runtime.Model`):
+        encoder (`openvino.Model`):
             The OpenVINO Runtime model associated to the encoder.
-        decoder (`openvino.runtime.Model`):
+        decoder (`openvino.Model`):
             The OpenVINO Runtime model associated to the decoder.
-        decoder_with_past (`openvino.runtime.Model`):
+        decoder_with_past (`openvino.Model`):
             The OpenVINO Runtime model associated  to the decoder with past key values.
         config (`transformers.PretrainedConfig`):
             [PretrainedConfig](https://huggingface.co/docs/transformers/main_classes/configuration#transformers.PretrainedConfig)
@@ -317,9 +317,9 @@ class OVModelForSeq2SeqLM(OVBaseModelForSeq2SeqLM, GenerationMixin):
 
     def __init__(
         self,
-        encoder: openvino.runtime.Model,
-        decoder: openvino.runtime.Model,
-        decoder_with_past: openvino.runtime.Model = None,
+        encoder: openvino.Model,
+        decoder: openvino.Model,
+        decoder_with_past: openvino.Model = None,
         config: transformers.PretrainedConfig = None,
         **kwargs,
     ):
@@ -472,11 +472,11 @@ class OVEncoder:
     Encoder model for OpenVINO inference.
 
     Arguments:
-        request (`openvino.runtime.ie_api.InferRequest`):
+        request (`openvino.ie_api.InferRequest`):
             The OpenVINO inference request associated to the encoder.
     """
 
-    def __init__(self, model: openvino.runtime.Model, parent_model: OVModelForSeq2SeqLM):
+    def __init__(self, model: openvino.Model, parent_model: OVModelForSeq2SeqLM):
         self.model = model
         self.parent_model = parent_model
         self._comple_only = parent_model._compile_only
@@ -557,13 +557,13 @@ class OVDecoder:
     Decoder model for OpenVINO inference.
 
     Arguments:
-        request (`openvino.runtime.ie_api.InferRequest`):
+        request (`openvino.ie_api.InferRequest`):
             The OpenVINO inference request associated to the decoder.
         device (`torch.device`):
             The device type used by this process.
     """
 
-    def __init__(self, model: openvino.runtime.Model, parent_model: OVModelForSeq2SeqLM):
+    def __init__(self, model: openvino.Model, parent_model: OVModelForSeq2SeqLM):
         self.model = model
         self.parent_model = parent_model
         self._compile_only = parent_model._compile_only
@@ -753,9 +753,9 @@ class OVModelForVision2Seq(OVModelForSeq2SeqLM):
 
     def __init__(
         self,
-        encoder: openvino.runtime.Model,
-        decoder: openvino.runtime.Model,
-        decoder_with_past: openvino.runtime.Model = None,
+        encoder: openvino.Model,
+        decoder: openvino.Model,
+        decoder_with_past: openvino.Model = None,
         config: transformers.PretrainedConfig = None,
         **kwargs,
     ):
@@ -822,7 +822,7 @@ class OVModelForVision2Seq(OVModelForSeq2SeqLM):
             **kwargs,
         )
 
-    def _reshape(self, model: openvino.runtime.Model, batch_size: int, sequence_length: int, is_decoder=True):
+    def _reshape(self, model: openvino.Model, batch_size: int, sequence_length: int, is_decoder=True):
         shapes = {}
         for inputs in model.inputs:
             shapes[inputs] = inputs.get_partial_shape()
@@ -907,7 +907,7 @@ class OVModelForPix2Struct(OVModelForSeq2SeqLM):
             **kwargs,
         )
 
-    def _reshape(self, model: openvino.runtime.Model, batch_size: int, sequence_length: int, is_decoder=True):
+    def _reshape(self, model: openvino.Model, batch_size: int, sequence_length: int, is_decoder=True):
         shapes = {}
         for inputs in model.inputs:
             shapes[inputs] = inputs.get_partial_shape()

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -32,8 +32,8 @@ from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from nncf.quantization.advanced_parameters import OverflowFix
 from nncf.torch import register_module
 from nncf.torch.initialization import PTInitializingDataLoader
-from openvino._offline_transformations import compress_quantize_weights_transformation
 from openvino import Core, Tensor
+from openvino._offline_transformations import compress_quantize_weights_transformation
 from PIL import Image
 from torch.utils._pytree import tree_map
 from torch.utils.data import DataLoader, RandomSampler

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -33,7 +33,7 @@ from nncf.quantization.advanced_parameters import OverflowFix
 from nncf.torch import register_module
 from nncf.torch.initialization import PTInitializingDataLoader
 from openvino._offline_transformations import compress_quantize_weights_transformation
-from openvino.runtime import Core, Tensor
+from openvino import Core, Tensor
 from PIL import Image
 from torch.utils._pytree import tree_map
 from torch.utils.data import DataLoader, RandomSampler
@@ -1290,7 +1290,7 @@ class OVQuantizer(OptimumQuantizer):
         ov_config.save_pretrained(save_directory)
 
     @staticmethod
-    def _save_pretrained(model: openvino.runtime.Model, output_path: str):
+    def _save_pretrained(model: openvino.Model, output_path: str):
         compress_quantize_weights_transformation(model)
         openvino.save_model(model, output_path, compress_to_fp16=False)
 
@@ -1390,11 +1390,11 @@ def _quantize_whisper_model(
 
 
 def _weight_only_quantization(
-    model: openvino.runtime.Model,
+    model: openvino.Model,
     quantization_config: Union[OVWeightQuantizationConfig, Dict],
     calibration_dataset: Optional[Union[nncf.Dataset, Iterable]] = None,
     **kwargs,
-) -> openvino.runtime.Model:
+) -> openvino.Model:
     _verify_not_optimized(model)
     config = quantization_config
     if isinstance(config, dict):
@@ -1445,7 +1445,7 @@ def _weight_only_quantization(
 
 
 def _full_quantization(
-    model: openvino.runtime.Model,
+    model: openvino.Model,
     quantization_config: OVQuantizationConfig,
     calibration_dataset: nncf.Dataset,
     verify_not_optimized: bool = True,
@@ -1525,15 +1525,15 @@ def _collect_ops_with_weights(model):
 
 
 def _hybrid_quantization(
-    model: openvino.runtime.Model, quantization_config: OVWeightQuantizationConfig, dataset: nncf.Dataset, **kwargs
-) -> openvino.runtime.Model:
+    model: openvino.Model, quantization_config: OVWeightQuantizationConfig, dataset: nncf.Dataset, **kwargs
+) -> openvino.Model:
     """
     Quantize a model in hybrid mode with NNCF which means that we quantize:
     weights of MatMul and Embedding layers and activations of other layers.
     The optimization specifications defined in `quantization_config`.
 
     Args:
-        model (`openvino.runtime.Model`):
+        model (`openvino.Model`):
             The OpenVINO Runtime model for applying hybrid quantization.
         quantization_config (`OVWeightQuantizationConfig`):
             The configuration containing the parameters related to quantization.
@@ -1583,7 +1583,7 @@ def _mixed_quantization(
     quantized to the precision given in the `full_quantization_config`.
 
     Args:
-        model (`openvino.runtime.Model`):
+        model (`openvino.Model`):
             The OpenVINO Runtime model for applying quantization.
         quantization_config (`OVMixedQuantizationConfig`):
             The configuration containing the parameters related to quantization.

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -28,8 +28,8 @@ from typing import Tuple, Type, Union
 import numpy as np
 import torch
 from huggingface_hub import model_info
-from openvino.runtime import Core, Model, properties
-from openvino.runtime import Type as OVType
+from openvino import Core, Model, properties
+from openvino import Type as OVType
 from packaging.version import Version
 from transformers import AutoTokenizer, CLIPTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 from transformers.onnx.utils import ParameterFormat, compute_serialized_parameters_size

--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -81,7 +81,7 @@ _openvino_available = importlib.util.find_spec("openvino") is not None
 _openvino_version = "N/A"
 if _openvino_available:
     try:
-        from openvino.runtime import get_version
+        from openvino import get_version
 
         version = get_version()
         # avoid invalid format

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ TESTS_REQUIRE = [
 QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]
 
 EXTRAS_REQUIRE = {
-    "nncf": ["nncf>=2.14.0"],
-    "openvino": ["nncf>=2.14.0", "openvino>=2024.5.0", "openvino-tokenizers>=2024.5.0"],
+    "nncf": ["nncf>=2.16.0"],
+    "openvino": ["nncf>=2.16.0", "openvino>=2025.1.0", "openvino-tokenizers>=2025.1.0"],
     "neural-compressor": ["neural-compressor[pt]>3.0", "accelerate", "transformers<4.46"],
     "ipex": ["intel-extension-for-pytorch>=2.6", "transformers>4.49,<4.52", "accelerate"],
     "diffusers": ["diffusers"],

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1204,7 +1204,7 @@ class OVWeightCompressionTest(unittest.TestCase):
             return compressed_model_mock_obj
 
         with unittest.mock.patch(
-            "openvino.runtime.op.Constant.shape", new_callable=unittest.mock.PropertyMock
+            "openvino.op.Constant.shape", new_callable=unittest.mock.PropertyMock
         ) as ov_constant_shape:
             ov_constant_shape.return_value = (2000000000,)
             with unittest.mock.patch(
@@ -1235,7 +1235,7 @@ class OVWeightCompressionTest(unittest.TestCase):
 
     def test_ovmodel_load_large_model_with_uncompressed_weights(self):
         with unittest.mock.patch(
-            "openvino.runtime.op.Constant.shape", new_callable=unittest.mock.PropertyMock
+            "openvino.op.Constant.shape", new_callable=unittest.mock.PropertyMock
         ) as ov_constant_shape:
             ov_constant_shape.return_value = (2000000000,)
             with unittest.mock.patch("nncf.compress_weights") as compress_weights_patch:
@@ -1255,7 +1255,7 @@ class OVWeightCompressionTest(unittest.TestCase):
             return compressed_model_mock_obj
 
         with unittest.mock.patch(
-            "openvino.runtime.op.Constant.shape", new_callable=unittest.mock.PropertyMock
+            "openvino.op.Constant.shape", new_callable=unittest.mock.PropertyMock
         ) as ov_constant_shape:
             ov_constant_shape.return_value = (2000000000,)
             with unittest.mock.patch(


### PR DESCRIPTION
# What does this PR do?

Avoid use of deprecate openvino.runtime namespace in favor of openvino. In 2025.1.0 openvino release, openvino namespace of the OpenVINO Python API has been redesigned, removing the nested openvino.runtime module. The old namespace is now considered deprecated and will be discontinued in 2026.0.

Fixes # TBD


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

