### PR TITLE
[OV] Add int8 PTQ configs for some fill-mask models.

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -353,6 +353,17 @@ _DEFAULT_4BIT_WQ_CONFIG = {
 
 # Default configs for int8 full quantization
 _DEFAULT_INT8_FQ_CONFIGS = {
+    "FacebookAI/roberta-large": {
+        "dtype": "int8",
+        "dataset": "wikitext2",
+        "num_samples": 300,
+        "smooth_quant_alpha": 0.5,
+    },
+    "google-bert/bert-base-multilingual-uncased": {
+        "dtype": "int8",
+        "dataset": "wikitext2",
+        "num_samples": 300,
+    },
     "openai/clip-vit-base-patch16": {
         "dtype": "int8",
         "dataset": "conceptual_captions",


### PR DESCRIPTION
# What does this PR do?

Add int8 ptq configs for `FacebookAI/roberta-large` and `google-bert/bert-base-multilingual-uncased`. More info at ticket 165770.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

