### PR TITLE
[OV] Resize large images during VLM calibration data collection

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -695,6 +695,11 @@ class OVCalibrationDatasetBuilder:
             instruction = item[dataset_metadata["inputs"]["instruction"]]
             image_url = item[dataset_metadata["inputs"]["image_url"]]
             image = Image.open(requests.get(image_url, stream=True).raw).convert("RGB")
+            # To avoid large images, resize them keeping the aspect ratio
+            scale_factor = max(image.size[0] / 600, image.size[1] / 600)
+            if scale_factor > 1:
+                new_size = (int(image.size[0] / scale_factor), int(image.size[1] / scale_factor))
+                image = image.resize(new_size)
 
             try:
                 inputs = self.model.preprocess_inputs(


### PR DESCRIPTION
# What does this PR do?

Resize large images during VLM calibration data collection to save time. This should not affect final model quality since the collected dataset currently is used for data-aware quantization of only language model.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

