### PR TITLE
[OV] Introduce default full quantization configs for clip models

### DIFF
--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -183,6 +183,21 @@ Besides weight-only quantization, you can also apply full model quantization inc
 optimum-cli export openvino -m openai/whisper-large-v3-turbo --quant-mode int8 --dataset librispeech --num-samples 32 --smooth-quant-alpha 0.9 ./whisper-large-v3-turbo
 ```
 
+#### Default quantization configs
+
+For some models we maintain a set of default quantization configs. To apply a default 4-bit weight-only quantization one should provide `--weight-format int4` without any additional arguments. For int8 weight & activation quantization it should be `--quant-mode int8`. For example:
+
+```bash
+optimum-cli export openvino -m microsoft/Phi-4-mini-instruct --weight-format int4 ./Phi-4-mini-instruct
+```
+
+or
+
+```bash
+optimum-cli export openvino -m openai/clip-vit-base-patch16 --quant-mode int8 ./clip-vit-base-patch16
+```
+
+
 ### Decoder models
 
 For models with a decoder, we enable the re-use of past keys and values by default. This allows to avoid recomputing the same intermediate activations at each generation step. To export the model without, you will need to remove the `-with-past` suffix when specifying the task.

--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -185,7 +185,7 @@ optimum-cli export openvino -m openai/whisper-large-v3-turbo --quant-mode int8 -
 
 #### Default quantization configs
 
-For some models we maintain a set of default quantization configs. To apply a default 4-bit weight-only quantization one should provide `--weight-format int4` without any additional arguments. For int8 weight & activation quantization it should be `--quant-mode int8`. For example:
+For some models we maintain a set of default quantization configs ([link](https://github.com/huggingface/optimum-intel/blob/main/optimum/intel/openvino/configuration.py)). To apply a default 4-bit weight-only quantization one should provide `--weight-format int4` without any additional arguments. For int8 weight & activation quantization it should be `--quant-mode int8`. For example:
 
 ```bash
 optimum-cli export openvino -m microsoft/Phi-4-mini-instruct --weight-format int4 ./Phi-4-mini-instruct

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -329,7 +329,7 @@ class OVExportCommand(BaseOptimumCLICommand):
     def run(self):
         from ...exporters.openvino.__main__ import infer_task, main_export, maybe_convert_tokenizers
         from ...exporters.openvino.utils import save_preprocessors
-        from ...intel.openvino.configuration import _DEFAULT_4BIT_CONFIG, OVConfig, get_default_int4_config
+        from ...intel.openvino.configuration import _DEFAULT_4BIT_WQ_CONFIG, OVConfig, get_default_quantization_config
 
         if self.args.library is None:
             # TODO: add revision, subfolder and token to args
@@ -363,43 +363,45 @@ class OVExportCommand(BaseOptimumCLICommand):
             if not is_nncf_available():
                 raise ImportError("Applying quantization requires nncf, please install it with `pip install nncf`")
 
+            default_quantization_config = get_default_quantization_config(
+                self.args.model, self.args.weight_format, self.args.quant_mode
+            )
             if self.args.weight_format is not None:
                 # For int4 quantization if no parameter is provided, then use the default config if exists
                 if no_compression_parameter_provided(self.args) and self.args.weight_format == "int4":
-                    quantization_config = get_default_int4_config(self.args.model)
+                    quantization_config = default_quantization_config or _DEFAULT_4BIT_WQ_CONFIG
                 else:
-                    quantization_config = prepare_wc_config(self.args, _DEFAULT_4BIT_CONFIG)
-
-                if quantization_config.get("dataset", None) is not None:
-                    quantization_config["trust_remote_code"] = self.args.trust_remote_code
-                ov_config = OVConfig(quantization_config=quantization_config)
+                    quantization_config = prepare_wc_config(self.args, _DEFAULT_4BIT_WQ_CONFIG)
             else:
-                if self.args.dataset is None:
-                    raise ValueError(
-                        "Dataset is required for full quantization. Please provide it with --dataset argument."
-                    )
-
-                if self.args.quant_mode in ["nf4_f8e4m3", "nf4_f8e5m2", "int4_f8e4m3", "int4_f8e5m2"]:
-                    if library_name == "diffusers":
-                        raise NotImplementedError("Mixed precision quantization isn't supported for diffusers.")
-
-                    wc_config = prepare_wc_config(self.args, _DEFAULT_4BIT_CONFIG)
-                    wc_dtype, q_dtype = self.args.quant_mode.split("_")
-                    wc_config["dtype"] = wc_dtype
-
-                    q_config = prepare_q_config(self.args)
-                    q_config["dtype"] = q_dtype
-
-                    quantization_config = {
-                        "weight_quantization_config": wc_config,
-                        "full_quantization_config": q_config,
-                        "num_samples": self.args.num_samples,
-                        "dataset": self.args.dataset,
-                        "trust_remote_code": self.args.trust_remote_code,
-                    }
+                if no_quantization_parameter_provided(self.args) and default_quantization_config is not None:
+                    quantization_config = default_quantization_config
                 else:
-                    quantization_config = prepare_q_config(self.args)
-                ov_config = OVConfig(quantization_config=quantization_config)
+                    if self.args.dataset is None:
+                        raise ValueError(
+                            "Dataset is required for full quantization. Please provide it with --dataset argument."
+                        )
+                    if self.args.quant_mode in ["nf4_f8e4m3", "nf4_f8e5m2", "int4_f8e4m3", "int4_f8e5m2"]:
+                        if library_name == "diffusers":
+                            raise NotImplementedError("Mixed precision quantization isn't supported for diffusers.")
+
+                        wc_config = prepare_wc_config(self.args, _DEFAULT_4BIT_WQ_CONFIG)
+                        wc_dtype, q_dtype = self.args.quant_mode.split("_")
+                        wc_config["dtype"] = wc_dtype
+
+                        q_config = prepare_q_config(self.args)
+                        q_config["dtype"] = q_dtype
+
+                        quantization_config = {
+                            "weight_quantization_config": wc_config,
+                            "full_quantization_config": q_config,
+                            "num_samples": self.args.num_samples,
+                            "dataset": self.args.dataset,
+                        }
+                    else:
+                        quantization_config = prepare_q_config(self.args)
+            if quantization_config.get("dataset", None):
+                quantization_config["trust_remote_code"] = self.args.trust_remote_code
+            ov_config = OVConfig(quantization_config=quantization_config)
 
         quantization_config = ov_config.quantization_config if ov_config else None
         quantize_with_dataset = quantization_config and getattr(quantization_config, "dataset", None) is not None

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -369,12 +369,23 @@ class OVExportCommand(BaseOptimumCLICommand):
             if self.args.weight_format is not None:
                 # For int4 quantization if no parameter is provided, then use the default config if exists
                 if no_compression_parameter_provided(self.args) and self.args.weight_format == "int4":
-                    quantization_config = default_quantization_config or _DEFAULT_4BIT_WQ_CONFIG
+                    if default_quantization_config is not None:
+                        quantization_config = default_quantization_config
+                        log_message = (
+                            f"Applying the default quantization config for {self.args.model}: {quantization_config}."
+                        )
+                    else:
+                        quantization_config = _DEFAULT_4BIT_WQ_CONFIG
+                        log_message = f"Applying a default quantization config: {quantization_config}."
+                    logger.info(log_message)
                 else:
                     quantization_config = prepare_wc_config(self.args, _DEFAULT_4BIT_WQ_CONFIG)
             else:
                 if no_quantization_parameter_provided(self.args) and default_quantization_config is not None:
                     quantization_config = default_quantization_config
+                    logger.info(
+                        f"Applying the default quantization config for {self.args.model}: {quantization_config}."
+                    )
                 else:
                     if self.args.dataset is None:
                         raise ValueError(

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -344,12 +344,6 @@ _DEFAULT_4BIT_WQ_CONFIG = {
 
 # Default configs for int8 full quantization
 _DEFAULT_INT8_FQ_CONFIGS = {
-    "hf-tiny-model-private/tiny-random-CLIPModel": {  # For test purposes
-        "dtype": "int8",
-        "dataset": "conceptual_captions",
-        "num_samples": 1,
-        "smooth_quant_alpha": 0.9,
-    },
     "openai/clip-vit-base-patch16": {
         "dtype": "int8",
         "dataset": "conceptual_captions",
@@ -367,6 +361,12 @@ _DEFAULT_INT8_FQ_CONFIGS = {
         "dataset": "conceptual_captions",
         "num_samples": 300,
         "smooth_quant_alpha": 0.6,
+    },
+    "hf-tiny-model-private/tiny-random-CLIPModel": {  # For test purposes
+        "dtype": "int8",
+        "dataset": "conceptual_captions",
+        "num_samples": 1,
+        "smooth_quant_alpha": 0.9,
     },
 }
 

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -344,6 +344,12 @@ _DEFAULT_4BIT_WQ_CONFIG = {
 
 # Default configs for int8 full quantization
 _DEFAULT_INT8_FQ_CONFIGS = {
+    "hf-tiny-model-private/tiny-random-CLIPModel": {  # For test purposes
+        "dtype": "int8",
+        "dataset": "conceptual_captions",
+        "num_samples": 1,
+        "smooth_quant_alpha": 0.9,
+    },
     "openai/clip-vit-base-patch16": {
         "dtype": "int8",
         "dataset": "conceptual_captions",

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -389,9 +389,9 @@ def get_default_quantization_config(
         model_id_or_path (`str`):
             id of the model or path to it.
         weight_format (`str`, *optional*):
-            The format of the weights. Currently on "int4" value is supported.
+            The format of the weights. Currently only "int4" value is supported.
         quant_mode (`str`, *optional*):
-            The quantization mode. Currently on "int8" value is supported.
+            The quantization mode. Currently only "int8" value is supported.
     Returns:
         Default quantization config for the given model if found and `None` otherwise.
     """

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -347,19 +347,19 @@ _DEFAULT_INT8_FQ_CONFIGS = {
     "openai/clip-vit-base-patch16": {
         "dytpe": "int8",
         "dataset": "conceptual_captions",
-        "num_samples": 128,
+        "num_samples": 300,
         "smooth_quant_alpha": 0.6,
     },
     "openai/clip-vit-base-patch32": {
         "dytpe": "int8",
         "dataset": "conceptual_captions",
-        "num_samples": 128,
+        "num_samples": 300,
         "smooth_quant_alpha": 0.6,
     },
     "openai/clip-vit-large-patch14": {
         "dytpe": "int8",
         "dataset": "conceptual_captions",
-        "num_samples": 128,
+        "num_samples": 300,
         "smooth_quant_alpha": 0.6,
     },
 }

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -47,7 +47,8 @@ class OVQuantizationMethod(str, Enum):
     AWQ = "awq"
 
 
-_DEFAULT_4BIT_CONFIGS = {
+# Default configs for 4-bit weight quantization
+_DEFAULT_4BIT_WQ_CONFIGS = {
     "databricks/dolly-v2-3b": {
         "bits": 4,
         "sym": False,
@@ -330,9 +331,9 @@ model_id_aliases = [
     ("meta-llama/Meta-Llama-3.1-8B", "meta-llama/Llama-3.1-8B"),
 ]
 for m_id_1, m_id_2 in model_id_aliases:
-    _DEFAULT_4BIT_CONFIGS[m_id_2] = _DEFAULT_4BIT_CONFIGS[m_id_1]
+    _DEFAULT_4BIT_WQ_CONFIGS[m_id_2] = _DEFAULT_4BIT_WQ_CONFIGS[m_id_1]
 
-_DEFAULT_4BIT_CONFIG = {
+_DEFAULT_4BIT_WQ_CONFIG = {
     "bits": 4,
     "ratio": 1.0,
     "sym": False,
@@ -341,25 +342,27 @@ _DEFAULT_4BIT_CONFIG = {
 }
 
 
-def _check_default_4bit_configs(model_id_or_path: str):
-    if model_id_or_path in _DEFAULT_4BIT_CONFIGS:
-        return _DEFAULT_4BIT_CONFIGS[model_id_or_path]
-
-    model_path = Path(model_id_or_path)
-    config_path = model_path / "config.json"
-    if config_path.exists():
-        with config_path.open("r") as config_f:
-            config = json.load(config_f)
-            original_model_name = config.get("_name_or_path", "")
-        if original_model_name in _DEFAULT_4BIT_CONFIGS:
-            return _DEFAULT_4BIT_CONFIGS[original_model_name]
-
-    for model_id, config in _DEFAULT_4BIT_CONFIGS.items():
-        short_id = model_id.split("/")[-1]
-        if model_path.name == short_id:
-            return config
-
-    return None
+# Default configs for int8 full quantization
+_DEFAULT_INT8_FQ_CONFIGS = {
+    "openai/clip-vit-base-patch16": {
+        "dytpe": "int8",
+        "dataset": "conceptual_captions",
+        "num_samples": 128,
+        "smooth_quant_alpha": 0.6,
+    },
+    "openai/clip-vit-base-patch32": {
+        "dytpe": "int8",
+        "dataset": "conceptual_captions",
+        "num_samples": 128,
+        "smooth_quant_alpha": 0.6,
+    },
+    "openai/clip-vit-large-patch14": {
+        "dytpe": "int8",
+        "dataset": "conceptual_captions",
+        "num_samples": 128,
+        "smooth_quant_alpha": 0.6,
+    },
+}
 
 
 def get_default_int4_config(model_id_or_path: str):
@@ -370,7 +373,60 @@ def get_default_int4_config(model_id_or_path: str):
     Returns:
         Default int4 config for the given model or generic default int4 config.
     """
-    return _check_default_4bit_configs(model_id_or_path) or _DEFAULT_4BIT_CONFIG
+    logger.warning(
+        "The `get_default_int4_config` function is deprecated and will be removed in optimum-intel v1.25.0. "
+        "Please use `get_default_quantization_config` instead."
+    )
+
+    return get_default_quantization_config(model_id_or_path, "int4") or _DEFAULT_4BIT_WQ_CONFIG
+
+
+def get_default_quantization_config(
+    model_id_or_path: str, weight_format: Optional[str] = None, quant_mode: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
+    """
+    Args:
+        model_id_or_path (`str`):
+            id of the model or path to it.
+        weight_format (`str`, *optional*):
+            The format of the weights. Currently on "int4" value is supported.
+        quant_mode (`str`, *optional*):
+            The quantization mode. Currently on "int8" value is supported.
+    Returns:
+        Default quantization config for the given model if found and `None` otherwise.
+    """
+
+    if weight_format is None and quant_mode is None:
+        raise ValueError("Either `weight_format` or `quant_mode` must be provided.")
+
+    if weight_format == "int4":
+        default_configs_dict = _DEFAULT_4BIT_WQ_CONFIGS
+    elif quant_mode == "int8":
+        default_configs_dict = _DEFAULT_INT8_FQ_CONFIGS
+    else:
+        return None
+
+    # Check if the model_id_or_path is in the default configs
+    if model_id_or_path in default_configs_dict:
+        return default_configs_dict[model_id_or_path]
+
+    # Try to match by config.json
+    model_path = Path(model_id_or_path)
+    config_path = model_path / "config.json"
+    if config_path.exists():
+        with config_path.open("r") as config_f:
+            config = json.load(config_f)
+            original_model_name = config.get("_name_or_path", "")
+        if original_model_name in default_configs_dict:
+            return default_configs_dict[original_model_name]
+
+    # Try to match by folder name
+    for model_id, config in default_configs_dict.items():
+        short_id = model_id.split("/")[-1]
+        if model_path.name == short_id:
+            return config
+
+    return None
 
 
 @dataclass

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -345,19 +345,19 @@ _DEFAULT_4BIT_WQ_CONFIG = {
 # Default configs for int8 full quantization
 _DEFAULT_INT8_FQ_CONFIGS = {
     "openai/clip-vit-base-patch16": {
-        "dytpe": "int8",
+        "dtype": "int8",
         "dataset": "conceptual_captions",
         "num_samples": 300,
         "smooth_quant_alpha": 0.6,
     },
     "openai/clip-vit-base-patch32": {
-        "dytpe": "int8",
+        "dtype": "int8",
         "dataset": "conceptual_captions",
         "num_samples": 300,
         "smooth_quant_alpha": 0.6,
     },
     "openai/clip-vit-large-patch14": {
-        "dytpe": "int8",
+        "dtype": "int8",
         "dataset": "conceptual_captions",
         "num_samples": 300,
         "smooth_quant_alpha": 0.6,

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -55,7 +55,7 @@ from optimum.intel import (  # noqa
     OVStableDiffusionPipeline,
     OVStableDiffusionXLPipeline,
 )
-from optimum.intel.openvino.configuration import _DEFAULT_4BIT_CONFIGS
+from optimum.intel.openvino.configuration import _DEFAULT_4BIT_WQ_CONFIGS
 from optimum.intel.openvino.utils import _HEAD_TO_AUTOMODELS, TemporaryDirectory
 from optimum.intel.utils.import_utils import (
     compare_versions,
@@ -907,7 +907,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             self.assertTrue("weight_compression" in rt_info["nncf"])
             model_weight_compression_config = rt_info["nncf"]["weight_compression"]
 
-            default_config = _DEFAULT_4BIT_CONFIGS["tiiuae/falcon-7b-instruct"]
+            default_config = _DEFAULT_4BIT_WQ_CONFIGS["tiiuae/falcon-7b-instruct"]
             bits = default_config.pop("bits", None)
             self.assertEqual(bits, 4)
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -70,8 +70,8 @@ from optimum.intel import (
 from optimum.intel.openvino.configuration import (
     OVQuantizationMethod,
     OVQuantizationConfigBase,
-    _DEFAULT_4BIT_CONFIGS,
-    _DEFAULT_4BIT_CONFIG,
+    _DEFAULT_4BIT_WQ_CONFIGS,
+    _DEFAULT_4BIT_WQ_CONFIG,
 )
 from optimum.intel.openvino.utils import TemporaryDirectory
 from copy import deepcopy
@@ -1667,8 +1667,8 @@ class OVQuantizationConfigTest(unittest.TestCase):
     )
 
     def get_default_configurations() -> dict:
-        default_configurations = deepcopy(_DEFAULT_4BIT_CONFIGS)
-        default_configurations.update({"default": _DEFAULT_4BIT_CONFIG})
+        default_configurations = deepcopy(_DEFAULT_4BIT_WQ_CONFIGS)
+        default_configurations.update({"default": _DEFAULT_4BIT_WQ_CONFIG})
         return default_configurations
 
     DEFAULT_CONFIGURATIONS = get_default_configurations()
@@ -1712,7 +1712,7 @@ class OVQuantizationConfigTest(unittest.TestCase):
 
     def test_for_no_short_id_duplicates(self):
         short_ids = set()
-        for model_id in _DEFAULT_4BIT_CONFIGS.keys():
+        for model_id in _DEFAULT_4BIT_WQ_CONFIGS.keys():
             short_id = model_id.split("/")[1]
             assert short_id not in short_ids
             short_ids.add(short_id)

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1231,7 +1231,7 @@ class OVWeightCompressionTest(unittest.TestCase):
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_4BIT_AUTOCOMPRESSED_MATMULS)
     @unittest.mock.patch.dict(
-        "optimum.intel.openvino.configuration._DEFAULT_4BIT_CONFIGS", {"facebook/opt-125m": DEFAULT_INT4_CONFIG}
+        "optimum.intel.openvino.configuration._DEFAULT_4BIT_WQ_CONFIGS", {"facebook/opt-125m": DEFAULT_INT4_CONFIG}
     )
     def test_ovmodel_4bit_auto_compression(self, model_cls, model_type, expected_ov_int8, expected_ov_int4):
         with TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
# What does this PR do?

Add functionally for adding default int8 quantization configs alongside default int4 weight compression configs. The need for such feature came up during enabling of clip models which require a specific `smooth_quant_alpha` parameter to increase accuracy.

| Model ID           | FP32 Accuracy    | INT8 PTQ Accuracy|
|---------------------------------|--------------------|---------------------|
| openai/clip-vit-base-patch16                |  68.33%             |      67.71% (-0.62%)         | 
| openai/clip-vit-base-patch32                 |   63.37%         |        62.52% (-0.85%)      | 
| openai/clip-vit-large-patch14                  |    75.55%       |     74.88% (-0.67%)         | 


INT8 PTQ was applied like this: 
```
optimum-cli export openvino -m openai/clip-vit-base-patch16 --quant-mode int8 ./save_dir
```

Accuracy was measured using https://github.com/l-bat/CLIP_benchmark with a command like this: 
```
python clip_benchmark/cli.py eval --model_type "optimum_intel" --model openai \
  --pretrained clip-vit-base-patch16 --dataset "imagenet1k" --seed 0 --task "zeroshot_classification" \
  --output "eval.json" --dataset_root <dataset_path> 
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

