### PR TITLE
Remove Gaudi mention from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,8 +104,3 @@ Do not forget to install requirements for every example:
 cd <example-folder>
 pip install -r requirements.txt
 ```
-
-
-## Gaudi
-
-To train your model on [Intel Gaudi AI Accelerators (HPU)](https://docs.habana.ai/en/latest/index.html), check out [Optimum Habana](https://github.com/huggingface/optimum-habana) which provides a set of tools enabling easy model loading, training and inference on single- and multi-HPU settings for different downstream tasks. After training your model, feel free to submit it to the Intel [leaderboard](https://huggingface.co/spaces/Intel/powered_by_intel_llm_leaderboard) which is designed to evaluate, score, and rank open-source LLMs that have been pre-trained or fine-tuned on Intel Hardwares. Models submitted to the leaderboard will be evaluated on the Intel Developer Cloud. The evaluation platform consists of Gaudi Accelerators and Xeon CPUs running benchmarks from the Eleuther AI Language Model Evaluation Harness.


### PR DESCRIPTION
# What does this PR do?

No need to advertise Gaudi in optimum-intel README. Gaudi is a separate product that should advertise itself on its own.

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [N/A] Did you make sure to update the documentation with your changes?
- [N/A] Did you write any new necessary tests?

