### PR TITLE
Fix NNCF versions comparison

### DIFF
--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -407,7 +407,8 @@ def is_nncf_version(operation: str, version: str):
     """
     if not _nncf_available:
         return False
-    return compare_versions(parse(_nncf_version), operation, version)
+    base_version = parse(_nncf_version).base_version
+    return compare_versions(parse(base_version), operation, version)
 
 
 def is_openvino_tokenizers_version(operation: str, version: str):


### PR DESCRIPTION
Fixes:
```
ImportError: NNCF version 2.19 or higher is required to use NNCF-based quantization. Please upgrade your NNCF installation. The current version of NNCF is 2.19.0.
```