### PR TITLE
remove forcing input_ids

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -728,7 +728,6 @@ def export_from_model(
             if hasattr(model.config, "forced_decoder_ids"):
                 model.config.forced_decoder_ids = None
             if hasattr(model, "generation_config") and hasattr(model.generation_config, "forced_decoder_ids"):
-                model.generation_config.input_ids = model.generation_config.forced_decoder_ids
                 model.generation_config.forced_decoder_ids = None
         # Saving the model config and preprocessor as this is needed sometimes.
         save_config(model.config, output)


### PR DESCRIPTION
# What does this PR do?

remove setting forced_decoder_ids to input_ids for whisper. For some cases, model works incorrectly with such update

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

