### PR TITLE
Fix attr name typo in model_configs for llava-next compatibility with transformers 4.51.3

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1905,7 +1905,7 @@ class LlavaNextVideoOpenVINOConfig(LlavaOpenVINOConfig):
         if behavior == LlavaNextVideoConfigBehavior.MULTI_MODAL_PROJECTOR:
             return (
                 model.multi_modal_projector
-                if hasattr(model, "multi_model_projector")
+                if hasattr(model, "multi_modal_projector")
                 else model.model.multi_modal_projector
             )
 


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)
This PR fixes a typo in optimum-intel code, replacing "mod**e**l" with "mod**a**l" for "multi_modal_projector" attr name here: https://github.com/huggingface/optimum-intel/blob/8f127ce3a2c17fca929ab2d38843dbfd16b1d4c0/optimum/exporters/openvino/model_configs.py#L1905-L1910
Without the fix: The following error is raised for transformers==4.51.3 
```"AttributeError: 'LlavaNextVideoForConditionalGeneration' object has no attribute 'model'"```

The issue has been introduced with a PR #1319 to optimum-intel with changes for compatibility with transformers 4.52
(working correctly).

## Before submitting
- [X] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests? 
   - **Please guide me if there is any appropriate test to be added for this issue**

