### PR TITLE
Introduce named test reference values per submodel

### DIFF
--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -15,7 +15,7 @@ import json
 import subprocess
 import unittest
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict
 
 from parameterized import parameterized
 from transformers import AutoModelForCausalLM, AutoProcessor, AutoTokenizer
@@ -200,11 +200,13 @@ class OVCLIExportTestCase(unittest.TestCase):
             "whisper",
             "int8",
             "--dataset librispeech --num-samples 1 --smooth-quant-alpha 0.9 --trust-remote-code",
-            [10, 12, 11] if is_transformers_version("<=", "4.36.0") else [8, 12, 25],
+            {"encoder": 10, "decoder": 12, "decoder_with_past": 11}
+            if is_transformers_version("<=", "4.36.0")
+            else {"encoder": 8, "decoder": 12, "decoder_with_past": 25},
             (
-                [{"int8": 8}, {"int8": 11}, {"int8": 9}]
+                {"encoder": {"int8": 8}, "decoder": {"int8": 11}, "decoder_with_past": {"int8": 9}}
                 if is_transformers_version("<=", "4.36.0")
-                else [{"int8": 8}, {"int8": 12}, {"int8": 18}]
+                else {"encoder": {"int8": 8}, "decoder": {"int8": 12}, "decoder_with_past": {"int8": 18}}
             ),
         ),
         (
@@ -212,11 +214,13 @@ class OVCLIExportTestCase(unittest.TestCase):
             "whisper",
             "f8e4m3",
             "--dataset librispeech --num-samples 1 --smooth-quant-alpha 0.9 --trust-remote-code",
-            [10, 12, 11] if is_transformers_version("<=", "4.36.0") else [8, 12, 25],
+            {"encoder": 10, "decoder": 12, "decoder_with_past": 11}
+            if is_transformers_version("<=", "4.36.0")
+            else {"encoder": 8, "decoder": 12, "decoder_with_past": 25},
             (
-                [{"f8e4m3": 8}, {"f8e4m3": 11}, {"f8e4m3": 9}]
+                {"encoder": {"f8e4m3": 8}, "decoder": {"f8e4m3": 11}, "decoder_with_past": {"f8e4m3": 9}}
                 if is_transformers_version("<=", "4.36.0")
-                else [{"f8e4m3": 8}, {"f8e4m3": 12}, {"f8e4m3": 18}]
+                else {"encoder": {"f8e4m3": 8}, "decoder": {"f8e4m3": 12}, "decoder_with_past": {"f8e4m3": 18}}
             ),
         ),
         (
@@ -224,220 +228,240 @@ class OVCLIExportTestCase(unittest.TestCase):
             "llama",
             "f8e4m3",
             "--dataset wikitext2 --smooth-quant-alpha 0.9 --trust-remote-code",
-            [
-                13,
-            ],
-            [
-                {"f8e4m3": 16},
-            ],
+            {
+                "model": 13,
+            },
+            {
+                "model": {"f8e4m3": 16},
+            },
         ),
         (
             "text-generation",
             "llama",
             "nf4_f8e4m3",
             "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code --ratio 0.5",
-            [
-                14,
-            ],
-            [
-                {"f8e4m3": 11, "nf4": 5},
-            ],
+            {
+                "model": 14,
+            },
+            {
+                "model": {"f8e4m3": 11, "nf4": 5},
+            },
         ),
         (
             "text-generation",
             "llama",
             "nf4_f8e5m2",
             "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code --sym --ratio 0.5",
-            [
-                14,
-            ],
-            [
-                {"f8e5m2": 11, "nf4": 5},
-            ],
+            {
+                "model": 14,
+            },
+            {
+                "model": {"f8e5m2": 11, "nf4": 5},
+            },
         ),
         (
             "text-generation",
             "llama",
             "int4_f8e4m3",
             "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code --sym --ratio 0.5",
-            [
-                14,
-            ],
-            [
-                {"f8e4m3": 11, "int4": 5},
-            ],
+            {
+                "model": 14,
+            },
+            {
+                "model": {"f8e4m3": 11, "int4": 5},
+            },
         ),
         (
             "text-generation",
             "llama",
             "int4_f8e5m2",
             "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code",
-            [
-                13,
-            ],
-            [
-                {"f8e5m2": 2, "int4": 28},
-            ],
+            {
+                "model": 13,
+            },
+            {
+                "model": {"f8e5m2": 2, "int4": 28},
+            },
         ),
         (
             "stable-diffusion",
             "stable-diffusion",
             "int8",
             "--dataset conceptual_captions --num-samples 1 --trust-remote-code",
-            [
-                112,
-                0,
-                0,
-                0,
-            ],
-            [
-                {"int8": 121},
-                {"int8": 42},
-                {"int8": 34},
-                {"int8": 64},
-            ],
+            {
+                "unet": 112,
+                "vae_decoder": 0,
+                "vae_encoder": 0,
+                "text_encoder": 0,
+            },
+            {
+                "unet": {"int8": 121},
+                "vae_decoder": {"int8": 42},
+                "vae_encoder": {"int8": 34},
+                "text_encoder": {"int8": 64},
+            },
         ),
         (
             "stable-diffusion-xl",
             "stable-diffusion-xl",
             "f8e5m2",
             "--dataset laion/220k-GPT4Vision-captions-from-LIVIS --num-samples 1 --trust-remote-code",
-            [
-                174,
-                0,
-                0,
-                0,
-                0,
-            ],
-            [
-                {"f8e5m2": 183},
-                {"int8": 42},
-                {"int8": 34},
-                {"int8": 64},
-                {"int8": 66},
-            ],
+            {
+                "unet": 174,
+                "vae_decoder": 0,
+                "vae_encoder": 0,
+                "text_encoder": 0,
+                "text_encoder_2": 0,
+            },
+            {
+                "unet": {"f8e5m2": 183},
+                "vae_decoder": {"int8": 42},
+                "vae_encoder": {"int8": 34},
+                "text_encoder": {"int8": 64},
+                "text_encoder_2": {"int8": 66},
+            },
         ),
         (
             "latent-consistency",
             "latent-consistency",
             "f8e4m3",
             "--dataset laion/filtered-wit --num-samples 1 --trust-remote-code",
-            [
-                79,
-                0,
-                0,
-                0,
-            ],
-            [
-                {"f8e4m3": 84},
-                {"int8": 42},
-                {"int8": 34},
-                {"int8": 40},
-            ],
+            {
+                "unet": 79,
+                "vae_decoder": 0,
+                "vae_encoder": 0,
+                "text_encoder": 0,
+            },
+            {
+                "unet": {"f8e4m3": 84},
+                "vae_decoder": {"int8": 42},
+                "vae_encoder": {"int8": 34},
+                "text_encoder": {"int8": 40},
+            },
         ),
         (
             "feature-extraction",
             "blenderbot",
             "int8",
             "--dataset wikitext2 --num-samples 1",
-            [
-                33,
-            ],
-            [
-                {"int8": 35},
-            ],
+            {
+                "model": 33,
+            },
+            {
+                "model": {"int8": 35},
+            },
         ),
         (
             "feature-extraction",
             "sentence-transformers-bert",
             "int8",
             "--library sentence_transformers --dataset c4 --num-samples 1",
-            [
-                12,
-            ],
-            [
-                {"int8": 15},
-            ],
+            {
+                "model": 12,
+            },
+            {
+                "model": {"int8": 15},
+            },
         ),
         (
             "fill-mask",
             "roberta",
             "int8",
             "--dataset wikitext2 --num-samples 1",
-            [
-                32,
-            ],
-            [
-                {"int8": 34},
-            ],
+            {
+                "model": 32,
+            },
+            {
+                "model": {"int8": 34},
+            },
         ),
         (
             "fill-mask",
             "xlm_roberta",
             "int8",
             "--library sentence_transformers --dataset c4 --num-samples 1",
-            [
-                14,
-            ],
-            [
-                {"int8": 16},
-            ],
+            {
+                "model": 14,
+            },
+            {
+                "model": {"int8": 16},
+            },
         ),
         (
             "zero-shot-image-classification",
             "clip",
             "int8",
             "--dataset conceptual_captions --num-samples 1",
-            [
-                65,
-            ],
-            [
-                {"int8": 65},
-            ],
+            {
+                "model": 65,
+            },
+            {
+                "model": {"int8": 65},
+            },
         ),
     ]
 
     TEST_4BIT_CONFIGURATIONS = [
-        ("text-generation-with-past", "opt125m", "int4 --sym --group-size 128", [{"int8": 4, "int4": 72}]),
-        ("text-generation-with-past", "opt125m", "int4 --group-size 64", [{"int8": 4, "int4": 144}]),
-        ("text-generation-with-past", "opt125m", "mxfp4", [{"int8": 4, "f4e2m1": 72, "f8e8m0": 72}]),
-        ("text-generation-with-past", "opt125m", "nf4", [{"int8": 4, "nf4": 72}]),
+        (
+            "text-generation-with-past",
+            "opt125m",
+            "int4 --sym --group-size 128",
+            {"model": {"int8": 4, "int4": 72}},
+        ),
+        (
+            "text-generation-with-past",
+            "opt125m",
+            "int4 --group-size 64",
+            {"model": {"int8": 4, "int4": 144}},
+        ),
+        (
+            "text-generation-with-past",
+            "opt125m",
+            "mxfp4",
+            {"model": {"int8": 4, "f4e2m1": 72, "f8e8m0": 72}},
+        ),
+        (
+            "text-generation-with-past",
+            "opt125m",
+            "nf4",
+            {"model": {"int8": 4, "nf4": 72}},
+        ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 8 --all-layers",
-            [{"int4": 16}],
+            {"model": {"int4": 16}},
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --awq --dataset wikitext2 --num-samples 100 "
             "--sensitivity-metric max_activation_variance",
-            [{"int8": 4, "int4": 14}],
+            {"model": {"int8": 4, "int4": 14}},
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --scale-estimation --dataset wikitext2 --num-samples 100 ",
-            [{"int8": 4, "int4": 14}],
+            {"model": {"int8": 4, "int4": 14}},
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --gptq --dataset wikitext2 --num-samples 100 ",
-            [{"int8": 4, "int4": 14}],
+            {"model": {"int8": 4, "int4": 14}},
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 16 --lora-correction --dataset auto --num-samples 16",
-            [{"int8": 60, "int4": 14}],
+            {"model": {"int8": 60, "int4": 14}},
         ),
         (
             "text-generation-with-past",
             "llama_awq",
             "int4 --group-size 16 --backup-precision none --ratio 0.5",
-            [{"int4": 6}],
+            {"model": {"int4": 6}},
         ),
     ]
 
@@ -448,27 +472,43 @@ class OVCLIExportTestCase(unittest.TestCase):
                     "image-text-to-text",
                     "llava_next",
                     "int4 --group-size 16 --ratio 0.8",
-                    [{"int8": 14, "int4": 16}, {"int8": 1}, {"int8": 9}],
+                    {
+                        "lm_model": {"int8": 14, "int4": 16},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 9},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "llava_next",
                     'int4 --group-size 16 --ratio 0.8 --sensitivity-metric "hessian_input_activation" '
                     "--dataset contextual --num-samples 1",
-                    [{"int8": 6, "int4": 24}, {"int8": 1}, {"int8": 9}],
+                    {
+                        "lm_model": {"int8": 6, "int4": 24},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 9},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "nanollava",
                     "int4 --group-size 8 --ratio 0.8 --trust-remote-code",
-                    [{"int8": 16, "int4": 14}, {"int8": 1}, {"int8": 15}],
+                    {
+                        "lm_model": {"int8": 16, "int4": 14},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 15},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "nanollava",
                     'int4 --group-size 8 --ratio 0.8 --sensitivity-metric "mean_activation_variance" '
                     "--dataset contextual --num-samples 1 --trust-remote-code",
-                    [{"int8": 16, "int4": 14}, {"int8": 1}, {"int8": 15}],
+                    {
+                        "lm_model": {"int8": 16, "int4": 14},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 15},
+                    },
                 ),
             ]
         )
@@ -481,7 +521,13 @@ class OVCLIExportTestCase(unittest.TestCase):
                     "llava_next_video",
                     'int4 --group-size 16 --ratio 0.8 --sensitivity-metric "hessian_input_activation" '
                     "--dataset contextual --num-samples 1",
-                    [{"int8": 6, "int4": 24}, {"int8": 1}, {"int8": 7}, {}, {"int8": 2}],
+                    {
+                        "lm_model": {"int8": 6, "int4": 24},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 7},
+                        "vision_resampler_model": {},
+                        "multi_modal_projector_model": {"int8": 2},
+                    },
                 ),
             ]
         )
@@ -493,47 +539,80 @@ class OVCLIExportTestCase(unittest.TestCase):
                     "image-text-to-text",
                     "minicpmv",
                     "int4 --group-size 4 --ratio 0.8 --trust-remote-code",
-                    [{"int8": 10, "int4": 20}, {"int8": 1}, {"int8": 26}, {"int8": 6}],
+                    {
+                        "lm_model": {"int8": 10, "int4": 20},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 26},
+                        "resampler_model": {"int8": 6},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "minicpmv",
                     'int4 --group-size 4 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
                     "--dataset contextual --num-samples 1 --trust-remote-code",
-                    [{"int8": 8, "int4": 22}, {"int8": 1}, {"int8": 26}, {"int8": 6}],
+                    {
+                        "lm_model": {"int8": 8, "int4": 22},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 26},
+                        "resampler_model": {"int8": 6},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "internvl2",
                     "int4 --group-size 4 --ratio 0.8 --trust-remote-code",
-                    [{"int8": 8, "int4": 22}, {"int8": 1}, {"int8": 11}],
+                    {
+                        "lm_model": {"int8": 8, "int4": 22},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 11},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "internvl2",
                     'int4 --group-size 4 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
                     "--dataset contextual --num-samples 1 --trust-remote-code",
-                    [{"int8": 8, "int4": 22}, {"int8": 1}, {"int8": 11}],
+                    {
+                        "lm_model": {"int8": 8, "int4": 22},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 11},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "phi3_v",
                     "int4 --group-size 4 --ratio 0.8 --trust-remote-code",
-                    [{"int8": 8, "int4": 10}, {"int8": 1}, {"int8": 7}, {"int8": 2}],
+                    {
+                        "lm_model": {"int8": 8, "int4": 10},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 7},
+                        "vision_projection_model": {"int8": 2},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "phi3_v",
                     'int4 --group-size 4 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
                     "--dataset contextual --num-samples 1 --trust-remote-code",
-                    [{"int8": 4, "int4": 14}, {"int8": 1}, {"int8": 7}, {"int8": 2}],
+                    {
+                        "lm_model": {"int8": 4, "int4": 14},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 7},
+                        "vision_projection_model": {"int8": 2},
+                    },
                 ),
                 (
                     "image-text-to-text",
                     "qwen2_vl",
                     'int4 --group-size 16 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
                     "--dataset contextual --num-samples 1",
-                    [{"int8": 10, "int4": 20}, {"int8": 1}, {"int8": 1}, {"int8": 10}],
+                    {
+                        "lm_model": {"int8": 10, "int4": 20},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 1},
+                        "vision_embeddings_merger_model": {"int8": 10},
+                    },
                 ),
             ]
         )
@@ -546,17 +625,17 @@ class OVCLIExportTestCase(unittest.TestCase):
                     "phi4mm",
                     'int4 --group-size 8 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
                     "--dataset contextual --num-samples 1 --trust-remote-code",
-                    [
-                        {"int8": 8, "int4": 42},
-                        {"int8": 1},
-                        {"int8": 8},
-                        {"int8": 2},
-                        {},
-                        {"int8": 6},
-                        {"int8": 25},
-                        {"int8": 2},
-                        {"int8": 2},
-                    ],
+                    {
+                        "lm_model": {"int8": 8, "int4": 42},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 8},
+                        "vision_projection_model": {"int8": 2},
+                        "audio_embeddings_model": {},
+                        "audio_forward_embeddings_model": {"int8": 6},
+                        "audio_encoder_model": {"int8": 25},
+                        "audio_vision_projection_model": {"int8": 2},
+                        "audio_speech_projection_model": {"int8": 2},
+                    },
                 ),
             ]
         )
@@ -796,10 +875,10 @@ class OVCLIExportTestCase(unittest.TestCase):
             ).from_pretrained(tmpdir, **model_kwargs)
 
             expected_int8 = _ARCHITECTURES_TO_EXPECTED_INT8[model_type]
-            expected_int8 = [{"int8": it} for it in expected_int8]
+            expected_int8 = {k: {"int8": v} for k, v in expected_int8.items()}
             if task.startswith("text2text-generation") and (not task.endswith("with-past") or model.decoder.stateful):
-                expected_int8 = expected_int8[:2]
-            check_compression_state_per_model(self, model.ov_submodels.values(), expected_int8)
+                del expected_int8["decoder_with_past"]
+            check_compression_state_per_model(self, model.ov_submodels, expected_int8)
 
     @parameterized.expand(SUPPORTED_SD_HYBRID_ARCHITECTURES)
     def test_exporters_cli_hybrid_quantization(
@@ -820,7 +899,7 @@ class OVCLIExportTestCase(unittest.TestCase):
 
     @parameterized.expand(TEST_4BIT_CONFIGURATIONS)
     def test_exporters_cli_4bit(
-        self, task: str, model_type: str, option: str, expected_num_weight_nodes_per_model: List[Dict]
+        self, task: str, model_type: str, option: str, expected_num_weight_nodes_per_model: Dict[str, Dict[str, int]]
     ):
         with TemporaryDirectory() as tmpdir:
             result = subprocess.run(
@@ -838,7 +917,7 @@ class OVCLIExportTestCase(unittest.TestCase):
                 else _HEAD_TO_AUTOMODELS[model_type.replace("-refiner", "")]
             ).from_pretrained(tmpdir, **model_kwargs)
 
-            check_compression_state_per_model(self, model.ov_submodels.values(), expected_num_weight_nodes_per_model)
+            check_compression_state_per_model(self, model.ov_submodels, expected_num_weight_nodes_per_model)
 
             self.assertTrue("--awq" not in option or b"Applying AWQ" in result.stdout)
             self.assertTrue("--scale-estimation" not in option or b"Applying Scale Estimation" in result.stdout)
@@ -854,8 +933,8 @@ class OVCLIExportTestCase(unittest.TestCase):
         model_type: str,
         quant_mode: str,
         option: str,
-        expected_fake_nodes_per_model: List[int],
-        expected_num_weight_nodes_per_model: List[Dict[str, int]],
+        expected_fake_nodes_per_model: Dict[str, int],
+        expected_num_weight_nodes_per_model: Dict[str, Dict[str, int]],
     ):
         with TemporaryDirectory() as tmpdir:
             subprocess.run(
@@ -872,13 +951,12 @@ class OVCLIExportTestCase(unittest.TestCase):
             model = model_cls.from_pretrained(tmpdir)
 
             if "automatic-speech-recognition" in task and model.decoder_with_past is None:
-                expected_num_weight_nodes_per_model = expected_num_weight_nodes_per_model[:-1]
-                expected_fake_nodes_per_model = expected_fake_nodes_per_model[:-1]
+                del expected_num_weight_nodes_per_model["decoder_with_past"]
+                del expected_fake_nodes_per_model["decoder_with_past"]
 
-            submodels = model.ov_submodels.values()
             check_compression_state_per_model(
                 self,
-                submodels,
+                model.ov_submodels,
                 expected_num_weight_nodes_per_model,
                 expected_fake_nodes_per_model,
             )

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -208,7 +208,7 @@ class OVQuantizerTest(unittest.TestCase):
                 "model": 7,
             },
             {
-                "model": {"f8e5m2": 8, "nf4": 2},
+                "model": {"f8e4m3": 8, "nf4": 2},
             },
         ),
         (
@@ -689,7 +689,7 @@ class OVWeightCompressionTest(unittest.TestCase):
             "gpt2",
             False,
             dict(bits=4, sym=False, group_size=-1, ratio=0.8, all_layers=True),
-            {"model": {"int8": 4, "int4": 26}},
+            {"model": {"int8": 18, "int4": 26}},
         ),
         (
             OVModelForCausalLM,
@@ -1328,7 +1328,9 @@ class OVWeightCompressionTest(unittest.TestCase):
         self.assertTrue(model.use_cache)
 
         _, num_weight_nodes = get_num_quantized_nodes(model)
-        check_compression_state_per_model(self, model.ov_submodels, _ARCHITECTURES_TO_EXPECTED_INT8[model_type])
+        expected_int8 = _ARCHITECTURES_TO_EXPECTED_INT8[model_type]
+        expected_int8 = {k: {"int8": v} for k, v in expected_int8.items()}
+        check_compression_state_per_model(self, model.ov_submodels, expected_int8)
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION)
     def test_ovmodel_load_with_uncompressed_weights(self, model_cls, model_type, trust_remote_code):

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -145,11 +145,13 @@ class OVQuantizerTest(unittest.TestCase):
                 trust_remote_code=True,
                 smooth_quant_alpha=0.95,
             ),
-            [10, 12, 11] if is_transformers_version("<=", "4.36.0") else [8, 12, 25],
+            {"encoder": 10, "decoder": 12, "decoder_with_past": 11}
+            if is_transformers_version("<=", "4.36.0")
+            else {"encoder": 8, "decoder": 12, "decoder_with_past": 25},
             (
-                [{"int8": 8}, {"int8": 11}, {"int8": 9}]
+                {"encoder": {"int8": 8}, "decoder": {"int8": 11}, "decoder_with_past": {"int8": 9}}
                 if is_transformers_version("<=", "4.36.0")
-                else [{"int8": 8}, {"int8": 12}, {"int8": 18}]
+                else {"encoder": {"int8": 8}, "decoder": {"int8": 12}, "decoder_with_past": {"int8": 18}}
             ),
         ),
         (
@@ -161,12 +163,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dtype="f8e4m3",
                 weight_only=False,
             ),
-            [
-                13,
-            ],
-            [
-                {"f8e4m3": 16},
-            ],
+            {
+                "model": 13,
+            },
+            {
+                "model": {"f8e4m3": 16},
+            },
         ),
         (
             OVModelForCausalLM,
@@ -177,12 +179,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="wikitext2",
                 num_samples=1,
             ),
-            [
-                14,
-            ],
-            [
-                {"f8e4m3": 11, "nf4": 5},
-            ],
+            {
+                "model": 14,
+            },
+            {
+                "model": {"f8e4m3": 11, "nf4": 5},
+            },
         ),
         (
             OVModelForCausalLM,
@@ -202,12 +204,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="wikitext2",
                 num_samples=1,
             ),
-            [
-                7,
-            ],
-            [
-                {"f8e4m3": 8, "nf4": 2},
-            ],
+            {
+                "model": 7,
+            },
+            {
+                "model": {"f8e5m2": 8, "nf4": 2},
+            },
         ),
         (
             OVModelForCausalLM,
@@ -227,12 +229,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="wikitext2",
                 num_samples=1,
             ),
-            [
-                7,
-            ],
-            [
-                {"f8e5m2": 8, "nf4": 2},
-            ],
+            {
+                "model": 7,
+            },
+            {
+                "model": {"f8e5m2": 8, "nf4": 2},
+            },
         ),
         (
             OVModelForCausalLM,
@@ -243,12 +245,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="wikitext2",
                 num_samples=1,
             ),
-            [
-                14,
-            ],
-            [
-                {"f8e4m3": 11, "int4": 10},
-            ],
+            {
+                "model": 14,
+            },
+            {
+                "model": {"f8e4m3": 11, "int4": 10},
+            },
         ),
         (
             OVModelForCausalLM,
@@ -259,12 +261,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="wikitext2",
                 num_samples=1,
             ),
-            [
-                13,
-            ],
-            [
-                {"f8e5m2": 2, "int4": 28},
-            ],
+            {
+                "model": 13,
+            },
+            {
+                "model": {"f8e5m2": 2, "int4": 28},
+            },
         ),
         (
             OVStableDiffusionPipeline,
@@ -276,18 +278,18 @@ class OVQuantizerTest(unittest.TestCase):
                 processor=MODEL_NAMES["stable-diffusion"],
                 trust_remote_code=True,
             ),
-            [
-                112,
-                0,
-                0,
-                0,
-            ],
-            [
-                {"int8": 121},
-                {"int8": 42},
-                {"int8": 34},
-                {"int8": 64},
-            ],
+            {
+                "unet": 112,
+                "vae_decoder": 0,
+                "vae_encoder": 0,
+                "text_encoder": 0,
+            },
+            {
+                "unet": {"int8": 121},
+                "vae_decoder": {"int8": 42},
+                "vae_encoder": {"int8": 34},
+                "text_encoder": {"int8": 64},
+            },
         ),
         (
             OVStableDiffusionXLPipeline,
@@ -300,20 +302,20 @@ class OVQuantizerTest(unittest.TestCase):
                 processor=MODEL_NAMES["stable-diffusion-xl"],
                 trust_remote_code=True,
             ),
-            [
-                174,
-                0,
-                0,
-                0,
-                0,
-            ],
-            [
-                {"f8e5m2": 183},
-                {"int8": 42},
-                {"int8": 34},
-                {"int8": 64},
-                {"int8": 66},
-            ],
+            {
+                "unet": 174,
+                "vae_decoder": 0,
+                "vae_encoder": 0,
+                "text_encoder": 0,
+                "text_encoder_2": 0,
+            },
+            {
+                "unet": {"f8e5m2": 183},
+                "vae_decoder": {"int8": 42},
+                "vae_encoder": {"int8": 34},
+                "text_encoder": {"int8": 64},
+                "text_encoder_2": {"int8": 66},
+            },
         ),
         (
             OVLatentConsistencyModelPipeline,
@@ -324,18 +326,18 @@ class OVQuantizerTest(unittest.TestCase):
                 num_samples=1,
                 trust_remote_code=True,
             ),
-            [
-                79,
-                0,
-                0,
-                0,
-            ],
-            [
-                {"f8e4m3": 84},
-                {"int8": 42},
-                {"int8": 34},
-                {"int8": 40},
-            ],
+            {
+                "unet": 79,
+                "vae_decoder": 0,
+                "vae_encoder": 0,
+                "text_encoder": 0,
+            },
+            {
+                "unet": {"f8e4m3": 84},
+                "vae_decoder": {"int8": 42},
+                "vae_encoder": {"int8": 34},
+                "text_encoder": {"int8": 40},
+            },
         ),
         (
             OVModelForFeatureExtraction,
@@ -345,12 +347,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="wikitext2",
                 num_samples=1,
             ),
-            [
-                33,
-            ],
-            [
-                {"int8": 35},
-            ],
+            {
+                "model": 33,
+            },
+            {
+                "model": {"int8": 35},
+            },
         ),
         (
             OVSentenceTransformer,
@@ -360,12 +362,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="c4",
                 num_samples=1,
             ),
-            [
-                12,
-            ],
-            [
-                {"int8": 15},
-            ],
+            {
+                "model": 12,
+            },
+            {
+                "model": {"int8": 15},
+            },
         ),
         (
             OVModelForMaskedLM,
@@ -375,12 +377,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="wikitext2",
                 num_samples=1,
             ),
-            [
-                32,
-            ],
-            [
-                {"int8": 34},
-            ],
+            {
+                "model": 32,
+            },
+            {
+                "model": {"int8": 34},
+            },
         ),
         (
             OVModelForMaskedLM,
@@ -390,12 +392,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="c4",
                 num_samples=1,
             ),
-            [
-                14,
-            ],
-            [
-                {"int8": 16},
-            ],
+            {
+                "model": 14,
+            },
+            {
+                "model": {"int8": 16},
+            },
         ),
         (
             OVModelForZeroShotImageClassification,
@@ -405,12 +407,12 @@ class OVQuantizerTest(unittest.TestCase):
                 dataset="conceptual_captions",
                 num_samples=1,
             ),
-            [
-                65,
-            ],
-            [
-                {"int8": 65},
-            ],
+            {
+                "model": 65,
+            },
+            {
+                "model": {"int8": 65},
+            },
         ),
     ]
 
@@ -601,12 +603,10 @@ class OVQuantizerTest(unittest.TestCase):
             ov_model = model_cls.from_pretrained(model_id, quantization_config=quantization_config)
             ov_model.save_pretrained(tmp_dir)
 
-            submodels = ov_model.ov_submodels.values()
-
             if model_cls == OVModelForSpeechSeq2Seq:
                 if ov_model.decoder_with_past is None:
-                    expected_num_weight_nodes_per_model = expected_num_weight_nodes_per_model[:-1]
-                    expected_fake_nodes_per_model = expected_fake_nodes_per_model[:-1]
+                    del expected_fake_nodes_per_model["decoder_with_past"]
+                    del expected_num_weight_nodes_per_model["decoder_with_past"]
 
                 input_features = torch.randn((1, ov_model.config.num_mel_bins, 3000), dtype=torch.float32)
                 ov_model.generate(input_features)
@@ -634,7 +634,7 @@ class OVQuantizerTest(unittest.TestCase):
 
             check_compression_state_per_model(
                 self,
-                submodels,
+                ov_model.ov_submodels,
                 expected_num_weight_nodes_per_model,
                 expected_fake_nodes_per_model,
             )
@@ -656,26 +656,21 @@ class OVWeightCompressionTest(unittest.TestCase):
             "gpt2",  # model name
             False,  # trust remote code
             dict(bits=4, sym=False, group_size=-1, ratio=0.8),  # quantization config
-            [{"int8": 14, "int4": 30}],  # reference number of low-precision nodes
+            {"model": {"int8": 14, "int4": 30}},  # reference number of low-precision nodes
         ),
         (
             OVModelForCausalLM,
             "gpt2",
             False,
             dict(bits=4, dtype="mxfp4", group_size=32),
-            [{"int8": 4, "f4e2m1": 20, "f8e8m0": 20}],
+            {"model": {"int8": 4, "f4e2m1": 20, "f8e8m0": 20}},
         ),
         (
             OVModelForCausalLM,
             "gpt2",
             False,
             dict(bits=4, dtype="nf4", group_size=32),
-            [
-                {
-                    "int8": 4,
-                    "nf4": 20,
-                }
-            ],
+            {"model": {"int8": 4, "nf4": 20}},
         ),
         (
             OVModelForCausalLM,
@@ -687,14 +682,14 @@ class OVWeightCompressionTest(unittest.TestCase):
                 group_size=32,
                 ignored_scope={"names": ["__module.model.transformer.h.2.mlp.c_fc/aten::addmm/MatMul"]},
             ),
-            [{"int8": 4, "int4": 38}],
+            {"model": {"int8": 4, "int4": 38}},
         ),
         (
             OVModelForCausalLM,
             "gpt2",
             False,
             dict(bits=4, sym=False, group_size=-1, ratio=0.8, all_layers=True),
-            [{"int8": 18, "int4": 26}],
+            {"model": {"int8": 4, "int4": 26}},
         ),
         (
             OVModelForCausalLM,
@@ -708,7 +703,9 @@ class OVWeightCompressionTest(unittest.TestCase):
                 sensitivity_metric="mean_activation_magnitude",
                 dataset="c4",
             ),
-            [{"int8": 18, "int4": 23}] if is_transformers_version(">=", "4.49") else [{"int8": 14, "int4": 25}],
+            {"model": {"int8": 18, "int4": 23}}
+            if is_transformers_version(">=", "4.49")
+            else {"model": {"int8": 14, "int4": 25}},
         ),
         (
             OVModelForCausalLM,
@@ -722,7 +719,9 @@ class OVWeightCompressionTest(unittest.TestCase):
                 sensitivity_metric="mean_activation_magnitude",
                 dataset=["one two, " * i for i in range(10)],
             ),
-            [{"int8": 18, "int4": 23}] if is_transformers_version(">=", "4.49") else [{"int8": 16, "int4": 24}],
+            {"model": {"int8": 18, "int4": 23}}
+            if is_transformers_version(">=", "4.49")
+            else {"model": {"int8": 16, "int4": 24}},
         ),
         (
             OVModelForCausalLM,
@@ -738,7 +737,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 quant_method=QuantizationMethod.AWQ,
                 scale_estimation=True,
             ),
-            [{"int8": 8, "int4": 12}],
+            {"model": {"int8": 8, "int4": 12}},
         ),
         (
             OVModelForCausalLM,
@@ -753,7 +752,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 dataset="c4",
                 quant_method="awq",
             ),
-            [{"int8": 8, "int4": 12}],
+            {"model": {"int8": 8, "int4": 12}},
         ),
         (
             OVModelForCausalLM,
@@ -768,7 +767,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 dataset="c4",
                 gptq=True,
             ),
-            [{"int8": 8, "int4": 12}],
+            {"model": {"int8": 8, "int4": 12}},
         ),
         (
             OVModelForCausalLM,
@@ -781,35 +780,35 @@ class OVWeightCompressionTest(unittest.TestCase):
                 dataset="auto",
                 lora_correction=True,
             ),
-            [{"int8": 60, "int4": 28}],
+            {"model": {"int8": 60, "int4": 28}},
         ),
         (
             OVModelForCausalLM,
             "llama_awq",
             False,
             dict(bits=4, backup_precision="none", group_size=16),
-            [{"int4": 28}],
+            {"model": {"int4": 28}},
         ),
         (
             OVModelForCausalLM,
             "llama_awq",
             False,
             dict(bits=4, backup_precision="none", group_size=16, ratio=0.5),
-            [{"int4": 6}],
+            {"model": {"int4": 6}},
         ),
         (
             OVModelForCausalLM,
             "llama_awq",
             False,
             dict(bits=4, backup_precision="int8_sym", group_size=16, ratio=0.5),
-            [{"int4": 6, "int8": 13}],
+            {"model": {"int8": 13, "int4": 6}},
         ),
         (
             OVModelForCausalLM,
             "llama_awq",
             False,
             dict(bits=4, backup_precision="int8_asym", group_size=16, ratio=0.5),
-            [{"int4": 6, "int8": 26}],
+            {"model": {"int8": 26, "int4": 6}},
         ),
     ]
 
@@ -829,7 +828,11 @@ class OVWeightCompressionTest(unittest.TestCase):
                         num_samples=1,
                         processor=MODEL_NAMES["llava_next"],
                     ),
-                    [{"int8": 6, "int4": 24}, {"int8": 1}, {"int8": 9}],
+                    {
+                        "lm_model": {"int8": 6, "int4": 24},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 9},
+                    },
                 ),
                 (
                     OVModelForVisualCausalLM,
@@ -846,7 +849,11 @@ class OVWeightCompressionTest(unittest.TestCase):
                         tokenizer=MODEL_NAMES["nanollava"],
                         trust_remote_code=True,
                     ),
-                    [{"int8": 16, "int4": 14}, {"int8": 1}, {"int8": 15}],
+                    {
+                        "lm_model": {"int8": 16, "int4": 14},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 15},
+                    },
                 ),
             ]
         )
@@ -867,7 +874,13 @@ class OVWeightCompressionTest(unittest.TestCase):
                         num_samples=1,
                         processor=MODEL_NAMES["llava_next_video"],
                     ),
-                    [{"int8": 6, "int4": 24}, {"int8": 1}, {"int8": 7}, {}, {"int8": 2}],
+                    {
+                        "lm_model": {"int8": 6, "int4": 24},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 7},
+                        "vision_resampler_model": {},
+                        "multi_modal_projector_model": {"int8": 2},
+                    },
                 ),
             ]
         )
@@ -889,7 +902,12 @@ class OVWeightCompressionTest(unittest.TestCase):
                         processor=MODEL_NAMES["minicpmv"],
                         trust_remote_code=True,
                     ),
-                    [{"int8": 8, "int4": 22}, {"int8": 1}, {"int8": 26}, {"int8": 6}],
+                    {
+                        "lm_model": {"int8": 8, "int4": 22},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 26},
+                        "resampler_model": {"int8": 6},
+                    },
                 ),
                 (
                     OVModelForVisualCausalLM,
@@ -904,7 +922,11 @@ class OVWeightCompressionTest(unittest.TestCase):
                         num_samples=1,
                         trust_remote_code=True,
                     ),
-                    [{"int8": 8, "int4": 22}, {"int8": 1}, {"int8": 11}],
+                    {
+                        "lm_model": {"int8": 8, "int4": 22},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 11},
+                    },
                 ),
                 (
                     OVModelForVisualCausalLM,
@@ -919,7 +941,12 @@ class OVWeightCompressionTest(unittest.TestCase):
                         num_samples=1,
                         trust_remote_code=True,
                     ),
-                    [{"int8": 4, "int4": 14}, {"int8": 1}, {"int8": 7}, {"int8": 2}],
+                    {
+                        "lm_model": {"int8": 4, "int4": 14},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 7},
+                        "vision_projection_model": {"int8": 2},
+                    },
                 ),
                 (
                     OVModelForVisualCausalLM,
@@ -933,7 +960,12 @@ class OVWeightCompressionTest(unittest.TestCase):
                         sensitivity_metric="mean_activation_magnitude",
                         num_samples=1,
                     ),
-                    [{"int8": 10, "int4": 20}, {"int8": 1}, {"int8": 1}, {"int8": 10}],
+                    {
+                        "lm_model": {"int8": 10, "int4": 20},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 1},
+                        "vision_embeddings_merger_model": {"int8": 10},
+                    },
                 ),
             ]
         )
@@ -954,17 +986,17 @@ class OVWeightCompressionTest(unittest.TestCase):
                         num_samples=1,
                         trust_remote_code=True,
                     ),
-                    [
-                        {"int8": 8, "int4": 42},
-                        {"int8": 1},
-                        {"int8": 8},
-                        {"int8": 2},
-                        {},
-                        {"int8": 6},
-                        {"int8": 25},
-                        {"int8": 2},
-                        {"int8": 2},
-                    ],
+                    {
+                        "lm_model": {"int8": 8, "int4": 42},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 8},
+                        "vision_projection_model": {"int8": 2},
+                        "audio_embeddings_model": {},
+                        "audio_forward_embeddings_model": {"int8": 6},
+                        "audio_encoder_model": {"int8": 25},
+                        "audio_vision_projection_model": {"int8": 2},
+                        "audio_speech_projection_model": {"int8": 2},
+                    },
                 ),
             ]
         )
@@ -1154,10 +1186,12 @@ class OVWeightCompressionTest(unittest.TestCase):
             check_optimization_not_applicable_to_optimized_model(model, quantization_config={"bits": 8})
 
         submodels = (
-            [model.text_model, model.visual_model] if model_type == "open-clip" else model.ov_submodels.values()
+            {"text_model": model.text_model, "visual_model": model.visual_model}
+            if model_type == "open-clip"
+            else model.ov_submodels
         )
         expected_ov_int8 = _ARCHITECTURES_TO_EXPECTED_INT8[model_type]
-        expected_ov_int8 = [{"int8": it} for it in expected_ov_int8]
+        expected_ov_int8 = {k: {"int8": v} for k, v in expected_ov_int8.items()}
         check_compression_state_per_model(self, submodels, expected_ov_int8)
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_HYBRID_QUANTIZATION)
@@ -1268,12 +1302,12 @@ class OVWeightCompressionTest(unittest.TestCase):
                 # TODO: Check that AWQ was actually applied
                 pass
 
-            submodels = list(model.ov_submodels.values())
+            submodels = model.ov_submodels
             check_compression_state_per_model(self, submodels, expected_num_weight_nodes_per_model)
 
             model.save_pretrained(tmp_dir)
             # At the moment the first model in the list is the only one we apply data-aware compression to
-            wc_rt_info = submodels[0].get_rt_info()["nncf"]["weight_compression"]
+            wc_rt_info = next(iter(submodels.values())).get_rt_info()["nncf"]["weight_compression"]
             self.assertEqual(quantization_config.quant_method.lower() == "awq", wc_rt_info["awq"].value == "True")
             self.assertEqual(
                 quantization_config.scale_estimation or False, wc_rt_info["scale_estimation"].value == "True"
@@ -1293,9 +1327,8 @@ class OVWeightCompressionTest(unittest.TestCase):
         self.assertTrue(model.stateful)
         self.assertTrue(model.use_cache)
 
-        expected_ov_int8 = _ARCHITECTURES_TO_EXPECTED_INT8[model_type][0]
         _, num_weight_nodes = get_num_quantized_nodes(model)
-        check_compression_state_per_model(self, [model.model], [{"int8": expected_ov_int8}])
+        check_compression_state_per_model(self, model.ov_submodels, _ARCHITECTURES_TO_EXPECTED_INT8[model_type])
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION)
     def test_ovmodel_load_with_uncompressed_weights(self, model_cls, model_type, trust_remote_code):
@@ -1422,7 +1455,7 @@ class OVWeightCompressionTest(unittest.TestCase):
             self.assertEqual(model.ov_config["DYNAMIC_QUANTIZATION_GROUP_SIZE"], str(group_size))
             self.assertEqual(model.ov_config["KV_CACHE_PRECISION"], "u8")
 
-            check_compression_state_per_model(self, model.ov_submodels.values(), expected_num_weight_nodes_per_model)
+            check_compression_state_per_model(self, model.ov_submodels, expected_num_weight_nodes_per_model)
 
             model.save_pretrained(tmp_dir)
             openvino_config = OVConfig.from_pretrained(tmp_dir)

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -13,7 +13,7 @@
 #  limitations under the License.
 import unittest
 from contextlib import contextmanager
-from typing import Dict, List, Optional, Union
+from typing import Dict, Optional, Union
 
 import numpy as np
 import openvino as ov
@@ -201,33 +201,121 @@ TENSOR_ALIAS_TO_TYPE = {
 SEED = 42
 
 _ARCHITECTURES_TO_EXPECTED_INT8 = {
-    "bert": (68,),
-    "roberta": (68,),
-    "albert": (84,),
-    "vit": (64,),
-    "blenderbot": (70,),
-    "gpt2": (44,),
-    "wav2vec2": (34,),
-    "distilbert": (66,),
-    "t5": (64, 104, 84),
-    "stable-diffusion": (242, 42, 34, 64),
-    "stable-diffusion-xl": (366, 42, 34, 64, 66),
-    "stable-diffusion-xl-refiner": (366, 42, 34, 66),
-    "open-clip": (20, 28),
-    "stable-diffusion-3": (66, 58, 42, 30, 30, 32),
-    "flux": (56, 28, 24, 64, 64),
-    "flux-fill": (56, 28, 24, 64, 64),
-    "llava": (30, 1, 9),
-    "llava_next": (30, 1, 9),
-    "minicpmv": (30, 1, 26, 6),
-    "llava_next_video": (30, 1, 7, 0, 2),
-    "nanollava": (30, 1, 15),
-    "qwen2_vl": (30, 1, 1, 10),
-    "sana": (58, 28, 28, 18),
-    "ltx-video": (34, 28, 28, 64),
-    "sam": (102, 100),
-    "speecht5": (28, 52, 10, 80),
-    "clip": (130,),
+    "bert": {"model": 68},
+    "roberta": {"model": 68},
+    "albert": {"model": 84},
+    "vit": {"model": 64},
+    "blenderbot": {"model": 70},
+    "gpt2": {"model": 44},
+    "wav2vec2": {"model": 34},
+    "distilbert": {"model": 66},
+    "t5": {
+        "encoder": 64,
+        "decoder": 104,
+        "decoder_with_past": 84,
+    },
+    "stable-diffusion": {
+        "unet": 242,
+        "vae_decoder": 42,
+        "vae_encoder": 34,
+        "text_encoder": 64,
+    },
+    "stable-diffusion-xl": {
+        "unet": 366,
+        "vae_decoder": 42,
+        "vae_encoder": 34,
+        "text_encoder": 64,
+        "text_encoder_2": 66,
+    },
+    "stable-diffusion-xl-refiner": {
+        "unet": 366,
+        "vae_decoder": 42,
+        "vae_encoder": 34,
+        "text_encoder_2": 66,
+    },
+    "open-clip": {
+        "text_model": 20,
+        "visual_model": 28,
+    },
+    "stable-diffusion-3": {
+        "transformer": 66,
+        "vae_decoder": 58,
+        "vae_encoder": 42,
+        "text_encoder": 30,
+        "text_encoder_2": 30,
+        "text_encoder_3": 32,
+    },
+    "flux": {
+        "transformer": 56,
+        "vae_decoder": 28,
+        "vae_encoder": 24,
+        "text_encoder": 64,
+        "text_encoder_2": 64,
+    },
+    "flux-fill": {
+        "transformer": 56,
+        "vae_decoder": 28,
+        "vae_encoder": 24,
+        "text_encoder": 64,
+        "text_encoder_2": 64,
+    },
+    "llava": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 9,
+    },
+    "llava_next": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 9,
+    },
+    "minicpmv": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 26,
+        "resampler_model": 6,
+    },
+    "llava_next_video": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 7,
+        "vision_resampler_model": 0,
+        "multi_modal_projector_model": 2,
+    },
+    "nanollava": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 15,
+    },
+    "qwen2_vl": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 1,
+        "vision_embeddings_merger_model": 10,
+    },
+    "sana": {
+        "transformer": 58,
+        "vae_decoder": 28,
+        "vae_encoder": 28,
+        "text_encoder": 18,
+    },
+    "ltx-video": {
+        "transformer": 34,
+        "vae_decoder": 28,
+        "vae_encoder": 28,
+        "text_encoder": 64,
+    },
+    "sam": {
+        "vision_encoder_model": 102,
+        "prompt_encoder_mask_decoder_model": 100,
+    },
+    "speecht5": {
+        "encoder": 28,
+        "decoder": 52,
+        "postnet": 10,
+        "vocoder": 80,
+    },
+    "clip": {"model": 130},
 }
 
 TEST_IMAGE_URL = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -317,20 +405,21 @@ def patch_awq_for_inference(to_patch):
 
 def check_compression_state_per_model(
     test_case: unittest.TestCase,
-    models: List[Union[ov.Model, OVBaseModel]],
-    expected_num_weight_nodes_per_model: List[Dict[str, int]],
-    expected_num_fake_nodes_per_model: Optional[List[int]] = None,
+    models: Dict[str, Union[ov.Model, OVBaseModel]],
+    expected_num_weight_nodes_per_model: Dict[str, Dict[str, int]],
+    expected_num_fake_nodes_per_model: Optional[Dict[str, int]] = None,
 ):
     test_case.assertEqual(len(models), len(expected_num_weight_nodes_per_model))
-    actual_num_weights_per_model = [{}] * len(models)
-    actual_num_fake_nodes_per_model = [0] * len(models)
-    for i, (submodel, expected_num_weight_nodes) in enumerate(zip(models, expected_num_weight_nodes_per_model)):
+    actual_num_weights_per_model = {}
+    actual_num_fake_nodes_per_model = {}
+    for submodel_name, submodel in models.items():
+        expected_num_weight_nodes = expected_num_weight_nodes_per_model[submodel_name]
         ov_model = submodel if isinstance(submodel, ov.Model) else submodel.model
         num_fake_nodes, num_weight_nodes = get_num_quantized_nodes(ov_model)
         expected_num_weight_nodes.update(dict.fromkeys(set(num_weight_nodes) - set(expected_num_weight_nodes), 0))
 
-        actual_num_weights_per_model[i] = num_weight_nodes
-        actual_num_fake_nodes_per_model[i] = num_fake_nodes
+        actual_num_weights_per_model[submodel_name] = num_weight_nodes
+        actual_num_fake_nodes_per_model[submodel_name] = num_fake_nodes
 
         test_case.assertFalse(ov_model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
 


### PR DESCRIPTION
# What does this PR do?

Addition of specifying reference number of compressed weights per pipeline component using a dictionary instead of a list for clarity.

https://github.com/huggingface/optimum-intel/pull/1292#discussion_r2082098121


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

