### PR TITLE
add activation scale factor for qwen2.5vl embeddings merger

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -3548,6 +3548,17 @@ class Qwen2_5_VLOpenVINOConfig(Qwen2VLOpenVINOConfig):
             return Qwen2_5_VLVisionEmbMergerPatcher(self, model, model_kwargs)
         return super().patch_model_for_export(model, model_kwargs)
 
+    @property
+    def runtime_options(self):
+        rt_options = getattr(self, "_rt_options", {})
+        if self._behavior == Qwen2VLConfigBehavior.VISION_EMBEDDINGS_MERGER:
+            rt_options.update({"ACTIVATIONS_SCALE_FACTOR": "8.0"})
+        return rt_options
+
+    @runtime_options.setter
+    def _set_runtime_options(self, options):
+        self._rt_options = options
+
 
 @register_in_tasks_manager(
     "glm",


### PR DESCRIPTION
# What does this PR do?

this patch adds activation scale factor hint into qwen2.5vl embeddings merger IR. This hint helps to prevent fp16 inference overflow during inference on GPU device 


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

