### PR TITLE
[OpenVINO] Use attention_mask_without_vmap for Arcee Trinity model

### DIFF
--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -7454,7 +7454,7 @@ def afmoe_moe_forward_patched(self, hidden_states):
     return output.view(batch_size, seq_len, hidden_dim)
 
 
-class AfmoeModelPatcher(ModelPatcher):
+class AfmoeModelPatcher(OVDecoderModelPatcher):
     def __enter__(self):
         super().__enter__()
         for idx, layer in enumerate(self._model.model.layers):

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -735,12 +735,6 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
                 f"generation config : {gen_config}, transformers output {transformers_outputs}, ov_model_stateful output {ov_stateful_outputs}",
             )
 
-            # beam search does not work for stateless afmoe:
-            # generation results for the second padded prompt in the batch is incorrect
-            # won't be fixed since stateless model is not used for OpenVINO GenAI
-            if model_arch in ["afmoe"]:
-                continue
-
             set_seed(SEED)
             ov_stateless_outputs = ov_model_stateless.generate(**tokens, generation_config=gen_config)
             self.assertTrue(


### PR DESCRIPTION
# What does this PR do?

Use attention_mask_without_vmap for Arcee Trinity model. It will fix nan values for non-stateful models on CPU

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [N/A] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

