### PR TITLE
Fix Typo in Error Message for Sequence Length Validation

### DIFF
--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -3769,7 +3769,7 @@ class _OVPhi4MMForCausalLM(OVModelForVisualCausalLM):
         seq_len = int(self.compute_lens_change(xs_pad.shape[1]))
         if seq_len <= 0:
             raise ValueError(
-                f"""The squence length after time reduction is invalid: {seq_len}.
+                f"""The sequence length after time reduction is invalid: {seq_len}.
                 Your input feature is too short. Consider filtering out the very
                 short sentence from data loader""",
             )


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the error message raised when the sequence length after time reduction is invalid in the `forward_embeddings` method of `modeling_visual_language.py`. The word "sequence" is now consistently highlighted in the error message. No functional changes were made to the code.