### PR TITLE
provide workaround for export openai whisper models

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -723,6 +723,13 @@ def export_from_model(
                     setattr(model.generation_config, param_name, param_value)
                     setattr(model.config, param_name, None)
 
+        # workaround for https://github.com/huggingface/transformers/issues/37172
+        if is_transformers_version(">=", "4.50.0") and model_type == "whisper":
+            if hasattr(model.config, "forced_decoder_ids"):
+                model.config.forced_decoder_ids = None
+            if hasattr(model, "generation_config") and hasattr(model.generation_config, "forced_decoder_ids"):
+                model.generation_config.input_ids = model.generation_config.forced_decoder_ids
+                model.generation_config.forced_decoder_ids = None
         # Saving the model config and preprocessor as this is needed sometimes.
         save_config(model.config, output)
         generation_config = getattr(model, "generation_config", None)


### PR DESCRIPTION
# What does this PR do?

starting with transformers 4.50 some of whisper models  e.g. `openai/whisper-tiny` become broken for usage with generate method.  Also affects model quantization with optimum-cli (inputs dataset collection). Provided workaround for correct config saving during export .
```
ValueError: You have explicitly specified `forced_decoder_ids`.
```
More details can be found in original transformers issue:
https://github.com/huggingface/transformers/issues/37172

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

