### PR TITLE
Add a condition based on the NNCF version to rename the mode from cb4 to cb4_f8e4m3

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -27,7 +27,10 @@ from transformers.utils.quantization_config import QuantizationConfigMixin
 
 from optimum.configuration_utils import BaseConfig
 
-from ..utils.import_utils import is_nncf_available
+from ..utils.import_utils import (
+    is_nncf_available,
+    is_nncf_version,
+)
 from .utils import (
     PREDEFINED_CAUSAL_LANGUAGE_DATASETS,
     PREDEFINED_LANGUAGE_DATASETS,
@@ -1060,7 +1063,8 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         mode = self.dtype if self.dtype else signed_bitness[self.bits]
         if mode in signed_bitness.values():
             mode += "_sym" if self.sym else "_asym"
-        if mode == "cb4":
+
+        if mode == "cb4" and is_nncf_version("<=", "2.19"):
             mode = "cb4_f8e4m3"
         mode = nncf.CompressWeightsMode(mode)
 


### PR DESCRIPTION
# What does this PR do?

The [PR#3827](https://github.com/openvinotoolkit/nncf/pull/3827) was recently merged into NNCF. This PR renames the `nncf.CompressWeightsMode.CB4_F8E4M3` parameter to `nncf.CompressWeightsMode.CB4`.

This PR reflects these changes and makes the required updates in optimum-intel.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?