### PR TITLE
Add 4-bit compression configs for Qwen3-VL-Instruct models

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -150,6 +150,28 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "dataset": "wikitext2",
         "scale_estimation": True,
     },
+    "Qwen/Qwen3-VL-2B-Instruct": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 128,
+        "ratio": 1.0,
+        "quant_method": OVQuantizationMethod.AWQ,
+    },
+    "Qwen/Qwen3-VL-4B-Instruct": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 128,
+        "ratio": 1.0,
+        "dataset": "contextual",
+        "quant_method": OVQuantizationMethod.AWQ,
+    },
+    "Qwen/Qwen3-VL-8B-Instruct": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 128,
+        "ratio": 1.0,
+        "quant_method": OVQuantizationMethod.AWQ,
+    },    
     "openlm-research/open_llama_3b": {"bits": 4, "sym": False, "group_size": 64, "all_layers": True},
     "openlm-research/open_llama_3b_v2": {
         "bits": 4,


### PR DESCRIPTION
# What does this PR do?

Added 4-bit compression configs to improve the accuracy (WWB Similarity):
Qwen3-VL-2B-Instruct: 0.818011 => 0.886057 
Qwen3-VL-4B-Instruct: 0.858663 => 0.921251 
Qwen3-VL-8B-Instruct: 0.867159 => 0.887357

Fixes # CVS-173549

## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

