### PR TITLE
int4 compression for qnguyen3/nanoLLaVA

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -426,6 +426,14 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
             "weight_only": True,
         },
     },
+    "qnguyen3/nanoLLaVA": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "ratio": 1.0,
+        "dataset": "contextual",
+        "scale_estimation": True,
+    },
 }
 
 _DEFAULT_8BIT_WQ_CONFIGS = {


### PR DESCRIPTION
# What does this PR do?

Added int4 compression config for qnguyen3/nanoLLaVA improving the accuracy (wwb similarity, CPU) from 0.769519 to 0.884534 

Fixes # 182556


## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

