### PR TITLE
[OpenVINO] Fix VLM mixed quantization

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -1426,11 +1426,13 @@ class OVQuantizer(OptimumQuantizer):
                 else:
                     # The model may be for example OVModelForImageClassification, OVModelForAudioClassification, etc.
                     quantization_configs["model"] = quantization_config
-            elif isinstance(quantization_config, OVQuantizationConfig):
+            elif isinstance(quantization_config, (OVQuantizationConfig, OVMixedQuantizationConfig)):
                 #
-                # Full quantization
+                # Full & Mixed quantization
                 #
                 if is_diffusers_available() and isinstance(self.model, OVDiffusionPipeline):
+                    if isinstance(quantization_config, OVMixedQuantizationConfig):
+                        raise NotImplementedError("Mixed precision quantization isn't supported for diffusers.")
                     diffusion_model_name = next(iter(calibration_dataset))
                     quantization_configs[diffusion_model_name] = quantization_config
                     default_config = OVWeightQuantizationConfig(bits=8)
@@ -1446,14 +1448,6 @@ class OVQuantizer(OptimumQuantizer):
                     default_config = OVWeightQuantizationConfig(bits=8, sym=True)
                 else:
                     default_config = quantization_config
-            elif isinstance(quantization_config, OVMixedQuantizationConfig):
-                #
-                # Mixed quantization
-                #
-                if is_diffusers_available() and isinstance(self.model, OVDiffusionPipeline):
-                    raise NotImplementedError("Mixed precision quantization isn't supported for diffusers.")
-
-                default_config = quantization_config
             else:
                 raise ValueError(f"Unsupported type of quantization config: {type(quantization_config)}")
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -387,6 +387,28 @@ class OVQuantizerTest(unittest.TestCase):
                 "vision_embeddings_merger_model": {"int8": 10},
             },
         ),
+        (
+            OVModelForVisualCausalLM,
+            "qwen2_vl",
+            OVMixedQuantizationConfig(
+                weight_quantization_config=OVWeightQuantizationConfig(bits=4, group_size=16, ratio=0.7),
+                full_quantization_config=OVQuantizationConfig(dtype="f8e4m3", smooth_quant_alpha=0.9),
+                dataset="contextual",
+                num_samples=1,
+            ),
+            {
+                "lm_model": 16,
+                "text_embeddings_model": 0,
+                "vision_embeddings_model": 1,
+                "vision_embeddings_merger_model": 16,
+            },
+            {
+                "lm_model": {"f8e4m3": 8, "int4": 14},
+                "text_embeddings_model": {"int8": 1},
+                "vision_embeddings_model": {"f8e4m3": 1},
+                "vision_embeddings_merger_model": {"f8e4m3": 2, "int4": 16},
+            },
+        ),
     ]
 
     @staticmethod


### PR DESCRIPTION
# What does this PR do?

Fix failures when mixed quantization config is selected for quantization of VLM models. Fixes https://github.com/huggingface/optimum-intel/issues/1552. Added a corresponding test case.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

