### PR TITLE
Add a note regarding English dataset for non-English models

### DIFF
--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -115,7 +115,9 @@ Optional arguments:
                         ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit']. For
                         visual language models the dataset must be set to 'contextual'. Note: if none of the data-aware
                         compression algorithms are selected and ratio parameter is omitted or equals 1.0, the dataset
-                        argument will not have an effect on the resulting model.
+                        argument will not have an effect on the resulting model. Note: for text generation task,
+                        datasets with English texts such as 'wikitext2','c4' or 'c4-new' usually work fine even for
+                        non-English models.
   --all-layers          Whether embeddings and last MatMul layers should be compressed to INT4. If not provided an
                         weight compression is applied, they are compressed to INT8.
   --awq                 Whether to apply AWQ algorithm. AWQ improves generation quality of INT4-compressed LLMs. If

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -176,6 +176,8 @@ def parse_args_openvino(parser: "ArgumentParser"):
             "For visual language models the dataset must be set to 'contextual'. "
             "Note: if none of the data-aware compression algorithms are selected and ratio parameter is omitted or "
             "equals 1.0, the dataset argument will not have an effect on the resulting model."
+            "Note: for text generation task, datasets with English texts such as 'wikitext2','c4' or 'c4-new' usually "
+            "work fine even for non-English models."
         ),
     )
     optional_group.add_argument(


### PR DESCRIPTION
# What does this PR do?

Add an explicit note stating that default English datasets are usually ok to use even for non-English models.

Ticket 171052

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

