### PR TITLE
Fix custom dataset processing for text encoding tasks

### DIFF
--- a/.github/workflows/test_openvino_notebooks.yml
+++ b/.github/workflows/test_openvino_notebooks.yml
@@ -28,7 +28,7 @@ jobs:
         test_file: [
             "optimum_openvino_inference.ipynb",
             "question_answering_quantization.ipynb",
-            # "sentence_transformer_quantization.ipynb", TODO: fix and run on any cpu
+            "sentence_transformer_quantization.ipynb",
             # "stable_diffusion_hybrid_quantization.ipynb", TODO: update and ran on a powerful cpu
           ]
 


### PR DESCRIPTION
# What does this PR do?

Add a previously missed support for calibration dataset creation from a custom dataset for text encoding tasks. In particular, this fixes sentence_transformer_quantization notebook.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

