### PR TITLE
Do not allow to provide --quant-mode and --weight-format arguments at the same time

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -381,6 +381,10 @@ class OVExportCommand(BaseOptimumCLICommand):
         else:
             if not is_nncf_available():
                 raise ImportError("Applying quantization requires nncf, please install it with `pip install nncf`")
+            if self.args.weight_format is not None and self.args.quant_mode is not None:
+                raise ValueError(
+                    "Both --weight-format and --quant-mode arguments are provided. Please provide only one of them."
+                )
 
             default_quantization_config = get_default_quantization_config(
                 self.args.model, self.args.weight_format, self.args.quant_mode


### PR DESCRIPTION
`--weight-format` is responsible for weight-only quantization and `--quant-mode` for static (weights and activations) quantization and these arguments are not compatible at the same time. 

That said, there is a way to apply this together, but for such case `--quant-mode` should be used. For example, `cb4_f8e4m3` is such mixed precision mode.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

