### PR TITLE
[OpenVINO] Add gsm8k as a dataset option for CausalLM quantization

### DIFF
--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -109,14 +109,14 @@ Optional arguments:
                         without zero point. 'int8_asym' stands for 8-bit integer asymmetric quantization with zero
                         points per each quantization group.
   --dataset DATASET     The dataset used for data-aware compression or quantization with NNCF. For language models you
-                        can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the dataset will
-                        be collected from model's generations. For diffusion models it should be on of
+                        can use the one from the list ['auto','wikitext2','c4','c4-new','gsm8k']. With 'auto' the
+                        dataset will be collected from model's generations. For diffusion models it should be on of
                         ['conceptual_captions','laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit']. For
                         visual language models the dataset must be set to 'contextual'. Note: if none of the data-aware
                         compression algorithms are selected and ratio parameter is omitted or equals 1.0, the dataset
                         argument will not have an effect on the resulting model. Note: for text generation task,
-                        datasets with English texts such as 'wikitext2','c4' or 'c4-new' usually work fine even for
-                        non-English models.
+                        datasets with English texts such as 'wikitext2','gsm8k','c4' or 'c4-new' usually work fine even
+                        for non-English models.
   --all-layers          Whether embeddings and last MatMul layers should be compressed to INT4. If not provided an
                         weight compression is applied, they are compressed to INT8.
   --awq                 Whether to apply AWQ algorithm. AWQ improves generation quality of INT4-compressed LLMs. If

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -160,14 +160,14 @@ def parse_args_openvino(parser: "ArgumentParser"):
         default=None,
         help=(
             "The dataset used for data-aware compression or quantization with NNCF. "
-            "For language models you can use the one from the list ['auto','wikitext2','c4','c4-new']. With 'auto' the "
+            "For language models you can use the one from the list ['auto','wikitext2','c4','c4-new','gsm8k']. With 'auto' the "
             "dataset will be collected from model's generations. "
             "For diffusion models it should be on of ['conceptual_captions',"
             "'laion/220k-GPT4Vision-captions-from-LIVIS','laion/filtered-wit']. "
             "For visual language models the dataset must be set to 'contextual'. "
             "Note: if none of the data-aware compression algorithms are selected and ratio parameter is omitted or "
             "equals 1.0, the dataset argument will not have an effect on the resulting model."
-            "Note: for text generation task, datasets with English texts such as 'wikitext2','c4' or 'c4-new' usually "
+            "Note: for text generation task, datasets with English texts such as 'wikitext2','gsm8k','c4' or 'c4-new' usually "
             "work fine even for non-English models."
         ),
     )

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -150,7 +150,7 @@ _HEAD_TO_AUTOMODELS = {
     "text-to-audio": "OVModelForTextToSpeechSeq2Seq",
 }
 
-PREDEFINED_CAUSAL_LANGUAGE_DATASETS = {"wikitext2", "c4", "c4-new", "auto"}
+PREDEFINED_CAUSAL_LANGUAGE_DATASETS = {"wikitext2", "c4", "c4-new", "auto", "gsm8k"}
 
 PREDEFINED_LANGUAGE_DATASETS = {
     "wikitext2": {"id": "wikitext", "name": "wikitext-2-raw-v1", "split": "train", "streaming": False},

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -318,7 +318,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             "text-generation",
             "llama",
             "int4_f8e5m2",
-            "--dataset wikitext2 --num-samples 1 --group-size 16 --trust-remote-code",
+            "--dataset gsm8k --num-samples 1 --group-size 16 --trust-remote-code",
             {
                 "model": 15,
             },
@@ -531,7 +531,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         (
             "text-generation-with-past",
             "llama_awq",
-            "int4 --ratio 1.0 --sym --group-size 16 --awq --dataset wikitext2 --num-samples 100 "
+            "int4 --ratio 1.0 --sym --group-size 16 --awq --dataset gsm8k --num-samples 100 "
             "--sensitivity-metric max_activation_variance",
             {"model": {"int8": 4, "int4": 14}},
         ),

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -206,7 +206,7 @@ class OVQuantizerTest(unittest.TestCase):
             OVMixedQuantizationConfig(
                 weight_quantization_config=OVWeightQuantizationConfig(bits=4, group_size=16),
                 full_quantization_config=OVQuantizationConfig(dtype="f8e5m2"),
-                dataset="wikitext2",
+                dataset="gsm8k",
                 num_samples=1,
             ),
             {
@@ -1816,7 +1816,7 @@ class OVQuantizationConfigTest(unittest.TestCase):
                     dtype="f8e4m3", ignored_scope={"patterns": [f"{pattern_prefix}.layers.0.mlp"]}
                 ),
                 ignored_scope={"patterns": [f"{pattern_prefix}.layers.1.self_attn"]},
-                dataset="wikitext2",
+                dataset="gsm8k",
                 num_samples=1,
             ),
         ),
@@ -1904,6 +1904,11 @@ class OVQuantizationConfigTest(unittest.TestCase):
         ),
         (
             dict(bits=4, dataset="wikitext2"),
+            OVWeightQuantizationConfig,
+            None,
+        ),
+        (
+            dict(bits=4, dataset="gsm8k"),
             OVWeightQuantizationConfig,
             None,
         ),


### PR DESCRIPTION
# What does this PR do?

In this PR "gsm8k" dataset option is added to apply data-aware quantization to causal language modes. Calibrating on "gsm8k" in some cases provides better results compared to "wikitext2":

| Model                   | Precision         | Calibration Dataset | seqlen | gsm8k_cot_llama (strict-match) | gsm8k_cot_llama (flexible-extract) |
|-------------------------|-------------------|----------------------|-------------|-------------------------------|-------------------------------------|
| Llama-3.1-8B-Instruct   | nf4 per-channel   | wikitext2            | 32          | 78.70%                       | 78.77%                              |
| Llama-3.1-8B-Instruct   | nf4 per-channel   | gsm8k                | 64          | 80.29%                       | 80.82%                              |
| Llama-3.1-8B-Instruct   | nf4 per-channel   | gsm8k                | 128         | 79.30%                       | 79.53%                              |
| Llama-3.1-8B-Instruct   | nf4 per-channel   | gsm8k                | 256         | **81.20%**                     | **81.50%**                          |



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

