### PR TITLE
4-bit compression config for Trinity model

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -388,7 +388,7 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
             "sym": False,
             "weight_only": True,
         },
-    },    
+    },
 }
 
 _DEFAULT_8BIT_WQ_CONFIGS = {


### PR DESCRIPTION
# What does this PR do?

Adds the compression configuration file which improves the Similarity of int4 model from 0.019552 to 0.920634 (CPU). This model is MoE and requires the ignored scope similar to GPT-OSS.

Fixes # 179269

## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

