### PR TITLE
Update number of int8 nodes for Segment Anything model

### DIFF
--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -307,7 +307,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "text_encoder": 64,
     },
     "sam": {
-        "vision_encoder_model": 102 if is_openvino_version("<=", "2025.1.0") else 150,
+        "vision_encoder_model": 102 if is_openvino_version("<", "2025.2.0") else 150,
         "prompt_encoder_mask_decoder_model": 100,
     },
     "speecht5": {

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -20,6 +20,7 @@ import openvino as ov
 import torch
 
 from optimum.intel.openvino.modeling_base import OVBaseModel
+from optimum.intel.utils.import_utils import is_openvino_version
 
 
 MODEL_NAMES = {
@@ -306,7 +307,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "text_encoder": 64,
     },
     "sam": {
-        "vision_encoder_model": 102,
+        "vision_encoder_model": 102 if is_openvino_version("<=", "2025.1.0") else 150,
         "prompt_encoder_mask_decoder_model": 100,
     },
     "speecht5": {


### PR DESCRIPTION
# What does this PR do?

In OpenVINO 2025.2 an embedding subgraph is represented differently resulting in it being quantized.

OV 2025.1:
![image](https://github.com/user-attachments/assets/9fc88cb7-5ef1-44e6-9a02-95e684d0be99)

OV 2025.2:
![image](https://github.com/user-attachments/assets/96d8d16a-0945-439f-92b9-7410e8909114)



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

