### PR TITLE
Updated Qwen3-8b compression config

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -142,7 +142,6 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "group_size": 128,
         "ratio": 1.0,
         "dataset": "wikitext2",
-        "quant_method": OVQuantizationMethod.AWQ,
         "scale_estimation": True,
     },
     "openlm-research/open_llama_3b": {"bits": 4, "sym": False, "group_size": 64, "all_layers": True},


### PR DESCRIPTION
# What does this PR do?

For this particular model AWQ leads to high values of weights which result in fp16 overflow in Intel GPU. While there is an ongoing analysis how to fix that, it was decided to remove the AWQ option for this model. 

Fixes # (issue)

168637
