### PR TITLE
Fix regexp error with searching onnx model

### DIFF
--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -479,7 +479,7 @@ class OVBaseModel(OptimizedModel):
 
             ov_files = _find_files_matching_pattern(
                 model_dir,
-                pattern=cls._search_pattern if not kwargs.get("from_onnx", False) else "*.onnx",
+                pattern=cls._search_pattern if not kwargs.get("from_onnx", False) else ".*\.onnx$",
                 subfolder=subfolder,
                 use_auth_token=token,
                 revision=revision,


### PR DESCRIPTION
Fix issue for onnx models with:
```
Could not infer whether the model was already converted or not to the OpenVINO IR, keeping `export=False`.
nothing to repeat at position 0
```


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

