### PR TITLE
[OV] Fix VLM calibration dataset collection

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -705,13 +705,7 @@ class OVCalibrationDatasetBuilder:
                     raise tokenizer_error
                 raise value_error
 
-            input_ids = inputs.get("input_ids")
-            position_ids = torch.arange(input_ids.size(1)).unsqueeze(0).to(input_ids.device)
-
-            inputs_embeds, attention_mask, position_ids = self.model.get_multimodal_embeddings(
-                **inputs,
-                position_ids=position_ids,
-            )
+            inputs_embeds, attention_mask, position_ids = self.model.get_multimodal_embeddings(**inputs)
 
             language_model_inputs = self.model.language_model.prepare_inputs(
                 input_ids=None,

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -638,6 +638,18 @@ class OVCLIExportTestCase(unittest.TestCase):
                         "audio_speech_projection_model": {"int8": 2},
                     },
                 ),
+                (
+                    "image-text-to-text",
+                    "qwen2_5_vl",
+                    'int4 --group-size 16 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
+                    "--dataset contextual --num-samples 1 --trust-remote-code",
+                    {
+                        "lm_model": {"int8": 14, "int4": 16},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 1},
+                        "vision_embeddings_merger_model": {"int8": 12},
+                    },
+                ),
             ]
         )
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -998,6 +998,25 @@ class OVWeightCompressionTest(unittest.TestCase):
                         "audio_speech_projection_model": {"int8": 2},
                     },
                 ),
+                (
+                    OVModelForVisualCausalLM,
+                    "qwen2_5_vl",
+                    False,
+                    dict(
+                        bits=4,
+                        group_size=16,
+                        dataset="contextual",
+                        ratio=0.8,
+                        sensitivity_metric="mean_activation_magnitude",
+                        num_samples=1,
+                    ),
+                    {
+                        "lm_model": {"int8": 14, "int4": 16},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 1},
+                        "vision_embeddings_merger_model": {"int8": 12},
+                    },
+                ),
             ]
         )
 


### PR DESCRIPTION
# What does this PR do?

Fix VLM calibration dataset collection: delegate `position_ids` creation to VLM input processing logic. This also fixes Qwen-2.5-VL quantization.


Fixes https://github.com/huggingface/optimum-intel/issues/1291


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

