### PR TITLE
Remove reshaping for stateful decoders

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -102,7 +102,7 @@ class OVBaseModel(OptimizedModel):
                 raise ValueError("`compile_only` expect that already compiled model will be provided")
 
             model_dynamic_shapes = model_has_dynamic_inputs(model)
-            if dynamic_shapes ^ model_dynamic_shapes:
+            if dynamic_shapes is not None and dynamic_shapes ^ model_dynamic_shapes:
                 raise ValueError(
                     f"Provided compiled model with {'dynamic' if model_dynamic_shapes else 'static'} shapes but requested to use {'dynamic' if dynamic_shapes else 'static'}. Please set `compile_only=False` or `dynamic_shapes`={model_dynamic_shapes}"
                 )

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -75,7 +75,7 @@ class OVBaseModel(OptimizedModel):
         model: openvino.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = None,
+        dynamic_shapes: bool = True,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Optional[Union[OVWeightQuantizationConfig, Dict]] = None,

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -75,7 +75,7 @@ class OVBaseModel(OptimizedModel):
         model: openvino.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Optional[Union[OVWeightQuantizationConfig, Dict]] = None,
@@ -85,7 +85,7 @@ class OVBaseModel(OptimizedModel):
         self.name_or_path = getattr(config, "name_or_path", None)
         self.model_save_dir = model_save_dir
         self._device = device.upper()
-        self.is_dynamic = dynamic_shapes
+        self.is_dynamic = dynamic_shapes if dynamic_shapes is not None else True
         self.ov_config = {} if ov_config is None else {**ov_config}
         self.preprocessors = kwargs.get("preprocessors", [])
         self._compile_only = kwargs.get("compile_only", False)
@@ -102,7 +102,7 @@ class OVBaseModel(OptimizedModel):
                 raise ValueError("`compile_only` expect that already compiled model will be provided")
 
             model_dynamic_shapes = model_has_dynamic_inputs(model)
-            if dynamic_shapes is not None and dynamic_shapes ^ model_dynamic_shapes:
+            if self.is_dynamic ^ model_dynamic_shapes:
                 raise ValueError(
                     f"Provided compiled model with {'dynamic' if model_dynamic_shapes else 'static'} shapes but requested to use {'dynamic' if dynamic_shapes else 'static'}. Please set `compile_only=False` or `dynamic_shapes`={model_dynamic_shapes}"
                 )

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -748,7 +748,7 @@ class OVBaseModel(OptimizedModel):
                 "`reshape()` is not supported with `compile_only` mode, please initialize model without this option"
             )
 
-        self.is_dynamic = True if batch_size == -1 and sequence_length == -1 else False
+        self.is_dynamic = batch_size == -1 and sequence_length == -1
         self.model = self._reshape(self.model, batch_size, sequence_length, height, width)
         self.request = None
         return self

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -125,6 +125,7 @@ class OVBaseDecoderModel(OVModel):
                 "`compile_only` mode does not support disabling compilation."
                 "Please provide `compile=True` if you want to use `compile_only=True` or set `compile_only=False`"
             )
+
         config.is_encoder_decoder = False
         super().__init__(
             model,
@@ -153,8 +154,6 @@ class OVBaseDecoderModel(OVModel):
         self._first_iter_beam_search = False
         self._second_iter_beam_search = False
         self.update_pkv_precision()
-        if self.is_dynamic and not self._compile_only:
-            self.model = self._reshape(self.model, -1, -1)
         is_stateful_supported = ensure_stateful_is_available(warn=False)
 
         if self.use_cache and not self.stateful:
@@ -210,7 +209,6 @@ class OVBaseDecoderModel(OVModel):
     def update_pkv_precision(self, force_fp32=False):
         if not self.use_cache or self.stateful or self._compile_only:
             return
-
         pkv_precision = Type.f32
         if not force_fp32:
             device = self._device.upper()
@@ -233,8 +231,6 @@ class OVBaseDecoderModel(OVModel):
             if hasattr(self, "_pkv_precision") and self._pkv_precision != Type.f32:
                 self.model = self._get_model_with_updated_pkv_precision(self.model, Type.f32)
                 self._pkv_precision = Type.f32
-                if self.is_dynamic:
-                    self.model = self._reshape(self.model, -1, -1)
                 self.request = None
 
     def _save_pretrained(self, save_directory: Union[str, Path]):

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -363,7 +363,6 @@ class OVBaseDecoderModel(OVModel):
             **kwargs,
         )
 
-
     def _reshape(
         self,
         model: openvino.Model,
@@ -401,7 +400,6 @@ class OVBaseDecoderModel(OVModel):
                 shapes[inputs][1] = -1
         model.reshape(shapes)
         return model
-    
 
     def reshape(self, batch_size: int, sequence_length: int):
         logger.warning("Static shapes are not supported for causal language model.")

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -106,14 +106,16 @@ class OVBaseDecoderModel(OVModel):
         model: openvino.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Optional[Union[OVWeightQuantizationConfig, Dict]] = None,
         **kwargs,
     ):
-        dynamic_shapes = kwargs.pop("dynamic_shapes", None)
         if dynamic_shapes is not None:
-            logger.warning(f"`dynamic_shapes` was set to {dynamic_shapes}, but this value will be ignored as only dynamic shapes are supported.")
+            logger.warning(
+                f"`dynamic_shapes` was set to {dynamic_shapes}, but this value will be ignored as only dynamic shapes are supported."
+            )
 
         compile_only = kwargs.get("compile_only", False)
         enable_compilation = kwargs.get("compile", True)
@@ -353,7 +355,7 @@ class OVBaseDecoderModel(OVModel):
             **kwargs,
         )
 
-    def reshape(self, batch_size: int, sequence_length: int):
+    def reshape(self, *args, **kwargs):
         logger.warning("Static shapes are not supported for causal language model.")
         return self
 

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -749,7 +749,7 @@ class OVModelForSeq2SeqLM(OVBaseModel, GenerationMixin):
             )
 
         logger.warning("Some part of the model's decoder do not support static shapes and will be kept dynamic.")
-        self.is_dynamic = True if batch_size == -1 and sequence_length == -1 else False
+        self.is_dynamic = batch_size == -1 and sequence_length == -1
         self.encoder.model = self._reshape(self.encoder.model, batch_size, sequence_length, is_decoder=False)
         self.decoder.model = self._reshape(self.decoder.model, batch_size, sequence_length)
         if self.decoder_with_past is not None:

--- a/optimum/intel/openvino/modeling_text2speech.py
+++ b/optimum/intel/openvino/modeling_text2speech.py
@@ -170,6 +170,10 @@ class OVModelForTextToSpeechSeq2Seq(OVModelForSeq2SeqLM):
 
             return super()._from_pretrained(model_id, config, **kwargs)
 
+    def reshape(self, *args, **kwargs):
+        logger.warning("Static shapes are not supported for this model.")
+        return self
+
 
 class _OVModelForSpeechT5ForTextToSpeech(OVModelForTextToSpeechSeq2Seq):
     """
@@ -192,17 +196,22 @@ class _OVModelForSpeechT5ForTextToSpeech(OVModelForTextToSpeechSeq2Seq):
         vocoder: openvino.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
+        if dynamic_shapes is not None:
+            logger.warning(
+                f"`dynamic_shapes` was set to {dynamic_shapes}, but this value will be ignored as only dynamic shapes are supported."
+            )
+
         self.config = config
         self.use_cache = model_has_state(decoder)
         self._model_save_dir = model_save_dir
         self._device = device.upper()
-        self.is_dynamic = dynamic_shapes
+        self.is_dynamic = True
         self.ov_config = {} if ov_config is None else {**ov_config}
         self.preprocessors = kwargs.get("preprocessors", [])
 
@@ -305,7 +314,7 @@ class _OVModelForSpeechT5ForTextToSpeech(OVModelForTextToSpeechSeq2Seq):
         **kwargs,
     ):
         device = kwargs.pop("device", "CPU")
-        dynamic_shapes = kwargs.pop("dynamic_shapes", True)
+        dynamic_shapes = kwargs.pop("dynamic_shapes", None)
         ov_config = kwargs.pop("ov_config", None)
         generation_config = kwargs.pop("generation_config", None)
         preprocessors = kwargs.pop("preprocessors", [])

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -84,7 +84,7 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
         text_embeds_model: ov.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Optional[Union[OVWeightQuantizationConfig, Dict]] = None,
@@ -100,7 +100,14 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
             self.request = self.model.create_infer_request()
 
         super().__init__(
-            model, config, device, dynamic_shapes, ov_config, model_save_dir, quantization_config, **kwargs
+            model=model,
+            config=config,
+            device=device,
+            dynamic_shapes=dynamic_shapes,
+            ov_config=ov_config,
+            model_save_dir=model_save_dir,
+            quantization_config=quantization_config,
+            **kwargs,
         )
 
     def compile(self):
@@ -349,17 +356,22 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
         vision_embeddings: ov.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
+        if dynamic_shapes is not None:
+            logger.warning(
+                f"`dynamic_shapes` was set to {dynamic_shapes}, but this value will be ignored as only dynamic shapes are supported."
+            )
+
+        self.is_dynamic = True
         self.config = config
         self.use_cache = kwargs.get("use_cache", True)
         self._model_save_dir = model_save_dir
         self._device = device.upper()
-        self.is_dynamic = dynamic_shapes
         self.ov_config = {} if ov_config is None else {**ov_config}
         self.preprocessors = kwargs.get("preprocessors", [])
         self.lm_model = language_model
@@ -929,7 +941,7 @@ class _OVLlavaForCausalLM(OVModelForVisualCausalLM):
         vision_embeddings: ov.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
@@ -1871,24 +1883,25 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
         vision_embeddings: ov.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
         super().__init__(
-            language_model,
-            text_embeddings,
-            vision_embeddings,
-            config,
-            device,
-            dynamic_shapes,
-            ov_config,
-            model_save_dir,
-            quantization_config,
+            language_model=language_model,
+            text_embeddings=text_embeddings,
+            vision_embeddings=vision_embeddings,
+            config=config,
+            device=device,
+            dynamic_shapes=dynamic_shapes,
+            ov_config=ov_config,
+            model_save_dir=model_save_dir,
+            quantization_config=quantization_config,
             **kwargs,
         )
+
         self.embed_dim = self.language_model.config.hidden_size
         max_size = self.config.vision_config.image_size // self.config.vision_config.patch_size
         self._pos_embeds = torch.from_numpy(self._get_2d_sincos_pos_embed(self.embed_dim, max_size)).float()
@@ -2327,24 +2340,25 @@ class _OVPhi3VisionForCausalLM(OVModelForVisualCausalLM):
         vision_embeddings: ov.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
         super().__init__(
-            language_model,
-            text_embeddings,
-            vision_embeddings,
-            config,
-            device,
-            dynamic_shapes,
-            ov_config,
-            model_save_dir,
-            quantization_config,
+            language_model=language_model,
+            text_embeddings=text_embeddings,
+            vision_embeddings=vision_embeddings,
+            config=config,
+            device=device,
+            dynamic_shapes=dynamic_shapes,
+            ov_config=ov_config,
+            model_save_dir=model_save_dir,
+            quantization_config=quantization_config,
             **kwargs,
         )
+
         self.sub_GN = torch.tensor(self.config.sub_GN)
         self.glb_GN = torch.tensor(self.config.glb_GN)
         self.image_dim_out = self.config.img_processor["image_dim_out"]
@@ -2496,7 +2510,7 @@ class _OVQwen2VLForCausalLM(OVModelForVisualCausalLM):
         vision_embeddings: ov.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
@@ -2775,7 +2789,7 @@ class _OVQwen2_5_VLForCausalLM(OVModelForVisualCausalLM):
         vision_embeddings: ov.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
@@ -3534,24 +3548,25 @@ class _OVPhi4MMForCausalLM(OVModelForVisualCausalLM):
         vision_embeddings: ov.Model,
         config: PretrainedConfig = None,
         device: str = "CPU",
-        dynamic_shapes: bool = True,
+        dynamic_shapes: bool = None,
         ov_config: Optional[Dict[str, str]] = None,
         model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
         super().__init__(
-            language_model,
-            text_embeddings,
-            vision_embeddings,
-            config,
-            device,
-            dynamic_shapes,
-            ov_config,
-            model_save_dir,
-            quantization_config,
+            language_model=language_model,
+            text_embeddings=text_embeddings,
+            vision_embeddings=vision_embeddings,
+            config=config,
+            device=device,
+            dynamic_shapes=dynamic_shapes,
+            ov_config=ov_config,
+            model_save_dir=model_save_dir,
+            quantization_config=quantization_config,
             **kwargs,
         )
+
         self.sub_GN = torch.tensor(self.config.sub_GN)
         self.glb_GN = torch.tensor(self.config.glb_GN)
         self.audio_config = (


### PR DESCRIPTION
Disable dynamic reshaping for decoder only models who already have dynamic shapes, default dynamic reshaping is still mandatory for non-stateful models to ensure compatibility with previously exported decoder only models (decoder_with_past used to be exported with inputs_ids fixed batch_size of 1)


For stateful model, the resulting graph was different than the one obtained with the CLI (resulting from the dynamic reshaping that shoudn't be applied in the first place for these models) cc @helena-intel who found a difference between the two graph
