### PR TITLE
add token classification for qwen2

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -259,7 +259,18 @@ class BaichaunOpenVINOConfig(TextDecoderWithPositionIdsOnnxConfig):
         return BaichuanModelPatcher(self, model, model_kwargs=model_kwargs)
 
 
-@register_in_tasks_manager("qwen2", *["text-generation", "text-generation-with-past"], library_name="transformers")
+@register_in_tasks_manager(
+    "qwen2",
+    *[
+        "text-generation",
+        "text-generation-with-past",
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-classification",
+        "token-classification",
+    ],
+    library_name="transformers",
+)
 class Qwen2OpenVINOConfig(TextDecoderWithPositionIdsOnnxConfig):
     DEFAULT_ONNX_OPSET = 14
 


### PR DESCRIPTION
# What does this PR do?

```
from optimum.intel.pipelines import pipeline

pipe = pipeline("token-classification", model="HuggingFaceH4/Qwen2.5-Math-1.5B-Instruct-PRM-0.2", accelerator="openvino")

example = {
    "prompt": "Let $a,$ $b,$ and $c$ be positive real numbers.  Find the set of all possible values of\n\\[\\frac{c}{a} + \\frac{a}{b + c} + \\frac{b}{c}.\\]",
    "completions": [
        "This problem involves finding the range of an expression involving three variables.",
        "One possible strategy is to try to eliminate some variables and write the expression in terms of one variable only.",
        "To do this, I might look for some common factors or symmetries in the expression.",
        "I notice that the first and last terms have $c$ in the denominator, so I can factor out $c$ from the whole expression and get\n\\[\\frac{1}{c}\\left(c + \\frac{a^2}{b + c} + b\\right).\\]"
    ],
    "labels": [True, True, True, False],
}


separator = "\n\n"  # It's important to use the same separator as the one used during training

for idx in range(1, len(example["completions"]) + 1):
    steps = example["completions"][0:idx]
    text = separator.join((example["prompt"], *steps)) + separator  # Add a separator between the prompt and each steps
    pred_entity = pipe(text)[-1]["entity"]
    pred = {"LABEL_0": False, "LABEL_1": True}[pred_entity]
    label = example["labels"][idx - 1]
    print(f"Step {idx}\tPredicted: {pred} \tLabel: {label}")

```

Fixes # (issue) https://github.com/huggingface/optimum-intel/issues/1295


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

