### PR TITLE
[OpenVINO] Fix data-free pipeline quantization

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -1335,7 +1335,7 @@ class OVQuantizer(OptimumQuantizer):
                 default_config = OVWeightQuantizationConfig(bits=8, sym=True)
             else:
                 default_config = quantization_config
-        else:
+        elif not isinstance(quantization_config, OVPipelineQuantizationConfig):
             #
             # Hybrid/Full/Mixed quantization
             #
@@ -1397,7 +1397,7 @@ class OVQuantizer(OptimumQuantizer):
                     raise NotImplementedError("Mixed precision quantization isn't supported for diffusers.")
 
                 default_config = quantization_config
-            elif not isinstance(quantization_config, OVPipelineQuantizationConfig):
+            else:
                 raise ValueError(f"Unsupported type of quantization config: {type(quantization_config)}")
 
         pipeline_quantization_config = (

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1489,6 +1489,14 @@ class OVPipelineQuantizationTest(unittest.TestCase):
     PIPELINE_QUANTIZATION_SCOPE = [
         (
             OVModelForCausalLM,
+            "gpt2",
+            False,
+            dict(quantization_configs={"model": dict(bits=8, weight_only=True)}),
+            {"model": 0},
+            {"model": {"int8": 44}},
+        ),
+        (
+            OVModelForCausalLM,
             "llama",
             False,
             dict(


### PR DESCRIPTION
# What does this PR do?

Currently an error is raised if quantization is run with pipeline quantization config containing only data-free sub-configs.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

