### PR TITLE
fix int value recompile

### DIFF
--- a/optimum/intel/ipex/modeling_base.py
+++ b/optimum/intel/ipex/modeling_base.py
@@ -243,8 +243,13 @@ class IPEXModel(OptimizedModel):
         from torch._inductor import config as inductor_config
 
         # System level optimization
-        # Patched model can disable cpp wrapper to get better performance.
-        inductor_config.cpp_wrapper = False if self._add_patch and self.export_feature == "text-generation" else True
+        inductor_config.cpp_wrapper = True
+        if self._add_patch and self.export_feature == "text-generation":
+            # To avoid int value recompile.
+            torch._dynamo.config.allow_unspec_int_on_nn_module = True
+            # Patched model can disable cpp wrapper to get better performance.
+            inductor_config.cpp_wrapper = False
+
         os.environ["TORCHINDUCTOR_FREEZING"] = "1"
         logger.info("Enable torch.compile optimization")
         self.model.forward = torch.compile(self.model.forward)


### PR DESCRIPTION
The patched model need to pass int value, we need to set `torch._dynamo.config.allow_unspec_int_on_nn_module = True` to avoid recompile.