### PR TITLE
[OpenVINO] Fix immediate quantized model save path

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -1419,8 +1419,8 @@ class OVQuantizer(OptimumQuantizer):
                         raise FileNotFoundError(f"Expected to find model file at {ov_model_path} to overwrite it.")
                     ov_model_path.unlink()
                     ov_model_path.with_suffix(".bin").unlink()
-                    temp_model_path.rename(save_directory / ov_model_path)
-                    temp_model_path.with_suffix(".bin").rename((save_directory / ov_model_path).with_suffix(".bin"))
+                    temp_model_path.rename(ov_model_path)
+                    temp_model_path.with_suffix(".bin").rename(ov_model_path.with_suffix(".bin"))
                 finally:
                     temporary_directory.cleanup()
 


### PR DESCRIPTION
# What does this PR do?

Fix a typo in quantized model path definition. At the moment it works because `save_directory` is always a path like `/tmp/XXX` and `Path("/tmp/XXX") / Path("/tmp/XXX/model.xml")` is `Path("/tmp/XXX/model.xml")`.


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

