### PR TITLE
Added int4 compression config for arcee-ai/Trinity-Mini

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -415,7 +415,7 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "quantization_config1": {
             "bits": 4,
             "sym": False,
-            "group_size": 128,
+            "group_size": 64,
             # With ignored scope below we keep some weights in their original precision during the first quantization
             # run and then quantize them to int8 in the second run.
             "ignored_scope": {"patterns": [".*self_attn.*", ".*router.*"]},


### PR DESCRIPTION
# What does this PR do?

Added int4 compression config for arcee-ai/Trinity-Mini improving the accuracy (wwb Similarity) from 0.029016 to 0.91278. This is a MOE model and requires a specific quantization config like gpt-oss.  

Fixes #181417


## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

