### PR TITLE
Compression config for Qwen/Qwen2.5-Coder-3B-Instruct

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -118,6 +118,14 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "quant_method": OVQuantizationMethod.AWQ,
         "scale_estimation": True,
     },
+    "Qwen/Qwen2.5-Coder-3B-Instruct": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "ratio": 1.0,
+        "dataset": "wikitext2",
+        "scale_estimation": True,
+    },
     "Qwen/Qwen3-1.7B": {
         "bits": 4,
         "sym": True,


### PR DESCRIPTION
# What does this PR do?

Improves the similarity of the compressed int4 model from 0.405464 to 0.903016 (0.897232 with GenAI) on CPU.

Fixes #169307
