### PR TITLE
[OV] Recover cache_position for Whisper

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 from transformers import AutoConfig, PretrainedConfig, PreTrainedModel
 
+from optimum.exporters.onnx.base import ConfigBehavior
 from optimum.exporters.onnx.config import OnnxConfig, TextDecoderOnnxConfig, TextDecoderWithPositionIdsOnnxConfig
 from optimum.exporters.onnx.model_configs import (
     BartOnnxConfig,
@@ -51,8 +52,6 @@ from optimum.exporters.onnx.model_configs import (
     VisionOnnxConfig,
     WhisperOnnxConfig,
 )
-
-from optimum.exporters.onnx.base import ConfigBehavior
 from optimum.exporters.onnx.model_patcher import ModelPatcher
 from optimum.exporters.tasks import TasksManager
 from optimum.utils import DEFAULT_DUMMY_SHAPES


### PR DESCRIPTION
# What does this PR do?

It recovers cache_position input in the exported whisper model. Regression happened in https://github.com/huggingface/optimum-intel/pull/1457

Fixes https://jira.devtools.intel.com/browse/CVS-174805

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [N/A] Did you make sure to update the documentation with your changes?
- [N/A] Did you write any new necessary tests?

