### PR TITLE
Add support for cb4_f8e4m3 quantization mode.

### DIFF
--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -31,7 +31,7 @@ Check out the help for more options:
 
 ```text
 usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt,tf}] [--trust-remote-code]
-                                   [--weight-format {fp32,fp16,int8,int4,mxfp4,nf4}]
+                                   [--weight-format {fp32,fp16,int8,int4,mxfp4,nf4,cb4_f8e4m3}]
                                    [--quant-mode {int8,f8e4m3,f8e5m2,nf4_f8e4m3,nf4_f8e5m2,int4_f8e4m3,int4_f8e5m2}]
                                    [--library {transformers,diffusers,timm,sentence_transformers,open_clip}]
                                    [--cache_dir CACHE_DIR] [--pad-token-id PAD_TOKEN_ID] [--ratio RATIO] [--sym]
@@ -67,7 +67,8 @@ Optional arguments:
                         only be set for repositories you trust and in which you have read the code, as it will execute
                         on your local machine arbitrary code present in the model repository.
   --weight-format {fp32,fp16,int8,int4,mxfp4,nf4}
-                        The weight format of the exported model.
+                        The weight format of the exported model. Option 'cb4_f8e4m3' represents a codebook with 16
+                        fixed fp8 values in E4M3 format.
   --quant-mode {int8,f8e4m3,f8e5m2,nf4_f8e4m3,nf4_f8e5m2,int4_f8e4m3,int4_f8e5m2}
                         Quantization precision mode. This is used for applying full model quantization including
                         activations.

--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -32,7 +32,7 @@ Check out the help for more options:
 ```text
 usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt,tf}] [--trust-remote-code]
                                    [--weight-format {fp32,fp16,int8,int4,mxfp4,nf4,cb4}]
-                                   [--quant-mode {int8,f8e4m3,f8e5m2,cb4_f8e4m3,int4_f8e4m3,int4_f8e5m2}]
+                                   [--quant-mode {int8,f8e4m3,f8e5m2,nf4_f8e4m3,nf4_f8e5m2,cb4_f8e4m3,int4_f8e4m3,int4_f8e5m2}]
                                    [--library {transformers,diffusers,timm,sentence_transformers,open_clip}]
                                    [--cache_dir CACHE_DIR] [--pad-token-id PAD_TOKEN_ID] [--ratio RATIO] [--sym]
                                    [--group-size GROUP_SIZE] [--backup-precision {none,int8_sym,int8_asym}]
@@ -69,7 +69,7 @@ Optional arguments:
   --weight-format {fp32,fp16,int8,int4,mxfp4,nf4,cb4}
                         The weight format of the exported model. Option 'cb4' represents a codebook with 16
                         fixed fp8 values in E4M3 format.
-  --quant-mode {int8,f8e4m3,f8e5m2,cb4_f8e4m3,int4_f8e4m3,int4_f8e5m2}
+  --quant-mode {int8,f8e4m3,f8e5m2,nf4_f8e4m3,nf4_f8e5m2,cb4_f8e4m3,int4_f8e4m3,int4_f8e5m2}
                         Quantization precision mode. This is used for applying full model quantization including
                         activations.
   --library {transformers,diffusers,timm,sentence_transformers,open_clip}

--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -31,8 +31,8 @@ Check out the help for more options:
 
 ```text
 usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt,tf}] [--trust-remote-code]
-                                   [--weight-format {fp32,fp16,int8,int4,mxfp4,nf4,cb4_f8e4m3}]
-                                   [--quant-mode {int8,f8e4m3,f8e5m2,nf4_f8e4m3,nf4_f8e5m2,int4_f8e4m3,int4_f8e5m2}]
+                                   [--weight-format {fp32,fp16,int8,int4,mxfp4,nf4,cb4}]
+                                   [--quant-mode {int8,f8e4m3,f8e5m2,cb4_f8e4m3,int4_f8e4m3,int4_f8e5m2}]
                                    [--library {transformers,diffusers,timm,sentence_transformers,open_clip}]
                                    [--cache_dir CACHE_DIR] [--pad-token-id PAD_TOKEN_ID] [--ratio RATIO] [--sym]
                                    [--group-size GROUP_SIZE] [--backup-precision {none,int8_sym,int8_asym}]
@@ -66,10 +66,10 @@ Optional arguments:
   --trust-remote-code   Allows to use custom code for the modeling hosted in the model repository. This option should
                         only be set for repositories you trust and in which you have read the code, as it will execute
                         on your local machine arbitrary code present in the model repository.
-  --weight-format {fp32,fp16,int8,int4,mxfp4,nf4}
-                        The weight format of the exported model. Option 'cb4_f8e4m3' represents a codebook with 16
+  --weight-format {fp32,fp16,int8,int4,mxfp4,nf4,cb4}
+                        The weight format of the exported model. Option 'cb4' represents a codebook with 16
                         fixed fp8 values in E4M3 format.
-  --quant-mode {int8,f8e4m3,f8e5m2,nf4_f8e4m3,nf4_f8e5m2,int4_f8e4m3,int4_f8e5m2}
+  --quant-mode {int8,f8e4m3,f8e5m2,cb4_f8e4m3,int4_f8e4m3,int4_f8e5m2}
                         Quantization precision mode. This is used for applying full model quantization including
                         activations.
   --library {transformers,diffusers,timm,sentence_transformers,open_clip}

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -86,7 +86,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--quant-mode",
         type=str,
-        choices=["int8", "f8e4m3", "f8e5m2", "cb4_f8e4m3", "int4_f8e4m3", "int4_f8e5m2"],
+        choices=["int8", "f8e4m3", "f8e5m2", "nf4_f8e4m3", "nf4_f8e5m2", "cb4_f8e4m3", "int4_f8e4m3", "int4_f8e5m2"],
         default=None,
         help=(
             "Quantization precision mode. This is used for applying full model quantization including activations. "
@@ -407,7 +407,13 @@ class OVExportCommand(BaseOptimumCLICommand):
                         raise ValueError(
                             "Dataset is required for full quantization. Please provide it with --dataset argument."
                         )
-                    if self.args.quant_mode in ["cb4_f8e4m3", "int4_f8e4m3", "int4_f8e5m2"]:
+                    if self.args.quant_mode in [
+                        "nf4_f8e4m3",
+                        "nf4_f8e5m2",
+                        "cb4_f8e4m3",
+                        "int4_f8e4m3",
+                        "int4_f8e5m2",
+                    ]:
                         if library_name == "diffusers":
                             raise NotImplementedError("Mixed precision quantization isn't supported for diffusers.")
 

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -72,9 +72,11 @@ def parse_args_openvino(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--weight-format",
         type=str,
-        choices=["fp32", "fp16", "int8", "int4", "mxfp4", "nf4"],
+        choices=["fp32", "fp16", "int8", "int4", "mxfp4", "nf4", "cb4_f8e4m3"],
         default=None,
-        help="The weight format of the exported model.",
+        help=(
+            "The weight format of the exported model. Option 'cb4_f8e4m3' represents a codebook with 16 fixed fp8 values in E4M3 format."
+        ),
     )
     optional_group.add_argument(
         "--quant-mode",

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -72,16 +72,16 @@ def parse_args_openvino(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--weight-format",
         type=str,
-        choices=["fp32", "fp16", "int8", "int4", "mxfp4", "nf4", "cb4_f8e4m3"],
+        choices=["fp32", "fp16", "int8", "int4", "mxfp4", "nf4", "cb4"],
         default=None,
         help=(
-            "The weight format of the exported model. Option 'cb4_f8e4m3' represents a codebook with 16 fixed fp8 values in E4M3 format."
+            "The weight format of the exported model. Option 'cb4' represents a codebook with 16 fixed fp8 values in E4M3 format."
         ),
     )
     optional_group.add_argument(
         "--quant-mode",
         type=str,
-        choices=["int8", "f8e4m3", "f8e5m2", "nf4_f8e4m3", "nf4_f8e5m2", "int4_f8e4m3", "int4_f8e5m2"],
+        choices=["int8", "f8e4m3", "f8e5m2", "cb4_f8e4m3", "int4_f8e4m3", "int4_f8e5m2"],
         default=None,
         help=(
             "Quantization precision mode. This is used for applying full model quantization including activations. "
@@ -394,7 +394,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                         raise ValueError(
                             "Dataset is required for full quantization. Please provide it with --dataset argument."
                         )
-                    if self.args.quant_mode in ["nf4_f8e4m3", "nf4_f8e5m2", "int4_f8e4m3", "int4_f8e5m2"]:
+                    if self.args.quant_mode in ["cb4_f8e4m3", "int4_f8e4m3", "int4_f8e5m2"]:
                         if library_name == "diffusers":
                             raise NotImplementedError("Mixed precision quantization isn't supported for diffusers.")
 

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -372,7 +372,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                 raise ImportError("Applying quantization requires nncf, please install it with `pip install nncf`")
 
             if (self.args.weight_format == "cb4" or self.args.quant_mode == "cb4_f8e4m3") and is_nncf_version(
-                "<", "2.18"
+                "<=", "2.17"
             ):
                 raise ImportError(
                     "Codebook quantization is currently supported only with NNCF develop. "

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -26,7 +26,6 @@ from ...intel.utils.import_utils import (
     DIFFUSERS_IMPORT_ERROR,
     is_diffusers_available,
     is_nncf_available,
-    is_nncf_version,
 )
 from ...intel.utils.modeling_utils import _infer_library_from_model_name_or_path
 from ...utils.save_utils import maybe_load_preprocessors
@@ -370,14 +369,6 @@ class OVExportCommand(BaseOptimumCLICommand):
         else:
             if not is_nncf_available():
                 raise ImportError("Applying quantization requires nncf, please install it with `pip install nncf`")
-
-            if (self.args.weight_format == "cb4" or self.args.quant_mode == "cb4_f8e4m3") and is_nncf_version(
-                "<=", "2.17"
-            ):
-                raise ImportError(
-                    "Codebook quantization is currently supported only with NNCF develop. "
-                    "Please run `pip install git+https://github.com/openvinotoolkit/nncf.git`."
-                )
 
             default_quantization_config = get_default_quantization_config(
                 self.args.model, self.args.weight_format, self.args.quant_mode

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -823,7 +823,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                     f"When applying weight compression with '{self.dtype}' data type, the `bits` parameter must be set to 4, but found {self.bits}"
                 )
             if self.dtype == "mxfp4":
-                if is_nncf_version("<", "2.18"):
+                if is_nncf_version("<=", "2.17"):
                     raise ImportError(
                         "Codebook quantization is currently supported only with NNCF develop. "
                         "Please run `pip install git+https://github.com/openvinotoolkit/nncf.git`."

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -629,7 +629,8 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             Indicates whether to apply a scale estimation algorithm that minimizes the L2 error between the original and
             compressed layers. Providing a dataset is required to run scale estimation.
         dtype (`str`, *optional*):
-            Data type weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4', 'nf4'].
+            Data type weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4', 'nf4', 'cb4_f8e4m3'].
+            Option 'cb4_f8e4m3' represents a codebook with 16 fixed fp8 values in E4M3 format.
         qptq (`bool`, *optional*):
             Whether to apply GPTQ algorithm. GPTQ optimizes compressed weights in a layer-wise fashion to minimize the
             difference between activations of a compressed and original layer. Dataset is required to run GPTQ.
@@ -811,11 +812,12 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
 
         if self.dtype is None:
             self.dtype = "int4" if self.bits == 4 else "int8"
-        if self.dtype not in ["int4", "int8", "mxfp4", "nf4"]:
+        if self.dtype not in ["int4", "int8", "mxfp4", "nf4", "cb4_f8e4m3"]:
             raise ValueError(
-                f"Weights quantization data type must be one of the following: ['int4', 'int8', 'mxfp4', 'nf4'], but found: {self.dtype}."
+                "Weights quantization data type must be one of the following: "
+                f"['int4', 'int8', 'mxfp4', 'nf4', 'cb4_f8e4m3'], but found: {self.dtype}."
             )
-        if self.dtype in ["mxfp4", "nf4"]:
+        if self.dtype in ["mxfp4", "nf4", "cb4_f8e4m3"]:
             if self.bits != 4:
                 raise ValueError(
                     f"When applying weight compression with '{self.dtype}' data type, the `bits` parameter must be set to 4, but found {self.bits}"

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -1215,6 +1215,18 @@ class OVMixedQuantizationConfig(OVQuantizationConfigBase):
 
         self.post_init()
 
+    def post_init(self):
+        super().post_init()
+
+        if self.weight_quantization_config.dtype == "nf4" and self.full_quantization_config.dtype in [
+            "f8e4m3",
+            "f8e5m2",
+        ]:
+            logger.warning(
+                "\n`nf4_f8e4m3` and `nf4_f8e5m2` mixed precision quantization modes are deprecated and will be "
+                "removed in optimum-intel v1.26. Please use `cb4_f8e4m3` instead.\n"
+            )
+
     @staticmethod
     def _initialize_quantization_config(
         config: Union[dict, OVWeightQuantizationConfig, OVQuantizationConfig],

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -823,6 +823,11 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                     f"When applying weight compression with '{self.dtype}' data type, the `bits` parameter must be set to 4, but found {self.bits}"
                 )
             if self.dtype == "mxfp4":
+                if is_nncf_version("<", "2.18"):
+                    raise ImportError(
+                        "Codebook quantization is currently supported only with NNCF develop. "
+                        "Please run `pip install git+https://github.com/openvinotoolkit/nncf.git`."
+                    )
                 if self.quant_method == OVQuantizationMethod.AWQ:
                     raise ValueError("The AWQ algorithm is not supported for 'mxpf4' data type")
                 if self.scale_estimation:
@@ -844,9 +849,9 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         if mode in signed_bitness.values():
             mode += "_sym" if self.sym else "_asym"
         if mode == "mxfp4":
-            mode = nncf.CompressWeightsMode.E2M1.value
+            mode = "e2m1"
         if mode == "cb4":
-            mode = nncf.CompressWeightsMode.CB4_F8E4M3.value
+            mode = "cb4_f8e4m3"
         mode = nncf.CompressWeightsMode(mode)
 
         awq = True if self.quant_method == OVQuantizationMethod.AWQ else None

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -818,16 +818,16 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 f"['int4', 'int8', 'mxfp4', 'nf4', 'cb4'], but found: {self.dtype}."
             )
         if self.dtype in ["mxfp4", "nf4", "cb4"]:
+            if self.dtype == "cb4" and is_nncf_version("<=", "2.17"):
+                raise ImportError(
+                    "Codebook quantization is currently supported only with NNCF develop. "
+                    "Please run `pip install git+https://github.com/openvinotoolkit/nncf.git`."
+                )
             if self.bits != 4:
                 raise ValueError(
                     f"When applying weight compression with '{self.dtype}' data type, the `bits` parameter must be set to 4, but found {self.bits}"
                 )
             if self.dtype == "mxfp4":
-                if is_nncf_version("<=", "2.17"):
-                    raise ImportError(
-                        "Codebook quantization is currently supported only with NNCF develop. "
-                        "Please run `pip install git+https://github.com/openvinotoolkit/nncf.git`."
-                    )
                 if self.quant_method == OVQuantizationMethod.AWQ:
                     raise ValueError("The AWQ algorithm is not supported for 'mxpf4' data type")
                 if self.scale_estimation:

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -629,8 +629,8 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             Indicates whether to apply a scale estimation algorithm that minimizes the L2 error between the original and
             compressed layers. Providing a dataset is required to run scale estimation.
         dtype (`str`, *optional*):
-            Data type weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4', 'nf4', 'cb4_f8e4m3'].
-            Option 'cb4_f8e4m3' represents a codebook with 16 fixed fp8 values in E4M3 format.
+            Data type weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4', 'nf4', 'cb4'].
+            Option 'cb4' represents a codebook with 16 fixed fp8 values in E4M3 format.
         qptq (`bool`, *optional*):
             Whether to apply GPTQ algorithm. GPTQ optimizes compressed weights in a layer-wise fashion to minimize the
             difference between activations of a compressed and original layer. Dataset is required to run GPTQ.
@@ -812,12 +812,12 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
 
         if self.dtype is None:
             self.dtype = "int4" if self.bits == 4 else "int8"
-        if self.dtype not in ["int4", "int8", "mxfp4", "nf4", "cb4_f8e4m3"]:
+        if self.dtype not in ["int4", "int8", "mxfp4", "nf4", "cb4"]:
             raise ValueError(
                 "Weights quantization data type must be one of the following: "
-                f"['int4', 'int8', 'mxfp4', 'nf4', 'cb4_f8e4m3'], but found: {self.dtype}."
+                f"['int4', 'int8', 'mxfp4', 'nf4', 'cb4'], but found: {self.dtype}."
             )
-        if self.dtype in ["mxfp4", "nf4", "cb4_f8e4m3"]:
+        if self.dtype in ["mxfp4", "nf4", "cb4"]:
             if self.bits != 4:
                 raise ValueError(
                     f"When applying weight compression with '{self.dtype}' data type, the `bits` parameter must be set to 4, but found {self.bits}"
@@ -844,7 +844,9 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         if mode in signed_bitness.values():
             mode += "_sym" if self.sym else "_asym"
         if mode == "mxfp4":
-            mode = "e2m1"
+            mode = nncf.CompressWeightsMode.E2M1.value
+        if mode == "cb4":
+            mode = nncf.CompressWeightsMode.CB4_F8E4M3.value
         mode = nncf.CompressWeightsMode(mode)
 
         awq = True if self.quant_method == OVQuantizationMethod.AWQ else None

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,11 @@ QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]
 
 EXTRAS_REQUIRE = {
     "nncf": ["nncf@git+https://github.com/openvinotoolkit/nncf.git@71ae2c19d51f19a7d5fe3204e1f180fc1f62e940"],
-    "openvino": ["nncf@git+https://github.com/openvinotoolkit/nncf.git@71ae2c19d51f19a7d5fe3204e1f180fc1f62e940", "openvino>=2025.1.0", "openvino-tokenizers>=2025.1.0"],
+    "openvino": [
+        "nncf@git+https://github.com/openvinotoolkit/nncf.git@71ae2c19d51f19a7d5fe3204e1f180fc1f62e940",
+        "openvino>=2025.1.0",
+        "openvino-tokenizers>=2025.1.0",
+    ],
     "neural-compressor": ["neural-compressor[pt]>=3.4.1", "accelerate", "transformers<4.46"],
     "ipex": ["intel-extension-for-pytorch>=2.6", "transformers>4.50,<4.53", "accelerate"],
     "diffusers": ["diffusers"],

--- a/setup.py
+++ b/setup.py
@@ -65,12 +65,8 @@ TESTS_REQUIRE = [
 QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]
 
 EXTRAS_REQUIRE = {
-    "nncf": ["nncf@git+https://github.com/openvinotoolkit/nncf.git@71ae2c19d51f19a7d5fe3204e1f180fc1f62e940"],
-    "openvino": [
-        "nncf@git+https://github.com/openvinotoolkit/nncf.git@71ae2c19d51f19a7d5fe3204e1f180fc1f62e940",
-        "openvino>=2025.1.0",
-        "openvino-tokenizers>=2025.1.0",
-    ],
+    "nncf": ["nncf>=2.16.0"],
+    "openvino": ["nncf>=2.16.0", "openvino>=2025.1.0", "openvino-tokenizers>=2025.1.0"],
     "neural-compressor": ["neural-compressor[pt]>=3.4.1", "accelerate", "transformers<4.46"],
     "ipex": ["intel-extension-for-pytorch>=2.6", "transformers>4.50,<4.53", "accelerate"],
     "diffusers": ["diffusers"],

--- a/setup.py
+++ b/setup.py
@@ -65,8 +65,8 @@ TESTS_REQUIRE = [
 QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]
 
 EXTRAS_REQUIRE = {
-    "nncf": ["nncf>=2.16.0"],
-    "openvino": ["nncf>=2.16.0", "openvino>=2025.1.0", "openvino-tokenizers>=2025.1.0"],
+    "nncf": ["nncf@git+https://github.com/openvinotoolkit/nncf.git@71ae2c19d51f19a7d5fe3204e1f180fc1f62e940"],
+    "openvino": ["nncf@git+https://github.com/openvinotoolkit/nncf.git@71ae2c19d51f19a7d5fe3204e1f180fc1f62e940", "openvino>=2025.1.0", "openvino-tokenizers>=2025.1.0"],
     "neural-compressor": ["neural-compressor[pt]>=3.4.1", "accelerate", "transformers<4.46"],
     "ipex": ["intel-extension-for-pytorch>=2.6", "transformers>4.50,<4.53", "accelerate"],
     "diffusers": ["diffusers"],

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -443,6 +443,12 @@ class OVCLIExportTestCase(unittest.TestCase):
         ),
         (
             "text-generation-with-past",
+            "gpt2",
+            "cb4_f8e4m3 --group-size 32",
+            {"model": {"int8": 24, "int4": 20, "f8e4m3": 20}},
+        ),
+        (
+            "text-generation-with-past",
             "llama_awq",
             "int4 --ratio 1.0 --sym --group-size 8 --all-layers",
             {"model": {"int4": 16}},

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -947,8 +947,8 @@ class OVCLIExportTestCase(unittest.TestCase):
     def test_exporters_cli_4bit(
         self, task: str, model_type: str, option: str, expected_num_weight_nodes_per_model: Dict[str, Dict[str, int]]
     ):
-        if option.startswith("cb4") and is_nncf_version("<", "2.18.0"):
-            pytest.skip("Codebook quantization is supported starting from NNCF 2.18.0")
+        if option.startswith("cb4") and is_nncf_version("<=", "2.17"):
+            pytest.skip("Codebook quantization is supported starting from NNCF 2.18")
         with TemporaryDirectory() as tmpdir:
             result = subprocess.run(
                 f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} --task {task} --weight-format {option} {tmpdir}",

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -241,6 +241,18 @@ class OVCLIExportTestCase(unittest.TestCase):
         (
             "text-generation",
             "llama",
+            "nf4_f8e4m3",
+            "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code --ratio 0.5",
+            {
+                "model": 16,
+            },
+            {
+                "model": {"f8e4m3": 11, "nf4": 5},
+            },
+        ),
+        (
+            "text-generation",
+            "llama",
             "cb4_f8e4m3",
             "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code --ratio 0.5",
             {
@@ -248,6 +260,18 @@ class OVCLIExportTestCase(unittest.TestCase):
             },
             {
                 "model": {"int8": 5, "int4": 5, "f8e4m3": 16},
+            },
+        ),
+        (
+            "text-generation",
+            "llama",
+            "nf4_f8e5m2",
+            "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code --sym --ratio 0.5",
+            {
+                "model": 16,
+            },
+            {
+                "model": {"f8e5m2": 11, "nf4": 5},
             },
         ),
         (

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -986,8 +986,8 @@ class OVCLIExportTestCase(unittest.TestCase):
         expected_fake_nodes_per_model: Dict[str, int],
         expected_num_weight_nodes_per_model: Dict[str, Dict[str, int]],
     ):
-        if quant_mode == "cb4_f8e4m3" and is_nncf_version("<", "2.18.0"):
-            pytest.skip("Codebook quantization is supported starting from NNCF 2.18.0")
+        if quant_mode == "cb4_f8e4m3" and is_nncf_version("<=", "2.17"):
+            pytest.skip("Codebook quantization is supported starting from NNCF 2.18")
         with TemporaryDirectory() as tmpdir:
             subprocess.run(
                 f"optimum-cli export openvino --task {task} --model {MODEL_NAMES[model_type]} "

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -239,25 +239,13 @@ class OVCLIExportTestCase(unittest.TestCase):
         (
             "text-generation",
             "llama",
-            "nf4_f8e4m3",
+            "cb4_f8e4m3",
             "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code --ratio 0.5",
             {
                 "model": 16,
             },
             {
-                "model": {"f8e4m3": 11, "nf4": 5},
-            },
-        ),
-        (
-            "text-generation",
-            "llama",
-            "nf4_f8e5m2",
-            "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code --sym --ratio 0.5",
-            {
-                "model": 16,
-            },
-            {
-                "model": {"f8e5m2": 11, "nf4": 5},
+                "model": {"int8": 5, "int4": 5, "f8e4m3": 16},
             },
         ),
         (
@@ -444,7 +432,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         (
             "text-generation-with-past",
             "gpt2",
-            "cb4_f8e4m3 --group-size 32",
+            "cb4 --group-size 32",
             {"model": {"int8": 24, "int4": 20, "f8e4m3": 20}},
         ),
         (

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -158,6 +158,31 @@ class OVQuantizerTest(unittest.TestCase):
             dict(
                 weight_quantization_config=dict(
                     bits=4,
+                    dtype="nf4",
+                    group_size=16,
+                    ratio=0.5,
+                    ignored_scope={"patterns": [f"{pattern_prefix}.layers.0.self_attn"]},
+                ),
+                full_quantization_config=OVQuantizationConfig(
+                    dtype="f8e4m3", ignored_scope={"patterns": [f"{pattern_prefix}.layers.0.mlp"]}
+                ),
+                ignored_scope={"patterns": [f"{pattern_prefix}.layers.1.self_attn"]},
+                dataset="wikitext2",
+                num_samples=1,
+            ),
+            {
+                "model": 8,
+            },
+            {
+                "model": {"f8e4m3": 8, "nf4": 2},
+            },
+        ),
+        (
+            OVModelForCausalLM,
+            "llama",
+            dict(
+                weight_quantization_config=dict(
+                    bits=4,
                     dtype="cb4",
                     group_size=16,
                     ratio=0.5,
@@ -175,6 +200,31 @@ class OVQuantizerTest(unittest.TestCase):
             },
             {
                 "model": {"int8": 2, "int4": 2, "f8e4m3": 10},
+            },
+        ),
+        (
+            OVModelForCausalLM,
+            "llama",
+            OVMixedQuantizationConfig(
+                weight_quantization_config=OVWeightQuantizationConfig(
+                    bits=4,
+                    dtype="nf4",
+                    group_size=16,
+                    ratio=0.5,
+                    ignored_scope={"patterns": [f"{pattern_prefix}.layers.0.self_attn"]},
+                ),
+                full_quantization_config=OVQuantizationConfig(
+                    dtype="f8e5m2", ignored_scope={"patterns": [f"{pattern_prefix}.layers.0.mlp"]}
+                ),
+                ignored_scope={"patterns": [f"{pattern_prefix}.layers.1.self_attn"]},
+                dataset="wikitext2",
+                num_samples=1,
+            ),
+            {
+                "model": 8,
+            },
+            {
+                "model": {"f8e5m2": 8, "nf4": 2},
             },
         ),
         (

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -562,9 +562,9 @@ class OVQuantizerTest(unittest.TestCase):
         if (
             isinstance(q_config, OVMixedQuantizationConfig)
             and q_config.weight_quantization_config.dtype == "cb4"
-            and is_nncf_version("<", "2.18.0")
+            and is_nncf_version("<=", "2.17")
         ):
-            pytest.skip("Codebook quantization is supported starting from NNCF 2.18.0")
+            pytest.skip("Codebook quantization is supported starting from NNCF 2.18")
         model_id = MODEL_NAMES[model_name]
 
         with TemporaryDirectory() as tmp_dir:

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1304,8 +1304,8 @@ class OVWeightCompressionTest(unittest.TestCase):
         self, model_cls, model_name, trust_remote_code, quantization_config, expected_num_weight_nodes_per_model
     ):
         q_config = _quantization_config_from_dict(quantization_config)
-        if q_config.dtype == "cb4" and is_nncf_version("<", "2.18.0"):
-            pytest.skip("Codebook quantization is supported starting from NNCF 2.18.0")
+        if q_config.dtype == "cb4" and is_nncf_version("<=", "2.17"):
+            pytest.skip("Codebook quantization is supported starting from NNCF 2.18")
 
         model_id = MODEL_NAMES[model_name]
         with TemporaryDirectory() as tmp_dir:

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1302,7 +1302,11 @@ class OVWeightCompressionTest(unittest.TestCase):
     def test_ovmodel_4bit_auto_compression_with_config(
         self, model_cls, model_name, trust_remote_code, quantization_config, expected_num_weight_nodes_per_model
     ):
-        if isinstance(quantization_config, dict) and quantization_config.get("dtype") == "cb4" and is_nncf_version("<=", "2.17"):
+        if (
+            isinstance(quantization_config, dict)
+            and quantization_config.get("dtype") == "cb4"
+            and is_nncf_version("<=", "2.17")
+        ):
             pytest.skip("Codebook quantization is supported starting from NNCF 2.18")
 
         model_id = MODEL_NAMES[model_name]

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -672,6 +672,13 @@ class OVWeightCompressionTest(unittest.TestCase):
             OVModelForCausalLM,
             "gpt2",
             False,
+            dict(bits=4, dtype="cb4_f8e4m3", group_size=32),
+            {"model": {"int8": 24, "int4": 20, "f8e4m3": 20}},
+        ),
+        (
+            OVModelForCausalLM,
+            "gpt2",
+            False,
             dict(
                 bits=4,
                 sym=False,

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -155,8 +155,8 @@ class OVQuantizerTest(unittest.TestCase):
         (
             OVModelForCausalLM,
             "llama",
-            OVMixedQuantizationConfig(
-                weight_quantization_config=OVWeightQuantizationConfig(
+            dict(
+                weight_quantization_config=dict(
                     bits=4,
                     dtype="cb4",
                     group_size=16,
@@ -558,10 +558,9 @@ class OVQuantizerTest(unittest.TestCase):
         expected_fake_nodes_per_model,
         expected_num_weight_nodes_per_model,
     ):
-        q_config = _quantization_config_from_dict(quantization_config)
         if (
-            isinstance(q_config, OVMixedQuantizationConfig)
-            and q_config.weight_quantization_config.dtype == "cb4"
+            isinstance(quantization_config, dict)
+            and quantization_config.get("weight_quantization_config", {}).get("dtype") == "cb4"
             and is_nncf_version("<=", "2.17")
         ):
             pytest.skip("Codebook quantization is supported starting from NNCF 2.18")
@@ -1303,8 +1302,7 @@ class OVWeightCompressionTest(unittest.TestCase):
     def test_ovmodel_4bit_auto_compression_with_config(
         self, model_cls, model_name, trust_remote_code, quantization_config, expected_num_weight_nodes_per_model
     ):
-        q_config = _quantization_config_from_dict(quantization_config)
-        if q_config.dtype == "cb4" and is_nncf_version("<=", "2.17"):
+        if isinstance(quantization_config, dict) and quantization_config.get("dtype") == "cb4" and is_nncf_version("<=", "2.17"):
             pytest.skip("Codebook quantization is supported starting from NNCF 2.18")
 
         model_id = MODEL_NAMES[model_name]

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -158,7 +158,7 @@ class OVQuantizerTest(unittest.TestCase):
             OVMixedQuantizationConfig(
                 weight_quantization_config=OVWeightQuantizationConfig(
                     bits=4,
-                    dtype="nf4",
+                    dtype="cb4",
                     group_size=16,
                     ratio=0.5,
                     ignored_scope={"patterns": [f"{pattern_prefix}.layers.0.self_attn"]},
@@ -174,32 +174,7 @@ class OVQuantizerTest(unittest.TestCase):
                 "model": 8,
             },
             {
-                "model": {"f8e4m3": 8, "nf4": 2},
-            },
-        ),
-        (
-            OVModelForCausalLM,
-            "llama",
-            OVMixedQuantizationConfig(
-                weight_quantization_config=OVWeightQuantizationConfig(
-                    bits=4,
-                    dtype="nf4",
-                    group_size=16,
-                    ratio=0.5,
-                    ignored_scope={"patterns": [f"{pattern_prefix}.layers.0.self_attn"]},
-                ),
-                full_quantization_config=OVQuantizationConfig(
-                    dtype="f8e5m2", ignored_scope={"patterns": [f"{pattern_prefix}.layers.0.mlp"]}
-                ),
-                ignored_scope={"patterns": [f"{pattern_prefix}.layers.1.self_attn"]},
-                dataset="wikitext2",
-                num_samples=1,
-            ),
-            {
-                "model": 8,
-            },
-            {
-                "model": {"f8e5m2": 8, "nf4": 2},
+                "model": {"int8": 2, "int4": 2, "f8e4m3": 10},
             },
         ),
         (
@@ -672,7 +647,7 @@ class OVWeightCompressionTest(unittest.TestCase):
             OVModelForCausalLM,
             "gpt2",
             False,
-            dict(bits=4, dtype="cb4_f8e4m3", group_size=32),
+            dict(bits=4, dtype="cb4", group_size=32),
             {"model": {"int8": 24, "int4": 20, "f8e4m3": 20}},
         ),
         (


### PR DESCRIPTION
# What does this PR do?

As in the title. The new `cb4` weight format option represents a codebook with 16 fixed fp8 values in E4M3 format. The `cb4_f8e4m3` quant mode adds on this the corresponding activations quantization in f8e4m3.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

