### PR TITLE
Default config for microsoft/Phi-4-multimodal-instruct

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -309,6 +309,16 @@ _DEFAULT_4BIT_CONFIGS = {
         "dataset": "wikitext2",
         "quant_method": OVQuantizationMethod.AWQ,
     },
+    "microsoft/Phi-4-multimodal-instruct": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 128,
+        "ignored_scope": {
+            "patterns": [
+                "__module\\.model\\.layers\\.\\d+\\.(mlp\\.(gate_up_proj|down_proj)|self_attn\\.(qkv_proj|o_proj))\\.lora_B\\.speech/ov_ext::linear/MatMul"
+            ]
+        },
+    },
 }
 
 # Add configs for model id aliases

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -315,8 +315,10 @@ _DEFAULT_4BIT_CONFIGS = {
         "group_size": 128,
         "ignored_scope": {
             "patterns": [
-                "__module\\.model\\.layers\\.\\d+\\.(mlp\\.(gate_up_proj|down_proj)|self_attn\\.(qkv_proj|o_proj))\\.lora_B\\.speech/ov_ext::linear/MatMul"
-            ]
+                "__module\\.model\\.layers\\.\\d+\\.(mlp\\.(gate_up_proj|down_proj)|self_attn\\.(qkv_proj|o_proj))\\.lora_B\\.speech/ov_ext::linear/MatMul",
+                "__module\\.img_processor\\.encoder\\.layers\\.\\d+\\.mlp\\.fc2/ov_ext::linear/MatMul",
+            ],
+            "validate": False,
         },
     },
 }


### PR DESCRIPTION
# What does this PR do?

Export command:
```
optimum-cli export openvino -m microsoft/Phi-4-multimodal-instruct --trust-remote-code --weight-format int4 <save_dir>
```

For the language model speech lora matmuls, e.g. "__module.model.layers.0.mlp.gate_up_proj.lora_B.speech/ov_ext::linear/MatMul" won't be compressed. For the image encoder model some matmuls after SDPA (e.g. "__module.img_processor.encoder.layers.0.mlp.fc2/ov_ext::linear/MatMul") will also be ignored. 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

