### PR TITLE
Update OpenVINO tests to use tiny-random-minicpm-o-2_6 model

### DIFF
--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -132,7 +132,7 @@ MODEL_NAMES = {
     "minicpm": "optimum-intel-internal-testing/tiny-random-minicpm",
     "minicpm3": "optimum-intel-internal-testing/tiny-random-minicpm3",
     "minicpmv": "optimum-intel-internal-testing/tiny-random-minicpmv-2_6",
-    "minicpmo": "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
+    "minicpmo": "ahmedzk11/tiny-random-minicpm-o-2_6",
     "mistral": "optimum-intel-internal-testing/tiny-random-mistral",
     "mistral-nemo": "optimum-intel-internal-testing/tiny-random-mistral-nemo",
     "mixtral": "optimum-intel-internal-testing/tiny-mixtral",


### PR DESCRIPTION
Summary
This PR updates the OpenVINO test suite to use the tiny-random-minicpm-o-2_6 model
instead of the optimum-intel-internal-testing model for faster testing.

Changes
- Updated `tests/openvino/utils_tests.py` line 135 to reference the new tiny model

 Model Details
- Model ID: `ahmedzk11/tiny-random-minicpm-o-2_6`
- Size: 37.7 MB (74% reduction)
- Architecture**: MiniCPMO
- Task: image-text-to-text

Related
- PR 1454: Support openbmb/MiniCPM-o-2_6 for image-text-to-text task