### PR TITLE
Skip marian tests on OpenVINO 2025.3

### DIFF
--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1942,12 +1942,15 @@ class OVModelForSeq2SeqLMIntegrationTest(unittest.TestCase):
         "blenderbot-small",
         # "longt5",
         "m2m_100",
-        "marian",
         "mbart",
         "mt5",
         "pegasus",
         "t5",
     )
+
+    if not (is_openvino_version(">=", "2025.3.0") and is_openvino_version("<", "2025.4.0")):
+        # There are known issues with marian model on OpenVINO 2025.3.x
+        SUPPORTED_ARCHITECTURES += ("marian",)
 
     GENERATION_LENGTH = 100
     SPEEDUP_CACHE = 1.1


### PR DESCRIPTION
# What does this PR do?

There are known issues with marian model on OpenVINO 2025.3, so the corresponding tests are skipped. The issues are planned to be fixed on the master in upcoming weeks.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

