### PR TITLE
[OpenVINO] Add default int4 config for inceptionai/jais-13b

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -350,6 +350,15 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "sym": False,
         "group_size": -1,
     },
+    "inceptionai/jais-13b": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 128,
+        "ratio": 1.0,
+        "advanced_parameters": nncf.AdvancedCompressionParameters(
+            group_size_fallback_mode=nncf.GroupSizeFallbackMode.ADJUST,
+        ),
+    },
 }
 
 # Add configs for model id aliases


### PR DESCRIPTION
# What does this PR do?

Otherwise the quantization fails on NNCF 2.19 because (down_proj?) MatMuls have 13653 channels, not divisible by 128. With the added config, those MatMuls will be quantized to int8_asym.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

