### PR TITLE
[OV] Update AWQ test to pass on NNCF develop

### DIFF
--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -390,6 +390,15 @@ def is_openvino_version(operation: str, version: str):
     return compare_versions(parse(_openvino_version), operation, version)
 
 
+def is_nncf_version(operation: str, version: str):
+    """
+    Compare the current NNCF version to a given reference with an operation.
+    """
+    if not _nncf_available:
+        return False
+    return compare_versions(parse(_nncf_version), operation, version)
+
+
 def is_openvino_tokenizers_version(operation: str, version: str):
     if not is_openvino_available():
         return False

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -60,6 +60,7 @@ from optimum.intel.openvino.configuration import _DEFAULT_4BIT_WQ_CONFIGS, _DEFA
 from optimum.intel.openvino.utils import _HEAD_TO_AUTOMODELS, TemporaryDirectory
 from optimum.intel.utils.import_utils import (
     compare_versions,
+    is_nncf_version,
     is_openvino_tokenizers_available,
     is_openvino_version,
     is_tokenizers_version,
@@ -932,7 +933,9 @@ class OVCLIExportTestCase(unittest.TestCase):
 
             check_compression_state_per_model(self, model.ov_submodels, expected_num_weight_nodes_per_model)
 
-            self.assertTrue("--awq" not in option or b"Applying AWQ" in result.stdout)
+            # Starting from NNCF 2.17 there is a support for data-free AWQ
+            awq_str = b"Applying data-aware AWQ" if is_nncf_version(">", "2.16") else b"Applying AWQ"
+            self.assertTrue("--awq" not in option or awq_str in result.stdout)
             self.assertTrue("--scale-estimation" not in option or b"Applying Scale Estimation" in result.stdout)
             self.assertTrue("--gptq" not in option or b"Applying GPTQ" in result.stdout)
             self.assertTrue(


### PR DESCRIPTION
# What does this PR do?

Starting from NNCF 2.17 there is a support for data-free AWQ besides data-aware AWQ, hence the log message has changed.

Will introduce a data-free AWQ test after the NNCF 2.17 release.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

