### PR TITLE
Fix incorrect task inference for the Phi-4-multimodal-instruct model

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -643,7 +643,7 @@ def _main_quantize(
     # explicitly. Because of this, we get an error.
     if original_task == "auto" and library_name == "transformers":
         config = AutoConfig.from_pretrained(
-            output,
+            model_name_or_path,
             subfolder=subfolder,
             revision=revision,
             cache_dir=cache_dir,


### PR DESCRIPTION
# What does this PR do?

Fixed the following error, which occurred on commit 2c48d6430c265ac259c1b264f3e2c4025cdd7b76:

```
RuntimeError: Exception from src/inference/src/cpp/core.cpp:97:
Check 'util::directory_exists(path) || util::file_exists(path)' failed at src/frontends/common/src/frontend.cpp:113:
FrontEnd API failed with GeneralFailure:
ir: Could not open the file: "/tmp/tmp2qkkght3/openvino_encoder_model.xml"
```

This error occurred when attempting to execute the command:

```
optimum-cli export openvino -m microsoft/Phi-4-multimodal-instruct tmp --trust-remote-code --weight-format int4 --group-size -1
```

**Root Cause:** The inferred task for this model.

https://github.com/huggingface/optimum-intel/blob/2c48d6430c265ac259c1b264f3e2c4025cdd7b76/optimum/exporters/openvino/__main__.py#L621

is `'automatic-speech-recognition'`. So the corresponding class

https://github.com/huggingface/optimum-intel/blob/2c48d6430c265ac259c1b264f3e2c4025cdd7b76/optimum/exporters/openvino/__main__.py#L656

is the `OVModelForSpeechSeq2Seq`. We can't load the model that was exported during `main_export()` via `OVModelForSpeechSeq2Seq.from_pretrained()`. The provided error occurred.

This fix is based on https://github.com/huggingface/optimum-intel/pull/1293

Versions:
```
transformers==4.51.3
peft==0.17
```

Fixes CVS-179936


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

