### PR TITLE
Add --revision to `optimum-cli export openvino`

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -383,7 +383,9 @@ def main_export(
 
     try:
         if library_name == "open_clip":
-            model = _OpenClipForZeroShotImageClassification.from_pretrained(model_name_or_path, cache_dir=cache_dir)
+            model = _OpenClipForZeroShotImageClassification.from_pretrained(
+                model_name_or_path, cache_dir=cache_dir, revision=revision
+            )
         else:
             model = TasksManager.get_model_from_task(
                 task,
@@ -407,7 +409,7 @@ def main_export(
             if pad_token_id is not None:
                 model.config.pad_token_id = pad_token_id
             else:
-                tok = AutoTokenizer.from_pretrained(model_name_or_path)
+                tok = AutoTokenizer.from_pretrained(model_name_or_path, revision=revision)
                 pad_token_id = getattr(tok, "pad_token_id", None)
                 if pad_token_id is None:
                     raise ValueError(

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -201,9 +201,11 @@ class OVCLIExportTestCase(unittest.TestCase):
             "whisper",
             "int8",
             "--dataset librispeech --num-samples 1 --smooth-quant-alpha 0.9 --trust-remote-code",
-            {"encoder": 10, "decoder": 12, "decoder_with_past": 11}
-            if is_transformers_version("<=", "4.36.0")
-            else {"encoder": 8, "decoder": 12, "decoder_with_past": 25},
+            (
+                {"encoder": 10, "decoder": 12, "decoder_with_past": 11}
+                if is_transformers_version("<=", "4.36.0")
+                else {"encoder": 8, "decoder": 12, "decoder_with_past": 25}
+            ),
             (
                 {"encoder": {"int8": 8}, "decoder": {"int8": 11}, "decoder_with_past": {"int8": 9}}
                 if is_transformers_version("<=", "4.36.0")
@@ -215,9 +217,11 @@ class OVCLIExportTestCase(unittest.TestCase):
             "whisper",
             "f8e4m3",
             "--dataset librispeech --num-samples 1 --smooth-quant-alpha 0.9 --trust-remote-code",
-            {"encoder": 10, "decoder": 12, "decoder_with_past": 11}
-            if is_transformers_version("<=", "4.36.0")
-            else {"encoder": 8, "decoder": 12, "decoder_with_past": 25},
+            (
+                {"encoder": 10, "decoder": 12, "decoder_with_past": 11}
+                if is_transformers_version("<=", "4.36.0")
+                else {"encoder": 8, "decoder": 12, "decoder_with_past": 25}
+            ),
             (
                 {"encoder": {"f8e4m3": 8}, "decoder": {"f8e4m3": 11}, "decoder_with_past": {"f8e4m3": 9}}
                 if is_transformers_version("<=", "4.36.0")
@@ -1142,3 +1146,24 @@ class OVCLIExportTestCase(unittest.TestCase):
             model = eval(_HEAD_TO_AUTOMODELS["stable-diffusion"]).from_pretrained(tmpdir, compile=False)
             for component in ["text_encoder", "tokenizer", "unet", "vae_encoder", "vae_decoder"]:
                 self.assertIsNotNone(getattr(model, component))
+
+    def test_export_openvino_with_revision(self):
+        with TemporaryDirectory() as tmpdir:
+            subprocess.run(
+                f"optimum-cli export openvino --model hf-internal-testing/tiny-random-MistralForCausalLM --revision 7158fab {tmpdir}",
+                shell=True,
+                check=True,
+            )
+            eval(_HEAD_TO_AUTOMODELS["text-generation"]).from_pretrained(tmpdir, compile=False)
+
+        with TemporaryDirectory() as tmpdir:
+            result = subprocess.run(
+                f"optimum-cli export openvino --model hf-internal-testing/tiny-random-MistralForCausalLM --revision 7158fac {tmpdir}",
+                shell=True,
+                check=False,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("not a valid git identifier", result.stderr)


### PR DESCRIPTION
Add `--revision` option to `optimum-cli export openvino`.

**TODO**:
-  this PR does not include loading preprocessors from a revision, because for that `maybe_load_preprocessors` from `optimum` is used, which does not support a revision argument. @echarlaix / @IlyasMoutawwakil would appreciate your input on how to handle this.
- add to documentation

I wanted to add a better test but did not see a way to check the revision of the model after it has been converted. If there is a tiny model where a new revision for example only makes a non-breaking change to the model config I could use that and check for the expected config in the test. I could also duplicate an existing tiny model to do that.

Unrelated changes are from formatting with `black`.