### PR TITLE
Add the compression config for microsoft/Phi-4-reasoning to improve the accuracy

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -275,6 +275,12 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "ratio": 1.0,
         "quant_method": OVQuantizationMethod.AWQ,
     },
+    "microsoft/Phi-4-reasoning": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "ratio": 1.0,
+    },
     "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B": {
         "bits": 4,
         "sym": False,


### PR DESCRIPTION
# What does this PR do?

Added the compression config for microsoft/Phi-4-reasoning to improve the accuracy from 
  0.775866 (optimum)
  0.783429 (genai)
to
  0.865509 (optimum)
  0.859994 (genai)

Data-aware methods improve it insignificantly but take a lot of time, so I decided to skip them.

Fixes # 171068


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

