### PR TITLE
allow skip trace check for sentence stransformers

### DIFF
--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -381,7 +381,7 @@ if is_transformers_version("<", "4.41"):
 def allow_skip_tracing_check(library_name, model_type):
     if is_openvino_version("<", "2025.0.0"):
         return False
-    if library_name == "diffusers":
+    if library_name in ["diffusers", "sentence_transformers"]:
         return True
     return model_type in SKIP_CHECK_TRACE_MODELS
 


### PR DESCRIPTION
# What does this PR do?
some sentence_transformers only supported models become broken after removing onnx export fallback


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

