### PR TITLE
[OpenVINO] Revert NNCF version check

### DIFF
--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -52,9 +52,17 @@ from .configuration import (
 )
 
 
+logger = logging.getLogger(__name__)
+
 if is_nncf_available():
     logging.disable(logging.INFO)
     import nncf
+
+    if is_nncf_version("<", "2.19"):
+        logger.warning(
+            "NNCF version 2.19 or higher is required to use NNCF-based quantization. "
+            f"Please upgrade your NNCF installation. The current version of NNCF is {nncf.__version__}."
+        )
 
     logging.disable(logging.NOTSET)
 


### PR DESCRIPTION
# What does this PR do?

Revert NNCF version check to be a warning until a proper solution is found. 

The current problem is that when NNCF is manually installed from the release branch, i.e. `pip install git+https://github.com/openvinotoolkit/nncf.git@release_v2190`, the version becomes `2.19.0.dev0+8a9d5871e` and it does not pass the condition. We also can't truncate the version because it will allow installing from any intermediate commit between NNCF 2.18 and 2.19 (in NNCF we raise version on the develop branch to the next one right after the release).

One solution is to do `if is_nncf_version("<", "2.19") and not is_nncf_version("==", "2.19.0.dev0+8a9d5871e"):`, but it looks hacky. Perhaps, we'll make changes on NNCF side to improve on this.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

