### PR TITLE
[OpenVINO] Support openbmb/MiniCPM-o-2_6 for image-text-to-text task

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -93,7 +93,7 @@ Here is the list of the supported architectures :
 - Marian
 - MiniCPM
 - MiniCPM3
-- MiniCPMO (image-text-to-text)
+- MiniCPM-o
 - MiniCPMV
 - Mistral
 - Mixtral

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -93,7 +93,7 @@ Here is the list of the supported architectures :
 - Marian
 - MiniCPM
 - MiniCPM3
-- MiniCPM-o
+- MiniCPM-o 
 - MiniCPMV
 - Mistral
 - Mixtral

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -93,6 +93,7 @@ Here is the list of the supported architectures :
 - Marian
 - MiniCPM
 - MiniCPM3
+- MiniCPMO (image-text-to-text)
 - MiniCPMV
 - Mistral
 - Mixtral

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -93,7 +93,7 @@ Here is the list of the supported architectures :
 - Marian
 - MiniCPM
 - MiniCPM3
-- MiniCPM-o 
+- MiniCPM-o
 - MiniCPMV
 - Mistral
 - Mixtral

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -739,7 +739,7 @@ def export_from_model(
         # some model configs may have issues with loading without parameters initialization
         try:
             misplaced_generation_parameters = model.config._get_non_default_generation_parameters()
-        except (KeyError, TypeError):
+        except (AttributeError, KeyError, TypeError):
             misplaced_generation_parameters = {}
         if isinstance(model, GenerationMixin) and len(misplaced_generation_parameters) > 0:
             logger.warning(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2768,7 +2768,6 @@ class MiniCPMVConfigBehavior(str, enum.Enum):
 
 
 @register_in_tasks_manager("minicpmv", *["image-text-to-text"], library_name="transformers")
-@register_in_tasks_manager("minicpmo", *["image-text-to-text"], library_name="transformers")
 class MiniCPMVOpenVINOConfig(BaseVLMOpenVINOConfig):
     SUPPORTED_BEHAVIORS = [model_type.value for model_type in MiniCPMVConfigBehavior]
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
@@ -2893,6 +2892,11 @@ class MiniCPMVOpenVINOConfig(BaseVLMOpenVINOConfig):
             return MiniCPMVResamplerModelPatcher(self, model, model_kwargs)
 
         return super().patch_model_for_export(model, model_kwargs)
+
+
+@register_in_tasks_manager("minicpmo", *["image-text-to-text"], library_name="transformers")
+class MiniCPMOOpenVINOConfig(MiniCPMVOpenVINOConfig):
+    MAX_TRANSFORMERS_VERSION = "4.51.0"
 
 
 class Phi3VisionConfigBehavior(str, enum.Enum):

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2896,6 +2896,7 @@ class MiniCPMVOpenVINOConfig(BaseVLMOpenVINOConfig):
 
 @register_in_tasks_manager("minicpmo", *["image-text-to-text"], library_name="transformers")
 class MiniCPMOOpenVINOConfig(MiniCPMVOpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "4.43.0"
     MAX_TRANSFORMERS_VERSION = "4.51.0"
 
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2685,7 +2685,7 @@ class MiniCPMVOpenVINOConfig(BaseVLMOpenVINOConfig):
 @register_in_tasks_manager("minicpmo", *["image-text-to-text"], library_name="transformers")
 class MiniCPMOOpenVINOConfig(MiniCPMVOpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "4.43.0"
-    MAX_TRANSFORMERS_VERSION = "4.52.0"
+    MAX_TRANSFORMERS_VERSION = "4.51.99"
 
 
 class Phi3VisionConfigBehavior(str, enum.Enum):

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2768,6 +2768,7 @@ class MiniCPMVConfigBehavior(str, enum.Enum):
 
 
 @register_in_tasks_manager("minicpmv", *["image-text-to-text"], library_name="transformers")
+@register_in_tasks_manager("minicpmo", *["image-text-to-text"], library_name="transformers")
 class MiniCPMVOpenVINOConfig(BaseVLMOpenVINOConfig):
     SUPPORTED_BEHAVIORS = [model_type.value for model_type in MiniCPMVConfigBehavior]
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2897,7 +2897,7 @@ class MiniCPMVOpenVINOConfig(BaseVLMOpenVINOConfig):
 @register_in_tasks_manager("minicpmo", *["image-text-to-text"], library_name="transformers")
 class MiniCPMOOpenVINOConfig(MiniCPMVOpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "4.43.0"
-    MAX_TRANSFORMERS_VERSION = "4.51.0"
+    MAX_TRANSFORMERS_VERSION = "4.52.0"
 
 
 class Phi3VisionConfigBehavior(str, enum.Enum):

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -234,6 +234,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "phi4mm",
     "phi4_multimodal",
     "llama4",
+    "minicpmo",
 ]
 
 SSM_MODELS = ["mamba", "falcon_mamba"]

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -25,6 +25,7 @@ from transformers import (
     PreTrainedTokenizer,
 )
 from transformers.modeling_outputs import BaseModelOutputWithPooling
+from transformers.models.qwen2_vl.modeling_qwen2_vl import VisionRotaryEmbedding
 from transformers.utils import ModelOutput
 
 from ...exporters.openvino import main_export
@@ -44,7 +45,6 @@ from .utils import (
 
 if is_transformers_version(">=", "4.46.0"):
     from transformers import AutoModelForImageTextToText
-    from transformers.models.qwen2_vl.modeling_qwen2_vl import VisionRotaryEmbedding
 
     transformers_auto_class = AutoModelForImageTextToText
 else:

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -41,9 +41,10 @@ from .utils import (
     TemporaryDirectory,
 )
 
+
 if is_transformers_version(">=", "4.46.0"):
-    from transformers.models.qwen2_vl.modeling_qwen2_vl import VisionRotaryEmbedding
     from transformers import AutoModelForImageTextToText
+    from transformers.models.qwen2_vl.modeling_qwen2_vl import VisionRotaryEmbedding
 
     transformers_auto_class = AutoModelForImageTextToText
 else:

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -25,7 +25,6 @@ from transformers import (
     PreTrainedTokenizer,
 )
 from transformers.modeling_outputs import BaseModelOutputWithPooling
-from transformers.models.qwen2_vl.modeling_qwen2_vl import VisionRotaryEmbedding
 from transformers.utils import ModelOutput
 
 from ...exporters.openvino import main_export
@@ -42,8 +41,8 @@ from .utils import (
     TemporaryDirectory,
 )
 
-
 if is_transformers_version(">=", "4.46.0"):
+    from transformers.models.qwen2_vl.modeling_qwen2_vl import VisionRotaryEmbedding
     from transformers import AutoModelForImageTextToText
 
     transformers_auto_class = AutoModelForImageTextToText
@@ -4355,4 +4354,5 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "phi4mm": _OVPhi4MMForCausalLM,
     "phi4_multimodal": _OVPhi4MMForCausalLM,
     "llama4": _OVLlama4ForCausalLM,
+    "minicpmo": _OVMiniCPMVForCausalLM,
 }

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -2114,6 +2114,36 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
         return inputs
 
 
+class _OVMiniCPMOForCausalLM(_OVMiniCPMVForCausalLM):
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        pixel_values=None,
+        image_sizes=None,
+        attention_mask=None,
+        audio_bounds=None,
+        spk_bounds=None,
+        audio_features=None,
+        audio_feature_lens=None,
+        **kwargs,
+    ):
+        # Audio modality is not supported for MiniCPMO
+        if audio_features is not None and len(audio_features) > 0:
+            raise ValueError("Audio input is not supported for MiniCPMO")
+
+        return super().prepare_inputs_for_generation(
+            input_ids=input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            image_sizes=image_sizes,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+
+
 class _OVNanoLlavaForCausalLM(OVModelForVisualCausalLM):
     def get_vision_embeddings(self, pixel_values, input_ids=None, **kwargs):
         if input_ids is not None and input_ids.shape[1] == 1:
@@ -4355,5 +4385,5 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "phi4mm": _OVPhi4MMForCausalLM,
     "phi4_multimodal": _OVPhi4MMForCausalLM,
     "llama4": _OVLlama4ForCausalLM,
-    "minicpmo": _OVMiniCPMVForCausalLM,
+    "minicpmo": _OVMiniCPMOForCausalLM,
 }

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ TESTS_REQUIRE = [
     "hf_xet",
     "num2words",
     "vocos",
+    "vector_quantize_pytorch",
 ]
 
 QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,7 @@ TESTS_REQUIRE = [
     "langchain-huggingface",
     "hf_xet",
     "num2words",
+    "vocos",
 ]
 
 QUALITY_REQUIRE = ["black~=23.1", "ruff==0.4.4"]

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -733,6 +733,29 @@ class OVCLIExportTestCase(unittest.TestCase):
                 "vision_embeddings_model": {"int8": 16},
             },
         ),
+        (
+            "image-text-to-text",
+            "minicpmo",
+            "int4 --group-size 4 --ratio 0.8 --trust-remote-code",
+            {
+                "lm_model": {"int8": 16, "int4": 14},
+                "text_embeddings_model": {"int8": 1},
+                "vision_embeddings_model": {"int8": 8},
+                "resampler_model": {"int8": 6},
+            },
+        ),
+        (
+            "image-text-to-text",
+            "minicpmo",
+            'int4 --group-size 4 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
+            "--dataset contextual --num-samples 1 --trust-remote-code",
+            {
+                "lm_model": {"int8": 8, "int4": 22},
+                "text_embeddings_model": {"int8": 1},
+                "vision_embeddings_model": {"int8": 8},
+                "resampler_model": {"int8": 6},
+            },
+        ),
     ]
 
     # filter models type depending on min max transformers version
@@ -1020,7 +1043,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             result = subprocess.run(
                 f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} --task {task} --weight-format {option} {tmpdir}",
                 shell=True,
-                check=True,
+                #check=True,
                 capture_output=True,
             )
             model_kwargs = {"use_cache": task.endswith("with-past")} if "generation" in task else {}

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -738,7 +738,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             "minicpmo",
             "int4 --group-size 4 --ratio 0.8 --trust-remote-code",
             {
-                "lm_model": {"int8": 16, "int4": 14},
+                "lm_model": {"int8": 14, "int4": 14},
                 "text_embeddings_model": {"int8": 1},
                 "vision_embeddings_model": {"int8": 8},
                 "resampler_model": {"int8": 6},

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -777,7 +777,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         elif is_transformers_version("<", "4.52"):
             expected = set()
         else:
-            expected = {"llava-qwen2", "phi3_v", "phi4mm"}
+            expected = {"llava-qwen2", "phi3_v", "phi4mm", "minicpmo"}
 
         all_model_type = {config[1] for config in cls.TRANSFORMERS_4BIT_CONFIGURATIONS}
         filtered_model_type = {config[1] for config in cls.SUPPORTED_4BIT_CONFIGURATIONS}

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -738,7 +738,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             "minicpmo",
             "int4 --group-size 4 --ratio 0.8 --trust-remote-code",
             {
-                "lm_model": {"int8": 14, "int4": 14},
+                "lm_model": {"int8": 14, "int4": 12},
                 "text_embeddings_model": {"int8": 1},
                 "vision_embeddings_model": {"int8": 8},
                 "resampler_model": {"int8": 6},

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -736,17 +736,6 @@ class OVCLIExportTestCase(unittest.TestCase):
         (
             "image-text-to-text",
             "minicpmo",
-            "int4 --group-size 4 --ratio 0.8 --trust-remote-code",
-            {
-                "lm_model": {"int8": 12, "int4": 4},
-                "text_embeddings_model": {"int8": 1},
-                "vision_embeddings_model": {"int8": 8},
-                "resampler_model": {"int8": 6},
-            },
-        ),
-        (
-            "image-text-to-text",
-            "minicpmo",
             'int4 --group-size 4 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
             "--dataset contextual --num-samples 1 --trust-remote-code",
             {

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -738,7 +738,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             "minicpmo",
             "int4 --group-size 4 --ratio 0.8 --trust-remote-code",
             {
-                "lm_model": {"int8": 14, "int4": 12},
+                "lm_model": {"int8": 12, "int4": 4},
                 "text_embeddings_model": {"int8": 1},
                 "vision_embeddings_model": {"int8": 8},
                 "resampler_model": {"int8": 6},
@@ -750,7 +750,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             'int4 --group-size 4 --ratio 0.8 --sensitivity-metric "mean_activation_magnitude" '
             "--dataset contextual --num-samples 1 --trust-remote-code",
             {
-                "lm_model": {"int8": 8, "int4": 22},
+                "lm_model": {"int8": 6, "int4": 10},
                 "text_embeddings_model": {"int8": 1},
                 "vision_embeddings_model": {"int8": 8},
                 "resampler_model": {"int8": 6},

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -1043,7 +1043,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             result = subprocess.run(
                 f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} --task {task} --weight-format {option} {tmpdir}",
                 shell=True,
-                #check=True,
+                check=True,
                 capture_output=True,
             )
             model_kwargs = {"use_cache": task.endswith("with-past")} if "generation" in task else {}

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1012,7 +1012,7 @@ class OVWeightCompressionTest(unittest.TestCase):
             True,
             dict(
                 bits=4,
-                group_size=16,
+                group_size=4,
                 dataset="contextual",
                 ratio=0.8,
                 sensitivity_metric="mean_activation_magnitude",
@@ -1021,7 +1021,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 trust_remote_code=True,
             ),
             {
-                "lm_model": {"int8": 4, "int4": 0},
+                "lm_model": {"int8": 6, "int4": 10},
                 "text_embeddings_model": {"int8": 1},
                 "vision_embeddings_model": {"int8": 8},
                 "resampler_model": {"int8": 6},

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1006,6 +1006,27 @@ class OVWeightCompressionTest(unittest.TestCase):
                 "vision_embeddings_model": {"int8": 16},
             },
         ),
+        (
+            OVModelForVisualCausalLM,
+            "minicpmo",
+            True,
+            dict(
+                bits=4,
+                group_size=16,
+                dataset="contextual",
+                ratio=0.8,
+                sensitivity_metric="mean_activation_magnitude",
+                num_samples=1,
+                processor=MODEL_NAMES["minicpmo"],
+                trust_remote_code=True,
+            ),
+            {
+                "lm_model": {"int8": 4, "int4": 2},
+                "text_embeddings_model": {"int8": 1},
+                "vision_embeddings_model": {"int8": 8},
+                "resampler_model": {"int8": 6},
+            },
+        ),
     ]
 
     # filter models type depending on min max transformers version
@@ -1032,6 +1053,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         (OVModelForVisualCausalLM, "llava_next_video", False),
         (OVModelForVisualCausalLM, "minicpmv", True),
         (OVModelForVisualCausalLM, "qwen2_vl", False),
+        (OVModelForVisualCausalLM, "minicpmo", True),
     ]
 
     if is_transformers_version("<", "4.54.0"):

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1080,7 +1080,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         elif is_transformers_version("<", "4.52"):
             expected = set()
         else:
-            expected = {"llava-qwen2", "phi3_v"}
+            expected = {"llava-qwen2", "phi3_v", "minicpmo"}
 
         all_model_type = {config[1] for config in cls.TRANSFORMERS_4BIT_CONFIGURATIONS}
         filtered_model_type = {config[1] for config in cls.LOAD_IN_4_BITS_SCOPE}

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1021,7 +1021,7 @@ class OVWeightCompressionTest(unittest.TestCase):
                 trust_remote_code=True,
             ),
             {
-                "lm_model": {"int8": 4, "int4": 2},
+                "lm_model": {"int8": 4, "int4": 0},
                 "text_embeddings_model": {"int8": 1},
                 "vision_embeddings_model": {"int8": 8},
                 "resampler_model": {"int8": 6},
@@ -1053,11 +1053,13 @@ class OVWeightCompressionTest(unittest.TestCase):
         (OVModelForVisualCausalLM, "llava_next_video", False),
         (OVModelForVisualCausalLM, "minicpmv", True),
         (OVModelForVisualCausalLM, "qwen2_vl", False),
-        (OVModelForVisualCausalLM, "minicpmo", True),
     ]
 
     if is_transformers_version("<", "4.54.0"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "llava-qwen2", True))
+
+    if is_transformers_version("<", "4.52.0"):
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "minicpmo", True))
 
     SUPPORTED_ARCHITECTURES_WITH_HYBRID_QUANTIZATION = [
         (OVStableDiffusionPipeline, "stable-diffusion", 72, 195),

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -658,7 +658,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             if model_arch in ["minicpmo"]:
                 # `generate` method for minicpmo requires tokenizer
                 tokenizer = AutoTokenizer.from_pretrained(
-                    model_id, trast_remote_code=model_arch in self.REMOTE_CODE_MODELS
+                    model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
                 )
             transformers_outputs = transformers_model.generate(
                 **transformers_inputs, generation_config=gen_config, tokenizer=tokenizer, **additional_inputs

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -496,7 +496,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
         SUPPORTED_ARCHITECTURES += ["gemma3", "smolvlm"]
     if is_transformers_version(">=", "4.51"):
         SUPPORTED_ARCHITECTURES += ["llama4"]
-    if is_transformers_version("<", "4.51"):
+    if is_transformers_version("<", "4.52"):
         SUPPORTED_ARCHITECTURES += ["minicpmo"]
 
     if is_transformers_version(">=", "4.54.0"):

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -654,14 +654,14 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             transformers_inputs["past_key_values"] = DynamicCache()
 
         with torch.no_grad():
-            tokenizer = None
             if model_arch in ["minicpmo"]:
                 # `generate` method for minicpmo requires tokenizer
                 tokenizer = AutoTokenizer.from_pretrained(
                     model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
                 )
+                additional_inputs["tokenizer"] = tokenizer
             transformers_outputs = transformers_model.generate(
-                **transformers_inputs, generation_config=gen_config, tokenizer=tokenizer, **additional_inputs
+                **transformers_inputs, generation_config=gen_config, **additional_inputs
             )
             if model_arch in ["minicpmo"]:
                 # retrieve decoded tokens for comparation

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -479,6 +479,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
         "llava_next_video",
         "llava-qwen2",
         "minicpmv",
+        "minicpmo",
         "phi3_v",
         "qwen2_vl",
     ]
@@ -502,7 +503,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
         SUPPORTED_ARCHITECTURES = set(SUPPORTED_ARCHITECTURES) - {"llava-qwen2", "phi3_v", "phi4mm"}
 
     TASK = "image-text-to-text"
-    REMOTE_CODE_MODELS = ["internvl_chat", "minicpmv", "llava-qwen2", "phi3_v", "maira2", "phi4mm"]
+    REMOTE_CODE_MODELS = ["internvl_chat", "minicpmv", "minicpmo", "llava-qwen2", "phi3_v", "maira2", "phi4mm"]
 
     IMAGE = Image.open(
         requests.get(
@@ -607,7 +608,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
         self._check_device_and_request(ov_model, test_device, False)
 
         # pytorch minicpmv and internvl_chat are not designed to be used via forward
-        if model_arch not in ["minicpmv", "internvl_chat"]:
+        if model_arch not in ["minicpmv", "minicpmo", "internvl_chat"]:
             set_seed(SEED)
             ov_outputs = ov_model(**inputs)
             set_seed(SEED)
@@ -657,7 +658,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             )
 
         # original minicpmv, internvl always skip input tokens in generation results, while transformers based approach provide them
-        if model_arch in ["minicpmv", "internvl_chat"]:
+        if model_arch in ["minicpmv", "minicpmo", "internvl_chat"]:
             ov_outputs = ov_outputs[:, inputs["input_ids"].shape[1] :]
         self.assertTrue(
             torch.equal(ov_outputs, transformers_outputs),
@@ -683,7 +684,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             transformers_inputs = copy.deepcopy(inputs)
             ov_outputs = ov_model.generate(**inputs, generation_config=gen_config)
             # original minicpmv, internvl always skip input tokens in generation results, while transformers based approach provide them
-            if model_arch in ["minicpmv", "internvl_chat"]:
+            if model_arch in ["minicpmv", "minicpmo", "internvl_chat"]:
                 ov_outputs = ov_outputs[:, inputs["input_ids"].shape[1] :]
             with torch.no_grad():
                 transformers_outputs = transformers_model.generate(
@@ -701,7 +702,7 @@ class OVModelForVisualCausalLMIntegrationTest(unittest.TestCase):
             transformers_inputs = copy.deepcopy(inputs)
             ov_outputs = ov_model.generate(**inputs, generation_config=gen_config)
             # original minicpmv, internvl always skip input tokens in generation results, while transformers based approach provide them
-            if model_arch in ["minicpmv", "internvl_chat"]:
+            if model_arch in ["minicpmv", "minicpmo", "internvl_chat"]:
                 ov_outputs = ov_outputs[:, inputs["input_ids"].shape[1] :]
             with torch.no_grad():
                 transformers_outputs = transformers_model.generate(

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -116,6 +116,7 @@ MODEL_NAMES = {
     "minicpm": "katuni4ka/tiny-random-minicpm",
     "minicpm3": "katuni4ka/tiny-random-minicpm3",
     "minicpmv": "katuni4ka/tiny-random-minicpmv-2_6",
+    "minicpmo": "rkazants/tiny-random-MiniCPM-o-2_6",
     "mistral": "echarlaix/tiny-random-mistral",
     "mistral-nemo": "katuni4ka/tiny-random-mistral-nemo",
     "mixtral": "TitanML/tiny-mixtral",

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -329,7 +329,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "mamba": {"model": 386},
     "falcon-mamba": {"model": 194},
     "minicpmo": {
-        "lm_model": 30,
+        "lm_model": 16,
         "text_embeddings_model": 1,
         "vision_embeddings_model": 8,
         "resampler_model": 6,

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -328,6 +328,12 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "clip": {"model": 130},
     "mamba": {"model": 386},
     "falcon-mamba": {"model": 194},
+    "minicpmo": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 8,
+        "resampler_model": 6,
+    },
 }
 
 TEST_IMAGE_URL = "http://images.cocodataset.org/val2017/000000039769.jpg"


### PR DESCRIPTION
# What does this PR do?

Command to export the model:
```sh
optimum-cli export openvino -m openbmb/MiniCPM-o-2_6 MiniCPM-o-2_6 --task=image-text-to-text --trust-remote-code
```

Example of inference:
```py
from optimum.intel.openvino import OVModelForVisualCausalLM
from transformers import AutoProcessor
from PIL import Image
import requests

model_id="openbmb/MiniCPM-o-2_6"

processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
prompt= "<|im_start|>user\n(<image>./</image>)\nWhat is in the image?<|im_end|>\n<|im_start|>assistant\n"
image = Image.open(requests.get("https://github.com/openvinotoolkit/openvino_notebooks/assets/29454499/d5fbbd1a-d484-415c-88cb-9986625b7b11", stream=True).raw).convert('RGB')

model = OVModelForVisualCausalLM.from_pretrained(model_id, trust_remote_code=True)

inputs = processor([prompt], [image], return_tensors="pt")

result  = model.generate(**inputs, max_new_tokens=20)

print(processor.tokenizer.batch_decode(result[:, inputs["input_ids"].shape[1]:]))
```

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

