### PR TITLE
[OpenVINO] Remove deprecated openvino.runtime module

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -1179,7 +1179,7 @@ class OVQuantizer(OptimumQuantizer):
             logger.warning("The `task` argument is ignored and will be removed in optimum-intel v1.27")
 
     @property
-    def task(self) -> Dict[str, Union[openvino.Model, openvino.CompiledModel]]:
+    def task(self) -> str:
         logger.warning("The `task` attribute is deprecated and will be removed in v1.27.")
         return self._task
 


### PR DESCRIPTION
`openvino.runtime` is deprecated in favor of flat `openvino` and is set to be removed in the upcoming 26.0 OpenVINO release.

- https://github.com/openvinotoolkit/openvino/pull/32698
<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->
