### PR TITLE
Revert "[Docs] Export whisper as stateless during quantization (#1435)"

### DIFF
--- a/docs/source/openvino/optimization.mdx
+++ b/docs/source/openvino/optimization.mdx
@@ -1014,7 +1014,7 @@ ov_model = OVModelForSpeechSeq2Seq.from_pretrained(
 )
 ```
 
-With this, encoder, decoder and decoder-with-past models of the Whisper pipeline will be fully quantized, including activations.
+With this, encoder and decoder models of the Whisper pipeline will be fully quantized, including activations.
 
 ##  Hybrid quantization
 


### PR DESCRIPTION
# What does this PR do?

This PR reverts #1435. After fixes were merged in https://github.com/huggingface/optimum-intel/pull/1505, using stateless models for quantization is no longer required as long as the latest NNCF version is used.

Ticket CVS-172705

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

