### PR TITLE
Add support for exporting CLIP submodels in OpenVINO

### DIFF
--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -41,6 +41,7 @@ usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt}
                                    [--quantization-statistics-path QUANTIZATION_STATISTICS_PATH]
                                    [--num-samples NUM_SAMPLES] [--disable-stateful] [--disable-convert-tokenizer]
                                    [--smooth-quant-alpha SMOOTH_QUANT_ALPHA]
+                                   [--submodel {vision,text,full}]
                                    output
 
 optional arguments:
@@ -165,6 +166,10 @@ Optional arguments:
   --smooth-quant-alpha SMOOTH_QUANT_ALPHA
                         SmoothQuant alpha parameter that improves the distribution of activations before MatMul layers
                         and reduces quantization error. Valid only when activations quantization is enabled.
+  --submodel {vision,text,full}
+                        For CLIP models (Transformers) with `feature-extraction`, export only the specified
+                        submodule. Use `vision` to export the vision encoder, `text` for the text encoder,
+                        or `full` to export the default combined behavior. Default is `full`.
 ```
 
 You can also apply fp16, 8-bit or 4-bit weight-only quantization on the Linear, Convolutional and Embedding layers when exporting your model by setting `--weight-format` to respectively `fp16`, `int8` or `int4`.
@@ -219,6 +224,26 @@ or
 ```bash
 optimum-cli export openvino -m openai/clip-vit-base-patch16 --quant-mode int8 ./clip-vit-base-patch16
 ```
+
+### CLIP submodules
+
+For CLIP models loaded via Transformers and exported for `feature-extraction`, you can export only the vision or only the text encoder using `--submodel`:
+
+- Vision encoder only:
+
+```bash
+optimum-cli export openvino --model openai/clip-vit-base-patch32 \
+  --task feature-extraction --submodel vision ov_clip_vision/
+```
+
+- Text encoder only:
+
+```bash
+optimum-cli export openvino --model openai/clip-vit-base-patch32 \
+  --task feature-extraction --submodel text ov_clip_text/
+```
+
+If `--submodel` is omitted or set to `full`, the default combined CLIP export is used.
 
 
 ### Decoder models

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -289,6 +289,16 @@ def parse_args_openvino(parser: "ArgumentParser"):
         ),
     )
     optional_group.add_argument(
+        "--submodel",
+        type=str,
+        choices=["vision", "text", "full"],
+        default="full",
+        help=(
+            "For CLIP/OpenCLIP feature-extraction, export only the specified submodule. "
+            "Use 'vision' to export the vision encoder, 'text' for the text encoder, or 'full' for the combined/default behavior."
+        ),
+    )
+    optional_group.add_argument(
         "--model-kwargs",
         type=json.loads,
         help=("Any kwargs passed to the model forward, or used to customize the export for a given model."),
@@ -480,6 +490,7 @@ class OVExportCommand(BaseOptimumCLICommand):
                 library_name=library_name,
                 variant=self.args.variant,
                 model_kwargs=self.args.model_kwargs,
+                submodel=self.args.submodel,
                 # **input_shapes,
             )
             if apply_main_quantize:

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -184,6 +184,7 @@ def main_export(
     library_name: Optional[str] = None,
     model_loading_kwargs: Optional[Dict[str, Any]] = None,
     variant: Optional[str] = None,
+    submodel: Optional[str] = None,
     **kwargs_shapes,
 ):
     """
@@ -484,6 +485,20 @@ def main_export(
                 library_name=library_name,
                 **loading_kwargs,
             )
+
+        # If user asks for a specific CLIP submodel, swap to that submodule so
+        # TasksManager sees the right model_type (e.g. clip_vision_model) and config.
+        if (
+            submodel in {"vision", "text"}
+            and library_name == "transformers"
+            and task == "feature-extraction"
+        ):
+            if submodel == "vision" and hasattr(model, "vision_model"):
+                logger.info("Exporting CLIP vision submodel via TasksManager registry.")
+                model = model.vision_model
+            elif submodel == "text" and hasattr(model, "text_model"):
+                logger.info("Exporting CLIP text submodel via TasksManager registry.")
+                model = model.text_model
 
         needs_pad_token_id = task == "text-classification" and getattr(model.config, "pad_token_id", None) is None
 

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -347,3 +347,39 @@ class CustomExportModelTest(unittest.TestCase):
         ov_outputs = ov_model(**tokens)
         self.assertTrue(torch.allclose(ov_outputs.token_embeddings, model_outputs.token_embeddings, atol=1e-4))
         self.assertTrue(torch.allclose(ov_outputs.sentence_embedding, model_outputs.sentence_embedding, atol=1e-4))
+
+
+class CLIPSubmodelExportTest(unittest.TestCase):
+    def test_export_clip_vision_submodel_feature_extraction(self):
+        model_id = MODEL_NAMES["clip"]
+        with TemporaryDirectory() as tmpdirname:
+            main_export(
+                model_name_or_path=model_id,
+                library_name="transformers",
+                output=Path(tmpdirname),
+                task="feature-extraction",
+                submodel="vision",
+            )
+
+            ov_model = OVModelForFeatureExtraction.from_pretrained(tmpdirname, device=OPENVINO_DEVICE)
+            self.assertIsInstance(ov_model, OVBaseModel)
+            # Vision submodel should accept image tensors, not text inputs
+            self.assertIn("pixel_values", ov_model.input_names)
+            self.assertNotIn("input_ids", ov_model.input_names)
+
+    def test_export_clip_text_submodel_feature_extraction(self):
+        model_id = MODEL_NAMES["clip"]
+        with TemporaryDirectory() as tmpdirname:
+            main_export(
+                model_name_or_path=model_id,
+                library_name="transformers",
+                output=Path(tmpdirname),
+                task="feature-extraction",
+                submodel="text",
+            )
+
+            ov_model = OVModelForFeatureExtraction.from_pretrained(tmpdirname, device=OPENVINO_DEVICE)
+            self.assertIsInstance(ov_model, OVBaseModel)
+            # Text submodel should accept token ids, not image tensors
+            self.assertIn("input_ids", ov_model.input_names)
+            self.assertNotIn("pixel_values", ov_model.input_names)


### PR DESCRIPTION
# What does this PR do?

- Purpose: Add --submodel {vision,text,full} to the export CLI to allow exporting only the CLIP vision or text encoder. This change stems from the need to simplify CLIP model conversion for the DL Streamer project.
- Motivation: DL Streamer benefits from separate CLIP submodules (vision/text) as standalone IRs. The flag removes downstream splitting complexity and leverages the existing TasksManager registry.
- Implementation: Routes --submodel from the CLI to main_export. For Transformers CLIP under feature-extraction, main_export swaps to model.vision_model or model.text_model so TasksManager resolves the correct clip_vision_model/clip_text_model.
- Documentation: Updates export.mdx with the new flag, usage, and examples for vision-only and text-only exports.
- Tests: Adds CLIPSubmodelExportTest validating that the exported IRs expose the expected inputs (pixel_values for vision, input_ids for text).
- Backward Compatibility: Default behavior remains unchanged (full export if the flag is omitted). No breaking changes.
- Scope: Supports Transformers CLIP for feature-extraction. OpenCLIP has registry coverage and can be similarly wired in a follow-up to map its submodules; not included in this PR.
- Impact: Cleaner exports, reducing integration overhead for DL Streamer and other consumers requiring separate CLIP encoders.



## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

