### PR TITLE
fix whisper with auto language detection

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -724,10 +724,10 @@ def export_from_model(
                     setattr(model.config, param_name, None)
 
         # workaround for https://github.com/huggingface/transformers/issues/37172
-        if is_transformers_version(">=", "4.50.0") and model_type == "whisper":
-            if hasattr(model, "generation_config") and hasattr(model.generation_config, "forced_decoder_ids"):
-                model.config.forced_decoder_ids = model.generation_config.forced_decoder_ids
-                model.generation_config.forced_decoder_ids = None
+        # if is_transformers_version(">=", "4.50.0") and model_type == "whisper":
+        #     if hasattr(model, "generation_config") and hasattr(model.generation_config, "forced_decoder_ids"):
+        #         model.config.forced_decoder_ids = model.generation_config.forced_decoder_ids
+        #         model.generation_config.forced_decoder_ids = None
         # Saving the model config and preprocessor as this is needed sometimes.
         save_config(model.config, output)
         generation_config = getattr(model, "generation_config", None)

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -724,10 +724,6 @@ def export_from_model(
                     setattr(model.config, param_name, None)
 
         # workaround for https://github.com/huggingface/transformers/issues/37172
-        # if is_transformers_version(">=", "4.50.0") and model_type == "whisper":
-        #     if hasattr(model, "generation_config") and hasattr(model.generation_config, "forced_decoder_ids"):
-        #         model.config.forced_decoder_ids = model.generation_config.forced_decoder_ids
-        #         model.generation_config.forced_decoder_ids = None
         # Saving the model config and preprocessor as this is needed sometimes.
         save_config(model.config, output)
         generation_config = getattr(model, "generation_config", None)

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -725,9 +725,8 @@ def export_from_model(
 
         # workaround for https://github.com/huggingface/transformers/issues/37172
         if is_transformers_version(">=", "4.50.0") and model_type == "whisper":
-            if hasattr(model.config, "forced_decoder_ids"):
-                model.config.forced_decoder_ids = None
             if hasattr(model, "generation_config") and hasattr(model.generation_config, "forced_decoder_ids"):
+                model.config.forced_decoder_ids = model.generation_config.forced_decoder_ids
                 model.generation_config.forced_decoder_ids = None
         # Saving the model config and preprocessor as this is needed sometimes.
         save_config(model.config, output)

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -16,7 +16,7 @@ import logging
 import os
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import openvino
@@ -36,7 +36,7 @@ from transformers import (
     WhisperForConditionalGeneration,
 )
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
-from transformers.generation import GenerationMixin
+from transformers.generation import GenerationMixin, LogitsProcessorList
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 from transformers.utils import http_user_agent
 
@@ -1340,13 +1340,6 @@ class _OVModelForWhisper(OVModelForSpeechSeq2Seq, WhisperForConditionalGeneratio
     # force the use of the WhisperForConditionalGeneration generate and prepare_inputs_for_generation methods
     generate = WhisperForConditionalGeneration.generate
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Restore multilingual model transcribe task by default after model export
-        if is_transformers_version(">=", "4.50"):
-            if self.generation_config.is_multilingual and self.generation_config.forced_decoder_ids is None:
-                self.config.forced_decoder_ids = [[1, None], [2, self.generation_config.task_to_id["transcribe"]]]
-
     @classmethod
     def _from_pretrained(
         cls,
@@ -1448,3 +1441,34 @@ class _OVModelForWhisper(OVModelForSpeechSeq2Seq, WhisperForConditionalGeneratio
             "decoder_position_ids": decoder_position_ids,
             "cache_position": cache_position,
         }
+
+    def _get_logits_processor(
+        self,
+        generation_config: GenerationConfig,
+        input_ids_seq_length: int,
+        encoder_input_ids: torch.LongTensor,
+        prefix_allowed_tokens_fn: Callable[[int, torch.Tensor], List[int]],
+        logits_processor: Optional[LogitsProcessorList],
+        device: Optional[str] = None,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+        negative_prompt_ids: Optional[torch.Tensor] = None,
+        negative_prompt_attention_mask: Optional[torch.Tensor] = None,
+    ) -> LogitsProcessorList:
+        forced_decoder_ids = generation_config.forced_decoder_ids
+        # Whisper uses forced_decoder_ids for default task and language specification, while original _get_logits_processor does not allow it
+        # see for details https://github.com/huggingface/transformers/issues/37172
+        if is_transformers_version(">=", "4.50.0"):
+            generation_config.forced_decoder_ids = None
+        logits_processor = super()._get_logits_processor(
+            generation_config,
+            input_ids_seq_length,
+            encoder_input_ids,
+            prefix_allowed_tokens_fn,
+            logits_processor,
+            device,
+            model_kwargs,
+            negative_prompt_ids,
+            negative_prompt_attention_mask,
+        )
+        generation_config.forced_decoder_ids = forced_decoder_ids
+        return logits_processor

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -1340,6 +1340,13 @@ class _OVModelForWhisper(OVModelForSpeechSeq2Seq, WhisperForConditionalGeneratio
     # force the use of the WhisperForConditionalGeneration generate and prepare_inputs_for_generation methods
     generate = WhisperForConditionalGeneration.generate
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Restore multilingual model transcribe task by default after model export
+        if is_transformers_version(">=", "4.50"):
+            if self.generation_config.is_multilingual and self.generation_config.forced_decoder_ids is None:
+                self.config.forced_decoder_ids = [[1, None], [2, self.generation_config.task_to_id["transcribe"]]]
+
     @classmethod
     def _from_pretrained(
         cls,

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -2837,6 +2837,10 @@ class OVModelForSpeechSeq2SeqIntegrationTest(unittest.TestCase):
             # Compare tensor outputs
             self.assertTrue(torch.allclose(torch.Tensor(ov_outputs.logits), transformers_outputs.logits, atol=1e-3))
 
+        generate_kwrgs = {}
+        if is_transformers_version(">=", "4.50"):
+            generate_kwrgs = {"use_model_defaults": False}
+
         gen_config = GenerationConfig(
             max_new_tokens=10,
             min_new_tokens=10,
@@ -2846,9 +2850,9 @@ class OVModelForSpeechSeq2SeqIntegrationTest(unittest.TestCase):
         )
 
         set_seed(SEED)
-        generated_tokens = transformers_model.generate(**pt_features, generation_config=gen_config)
+        generated_tokens = transformers_model.generate(**pt_features, generation_config=gen_config, **generate_kwrgs)
         set_seed(SEED)
-        ov_generated_tokens = ov_model.generate(**pt_features, generation_config=gen_config)
+        ov_generated_tokens = ov_model.generate(**pt_features, generation_config=gen_config, **generate_kwrgs)
 
         self.assertTrue(torch.equal(generated_tokens, ov_generated_tokens))
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -177,7 +177,7 @@ MODEL_NAMES = {
     "wav2vec2": "anton-l/wav2vec2-random-tiny-classifier",
     "wav2vec2-hf": "hf-internal-testing/tiny-random-Wav2Vec2Model",
     "wav2vec2-conformer": "hf-internal-testing/tiny-random-wav2vec2-conformer",
-    "whisper": "optimum-internal-testing/tiny-random-whisper",
+    "whisper": "katuni4ka/tiny-random-whisper",
     "xlm": "hf-internal-testing/tiny-random-xlm",
     "xlm_roberta": "hf-internal-testing/tiny-xlm-roberta",
     "xglm": "hf-internal-testing/tiny-random-XGLMForCausalLM",


### PR DESCRIPTION
# What does this PR do?

after providing previous workaround for whisper, model starts to behave differently in preference for selection task by default.
Original transformers models have 2 places for forcing decoder ids: [generation_config](https://huggingface.co/openai/whisper-tiny/blob/main/generation_config.json#L35) and [config](https://huggingface.co/openai/whisper-tiny/blob/main/config.json#L26)

as it can see in whisper-tiny, they may be inaligned and as the result in case, when we use from_pretrained, it loads config without provided update and forces decoder ids from it.

For alignment in behavior with transformers, suggested to force decoder ids in config and keep it aligned with transcribe task as described in https://github.com/huggingface/transformers/pull/28687


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

