### PR TITLE
[OpenVINO] Add `cache_position` input inside `prepare_inputs` method for Mamba

### DIFF
--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -1305,9 +1305,9 @@ class OVModelWithMambaForCausalLM(OVModelForCausalLM):
         **kwargs,
     ) -> Dict:
         if kwargs.get("past_key_values") is not None:
-            raise ValueError("`past_key_values` input is not supported for OVModelWithMambaForCausalLM")
+            raise ValueError("`past_key_values` input is not supported for `OVModelWithMambaForCausalLM`")
         if kwargs.get("position_ids") is not None:
-            raise ValueError("`position_ids` input is not supported for OVModelWithMambaForCausalLM")
+            raise ValueError("`position_ids` input is not supported for `OVModelWithMambaForCausalLM`")
 
         inputs = {"input_ids": input_ids}
         if "cache_position" in self.input_names:


### PR DESCRIPTION
# What does this PR do?

`cache_position` input is required to run inference. Needed for enabling data-aware quantization of Mamba model https://github.com/openvinotoolkit/nncf/pull/3725 .


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

