### PR TITLE
Do not use openvino extras in tests

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           pip install --upgrade pip uv
           uv pip install git+https://github.com/huggingface/doc-builder
-          uv pip install .[quality] nncf openvino neural-compressor[pt]>3.4 diffusers accelerate datasets
+          uv pip install .[quality] neural-compressor[pt]>3.4 diffusers accelerate datasets
 
       - name: Make documentation
         shell: bash

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           pip install --upgrade pip uv
           uv pip install git+https://github.com/huggingface/doc-builder
-          uv pip install .[quality] nncf openvino neural-compressor[pt]>3.4 diffusers accelerate datasets
+          uv pip install .[quality] neural-compressor[pt]>3.4 diffusers accelerate datasets
 
       - name: Make documentation
         shell: bash

--- a/.github/workflows/test_offline.yaml
+++ b/.github/workflows/test_offline.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip uv
-          uv pip install .[openvino,diffusers,tests]
+          uv pip install .[diffusers,tests]
 
       - name: Test
         run: |

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip uv
-          uv pip install .[openvino,diffusers,tests]
+          uv pip install .[diffusers,tests]
 
       - if: ${{ matrix.transformers-version != 'latest' }}
         name: Install specific dependencies and versions required for older transformers

--- a/.github/workflows/test_openvino_nightly.yml
+++ b/.github/workflows/test_openvino_nightly.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip uv
-          uv pip install .[openvino,diffusers,tests]
+          uv pip install .[diffusers,tests]
 
       - if: ${{ matrix.openvino-version == 'openvino-nightly' }}
         name: Install OpenVINO Nightly

--- a/.github/workflows/test_openvino_notebooks.yml
+++ b/.github/workflows/test_openvino_notebooks.yml
@@ -53,7 +53,7 @@ jobs:
         run: |
           pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
           pip install -r notebooks/openvino/requirements.txt
-          pip install .[tests,openvino] nbval
+          pip install .[tests] nbval
 
       - name: Change some variables
         run: |

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip uv
-          uv pip install .[openvino,tests,diffusers] transformers[testing]
+          uv pip install .[tests,diffusers] transformers[testing]
 
       - if: ${{ matrix.transformers-version != 'latest' && matrix.transformers-version != 'main' }}
         name: Install specific dependencies and versions required for older transformers


### PR DESCRIPTION
# What does this PR do?

OpenVINO and NNCF are now installed without extras. Extras are deprecated way so use the latest recommended path.

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [N/A] Did you make sure to update the documentation with your changes?
- [N/A] Did you write any new necessary tests?

