### PR TITLE
[OV] Fix VLM in-place static quantization

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -1440,6 +1440,15 @@ class OVQuantizer(OptimumQuantizer):
                     quantized_model = _mixed_quantization(submodel, config, nncf_dataset, **kwargs)
 
                 # Replace the original model with the quantized model
+                if isinstance(self.model, OVModelForVisualCausalLM):
+                    # Special handling of submodels in OVModelForVisualCausalLM
+                    # TODO (nikita.savelyevv): Implement a proper fix including other model types
+                    if submodel_name == "lm_model":
+                        self.model.language_model.model = quantized_model
+                    elif submodel_name == "text_embeddings_model":
+                        self.model.language_model.text_emb_model = quantized_model
+                    elif submodel_name == "vision_embeddings_model":
+                        self.model.vision_embeddings.model = quantized_model
                 if isinstance(getattr(self.model, submodel_name), openvino.Model):
                     setattr(self.model, submodel_name, quantized_model)
                 elif isinstance(getattr(getattr(self.model, submodel_name), "model"), openvino.Model):


### PR DESCRIPTION
# What does this PR do?

Executing VLMs after static quantization but before serialization leads to original non-quantized models being inferred instead. For example in case of vision embeddings model within a VLM pipeline, the model is replaced at OVModelForVisualCausalLM level, but on at OVVisionEmbedding level.

This is a fast fix for VLMs only, full fix is here #1461


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

