### PR TITLE
[OpenVINO] Add transformers==4.52 constraint to vision_language_quantization notebook

### DIFF
--- a/notebooks/openvino/vision_language_quantization.ipynb
+++ b/notebooks/openvino/vision_language_quantization.ipynb
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! pip install \"optimum-intel[openvino]\" datasets num2words torchvision\n",
+    "! pip install \"optimum-intel[openvino]\" datasets num2words torchvision transformers==4.52.*\n",
     "! pip install git+https://github.com/huggingface/optimum-benchmark.git"
    ]
   },


### PR DESCRIPTION
# What does this PR do?

To avoid possible issues on SPR CPUs. Should be replaced by "openvino>=2025.4" after its release.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

