### PR TITLE
Resolve logger warnings

### DIFF
--- a/examples/neural_compressor/question-answering/trainer_qa.py
+++ b/examples/neural_compressor/question-answering/trainer_qa.py
@@ -46,7 +46,7 @@ class QuestionAnsweringINCTrainer(INCTrainer):
             and getattr(self.model.config, "framework", None) in {"pytorch", "pytorch_fx"}
             and self.use_cpu_amp
         ):
-            logger.warn(
+            logger.warning(
                 f"{self.model.config.framework} quantized model doesn't support BFloat16 input, setting `use_cpu_amp` to False."
             )
             self.use_cpu_amp = False

--- a/optimum/intel/neural_compressor/trainer.py
+++ b/optimum/intel/neural_compressor/trainer.py
@@ -877,7 +877,7 @@ class INCTrainer(Trainer):
             and getattr(self.model.config, "framework", None) in {"pytorch", "pytorch_fx"}
             and self.use_cpu_amp
         ):
-            logger.warn(
+            logger.warning(
                 f"{self.model.config.framework} quantized model doesn't support BFloat16 input, setting `use_cpu_amp` to False."
             )
             self.use_cpu_amp = False

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -158,7 +158,7 @@ class OVBaseDecoderModel(OVModel):
         is_stateful_supported = ensure_stateful_is_available(warn=False)
 
         if self.use_cache and not self.stateful:
-            logger.warn(
+            logger.warning(
                 "Provided model does not contain state. It may lead to sub-optimal performance."
                 "Please reexport model with updated OpenVINO version >= 2023.3.0 calling the `from_pretrained` method with original model "
                 "and `export=True` parameter"

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -1346,7 +1346,7 @@ class OVQuantizer(OptimumQuantizer):
             if not isinstance(quantization_config, OVQuantizationConfig):
                 raise ValueError(f"Unsupported type of quantization config: {type(quantization_config)}")
             if stateful:
-                logger.warn(
+                logger.warning(
                     "Quantization algorithm does not support optimized stateful models. "
                     "The original model without optimization will be quantized and exported."
                 )


### PR DESCRIPTION
# What does this PR do?
This small PR resolves the annoying deprecation warnings of the `logger` library:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

