### PR TITLE
Convert dataclasses to dicts in quantization config before saving

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -12,6 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 import copy
+import dataclasses
 import inspect
 import json
 import logging
@@ -530,7 +531,20 @@ class OVQuantizationConfigBase(QuantizationConfigMixin):
         # Unpack kwargs dict
         result = super().to_dict()
         result = result | result.pop("kwargs", {})
+        self._dataclasses_to_dict(result)
         return result
+
+    @staticmethod
+    def _dataclasses_to_dict(d: dict):
+        """
+        Search for dataclasses in the dict and convert them to dicts.
+        """
+        for k in d:
+            v = d[k]
+            if isinstance(v, dict):
+                OVQuantizationConfigBase._dataclasses_to_dict(v)
+            elif dataclasses.is_dataclass(v):
+                d[k] = dataclasses.asdict(v)
 
 
 @dataclass

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -333,12 +333,10 @@ class OVBaseModel(OptimizedModel):
 
     def _save_openvino_config(self, save_directory: Union[str, Path]):
         if self._openvino_config is not None:
-            quantization_config = self._openvino_config.quantization_config
-            if not isinstance(quantization_config.dataset, (str, type(None))):
-                quantization_config.dataset = None
-            ov_config = copy.deepcopy(self._openvino_config)
-            ov_config.quantization_config = self._openvino_config.quantization_config.to_dict()
-            ov_config.save_pretrained(save_directory)
+            if not isinstance(self._openvino_config.quantization_config.dataset, (str, type(None))):
+                self._openvino_config.quantization_config.dataset = None
+
+            self._openvino_config.save_pretrained(save_directory)
 
     @classmethod
     def _from_pretrained(

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -333,10 +333,12 @@ class OVBaseModel(OptimizedModel):
 
     def _save_openvino_config(self, save_directory: Union[str, Path]):
         if self._openvino_config is not None:
-            if not isinstance(self._openvino_config.quantization_config.dataset, (str, type(None))):
-                self._openvino_config.quantization_config.dataset = None
-
-            self._openvino_config.save_pretrained(save_directory)
+            quantization_config = self._openvino_config.quantization_config
+            if not isinstance(quantization_config.dataset, (str, type(None))):
+                quantization_config.dataset = None
+            ov_config = copy.deepcopy(self._openvino_config)
+            ov_config.quantization_config = self._openvino_config.quantization_config.to_dict()
+            ov_config.save_pretrained(save_directory)
 
     @classmethod
     def _from_pretrained(

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1859,6 +1859,11 @@ class OVQuantizationConfigTest(unittest.TestCase):
                 }
             ),
         ),
+        (
+            OVQuantizationConfig(
+                advanced_parameters=nncf.AdvancedCompressionParameters(),
+            ),
+        ),
     )
 
     QUANTIZATION_CONFIG_DICTS = (


### PR DESCRIPTION
# What does this PR do?

The changes cover the following use case:
```python
OVModelForCausalLM.from_pretrained(
    model_id,
    quantization_config={
        "bits": 4,
        "advanced_parameters": nncf.AdvancedCompressionParameters(), # some advanced params
    },
).save_pretrained(save_dir)
```

Here, `nncf.AdvancedCompressionParameters()` is a dataclass and it needs to be converted to dict in order for the model to be saved properly.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

