### PR TITLE
Add Qwen3-Omni (dense) OpenVINO export and inference support

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -422,7 +422,7 @@ def main_export(
 
         if original_task == "auto" and model_type in {"phi4mm", "phi4_multimodal"}:
             task = "image-text-to-text"
-        elif model_type == "qwen3_omni_moe":
+        elif model_type in {"qwen3_omni_moe", "qwen3_omni"}:
             task = "image-text-to-text"
 
         if model_type not in TasksManager._SUPPORTED_MODEL_TYPE:
@@ -747,8 +747,8 @@ def _main_quantize(
     # would otherwise route to the wrong OV class:
     #   - Phi-4-multimodal-instruct: its model card pins pipeline_tag=automatic-speech-recognition, so the
     #     *inferred* (auto) task is wrong and would pick OVModelForSpeechSeq2Seq.
-    #   - Qwen3-Omni-MoE: registers several tasks (text-to-audio, ASR, image-text-to-text); any of them,
-    #     whether inferred or passed explicitly, must still load through OVModelForVisualCausalLM.
+    #   - Qwen3-Omni (dense and MoE): register several tasks (text-to-audio, ASR, image-text-to-text); any of
+    #     them, whether inferred or passed explicitly, must still load through OVModelForVisualCausalLM.
     # AutoConfig is cheap (cached) so we always read it to decide on the redirect.
     if library_name == "transformers":
         config = AutoConfig.from_pretrained(
@@ -763,7 +763,7 @@ def _main_quantize(
         # phi4mm is only misrouted by task inference, so keep its redirect limited to the auto case.
         if original_task == "auto" and model_type in ["phi4mm", "phi4_multimodal"]:
             task = "image-text-to-text"
-        elif model_type == "qwen3_omni_moe":
+        elif model_type in ["qwen3_omni_moe", "qwen3_omni"]:
             task = "image-text-to-text"
 
     # Step 1. Obtain the correct OpenVINO model class
@@ -830,6 +830,10 @@ def maybe_convert_tokenizers(library_name: str, output: Path, model=None, prepro
     from optimum.exporters.openvino.convert import export_tokenizer
 
     if is_openvino_tokenizers_available():
+        model_type = None
+        if model and hasattr(model, "config"):
+            model_type = getattr(model.config, "export_model_type", None) or getattr(model.config, "model_type", None)
+
         if library_name != "diffusers" and preprocessors:
             processor_chat_template = None
             tokenizer = next(filter(lambda it: isinstance(it, PreTrainedTokenizerBase), preprocessors), None)
@@ -844,6 +848,7 @@ def maybe_convert_tokenizers(library_name: str, output: Path, model=None, prepro
                         output,
                         task=task,
                         processor_chat_template=processor_chat_template,
+                        model_type=model_type,
                     )
                 except Exception as exception:
                     logger.warning(
@@ -854,7 +859,7 @@ def maybe_convert_tokenizers(library_name: str, output: Path, model=None, prepro
             for tokenizer_name in ("tokenizer", "tokenizer_2", "tokenizer_3"):
                 tokenizer = getattr(model, tokenizer_name, None)
                 if tokenizer:
-                    export_tokenizer(tokenizer, output / tokenizer_name, task=task)
+                    export_tokenizer(tokenizer, output / tokenizer_name, task=task, model_type=model_type)
     else:
         logger.warning("Tokenizer won't be converted.")
 

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -97,6 +97,13 @@ if TYPE_CHECKING:
     from optimum.intel.openvino.configuration import OVConfig
 
 
+_VLM_LANGUAGE_MODEL_TASKS = ("image-text-to-text", "text-to-audio", "automatic-speech-recognition")
+
+
+def _is_vlm_language_model(task: str, model_name: str) -> bool:
+    return model_name == "language_model" and any(t in task for t in _VLM_LANGUAGE_MODEL_TASKS)
+
+
 def _set_runtime_options(
     models_and_export_configs: Dict[
         str,
@@ -112,13 +119,13 @@ def _set_runtime_options(
             sub_export_config.runtime_options = {}
         if (
             "text-generation" in task
-            or ("image-text-to-text" in task and model_name == "language_model")
+            or _is_vlm_language_model(task, model_name)
             or getattr(sub_export_config, "stateful", False)
         ):
             sub_export_config.runtime_options["ACTIVATIONS_SCALE_FACTOR"] = "8.0"
         if not quantized_model and (
             "text-generation" in task
-            or ("image-text-to-text" in task and model_name == "language_model")
+            or _is_vlm_language_model(task, model_name)
             or getattr(sub_export_config, "stateful", False)
         ):
             sub_export_config.runtime_options["KV_CACHE_PRECISION"] = "f16"
@@ -840,6 +847,7 @@ def export_tokenizer(
     suffix: Optional[str] = "",
     task: Optional[str] = None,
     processor_chat_template: Optional[str] = None,
+    model_type: Optional[str] = None,
 ):
     # avoid circular imports
     from optimum.intel.openvino import OV_DETOKENIZER_NAME, OV_TOKENIZER_NAME
@@ -856,11 +864,16 @@ def export_tokenizer(
     if output.exists():
         tokenizer = maybe_convert_tokenizer_to_fast(tokenizer, output)
 
-    if (
-        task is not None
-        and (task.startswith("text-generation") or task == "image-text-to-text")
-        and compare_versions("openvino-tokenizers", ">=", "2024.3.0.0")
-    ):
+    # Left-padding is required for decoder-only generation (text-generation and VLMs). For audio tasks
+    # it is only correct for the multimodal models that route audio through a decoder-only language model,
+    # so gate it by model_type instead of enabling it for every audio model.
+    left_padding_audio_model_types = ("qwen3_omni_moe", "qwen3_omni", "qwen2_vl")
+    needs_left_padding = task is not None and (
+        task.startswith("text-generation")
+        or task == "image-text-to-text"
+        or (task in ("text-to-audio", "automatic-speech-recognition") and model_type in left_padding_audio_model_types)
+    )
+    if needs_left_padding and compare_versions("openvino-tokenizers", ">=", "2024.3.0.0"):
         logger.info(f"Set tokenizer padding side to left for `{task}` task.")
         tokenizer.padding_side = "left"
         tokenizer.truncation_side = "left"

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -190,6 +190,7 @@ from optimum.intel.utils.import_utils import (
     is_transformers_version,
 )
 from optimum.utils.input_generators import (
+    DTYPE_MAPPER,
     ASTDummyAudioInputGenerator,
     BartDummyTextInputGenerator,
     BloomDummyPastKeyValuesGenerator,
@@ -343,6 +344,22 @@ def init_model_configs():
             "Qwen3OmniMoeForConditionalGeneration",
         )
 
+    # Dense Qwen3Omni has the same routing gap and needs the same custom-class registration. The class
+    # names are resolved lazily on export, so registering the strings is safe even when the dense
+    # Qwen3OmniForConditionalGeneration is not importable in the current transformers build.
+    TasksManager._CUSTOM_CLASSES[("pt", "qwen3_omni", "automatic-speech-recognition")] = (
+        "transformers",
+        "Qwen3OmniForConditionalGeneration",
+    )
+    TasksManager._CUSTOM_CLASSES[("pt", "qwen3_omni", "image-text-to-text")] = (
+        "transformers",
+        "Qwen3OmniForConditionalGeneration",
+    )
+    TasksManager._CUSTOM_CLASSES[("pt", "qwen3_omni", "text-to-audio")] = (
+        "transformers",
+        "Qwen3OmniForConditionalGeneration",
+    )
+
     if is_diffusers_available() and "fill" not in TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS:
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS["fill"] = "FluxFillPipeline"
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["fill"] = {"flux": "FluxFillPipeline"}
@@ -473,6 +490,37 @@ class Qwen3OmniMoeTalkerTextOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOCon
     DUMMY_PKV_GENERATOR_CLASS = GemmaDummyPastKeyValuesGenerator
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
     _MODEL_PATCHER = Qwen3OmniMoeTalkerLanguageModelPatcher
+
+
+@register_in_tasks_manager(
+    "qwen3_omni_text",
+    *["text-generation", "text-generation-with-past"],
+    library_name="transformers",
+)
+class Qwen3OmniTextOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3VLLMInputGenerator, GemmaDummyPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = GemmaDummyPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+    _MODEL_PATCHER = OVDecoderModelPatcher
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        common_inputs = super().inputs
+        common_inputs["visual_pos_masks"] = {0: "batch_size", 1: "sequence_length"}
+        common_inputs["deepstack_visual_embeds"] = {0: "num_layers", 1: "visual_seqlen"}
+        return common_inputs
+
+
+@register_in_tasks_manager(
+    "qwen3_omni_talker_text",
+    *["text-generation", "text-generation-with-past"],
+    library_name="transformers",
+)
+class Qwen3OmniTalkerTextOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, GemmaDummyPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = GemmaDummyPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+    _MODEL_PATCHER = OVDecoderModelPatcher
 
 
 @register_in_tasks_manager(
@@ -3840,6 +3888,523 @@ class Qwen3OmniMoeOpenVINOConfig(BaseVLMOpenVINOConfig):
             has_talker = talker_config is not None and getattr(talker_config, "accept_hidden_layer", None) is not None
             return _append_hidden_states_output(base_outputs, include_intermediate=has_talker)
         raise Exception("Unknown Qwen3-Omni-MoE behavior type.")
+
+
+class Qwen3OmniConfigBehavior(str, enum.Enum):
+    LANGUAGE = "language"
+    TEXT_EMBEDDINGS = "text_embeddings"
+    VISION_EMBEDDINGS = "vision_embeddings"
+    VISION_EMBEDDINGS_POS = "vision_embeddings_pos"
+    AUDIO_ENCODER = "audio_encoder"
+    TALKER = "talker"
+    TALKER_TEXT_EMBEDDINGS = "talker_text_embeddings"
+    TALKER_PROJECTIONS = "talker_projections"
+    CODE_PREDICTOR = "code_predictor"
+    CODE2WAV = "code2wav"
+
+
+class Qwen3OmniLMConfigHelper(LMInputEmbedsConfigHelper):
+    def __init__(
+        self, export_config, patcher_cls=None, dummy_input_generator=None, inputs_update=None, model_config=None
+    ):
+        super().__init__(export_config, patcher_cls, dummy_input_generator, inputs_update)
+        self._model_config = model_config
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        base_outputs = self.orig_export_config.outputs
+        has_talker = False
+        if self._model_config is not None:
+            talker_config = getattr(self._model_config, "talker_config", None)
+            has_talker = talker_config is not None and getattr(talker_config, "accept_hidden_layer", None) is not None
+        result = {}
+        for key, value in base_outputs.items():
+            result[key] = value
+            if key == "logits":
+                result["hidden_states"] = {0: "batch_size", 1: "sequence_length"}
+                # intermediate_hidden_states must follow hidden_states to match the patcher's return-tuple order.
+                if has_talker:
+                    result["intermediate_hidden_states"] = {0: "batch_size", 1: "sequence_length"}
+        return result
+
+
+class DummyQwen3OmniLMInputGenerator(DummyQwen3VLLMInputGenerator):
+    def generate(
+        self,
+        input_name: str,
+        framework: str = "pt",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        bool_dtype: str = "bool",
+    ):
+        if input_name == "position_ids":
+            base = DummyTextInputGenerator.generate(self, input_name, framework, int_dtype, float_dtype)
+            return base.unsqueeze(0).expand(4, -1, -1)
+        return super().generate(input_name, framework, int_dtype, float_dtype, bool_dtype)
+
+
+class Qwen3OmniTalkerLMConfigHelper(LMInputEmbedsConfigHelper):
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        base_outputs = self.orig_export_config.outputs
+        result = {}
+        for key, value in base_outputs.items():
+            result[key] = value
+            if key == "logits":
+                result["hidden_states"] = {0: "batch_size", 1: "sequence_length"}
+        return result
+
+
+class Qwen3OmniCodePredictorLMConfigHelper(LMInputEmbedsConfigHelper):
+    # Single-step CodePredictor: one graph call runs a single inner step and grows the KV cache,
+    # which patch_stateful hides inside the model (use_past stays True, inherited from the internal
+    # talker-text config). The Python-side loop drives num_code_groups-1 calls. Sampling is in-graph
+    # (Gumbel-max) with a per-call seed, so the graph also returns the sampled code's codec embedding
+    # (`token_embed`) that the caller feeds into the next step. Because the codec embedding is baked
+    # into the graph, no separate codec_embedding weights file is exported.
+
+    # Scalar sampling controls + per-step index that augment the standard decoder inputs.
+    _EXTRA_INPUTS = {
+        "step": {},
+        "seed": {},
+        "temperature": {},
+        "top_k": {},
+    }
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        # Parent supplies inputs_embeds, attention_mask, position_ids, and past_key_values.* .
+        common_inputs = super().inputs
+        common_inputs.update(self._EXTRA_INPUTS)
+        return common_inputs
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        # Replace the decoder's logits output with the sampled code + its codec embedding,
+        # keeping the present.* KV outputs that patch_stateful turns into state.
+        common_outputs = self.orig_export_config.outputs
+        common_outputs.pop("logits", None)
+        return {
+            "code": {0: "batch_size", 1: "sequence_length"},
+            "token_embed": {0: "batch_size", 1: "sequence_length"},
+            **common_outputs,
+        }
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
+        # Reuse the parent (inputs_embeds + attention_mask + position_ids + past_key_values),
+        # then add the scalar controls the single-step graph consumes.
+        dummy_inputs = super().generate_dummy_inputs(framework, **kwargs)
+        dummy_inputs["step"] = torch.tensor(0, dtype=torch.int64)
+        dummy_inputs["seed"] = torch.tensor(1, dtype=torch.int64)
+        dummy_inputs["temperature"] = torch.tensor(0.9, dtype=torch.float32)
+        dummy_inputs["top_k"] = torch.tensor(50, dtype=torch.int64)
+        return dummy_inputs
+
+
+class DummyQwen3OmniAudioInputGenerator(DummyInputGenerator):
+    SUPPORTED_INPUT_NAMES = ("padded_feature", "padded_mask_after_cnn", "aftercnn_lens", "cu_seqlens")
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = 3,
+        **kwargs,
+    ):
+        self.batch_size = batch_size
+        audio_config = normalized_config.config
+        self.num_mels = getattr(audio_config, "num_mel_bins", 128)
+        self.time_in = 200
+        self.aftercnn_time = self.time_in // 8
+        n_window = getattr(audio_config, "n_window", 100)
+        n_window_infer = getattr(audio_config, "n_window_infer", 400)
+        window_aftercnn = self.aftercnn_time * (n_window_infer // (n_window * 2))
+        num_full = self.aftercnn_time // window_aftercnn
+        single_batch_chunks = [window_aftercnn] * num_full
+        remainder = self.aftercnn_time % window_aftercnn
+        if remainder != 0:
+            single_batch_chunks.append(remainder)
+        cu_chunk_lens = single_batch_chunks * self.batch_size
+        cumsum = [0]
+        for length in cu_chunk_lens:
+            cumsum.append(cumsum[-1] + length)
+        self._cu_seqlens = cumsum
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "padded_feature":
+            return self.random_float_tensor([self.batch_size, self.num_mels, self.time_in], framework=framework)
+        if input_name == "padded_mask_after_cnn":
+            return self.constant_tensor(
+                [self.batch_size, self.aftercnn_time], framework=framework, value=1, dtype=DTYPE_MAPPER.pt("bool")
+            )
+        if input_name == "aftercnn_lens":
+            return self.constant_tensor(
+                [self.batch_size], framework=framework, value=self.aftercnn_time, dtype=DTYPE_MAPPER.pt(int_dtype)
+            )
+        if input_name == "cu_seqlens":
+            import torch
+
+            return torch.tensor(self._cu_seqlens, dtype=torch.int32)
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+class DummyQwen3OmniCode2WavInputGenerator(DummyInputGenerator):
+    SUPPORTED_INPUT_NAMES = ("codes",)
+
+    def __init__(self, task: str, normalized_config: NormalizedVisionConfig, batch_size: int = 1, **kwargs):
+        self.batch_size = batch_size
+        code2wav_config = normalized_config.config
+        self.num_quantizers = getattr(code2wav_config, "num_quantizers", 16)
+        self.codebook_size = getattr(code2wav_config, "codebook_size", 2048)
+        self.seq_len = 10
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "codes":
+            return self.random_int_tensor(
+                [self.batch_size, self.num_quantizers, self.seq_len],
+                min_value=0,
+                max_value=self.codebook_size,
+                framework=framework,
+            )
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+class DummyQwen3OmniProjectionInputGenerator(DummyInputGenerator):
+    SUPPORTED_INPUT_NAMES = ("hidden_state",)
+
+    def __init__(self, task: str, normalized_config: NormalizedVisionConfig, batch_size: int = 1, **kwargs):
+        self.batch_size = batch_size
+        config = normalized_config.config
+        text_config = getattr(config, "text_config", config)
+        self.hidden_size = getattr(text_config, "hidden_size", 2560)
+        self.seq_len = 10
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "hidden_state":
+            return self.random_float_tensor([self.batch_size, self.seq_len, self.hidden_size], framework=framework)
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+def _make_qwen3_omni_projections_wrapper(text_proj, hidden_proj, config):
+    import torch
+
+    class _Qwen3OmniProjectionsWrapper(torch.nn.Module):
+        def __init__(self, text_proj, hidden_proj, config):
+            super().__init__()
+            self.text_projection = text_proj
+            self.hidden_projection = hidden_proj
+            self.config = config
+
+        def forward(self, hidden_state):
+            return self.text_projection(hidden_state), self.hidden_projection(hidden_state)
+
+    return _Qwen3OmniProjectionsWrapper(text_proj, hidden_proj, config)
+
+
+class DummyQwen3OmniVisionInputGenerator(DummyQwen3VLVisionEmbedInputGenerator):
+    SUPPORTED_INPUT_NAMES = ("hidden_states", "pos_embeds", "attention_mask", "rotary_pos_emb", "input")
+
+    def __init__(self, task, normalized_config, batch_size=1, **kwargs):
+        super().__init__(task, normalized_config, batch_size=batch_size, **kwargs)
+        self.patch_channels = (
+            normalized_config.config.in_channels
+            * normalized_config.config.temporal_patch_size
+            * normalized_config.config.patch_size
+            * normalized_config.config.patch_size
+        )
+
+    def generate(self, input_name, framework="pt", int_dtype="int64", float_dtype="fp32"):
+        grid_h, grid_w = self.height // self.patch_size, self.width // self.patch_size
+        seq_len = self.batch_size * grid_h * grid_w
+
+        if input_name == "hidden_states":
+            return self.random_float_tensor([seq_len, self.patch_channels], framework=framework, dtype=float_dtype)
+
+        if input_name == "pos_embeds":
+            return self.random_float_tensor([seq_len, self.embed_dim], framework=framework, dtype=float_dtype)
+
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+@register_in_tasks_manager(
+    "qwen3_omni", *["image-text-to-text", "text-to-audio", "automatic-speech-recognition"], library_name="transformers"
+)
+class Qwen3OmniOpenVINOConfig(BaseVLMOpenVINOConfig):
+    SUPPORTED_BEHAVIORS = [b.value for b in Qwen3OmniConfigBehavior]
+    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3VLVisionEmbedInputGenerator,)
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: Qwen3OmniConfigBehavior = Qwen3OmniConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self._behavior = behavior
+        self._orig_config = config
+        thinker_config = getattr(config, "thinker_config", config)
+        vision_config = getattr(thinker_config, "vision_config", None)
+        audio_config = getattr(thinker_config, "audio_config", None)
+
+        talker_config = getattr(config, "talker_config", None)
+        code2wav_config = getattr(config, "code2wav_config", None)
+        talker_behaviors = {
+            Qwen3OmniConfigBehavior.TALKER.value,
+            Qwen3OmniConfigBehavior.TALKER_TEXT_EMBEDDINGS.value,
+            Qwen3OmniConfigBehavior.TALKER_PROJECTIONS.value,
+            Qwen3OmniConfigBehavior.CODE_PREDICTOR.value,
+            Qwen3OmniConfigBehavior.CODE2WAV.value,
+        }
+        if talker_config is None or code2wav_config is None:
+            self.SUPPORTED_BEHAVIORS = [b for b in self.SUPPORTED_BEHAVIORS if b not in talker_behaviors]
+
+        if (
+            self._behavior
+            in (Qwen3OmniConfigBehavior.VISION_EMBEDDINGS, Qwen3OmniConfigBehavior.VISION_EMBEDDINGS_POS)
+            and vision_config is not None
+        ):
+            self._config = vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+            self._normalized_config.use_embed_dim = True
+
+        if self._behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS:
+            self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3OmniVisionInputGenerator,)
+
+        if self._behavior == Qwen3OmniConfigBehavior.AUDIO_ENCODER and audio_config is not None:
+            self._config = audio_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+            self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3OmniAudioInputGenerator,)
+
+        if self._behavior == Qwen3OmniConfigBehavior.CODE2WAV:
+            self._config = code2wav_config or config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+            self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3OmniCode2WavInputGenerator,)
+
+        if self._behavior == Qwen3OmniConfigBehavior.TALKER_PROJECTIONS:
+            self._config = thinker_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+            self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3OmniProjectionInputGenerator,)
+
+    @staticmethod
+    def get_model_for_behavior(model, behavior: Union[str, "Qwen3OmniConfigBehavior"]):
+        if isinstance(behavior, str) and not isinstance(behavior, Qwen3OmniConfigBehavior):
+            behavior = Qwen3OmniConfigBehavior(behavior)
+
+        if behavior == Qwen3OmniConfigBehavior.LANGUAGE:
+            return model
+
+        if behavior == Qwen3OmniConfigBehavior.TEXT_EMBEDDINGS:
+            text_embedding = model.thinker.model.get_input_embeddings()
+            text_embedding.config = model.config
+            return text_embedding
+
+        if behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS:
+            thinker_config = getattr(model.config, "thinker_config", model.config)
+            vision_model = model.thinker.visual
+            vision_model.config = getattr(thinker_config, "vision_config", thinker_config)
+            return vision_model
+
+        if behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS_POS:
+            thinker_config = getattr(model.config, "thinker_config", model.config)
+            vision_pos = model.thinker.visual.pos_embed
+            vision_pos.config = getattr(thinker_config, "vision_config", thinker_config)
+            return vision_pos
+
+        if behavior == Qwen3OmniConfigBehavior.AUDIO_ENCODER:
+            thinker_config = getattr(model.config, "thinker_config", model.config)
+            audio_encoder = model.thinker.audio_tower
+            audio_encoder.config = getattr(thinker_config, "audio_config", thinker_config)
+            return audio_encoder
+
+        if behavior == Qwen3OmniConfigBehavior.TALKER:
+            return model
+
+        if behavior == Qwen3OmniConfigBehavior.TALKER_TEXT_EMBEDDINGS:
+            text_embedding = model.talker.model.get_input_embeddings()
+            text_embedding.config = model.config
+            return text_embedding
+
+        if behavior == Qwen3OmniConfigBehavior.TALKER_PROJECTIONS:
+            return _make_qwen3_omni_projections_wrapper(
+                model.talker.text_projection, model.talker.hidden_projection, model.config
+            )
+
+        if behavior == Qwen3OmniConfigBehavior.CODE_PREDICTOR:
+            return model
+
+        if behavior == Qwen3OmniConfigBehavior.CODE2WAV:
+            model.code2wav.config = getattr(model.config, "code2wav_config", model.config)
+            return model.code2wav
+
+        raise ValueError(f"Unsupported Qwen3-Omni behavior: {behavior}")
+
+    def with_behavior(self, behavior: Union[str, "Qwen3OmniConfigBehavior"]):
+        if isinstance(behavior, str) and not isinstance(behavior, Qwen3OmniConfigBehavior):
+            behavior = Qwen3OmniConfigBehavior(behavior)
+
+        thinker_config = getattr(self._orig_config, "thinker_config", self._orig_config)
+
+        if behavior == Qwen3OmniConfigBehavior.TEXT_EMBEDDINGS:
+            text_config = getattr(thinker_config, "text_config", thinker_config)
+            return get_vlm_text_embeddings_config("qwen3_omni_text", text_config, self.int_dtype, self.float_dtype)
+
+        if behavior == Qwen3OmniConfigBehavior.LANGUAGE:
+            from .model_patcher import Qwen3OmniLanguageModelPatcher
+
+            text_config = getattr(thinker_config, "text_config", thinker_config)
+            internal_config = get_vlm_internal_text_generation_config(
+                "qwen3_omni_text", text_config, self.int_dtype, self.float_dtype
+            )
+            config = Qwen3OmniLMConfigHelper(
+                internal_config,
+                patcher_cls=Qwen3OmniLanguageModelPatcher,
+                dummy_input_generator=DummyQwen3OmniLMInputGenerator,
+                inputs_update={"position_ids": {1: "batch_size", 2: "sequence_length"}},
+                model_config=self._orig_config,
+            )
+            config._normalized_config = internal_config._normalized_config
+            vision_config = getattr(thinker_config, "vision_config", None)
+            if vision_config is not None:
+                config._normalized_config.deepstack_visual_indexes = vision_config.deepstack_visual_indexes
+            return config
+
+        if behavior == Qwen3OmniConfigBehavior.TALKER_TEXT_EMBEDDINGS:
+            talker_config = getattr(self._orig_config, "talker_config", self._orig_config)
+            talker_text_config = getattr(talker_config, "text_config", talker_config)
+            return get_vlm_text_embeddings_config(
+                "qwen3_omni_talker_text", talker_text_config, self.int_dtype, self.float_dtype
+            )
+
+        if behavior == Qwen3OmniConfigBehavior.TALKER:
+            from .model_patcher import Qwen3OmniTalkerLanguageModelPatcher
+
+            talker_config = getattr(self._orig_config, "talker_config", self._orig_config)
+            talker_text_config = getattr(talker_config, "text_config", talker_config)
+            internal_config = get_vlm_internal_text_generation_config(
+                "qwen3_omni_talker_text", talker_text_config, self.int_dtype, self.float_dtype
+            )
+            config = Qwen3OmniTalkerLMConfigHelper(
+                internal_config,
+                patcher_cls=Qwen3OmniTalkerLanguageModelPatcher,
+            )
+            config._normalized_config = internal_config._normalized_config
+            return config
+
+        if behavior == Qwen3OmniConfigBehavior.CODE_PREDICTOR:
+            from .model_patcher import Qwen3OmniCodePredictorPatcher
+
+            talker_config = getattr(self._orig_config, "talker_config", self._orig_config)
+            cp_config = getattr(talker_config, "code_predictor_config", talker_config)
+            internal_config = get_vlm_internal_text_generation_config(
+                "qwen3_omni_talker_text", cp_config, self.int_dtype, self.float_dtype
+            )
+            config = Qwen3OmniCodePredictorLMConfigHelper(
+                internal_config,
+                patcher_cls=Qwen3OmniCodePredictorPatcher,
+            )
+            config._normalized_config = internal_config._normalized_config
+            return config
+
+        return self.__class__(
+            self._orig_config,
+            task=self.task,
+            int_dtype=self.int_dtype,
+            float_dtype=self.float_dtype,
+            behavior=behavior,
+            preprocessors=self._preprocessors,
+        )
+
+    def patch_model_for_export(self, model: Union["PreTrainedModel"], model_kwargs: Optional[Dict[str, Any]] = None):
+        model_kwargs = model_kwargs or {}
+        if self._behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS:
+            from .model_patcher import Qwen3OmniVisionMergerPatcher
+
+            return Qwen3OmniVisionMergerPatcher(self, model, model_kwargs)
+        if self._behavior == Qwen3OmniConfigBehavior.AUDIO_ENCODER:
+            from .model_patcher import Qwen3OmniAudioEncoderPatcher
+
+            return Qwen3OmniAudioEncoderPatcher(self, model, model_kwargs)
+        if self._behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS_POS:
+            return InputEmbeddingPatcher(self, model, model_kwargs=model_kwargs)
+        if self._behavior == Qwen3OmniConfigBehavior.CODE2WAV:
+            from .model_patcher import Qwen3OmniCode2WavPatcher
+
+            return Qwen3OmniCode2WavPatcher(self, model, model_kwargs)
+        if self._behavior == Qwen3OmniConfigBehavior.TALKER_PROJECTIONS:
+            return ModelPatcher(self, model, model_kwargs=model_kwargs)
+        return super().patch_model_for_export(model, model_kwargs)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS:
+            return {
+                "hidden_states": {0: "total_patches"},
+                "pos_embeds": {0: "total_patches"},
+                "attention_mask": {1: "total_patches", 2: "total_patches"},
+                "rotary_pos_emb": {0: "total_patches"},
+            }
+        if self._behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS_POS:
+            return {"input": {1: "sequence_length"}}
+        if self._behavior == Qwen3OmniConfigBehavior.AUDIO_ENCODER:
+            return {
+                "padded_feature": {0: "batch_size", 2: "time"},
+                "padded_mask_after_cnn": {0: "batch_size", 1: "aftercnn_time"},
+                "aftercnn_lens": {0: "batch_size"},
+                "cu_seqlens": {0: "num_windows"},
+            }
+        if self._behavior == Qwen3OmniConfigBehavior.CODE2WAV:
+            return {"codes": {0: "batch_size", 2: "code_sequence_length"}}
+        if self._behavior == Qwen3OmniConfigBehavior.TALKER_PROJECTIONS:
+            return {"hidden_state": {0: "batch_size", 1: "sequence_length"}}
+        raise Exception("Unknown Qwen3Omni behavior type.")
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS:
+            return {"last_hidden_state": {0: "seq_len"}, "deepstack_feature_lists": {1: "seq_len"}}
+        if self._behavior == Qwen3OmniConfigBehavior.VISION_EMBEDDINGS_POS:
+            return {"last_hidden_state": {0: "seq_len", 1: "seq_len"}}
+        if self._behavior == Qwen3OmniConfigBehavior.TEXT_EMBEDDINGS:
+            return {"inputs_embeds": {0: "batch_size", 1: "sequence_length"}}
+        if self._behavior == Qwen3OmniConfigBehavior.AUDIO_ENCODER:
+            return {"audio_features": {0: "batch_size", 1: "aftercnn_time"}}
+        if self._behavior == Qwen3OmniConfigBehavior.CODE2WAV:
+            return {"waveform": {0: "batch_size", 2: "audio_length"}}
+        if self._behavior == Qwen3OmniConfigBehavior.TALKER_TEXT_EMBEDDINGS:
+            return {"inputs_embeds": {0: "batch_size", 1: "sequence_length"}}
+        if self._behavior == Qwen3OmniConfigBehavior.TALKER_PROJECTIONS:
+            return {
+                "text_projection": {0: "batch_size", 1: "sequence_length"},
+                "hidden_projection": {0: "batch_size", 1: "sequence_length"},
+            }
+        if self._behavior == Qwen3OmniConfigBehavior.LANGUAGE:
+            text_config = getattr(
+                getattr(self._orig_config, "thinker_config", self._orig_config), "text_config", self._orig_config
+            )
+            base_outputs = get_vlm_internal_text_generation_config(
+                "qwen3_omni_text", text_config, self.int_dtype, self.float_dtype
+            ).outputs
+            talker_config = getattr(self._orig_config, "talker_config", None)
+            has_talker = talker_config is not None and getattr(talker_config, "accept_hidden_layer", None) is not None
+            result = {}
+            for key, value in base_outputs.items():
+                result[key] = value
+                if key == "logits":
+                    result["hidden_states"] = {0: "batch_size", 1: "sequence_length"}
+                    if has_talker:
+                        result["intermediate_hidden_states"] = {0: "batch_size", 1: "sequence_length"}
+            return result
+        raise Exception("Unknown Qwen3Omni behavior type.")
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -4597,6 +4597,330 @@ class Qwen3OmniMoeCode2WavPatcher(ModelPatcher):
             )
 
 
+class Qwen3OmniVisionMergerPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: Union["PreTrainedModel"],
+        model_kwargs: Dict[str, Any] = None,
+    ):
+        model.__orig_forward = model.forward
+
+        def image_embed_forward(
+            self,
+            hidden_states: torch.Tensor,
+            pos_embeds: torch.Tensor,
+            attention_mask: torch.Tensor,
+            rotary_pos_emb: torch.Tensor,
+        ) -> torch.Tensor:
+            hidden_states = self.patch_embed(hidden_states)
+            hidden_states = hidden_states + pos_embeds
+            deepstack_feature_lists = []
+            for layer_num, blk in enumerate(self.blocks):
+                hidden_states = blk(hidden_states, attention_mask=attention_mask, rotary_pos_emb=rotary_pos_emb)
+                if layer_num in self.deepstack_visual_indexes:
+                    deepstack_feature = self.merger_list[self.deepstack_visual_indexes.index(layer_num)](hidden_states)
+                    deepstack_feature_lists.append(deepstack_feature)
+            last_hidden_state = self.merger(hidden_states)
+            return last_hidden_state, torch.stack(deepstack_feature_lists, dim=0)
+
+        model.forward = types.MethodType(image_embed_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __enter__(self):
+        patch_qwen2vl_vision_blocks(self._model)
+        super().__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+        for block in self._model.blocks:
+            block.forward = block._orig_forward
+            block.attn.forward = block.attn._orig_forward
+
+
+class Qwen3OmniAudioEncoderPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: Union["PreTrainedModel"],
+        model_kwargs: Dict[str, Any] = None,
+    ):
+        model.__orig_forward = model.forward
+
+        def audio_forward(
+            self,
+            padded_feature: torch.Tensor,
+            padded_mask_after_cnn: torch.Tensor,
+            aftercnn_lens: torch.Tensor,
+            cu_seqlens: torch.Tensor,
+        ) -> torch.Tensor:
+            padded_feature = padded_feature.unsqueeze(1)
+            padded_embed = torch.nn.functional.gelu(self.conv2d1(padded_feature))
+            padded_embed = torch.nn.functional.gelu(self.conv2d2(padded_embed))
+            padded_embed = torch.nn.functional.gelu(self.conv2d3(padded_embed))
+            b, c, f, t = padded_embed.size()
+            padded_embed = self.conv_out(padded_embed.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+            positional_embedding = (
+                self.positional_embedding.positional_embedding[: padded_embed.shape[1], :]
+                .unsqueeze(0)
+                .to(padded_embed.dtype)
+            )
+            padded_embed = padded_embed + positional_embedding
+
+            # Flatten rather than boolean-index: the latter bakes a data-dependent shape that OV can't trace.
+            # Encoder layers run with eager attention during export, so cu_seqlens don't affect the output.
+            b, t, d = padded_embed.shape
+            hidden_states = padded_embed.reshape(b * t, d)
+
+            for encoder_layer in self.layers:
+                layer_outputs = encoder_layer(hidden_states, cu_seqlens)
+                hidden_states = layer_outputs[0]
+
+            hidden_states = self.ln_post(hidden_states)
+            hidden_states = self.proj1(hidden_states)
+            hidden_states = self.act(hidden_states)
+            hidden_states = self.proj2(hidden_states)
+
+            hidden_states = hidden_states.reshape(b, t, -1)
+            hidden_states = hidden_states * padded_mask_after_cnn.to(hidden_states.dtype).unsqueeze(-1)
+            return hidden_states
+
+        model.forward = types.MethodType(audio_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
+class Qwen3OmniLanguageModelPatcher(OVDecoderModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: Union["PreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        # Talker consumes one intermediate layer's hidden state; layer index comes from talker_config.
+        talker_config = getattr(model.config, "talker_config", None)
+        accept_hidden_layer = getattr(talker_config, "accept_hidden_layer", None)
+
+        def lm_forward(
+            self,
+            attention_mask,
+            position_ids,
+            past_key_values,
+            inputs_embeds,
+            visual_pos_masks,
+            deepstack_visual_embeds,
+            use_cache=True,
+        ):
+            if is_transformers_version("<", "5"):
+                pkv = DynamicCache.from_legacy_cache(past_key_values)
+            else:
+                pkv = DynamicCache(past_key_values)
+            outputs = self.thinker.model(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                use_cache=use_cache,
+                past_key_values=pkv,
+                visual_pos_masks=visual_pos_masks,
+                deepstack_visual_embeds=deepstack_visual_embeds,
+                output_hidden_states=accept_hidden_layer is not None,
+            )
+            hidden_states = outputs[0]
+            logits = self.thinker.lm_head(hidden_states)
+            pkv_tuple = postprocess_past_key_values(outputs.past_key_values)
+            if accept_hidden_layer is not None:
+                intermediate_hidden_states = outputs.hidden_states[accept_hidden_layer]
+                return (logits, hidden_states, intermediate_hidden_states, pkv_tuple)
+            return (logits, hidden_states, pkv_tuple)
+
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(lm_forward, model)
+
+        thinker_model = model.thinker.model
+        thinker_model.__orig_deepstack_process = thinker_model._deepstack_process
+        thinker_model._deepstack_process = types.MethodType(_deepstack_process_patched, thinker_model)
+
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+        thinker_model = self._model.thinker.model
+        thinker_model._deepstack_process = thinker_model.__orig_deepstack_process
+
+
+class Qwen3OmniTalkerLanguageModelPatcher(OVDecoderModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: Union["PreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        def lm_forward(self, inputs_embeds, attention_mask, position_ids, past_key_values, use_cache=True):
+            if is_transformers_version("<", "5"):
+                pkv = DynamicCache.from_legacy_cache(past_key_values)
+            else:
+                pkv = DynamicCache(past_key_values)
+            outputs = self.talker.model(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                use_cache=use_cache,
+                past_key_values=pkv,
+            )
+            hidden_states = outputs[0]
+            logits = self.talker.codec_head(hidden_states)
+            return (logits, hidden_states, postprocess_past_key_values(outputs.past_key_values))
+
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(lm_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
+class Qwen3OmniCodePredictorPatcher(OVDecoderModelPatcher):
+    # Single-step CodePredictor graph: one call runs one inner step and grows the KV cache.
+    # The Python-side loop (OVCodePredictorDecoder) invokes it num_code_groups-1 times.
+    # This replaces the earlier fully-unrolled graph, whose num_code_groups-1 inlined transformer
+    # forwards each allocated their own FP32 activations, ballooning peak device memory. A
+    # single-step stateful graph keeps peak activations at ~1x.
+    # Sampling stays in-graph via the Gumbel-max trick (argmax(logits + Gumbel(0,1)) ~ Categorical),
+    # because the sampled code must be turned back into a codec embedding within the same call to
+    # feed the next step; a per-call int64 seed keeps runs reproducible. Baking the codec embedding
+    # into the graph (via token_embed) means no separate codec_embedding weights file is needed.
+
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: Union["PreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        code_predictor = model.talker.code_predictor
+        # Dummy inputs are float32; upcasting the module avoids dtype mismatches during tracing.
+        code_predictor.float()
+
+        # Per-step lm_head / codec_embedding are selected by a runtime `step` index, so their
+        # weights are stacked into a single tensor that index_select can gather from during tracing.
+        stacked_heads = torch.stack([head.weight for head in code_predictor.lm_head])
+        stacked_codec_embeds = torch.stack([emb.weight for emb in code_predictor.model.codec_embedding])
+
+        def _seeded_uniform(seed, shape, dtype, device):
+            # Traceable PRNG: pure arithmetic on the seed tensor, no CPU fallback.
+            # Emits a (0, 1) uniform tensor of the requested shape; identical seeds
+            # produce identical draws run to run, independent of batch or device state.
+            idx = torch.arange(shape[-1], device=device, dtype=torch.float32)
+            seed_f = seed.to(torch.float32)
+            # Two-term hash keeps correlations low across adjacent indices.
+            raw = torch.sin(seed_f * 12.9898 + idx * 78.233) * 43758.5453
+            u = raw - torch.floor(raw)  # fractional part ~ uniform(0, 1)
+            return u.clamp(min=1e-20, max=1.0 - 1e-20).to(dtype).expand(shape)
+
+        def _gumbel_sample(logits, top_k, seed):
+            # argmax(logits + Gumbel(0,1)) ~ Categorical(softmax(logits)). Top-k masking uses
+            # sort + index_select so top_k can be a runtime int64 tensor (torch.topk requires
+            # a Python int for k, which breaks tracing).
+            sorted_logits, _ = torch.sort(logits, dim=-1, descending=True)
+            top_k_idx = torch.clamp(top_k.reshape(1) - 1, min=0)
+            threshold = torch.index_select(sorted_logits, -1, top_k_idx)
+            logits = torch.where(logits < threshold, torch.full_like(logits, float("-inf")), logits)
+            u = _seeded_uniform(seed, logits.shape, logits.dtype, logits.device)
+            gumbel = -torch.log(-torch.log(u))
+            return (logits + gumbel).argmax(dim=-1)
+
+        def cp_forward(
+            self,
+            inputs_embeds,
+            attention_mask,
+            position_ids,
+            step,
+            seed,
+            temperature,
+            top_k,
+            past_key_values=None,
+            **kwargs,
+        ):
+            # inputs_embeds: prefill [B, 2, hidden] = concat(prefix_hidden[:, -1:], first_code_embed),
+            #                decode  [B, 1, hidden] = previous step's codec embedding.
+            # step: scalar int64 index into lm_head / codec_embedding; seed: scalar int64;
+            # temperature: scalar float32; top_k: scalar int64.
+
+            # KV cache passed in as legacy tuples; wrapped for the Transformers 4.x/5.x API.
+            if is_transformers_version("<", "5"):
+                pkv = DynamicCache.from_legacy_cache(past_key_values)
+            else:
+                pkv = DynamicCache(past_key_values)
+
+            outputs = self.talker.code_predictor.model(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                use_cache=True,
+                past_key_values=pkv,
+            )
+            hidden_states = outputs.last_hidden_state
+            present = postprocess_past_key_values(outputs.past_key_values)
+
+            # Gather the per-step lm_head / codec_embedding weights via the runtime step index.
+            step_idx = step.reshape(1)
+            head_weight = torch.index_select(stacked_heads, 0, step_idx).squeeze(0)
+            embed_weight = torch.index_select(stacked_codec_embeds, 0, step_idx).squeeze(0)
+
+            # Original: self.lm_head[step](hidden_states), then torch.multinomial() sampling.
+            step_logits = torch.nn.functional.linear(hidden_states[:, -1, :], head_weight)
+            step_logits = step_logits / torch.clamp(temperature, min=1e-6)
+            token = _gumbel_sample(step_logits, top_k, seed)
+
+            # Original: self.model.codec_embedding[step](token). Emitted so the caller can both
+            # feed it as the next step's input and accumulate it into codec_hiddens_sum.
+            token_embed = torch.nn.functional.embedding(token, embed_weight).unsqueeze(1)
+            code = token.unsqueeze(-1)  # [B, 1]
+            return (code, token_embed, present)
+
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(cp_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
+class Qwen3OmniCode2WavPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: Union["PreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(config, model, model_kwargs=model_kwargs or {})
+        self._orig_get_extra_padding = None
+
+    def __enter__(self):
+        super().__enter__()
+        # Override Qwen3OmniCausalConvNet._get_extra_padding_for_conv1d: the original uses math.ceil
+        # on dynamic shapes which can't be traced. For every Code2Wav conv config, extra_padding == 0.
+        import transformers.models.qwen3_omni.modeling_qwen3_omni as qwen3_omni_module
+
+        self._orig_get_extra_padding = qwen3_omni_module.Qwen3OmniCausalConvNet._get_extra_padding_for_conv1d
+        qwen3_omni_module.Qwen3OmniCausalConvNet._get_extra_padding_for_conv1d = lambda self, hidden_state: 0
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if self._orig_get_extra_padding is not None:
+            import transformers.models.qwen3_omni.modeling_qwen3_omni as qwen3_omni_module
+
+            qwen3_omni_module.Qwen3OmniCausalConvNet._get_extra_padding_for_conv1d = self._orig_get_extra_padding
+
+
 # copied from https://github.com/huggingface/transformers/blob/v4.47.1/src/transformers/models/granitemoe/modeling_granitemoe.py#L321
 def _granite_moe_topk_gating_forward(self, hidden_states):
     # compute the top_k routing decision

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -339,6 +339,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "minicpmo",
     "videochat_flash_qwen",
     "qwen3_omni_moe",
+    "qwen3_omni",
 ]
 
 SSM_MODELS = [

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -75,6 +75,7 @@ _import_structure = {
         "OVModelForTextToSpeechSeq2Seq",
         "OVModelForVision2Seq",
         "OVModelForVisualCausalLM",
+        "OVModelForMultimodalLM",
         "OVModelForSequenceClassification",
         "OVModelForTokenClassification",
         "OVConfig",

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -1070,6 +1070,7 @@ class OVModelPart(OVModelHostMixin):
         self._model_name = model_name
         self.config = self.parent_model.config
         self._model_dir = Path(model_dir or parent_model.model_save_dir)
+        # Per-part device override for multi-component models (e.g., place audio_encoder on GPU, talker on CPU)
         self._device_override: Optional[str] = None
 
     def compile(self):

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -223,7 +223,7 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
             elif (self.config.model_type in ["qwen2_vl", "qwen2_5_vl", "qwen3_vl"]) and position_ids.ndim == 2:
                 # Qwen2-VL and Qwen3-VL use 3D mrope (3 spatial dimensions)
                 position_ids = np.repeat(np.expand_dims(position_ids, 0), 3, axis=0)
-            elif self.config.model_type == "qwen3_omni_moe" and position_ids.ndim == 2:
+            elif self.config.model_type in ("qwen3_omni_moe", "qwen3_omni") and position_ids.ndim == 2:
                 # Qwen3-Omni uses 4D mrope (temporal + 3 spatial dimensions)
                 position_ids = np.repeat(np.expand_dims(position_ids, 0), 4, axis=0)
 
@@ -437,6 +437,7 @@ class OVTalkerDecoder(OVModelPart):
         attention_mask: Optional[torch.LongTensor] = None,
         past_key_values: Optional[Tuple] = None,
         position_ids: Optional[torch.LongTensor] = None,
+        generation_steps: int = 0,
         **kwargs,
     ):
         self.compile()
@@ -452,6 +453,9 @@ class OVTalkerDecoder(OVModelPart):
 
         past_len = self._past_length
         inputs["inputs_embeds"] = inputs_embeds
+
+        if "generation_steps" in self.input_names:
+            inputs["generation_steps"] = np.array(generation_steps, dtype=np.int64)
 
         if attention_mask is not None:
             inputs["attention_mask"] = np.array(attention_mask)
@@ -495,7 +499,8 @@ class OVCodePredictorDecoder(OVModelPart):
     Each call runs one inner generation step and grows the hidden KV state; the Python-side loop
     in `_run_talker_generation` invokes it num_code_groups-1 times, feeding each step's `token_embed`
     back as the next step's input. Sampling stays in-graph (Gumbel-max) so a sampled code can be
-    turned into its codec embedding within the same call.
+    turned into its codec embedding within the same call — the codec embedding is baked into the
+    graph, so no separate weights file is loaded.
     """
 
     _model_name = "code_predictor"
@@ -628,6 +633,7 @@ class OVCode2Wav(OVModelPart):
         self._ensure_infer_pool(min(len(starts), 4))
         pool = self._async_infer_requests or [self.request]
 
+        # Dispatch chunks round-robin onto the pool; each request does start_async then wait.
         segments: List[np.ndarray] = []
         for i, start in enumerate(starts):
             end = min(start + chunk_size, total_t)
@@ -1194,7 +1200,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
 
         # Prepare additional kwargs for qwen3_vl models
         additional_kwargs = {}
-        if self.config.model_type in ("qwen3_vl", "qwen3_omni_moe") and extra_outputs:
+        if self.config.model_type in ("qwen3_vl", "qwen3_omni_moe", "qwen3_omni") and extra_outputs:
             additional_kwargs["visual_pos_masks"] = extra_outputs[0]
             additional_kwargs["deepstack_visual_embeds"] = extra_outputs[1]
 
@@ -3676,6 +3682,31 @@ if is_transformers_version(">=", "4.57"):
     _OVQwen2_5_VLForCausalLM.get_vision_position_ids = getattr(Qwen2_5_VLModel, "get_vision_position_ids", None)
 
 
+if is_transformers_version(">=", "4.57.0.dev0"):
+    # The same helper lives in the MoE and dense omni processing modules; only one of the two omni
+    # modules exists in any given transformers build, so import from whichever is available.
+    try:
+        from transformers.models.qwen3_omni_moe.processing_qwen3_omni_moe import (
+            _get_feat_extract_output_lengths,
+        )
+    except ImportError:
+        from transformers.models.qwen3_omni.processing_qwen3_omni import _get_feat_extract_output_lengths
+    from transformers.models.qwen3_vl.modeling_qwen3_vl import (
+        Qwen3VLModel,
+        Qwen3VLVisionModel,
+        Qwen3VLVisionRotaryEmbedding,
+    )
+else:
+
+    class Qwen3VLModel:
+        pass
+
+    class Qwen3VLVisionModel:
+        pass
+
+    Qwen3VLVisionRotaryEmbedding = VisionRotaryEmbedding
+
+
 class _OVQwen3VLForCausalLM(OVModelForVisualCausalLM):
     additional_parts = ["vision_embeddings_merger", "vision_embeddings_pos"]
 
@@ -3692,7 +3723,7 @@ class _OVQwen3VLForCausalLM(OVModelForVisualCausalLM):
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
-        if is_transformers_version("<", "4.57.0"):
+        if is_transformers_version("<", "4.57.0.dev0"):
             raise Exception("Qwen3VL is not supported in transformers versions earlier than 4.57.0.")
 
         super().__init__(
@@ -4083,7 +4114,6 @@ class _OVQwen3VLForCausalLM(OVModelForVisualCausalLM):
         return final_result
 
     def generate(self, *args, **kwargs):
-        # Clear cached rope delta from previous generations
         self.rope_deltas = None
 
         return super().generate(*args, **kwargs)
@@ -4097,7 +4127,10 @@ if is_transformers_version(">=", "4.57"):
     _OVQwen3VLForCausalLM.get_vision_position_ids = getattr(Qwen3VLModel, "get_vision_position_ids", None)
 
 
-class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
+class _OVQwen3OmniBase(OVModelForVisualCausalLM):
+    # Shared Qwen3-Omni OpenVINO wrapper for both the dense and MoE variants. Subclasses set
+    # _MIN_TRANSFORMERS_VERSION / _ARCH_LABEL and override only the handful of methods that
+    # genuinely differ between the two architectures.
     additional_parts = [
         "vision_embeddings_pos",
         "audio_encoder",
@@ -4121,8 +4154,11 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
         quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
         **kwargs,
     ):
-        if is_transformers_version("<", "4.57.0"):
-            raise Exception("Qwen3-Omni-MoE is not supported in transformers versions earlier than 4.57.0.")
+        if is_transformers_version("<", self._MIN_TRANSFORMERS_VERSION):
+            raise Exception(
+                f"{self._ARCH_LABEL} is not supported in transformers versions earlier than "
+                f"{self._MIN_TRANSFORMERS_VERSION}."
+            )
 
         # Extract per-component device / ov_config overrides before passing ov_config to the
         # OpenVINO core. Keys of the form "<component>.device" (e.g. "audio_encoder.device") pin
@@ -4151,7 +4187,7 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
             compile=False,
             **kwargs,
         )
-        # OVQwen3OmniMoeVisionEmbeddings merges deepstack into the vision graph; swap in for the default wrapper.
+        # Qwen3-Omni merges deepstack into the vision graph; swap in for the default wrapper.
         self.vision_embeddings = OVQwen3OmniMoeVisionEmbeddings(self.vision_embeddings.model, self)
 
         self._apply_component_device_overrides()
@@ -4182,29 +4218,6 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
             self.spatial_merge_size = vision_config.spatial_merge_size
             head_dim = vision_config.hidden_size // vision_config.num_heads
             self.rotary_pos_emb = Qwen3VLVisionRotaryEmbedding(head_dim // 2)
-
-    def _set_ov_config_parameters(self):
-        super()._set_ov_config_parameters()
-        # MoE models require FP32 activation precision to avoid numerical errors from BF16
-        # inference; expert routing errors otherwise compound through layers. This governs
-        # activations only and remains compatible with INT4/INT8 weight compression.
-        if self.ov_config.get("INFERENCE_PRECISION_HINT") is None:
-            self.ov_config["INFERENCE_PRECISION_HINT"] = "f32"
-
-    def _save_pretrained(self, save_directory):
-        super()._save_pretrained(save_directory)
-
-        dest_preprocessor = Path(save_directory) / "preprocessor_config.json"
-        if not dest_preprocessor.exists():
-            source_model_path = getattr(self.config, "_name_or_path", None)
-            if source_model_path:
-                source_preprocessor = Path(source_model_path) / "preprocessor_config.json"
-                if source_preprocessor.exists():
-                    try:
-                        shutil.copy2(source_preprocessor, dest_preprocessor)
-                        logger.info("Copied preprocessor_config.json from source model")
-                    except OSError as ex:
-                        logger.warning(f"Failed to copy preprocessor_config.json: {ex}")
 
     def fast_pos_embed_interpolate(self, grid_thw):
         thinker_config = getattr(self.config, "thinker_config", self.config)
@@ -4314,66 +4327,6 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
         res = self.vision_embeddings(pixel_values, pos_embeds, causal_mask, rotary_pos_emb)
         return np.array(res[0]), np.array(res[1])
 
-    def get_multimodal_embeddings(
-        self,
-        input_ids,
-        pixel_values=None,
-        attention_mask=None,
-        position_ids=None,
-        image_grid_thw=None,
-        audio_features=None,
-        audio_feature_lens=None,
-        cache_position=None,
-        **kwargs,
-    ):
-        inputs_embeds = torch.from_numpy(self.get_text_embeddings(input_ids))
-        thinker_config = getattr(self.config, "thinker_config", self.config)
-
-        visual_pos_masks = None
-        deepstack_visual_embeds = None
-
-        if pixel_values is not None and image_grid_thw is not None:
-            image_embeds, deepstack_image_embeds = self.get_vision_embeddings(pixel_values, image_grid_thw)
-            image_embeds = torch.from_numpy(image_embeds)
-            image_token_id = getattr(thinker_config, "image_token_id", None)
-            if image_token_id is not None:
-                image_mask = (input_ids == image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
-                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
-                visual_pos_masks = image_mask[..., 0]
-                deepstack_visual_embeds = deepstack_image_embeds
-
-        if audio_features is not None:
-            audio_embeds = (
-                torch.from_numpy(audio_features) if not isinstance(audio_features, torch.Tensor) else audio_features
-            )
-            audio_token_id = getattr(thinker_config, "audio_token_id", None)
-            if audio_token_id is not None:
-                audio_mask = (input_ids == audio_token_id).unsqueeze(-1).expand_as(inputs_embeds)
-                inputs_embeds = inputs_embeds.masked_scatter(audio_mask, audio_embeds)
-
-        if position_ids is None:
-            batch_size, seq_length, _ = inputs_embeds.shape
-            if (cache_position is not None and cache_position[0] == 0) or self.rope_deltas is None:
-                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
-                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
-                position_ids = position_ids.unsqueeze(0).expand(4, -1, -1)
-                max_position_ids = position_ids.max(0, keepdim=False)[0].max(-1, keepdim=True)[0]
-                self.rope_deltas = max_position_ids + 1 - seq_length
-            else:
-                delta = (
-                    (cache_position[0] + self.rope_deltas).to(inputs_embeds.device)
-                    if cache_position is not None
-                    else 0
-                )
-                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
-                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
-                if cache_position is not None:
-                    delta = delta.repeat_interleave(batch_size // delta.shape[0], dim=0)
-                position_ids = position_ids.add(delta)
-                position_ids = position_ids.unsqueeze(0).expand(4, -1, -1)
-
-        return inputs_embeds, attention_mask, position_ids, visual_pos_masks, deepstack_visual_embeds
-
     def prepare_inputs_for_generation(
         self,
         input_ids,
@@ -4421,39 +4374,6 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
             }
         )
         return model_inputs
-
-    @staticmethod
-    def preprocess_inputs(
-        text: str,
-        image: Optional["Image"] = None,
-        processor: Optional[AutoImageProcessor] = None,
-        tokenizer: Optional[PreTrainedTokenizer] = None,
-        config: Optional[PretrainedConfig] = None,
-        video: Optional["VideoInput"] = None,
-        audio: Optional[np.ndarray] = None,
-    ):
-        if processor is None:
-            raise ValueError("Processor is required.")
-        if video is not None:
-            raise ValueError("Video input is not supported")
-        if isinstance(audio, (list, tuple)) and len(audio) == 1:
-            audio = audio[0]
-        sampling_rate = None
-        if isinstance(audio, tuple) and len(audio) == 2:
-            audio, sampling_rate = audio
-
-        conversation = [{"role": "user", "content": [{"type": "text", "text": text}]}]
-        if image is not None:
-            conversation[0]["content"].insert(0, {"type": "image"})
-        if audio is not None:
-            conversation[0]["content"].insert(0, {"type": "audio"})
-
-        text_prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
-        processor_kwargs = {}
-        if sampling_rate is not None:
-            processor_kwargs["sampling_rate"] = sampling_rate
-        inputs = processor(images=image, text=text_prompt, audio=audio, return_tensors="pt", **processor_kwargs)
-        return inputs
 
     def forward(
         self,
@@ -4807,114 +4727,6 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
         input_embeds = assistant_text_hidden + assistant_codec_hidden
         return input_embeds, trailing_text_hidden
 
-    def _run_talker_generation(
-        self,
-        talker_input_embeds,
-        trailing_text_hidden,
-        tts_pad_embed,
-        talker_kwargs,
-    ):
-        batch_size = talker_input_embeds.shape[0]
-        if batch_size != 1:
-            raise ValueError(f"Talker generation only supports batch_size=1, got {batch_size}")
-
-        talker_config = getattr(self.config, "talker_config", None)
-        if talker_config is None:
-            raise ValueError("talker_config is required for talker generation")
-        max_new_tokens = talker_kwargs.get("max_new_tokens", 4096)
-        temperature = float(talker_kwargs.get("temperature", 0.9))
-        top_k = int(talker_kwargs.get("top_k", 50))
-        eos_token_id = talker_kwargs.get("eos_token_id", talker_config.codec_eos_token_id)
-        num_code_groups = (
-            talker_config.code_predictor_config.num_code_groups
-            if hasattr(talker_config, "code_predictor_config")
-            else 16
-        )
-        num_inner_steps = max(0, num_code_groups - 1)
-        # Single numpy RNG drives all per-step seeds; caller can pin reproducibility via talker_seed.
-        rng = np.random.default_rng(talker_kwargs.get("seed"))
-
-        self.talker.reset()
-        logits, hidden_states = self.talker(inputs_embeds=talker_input_embeds)
-
-        all_codec_codes = []
-        trailing_idx = 0
-
-        for _ in range(max_new_tokens):
-            next_logits = logits[:, -1, :]
-            # Replace any non-finite logits (NaN/Inf can appear with extreme or untrained weights) so
-            # softmax/multinomial below receive a valid probability distribution instead of crashing.
-            next_logits = torch.nan_to_num(next_logits, nan=0.0, posinf=0.0, neginf=float("-inf"))
-
-            if temperature > 0:
-                scaled_logits = next_logits / temperature if temperature != 1.0 else next_logits
-                if top_k > 0:
-                    indices_to_remove = scaled_logits < torch.topk(scaled_logits, top_k)[0][..., -1, None]
-                    scaled_logits = scaled_logits.masked_fill(indices_to_remove, float("-inf"))
-                probs = torch.nn.functional.softmax(scaled_logits, dim=-1)
-                next_token = torch.multinomial(probs, num_samples=1).squeeze(-1)
-            else:
-                next_token = next_logits.argmax(dim=-1)
-
-            if next_token.item() == eos_token_id:
-                break
-
-            first_code = next_token.item()
-            next_token_tensor = next_token.unsqueeze(0)
-            first_code_embed = self.talker_text_embeddings(next_token_tensor)
-            if isinstance(first_code_embed, np.ndarray):
-                first_code_embed = torch.from_numpy(first_code_embed).float()
-
-            step_codes = [first_code]
-
-            if self.code_predictor is not None and num_inner_steps > 0:
-                # Single-step CP: loop num_inner_steps calls, feeding each step's codec embedding back
-                # as the next step's input. The prefill call sees [prefix_hidden, first_code_embed];
-                # subsequent calls see the previous step's token_embed. Accumulation mirrors the
-                # original graph: codec_hiddens_sum = first_code_embed + sum(token_embed_i).
-                cp_prefill = torch.cat([hidden_states[:, -1:, :].float(), first_code_embed.float()], dim=1)
-                seeds = rng.integers(1, np.iinfo(np.int64).max, size=num_inner_steps, dtype=np.int64)
-                cp_temperature = temperature if temperature > 0 else 1.0
-                cp_top_k = top_k if top_k > 0 else 1
-
-                codec_hiddens_sum = first_code_embed
-                cp_input = cp_prefill
-                for cp_step in range(num_inner_steps):
-                    code, token_embed = self.code_predictor(
-                        inputs_embeds=cp_input,
-                        step=int(cp_step),
-                        seed=int(seeds[cp_step]),
-                        temperature=cp_temperature,
-                        top_k=cp_top_k,
-                        is_prefill=(cp_step == 0),
-                    )
-                    step_codes.append(int(code.reshape(-1)[0]))
-                    codec_hiddens_sum = codec_hiddens_sum + token_embed
-                    cp_input = token_embed
-
-                next_embed = first_code_embed + codec_hiddens_sum
-            else:
-                next_embed = first_code_embed
-
-            all_codec_codes.append(step_codes)
-
-            if trailing_idx < trailing_text_hidden.shape[1]:
-                next_input = next_embed + trailing_text_hidden[:, trailing_idx : trailing_idx + 1, :]
-                trailing_idx += 1
-            else:
-                next_input = next_embed + tts_pad_embed
-
-            logits, hidden_states = self.talker(
-                inputs_embeds=next_input,
-                past_key_values=((),),
-            )
-
-        if not all_codec_codes:
-            return None
-
-        codes_tensor = torch.tensor(all_codec_codes, dtype=torch.long).unsqueeze(0).permute(0, 2, 1)
-        return codes_tensor
-
     def _split_talker_thinker_kwargs(self, kwargs):
         # Strip `talker_`/`thinker_` prefixes: talker_* keys go to a separate dict,
         # thinker_* keys are folded back into kwargs and thus override plain keys.
@@ -5120,11 +4932,445 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
         return thinker_result, waveform.float()
 
 
+class _OVQwen3OmniMoeForCausalLM(_OVQwen3OmniBase):
+    _MIN_TRANSFORMERS_VERSION = "4.57.0"
+    _ARCH_LABEL = "Qwen3-Omni-MoE"
+
+    def _set_ov_config_parameters(self):
+        super()._set_ov_config_parameters()
+        # MoE models require FP32 activation precision to avoid numerical errors from BF16
+        # inference; expert routing errors otherwise compound through layers. This governs
+        # activations only and remains compatible with INT4/INT8 weight compression.
+        if self.ov_config.get("INFERENCE_PRECISION_HINT") is None:
+            self.ov_config["INFERENCE_PRECISION_HINT"] = "f32"
+
+    def _save_pretrained(self, save_directory):
+        super()._save_pretrained(save_directory)
+
+        dest_preprocessor = Path(save_directory) / "preprocessor_config.json"
+        if not dest_preprocessor.exists():
+            source_model_path = getattr(self.config, "_name_or_path", None)
+            if source_model_path:
+                source_preprocessor = Path(source_model_path) / "preprocessor_config.json"
+                if source_preprocessor.exists():
+                    try:
+                        shutil.copy2(source_preprocessor, dest_preprocessor)
+                        logger.info("Copied preprocessor_config.json from source model")
+                    except OSError as ex:
+                        logger.warning(f"Failed to copy preprocessor_config.json: {ex}")
+
+    def get_multimodal_embeddings(
+        self,
+        input_ids,
+        pixel_values=None,
+        attention_mask=None,
+        position_ids=None,
+        image_grid_thw=None,
+        audio_features=None,
+        audio_feature_lens=None,
+        cache_position=None,
+        **kwargs,
+    ):
+        inputs_embeds = torch.from_numpy(self.get_text_embeddings(input_ids))
+        thinker_config = getattr(self.config, "thinker_config", self.config)
+
+        visual_pos_masks = None
+        deepstack_visual_embeds = None
+
+        if pixel_values is not None and image_grid_thw is not None:
+            image_embeds, deepstack_image_embeds = self.get_vision_embeddings(pixel_values, image_grid_thw)
+            image_embeds = torch.from_numpy(image_embeds)
+            image_token_id = getattr(thinker_config, "image_token_id", None)
+            if image_token_id is not None:
+                image_mask = (input_ids == image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+                visual_pos_masks = image_mask[..., 0]
+                deepstack_visual_embeds = deepstack_image_embeds
+
+        if audio_features is not None:
+            audio_embeds = (
+                torch.from_numpy(audio_features) if not isinstance(audio_features, torch.Tensor) else audio_features
+            )
+            audio_token_id = getattr(thinker_config, "audio_token_id", None)
+            if audio_token_id is not None:
+                audio_mask = (input_ids == audio_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+                inputs_embeds = inputs_embeds.masked_scatter(audio_mask, audio_embeds)
+
+        if position_ids is None:
+            batch_size, seq_length, _ = inputs_embeds.shape
+            if (cache_position is not None and cache_position[0] == 0) or self.rope_deltas is None:
+                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+                position_ids = position_ids.unsqueeze(0).expand(4, -1, -1)
+                max_position_ids = position_ids.max(0, keepdim=False)[0].max(-1, keepdim=True)[0]
+                self.rope_deltas = max_position_ids + 1 - seq_length
+            else:
+                delta = (
+                    (cache_position[0] + self.rope_deltas).to(inputs_embeds.device)
+                    if cache_position is not None
+                    else 0
+                )
+                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+                if cache_position is not None:
+                    delta = delta.repeat_interleave(batch_size // delta.shape[0], dim=0)
+                position_ids = position_ids.add(delta)
+                position_ids = position_ids.unsqueeze(0).expand(4, -1, -1)
+
+        return inputs_embeds, attention_mask, position_ids, visual_pos_masks, deepstack_visual_embeds
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None:
+            raise ValueError("Processor is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if isinstance(audio, (list, tuple)) and len(audio) == 1:
+            audio = audio[0]
+        sampling_rate = None
+        if isinstance(audio, tuple) and len(audio) == 2:
+            audio, sampling_rate = audio
+
+        conversation = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+        if image is not None:
+            conversation[0]["content"].insert(0, {"type": "image"})
+        if audio is not None:
+            conversation[0]["content"].insert(0, {"type": "audio"})
+
+        text_prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
+        processor_kwargs = {}
+        if sampling_rate is not None:
+            processor_kwargs["sampling_rate"] = sampling_rate
+        inputs = processor(images=image, text=text_prompt, audio=audio, return_tensors="pt", **processor_kwargs)
+        return inputs
+
+    def _run_talker_generation(
+        self,
+        talker_input_embeds,
+        trailing_text_hidden,
+        tts_pad_embed,
+        talker_kwargs,
+    ):
+        batch_size = talker_input_embeds.shape[0]
+        if batch_size != 1:
+            raise ValueError(f"Talker generation only supports batch_size=1, got {batch_size}")
+
+        talker_config = getattr(self.config, "talker_config", None)
+        if talker_config is None:
+            raise ValueError("talker_config is required for talker generation")
+        max_new_tokens = talker_kwargs.get("max_new_tokens", 4096)
+        temperature = float(talker_kwargs.get("temperature", 0.9))
+        top_k = int(talker_kwargs.get("top_k", 50))
+        eos_token_id = talker_kwargs.get("eos_token_id", talker_config.codec_eos_token_id)
+        num_code_groups = (
+            talker_config.code_predictor_config.num_code_groups
+            if hasattr(talker_config, "code_predictor_config")
+            else 16
+        )
+        num_inner_steps = max(0, num_code_groups - 1)
+        # Single numpy RNG drives all per-step seeds; caller can pin reproducibility via talker_seed.
+        rng = np.random.default_rng(talker_kwargs.get("seed"))
+
+        self.talker.reset()
+        logits, hidden_states = self.talker(inputs_embeds=talker_input_embeds)
+
+        all_codec_codes = []
+        trailing_idx = 0
+
+        for _ in range(max_new_tokens):
+            next_logits = logits[:, -1, :]
+            # Replace any non-finite logits (NaN/Inf can appear with extreme or untrained weights) so
+            # softmax/multinomial below receive a valid probability distribution instead of crashing.
+            next_logits = torch.nan_to_num(next_logits, nan=0.0, posinf=0.0, neginf=float("-inf"))
+
+            if temperature > 0:
+                scaled_logits = next_logits / temperature if temperature != 1.0 else next_logits
+                if top_k > 0:
+                    indices_to_remove = scaled_logits < torch.topk(scaled_logits, top_k)[0][..., -1, None]
+                    scaled_logits = scaled_logits.masked_fill(indices_to_remove, float("-inf"))
+                probs = torch.nn.functional.softmax(scaled_logits, dim=-1)
+                next_token = torch.multinomial(probs, num_samples=1).squeeze(-1)
+            else:
+                next_token = next_logits.argmax(dim=-1)
+
+            if next_token.item() == eos_token_id:
+                break
+
+            first_code = next_token.item()
+            next_token_tensor = next_token.unsqueeze(0)
+            first_code_embed = self.talker_text_embeddings(next_token_tensor)
+            if isinstance(first_code_embed, np.ndarray):
+                first_code_embed = torch.from_numpy(first_code_embed).float()
+
+            step_codes = [first_code]
+
+            if self.code_predictor is not None and num_inner_steps > 0:
+                # Single-step CP: loop num_inner_steps calls, feeding each step's codec embedding back
+                # as the next step's input. The prefill call sees [prefix_hidden, first_code_embed];
+                # subsequent calls see the previous step's token_embed. Accumulation mirrors the
+                # original graph: codec_hiddens_sum = first_code_embed + sum(token_embed_i).
+                cp_prefill = torch.cat([hidden_states[:, -1:, :].float(), first_code_embed.float()], dim=1)
+                seeds = rng.integers(1, np.iinfo(np.int64).max, size=num_inner_steps, dtype=np.int64)
+                cp_temperature = temperature if temperature > 0 else 1.0
+                cp_top_k = top_k if top_k > 0 else 1
+
+                codec_hiddens_sum = first_code_embed
+                cp_input = cp_prefill
+                for cp_step in range(num_inner_steps):
+                    code, token_embed = self.code_predictor(
+                        inputs_embeds=cp_input,
+                        step=int(cp_step),
+                        seed=int(seeds[cp_step]),
+                        temperature=cp_temperature,
+                        top_k=cp_top_k,
+                        is_prefill=(cp_step == 0),
+                    )
+                    step_codes.append(int(code.reshape(-1)[0]))
+                    codec_hiddens_sum = codec_hiddens_sum + token_embed
+                    cp_input = token_embed
+
+                next_embed = first_code_embed + codec_hiddens_sum
+            else:
+                next_embed = first_code_embed
+
+            all_codec_codes.append(step_codes)
+
+            if trailing_idx < trailing_text_hidden.shape[1]:
+                next_input = next_embed + trailing_text_hidden[:, trailing_idx : trailing_idx + 1, :]
+                trailing_idx += 1
+            else:
+                next_input = next_embed + tts_pad_embed
+
+            logits, hidden_states = self.talker(
+                inputs_embeds=next_input,
+                past_key_values=((),),
+            )
+
+        if not all_codec_codes:
+            return None
+
+        codes_tensor = torch.tensor(all_codec_codes, dtype=torch.long).unsqueeze(0).permute(0, 2, 1)
+        return codes_tensor
+
+
+class _OVQwen3OmniForCausalLM(_OVQwen3OmniBase):
+    _MIN_TRANSFORMERS_VERSION = "4.57.0.dev0"
+    _ARCH_LABEL = "Qwen3Omni"
+
+    @classproperty
+    def _all_ov_model_paths(cls) -> Dict[str, str]:
+        parent_fn = OVModelForVisualCausalLM.__dict__["_all_ov_model_paths"].fget
+        return parent_fn(cls)
+
+    def get_multimodal_embeddings(
+        self,
+        input_ids,
+        pixel_values=None,
+        attention_mask=None,
+        position_ids=None,
+        image_grid_thw=None,
+        audio_features=None,
+        audio_feature_lens=None,
+        cache_position=None,
+        **kwargs,
+    ):
+        inputs_embeds = torch.from_numpy(self.get_text_embeddings(input_ids))
+        thinker_config = getattr(self.config, "thinker_config", self.config)
+
+        visual_pos_masks = None
+        deepstack_visual_embeds = None
+
+        if pixel_values is not None and image_grid_thw is not None:
+            image_embeds, deepstack_image_embeds = self.get_vision_embeddings(pixel_values, image_grid_thw)
+            image_embeds = torch.from_numpy(image_embeds)
+            image_token_id = getattr(thinker_config, "image_token_id", None)
+            if image_token_id is not None:
+                image_mask = (input_ids == image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+                inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+                visual_pos_masks = image_mask[..., 0]
+                deepstack_visual_embeds = deepstack_image_embeds
+
+        if audio_features is not None:
+            audio_embeds = (
+                torch.from_numpy(audio_features) if not isinstance(audio_features, torch.Tensor) else audio_features
+            )
+            audio_token_id = getattr(thinker_config, "audio_token_id", None)
+            if audio_token_id is not None:
+                audio_mask = (input_ids == audio_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+                inputs_embeds = inputs_embeds.masked_scatter(audio_mask, audio_embeds)
+
+        if position_ids is None:
+            batch_size, seq_length, _ = inputs_embeds.shape
+            if self.rope_deltas is None:
+                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+                position_ids = position_ids.unsqueeze(0).expand(4, -1, -1)
+            else:
+                delta = (
+                    (cache_position[0] + self.rope_deltas).to(inputs_embeds.device)
+                    if cache_position is not None
+                    else 0
+                )
+                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+                if cache_position is not None:
+                    delta = delta.repeat_interleave(batch_size // delta.shape[0], dim=0)
+                position_ids = position_ids.add(delta)
+                position_ids = position_ids.unsqueeze(0).expand(4, -1, -1)
+
+        return inputs_embeds, attention_mask, position_ids, visual_pos_masks, deepstack_visual_embeds
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None:
+            raise ValueError("Processor is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if isinstance(audio, (list, tuple)) and len(audio) == 1:
+            audio = audio[0]
+        if isinstance(audio, tuple):
+            audio = audio[0]
+
+        conversation = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+        if image is not None:
+            conversation[0]["content"].insert(0, {"type": "image"})
+        if audio is not None:
+            conversation[0]["content"].insert(0, {"type": "audio"})
+
+        text_prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
+        inputs = processor(images=image, text=text_prompt, audio=audio, return_tensors="pt")
+        return inputs
+
+    def _run_talker_generation(
+        self,
+        talker_input_embeds,
+        trailing_text_hidden,
+        tts_pad_embed,
+        talker_kwargs,
+    ):
+        batch_size = talker_input_embeds.shape[0]
+        if batch_size != 1:
+            raise ValueError(f"Talker generation only supports batch_size=1, got {batch_size}")
+
+        talker_config = getattr(self.config, "talker_config", None)
+        if talker_config is None:
+            raise ValueError("talker_config is required for talker generation")
+        max_new_tokens = talker_kwargs.get("max_new_tokens", 4096)
+        temperature = talker_kwargs.get("temperature", 0.9)
+        top_k = talker_kwargs.get("top_k", 50)
+        eos_token_id = talker_kwargs.get("eos_token_id", talker_config.codec_eos_token_id)
+        num_code_groups = (
+            talker_config.code_predictor_config.num_code_groups
+            if hasattr(talker_config, "code_predictor_config")
+            else 16
+        )
+        # Single numpy RNG drives all per-step CodePredictor seeds; caller can pin it via talker_seed.
+        rng = np.random.default_rng(talker_kwargs.get("seed"))
+
+        self.talker.reset()
+        logits, hidden_states = self.talker(inputs_embeds=talker_input_embeds)
+
+        all_codec_codes = []
+        trailing_idx = 0
+
+        for step in range(max_new_tokens):
+            next_logits = logits[:, -1, :]
+
+            if temperature > 0:
+                if temperature != 1.0:
+                    next_logits = next_logits / temperature
+                if top_k > 0:
+                    indices_to_remove = next_logits < torch.topk(next_logits, top_k)[0][..., -1, None]
+                    next_logits[indices_to_remove] = float("-inf")
+                probs = torch.nn.functional.softmax(next_logits, dim=-1)
+                next_token = torch.multinomial(probs, num_samples=1).squeeze(-1)
+            else:
+                next_token = next_logits.argmax(dim=-1)
+
+            if next_token.item() == eos_token_id:
+                break
+
+            first_code = next_token.item()
+
+            next_token_tensor = next_token.unsqueeze(0)
+            first_code_embed = self.talker_text_embeddings(next_token_tensor)
+            if isinstance(first_code_embed, np.ndarray):
+                first_code_embed = torch.from_numpy(first_code_embed).float()
+
+            step_codes = [first_code]
+            codec_hiddens = [first_code_embed]
+
+            if self.code_predictor is not None and num_code_groups > 1:
+                # Single-step CP: one call per inner step, feeding each step's codec embedding back as
+                # the next input. Sampling + codec embedding happen in-graph; the graph returns the
+                # sampled code and its embedding. The prefill call sees [prefix_hidden, first_code_embed].
+                num_inner_steps = num_code_groups - 1
+                cp_prefill = torch.cat([hidden_states[:, -1:, :].float(), first_code_embed.float()], dim=1)
+                seeds = rng.integers(1, np.iinfo(np.int64).max, size=num_inner_steps, dtype=np.int64)
+                cp_temperature = temperature if temperature > 0 else 1.0
+                cp_top_k = top_k if top_k > 0 else 1
+
+                cp_input = cp_prefill
+                for cp_step in range(num_inner_steps):
+                    code, token_embed = self.code_predictor(
+                        inputs_embeds=cp_input,
+                        step=int(cp_step),
+                        seed=int(seeds[cp_step]),
+                        temperature=cp_temperature,
+                        top_k=cp_top_k,
+                        is_prefill=(cp_step == 0),
+                    )
+                    step_codes.append(int(code.reshape(-1)[0]))
+                    codec_hiddens.append(token_embed)
+                    cp_input = token_embed
+
+            all_codec_codes.append(step_codes)
+
+            # HF: codec_hiddens.sum(1, keepdim=True) + trailing_text
+            if len(codec_hiddens) > 1:
+                next_embed = torch.cat(codec_hiddens, dim=1).sum(dim=1, keepdim=True)
+            else:
+                next_embed = codec_hiddens[0]
+
+            if trailing_idx < trailing_text_hidden.shape[1]:
+                next_input = next_embed + trailing_text_hidden[:, trailing_idx : trailing_idx + 1, :]
+                trailing_idx += 1
+            else:
+                next_input = next_embed + tts_pad_embed
+
+            logits, hidden_states = self.talker(
+                inputs_embeds=next_input,
+                past_key_values=((),),
+            )
+
+        if not all_codec_codes:
+            return None
+
+        codes_tensor = torch.tensor(all_codec_codes, dtype=torch.long).unsqueeze(0).permute(0, 2, 1)
+        return codes_tensor
+
+
 class OVModelForMultimodalLM(OVBaseModel, GenerationMixin):
     export_feature = "image-text-to-text"
     auto_model_class = transformers_auto_class
 
-    def __init__(self, *, _inner: _OVQwen3OmniMoeForCausalLM, **kwargs):
+    def __init__(self, *, _inner: _OVQwen3OmniBase, **kwargs):
         object.__setattr__(self, "_inner", _inner)
 
         self.config = _inner.config
@@ -5197,7 +5443,8 @@ class OVModelForMultimodalLM(OVBaseModel, GenerationMixin):
 
     @classproperty
     def _all_ov_model_paths(cls) -> Dict[str, str]:
-        return _OVQwen3OmniMoeForCausalLM._all_ov_model_paths.copy()
+        # Both dense and MoE variants share the same component layout via _OVQwen3OmniBase.
+        return _OVQwen3OmniBase._all_ov_model_paths.copy()
 
     @property
     def ov_models(self) -> Dict[str, Union[openvino.Model, openvino.CompiledModel]]:
@@ -5209,8 +5456,8 @@ class OVModelForMultimodalLM(OVBaseModel, GenerationMixin):
     def forward(self, *args, **kwargs):
         return self._inner.forward(*args, **kwargs)
 
-    @staticmethod
     def preprocess_inputs(
+        self,
         text: str,
         image: Optional["Image"] = None,
         processor: Optional[AutoImageProcessor] = None,
@@ -5219,7 +5466,9 @@ class OVModelForMultimodalLM(OVBaseModel, GenerationMixin):
         video: Optional["VideoInput"] = None,
         audio: Optional[np.ndarray] = None,
     ):
-        return _OVQwen3OmniMoeForCausalLM.preprocess_inputs(
+        # Dense and MoE differ in how audio sampling_rate is threaded through the processor, so
+        # dispatch to the concrete inner class rather than hardcoding one architecture's variant.
+        return type(self._inner).preprocess_inputs(
             text=text,
             image=image,
             processor=processor,
@@ -5269,9 +5518,9 @@ class OVModelForMultimodalLM(OVBaseModel, GenerationMixin):
         config: PretrainedConfig,
         **kwargs,
     ):
-        if getattr(config, "model_type", None) != "qwen3_omni_moe":
+        if getattr(config, "model_type", None) not in ("qwen3_omni_moe", "qwen3_omni"):
             raise ValueError(
-                f"OVModelForMultimodalLM only supports qwen3_omni_moe models, "
+                f"OVModelForMultimodalLM only supports qwen3_omni_moe and qwen3_omni models, "
                 f"but got config.model_type={getattr(config, 'model_type', None)!r}. "
                 f"Use OVModelForVisualCausalLM for other vision-language architectures."
             )
@@ -5285,9 +5534,9 @@ class OVModelForMultimodalLM(OVBaseModel, GenerationMixin):
         config: PretrainedConfig,
         **kwargs,
     ):
-        if getattr(config, "model_type", None) != "qwen3_omni_moe":
+        if getattr(config, "model_type", None) not in ("qwen3_omni_moe", "qwen3_omni"):
             raise ValueError(
-                f"OVModelForMultimodalLM only supports qwen3_omni_moe models, "
+                f"OVModelForMultimodalLM only supports qwen3_omni_moe and qwen3_omni models, "
                 f"but got config.model_type={getattr(config, 'model_type', None)!r}. "
                 f"Use OVModelForVisualCausalLM for other vision-language architectures."
             )
@@ -7375,6 +7624,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen3_5_moe": _OVQwen3_5ForCausalLM,
     "qwen3_5_moe_text": _OVQwen3_5ForCausalLM,
     "qwen3_omni_moe": _OVQwen3OmniMoeForCausalLM,
+    "qwen3_omni": _OVQwen3OmniForCausalLM,
     "minicpmo": _OVMiniCPMOForCausalLM,
     "videochat_flash_qwen": _OVVideoChatFlashQwenForCausalLM,
 }

--- a/optimum/intel/pipelines/accelerator_utils.py
+++ b/optimum/intel/pipelines/accelerator_utils.py
@@ -89,7 +89,7 @@ def get_openvino_model_class(
             config = AutoConfig.from_pretrained(model_id, **hub_kwargs)
         if any(arch.endswith("ForCTC") for arch in config.architectures):
             ov_model_class = OV_TASKS_MAPPING[task][0]
-        elif getattr(config, "model_type", None) == "qwen3_omni_moe":
+        elif getattr(config, "model_type", None) in ("qwen3_omni_moe", "qwen3_omni"):
             ov_model_class = OV_TASKS_MAPPING[task][2]
         else:
             ov_model_class = OV_TASKS_MAPPING[task][1]
@@ -103,7 +103,7 @@ def get_openvino_model_class(
                     "token": model_kwargs.pop("token", None),
                 }
                 config = AutoConfig.from_pretrained(model_id, **hub_kwargs)
-            if getattr(config, "model_type", None) == "qwen3_omni_moe":
+            if getattr(config, "model_type", None) in ("qwen3_omni_moe", "qwen3_omni"):
                 ov_model_class = OVModelForMultimodalLM
             else:
                 ov_model_class = task_classes[0]

--- a/tests/openvino/conftest.py
+++ b/tests/openvino/conftest.py
@@ -1,4 +1,7 @@
+import shutil
+
 import pytest
+from utils_tests import MODEL_NAMES, is_qwen3_omni_available
 
 
 @pytest.hookimpl(tryfirst=True)
@@ -9,3 +12,23 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "gemma4" in item.nodeid:
             item.add_marker(gemma4_marker)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def qwen3_omni_model_path(tmp_path_factory: pytest.TempPathFactory) -> None:
+    # This autouse fixture generates the dense tiny model, so it must not import the generator (which
+    # pulls in transformers' dense qwen3_omni classes) on builds where that architecture is absent —
+    # doing so would break the whole session. See is_qwen3_omni_available for why a version check
+    # alone is insufficient.
+    if not is_qwen3_omni_available():
+        MODEL_NAMES["qwen3_omni"] = ""
+        yield
+        return
+
+    from models.tiny_qwen3_omni import generate as generate_tiny_qwen3_omni
+
+    output_dir = tmp_path_factory.mktemp("tiny-qwen3-omni")
+    generate_tiny_qwen3_omni(output_dir)
+    MODEL_NAMES["qwen3_omni"] = str(output_dir)
+    yield
+    shutil.rmtree(output_dir, ignore_errors=True)

--- a/tests/openvino/models/tiny_qwen3_omni.py
+++ b/tests/openvino/models/tiny_qwen3_omni.py
@@ -1,0 +1,185 @@
+from pathlib import Path
+from typing import Union
+
+from tokenizers import Tokenizer, decoders, models, pre_tokenizers
+from transformers import (
+    Qwen2TokenizerFast,
+    Qwen2VLImageProcessor,
+    Qwen2VLVideoProcessor,
+    Qwen3OmniForConditionalGeneration,
+    WhisperFeatureExtractor,
+)
+from transformers.models.qwen3_omni.configuration_qwen3_omni import Qwen3OmniConfig
+from transformers.models.qwen3_omni.processing_qwen3_omni import Qwen3OmniProcessor
+
+
+_HIDDEN: int = 64
+_HEAD_DIM: int = 32
+_NUM_HEADS: int = 2
+_NUM_KV_HEADS: int = 2
+_NUM_LAYERS: int = 2
+_INTERMEDIATE: int = 128
+_MROPE_SECTION: list[int] = [8, 4, 4]
+_PIXEL_BOUND: int = 16 * 28 * 28
+
+_SPECIAL_TOKENS: list[str] = [
+    "<|endoftext|>",
+    "<|im_start|>",
+    "<|im_end|>",
+    "<|image_pad|>",
+    "<|video_pad|>",
+    "<|audio_bos|>",
+    "<|audio_eos|>",
+    "<|vision_bos|>",
+    "<|vision_eos|>",
+    "<|AUDIO|>",
+    "<|IMAGE|>",
+    "<|VIDEO|>",
+]
+
+_EXTRA_TOKEN_ATTRS: dict[str, str] = {
+    "image_token": "<|IMAGE|>",
+    "audio_token": "<|AUDIO|>",
+    "video_token": "<|VIDEO|>",
+    "vision_bos_token": "<|vision_bos|>",
+    "vision_eos_token": "<|vision_eos|>",
+    "audio_bos_token": "<|audio_bos|>",
+    "audio_eos_token": "<|audio_eos|>",
+}
+
+
+def _rope_scaling() -> dict[str, object]:
+    return {"mrope_section": _MROPE_SECTION, "rope_type": "default"}
+
+
+def _build_config() -> Qwen3OmniConfig:
+    text_kwargs = {
+        "hidden_size": _HIDDEN,
+        "intermediate_size": _INTERMEDIATE,
+        "num_hidden_layers": _NUM_LAYERS,
+        "num_attention_heads": _NUM_HEADS,
+        "num_key_value_heads": _NUM_KV_HEADS,
+        "head_dim": _HEAD_DIM,
+    }
+
+    return Qwen3OmniConfig(
+        thinker_config={
+            "text_config": {
+                **text_kwargs,
+                "vocab_size": 152064,
+                "rope_scaling": _rope_scaling(),
+            },
+            "audio_config": {
+                "d_model": _HIDDEN,
+                "encoder_layers": _NUM_LAYERS,
+                "encoder_attention_heads": _NUM_HEADS,
+                "encoder_ffn_dim": _INTERMEDIATE,
+                "num_mel_bins": 16,
+                "output_dim": _HIDDEN,
+                "n_window": 4,
+                "n_window_infer": 16,
+                "conv_chunksize": 10,
+                "downsample_hidden_size": 32,
+            },
+            "vision_config": {
+                "hidden_size": _HIDDEN,
+                "depth": _NUM_LAYERS,
+                "num_heads": _NUM_HEADS,
+                "intermediate_size": _INTERMEDIATE,
+                "out_hidden_size": _HIDDEN,
+                "deepstack_visual_indexes": [0],
+                "patch_size": 16,
+                "temporal_patch_size": 2,
+                "spatial_merge_size": 2,
+            },
+        },
+        talker_config={
+            "text_config": {
+                **text_kwargs,
+                "vocab_size": 256,
+                "rope_scaling": _rope_scaling(),
+            },
+            "code_predictor_config": {
+                **text_kwargs,
+                "vocab_size": 128,
+                "num_code_groups": 4,
+            },
+            "thinker_hidden_size": _HIDDEN,
+            "num_code_groups": 4,
+            "accept_hidden_layer": 1,
+            "spatial_merge_size": 2,
+        },
+        code2wav_config={
+            "hidden_size": _HIDDEN,
+            "intermediate_size": _INTERMEDIATE,
+            "num_hidden_layers": _NUM_LAYERS,
+            "num_attention_heads": _NUM_HEADS,
+            "num_key_value_heads": _NUM_KV_HEADS,
+            "codebook_size": 32,
+            "num_quantizers": 4,
+            "decoder_dim": _HIDDEN,
+            "upsample_rates": (2, 2, 2, 2),
+            "upsampling_ratios": (2, 2),
+            "sliding_window": 8,
+        },
+        enable_audio_output=True,
+    )
+
+
+def _build_tokenizer() -> Qwen2TokenizerFast:
+    tok_obj = Tokenizer(models.BPE())
+    tok_obj.pre_tokenizer = pre_tokenizers.ByteLevel(add_prefix_space=False)
+    tok_obj.decoder = decoders.ByteLevel()
+    tok_obj.add_tokens(_SPECIAL_TOKENS + [f"tok{i}" for i in range(500)])
+
+    tokenizer = Qwen2TokenizerFast(
+        tokenizer_object=tok_obj,
+        bos_token="<|endoftext|>",
+        eos_token="<|im_end|>",
+        pad_token="<|endoftext|>",
+    )
+    for attr, value in _EXTRA_TOKEN_ATTRS.items():
+        setattr(tokenizer, attr, value)
+        tokenizer.init_kwargs[attr] = value
+    return tokenizer
+
+
+_CHAT_TEMPLATE: str = (
+    "{% for message in messages %}"
+    "{{'<|im_start|>' + message['role'] + '\n'}}"
+    "{% if message['content'] is string %}"
+    "{{ message['content'] }}"
+    "{% else %}"
+    "{% for content in message['content'] %}"
+    "{% if content['type'] == 'image' %}"
+    "{{ '<|vision_start|><|image_pad|><|vision_end|>' }}"
+    "{% elif content['type'] == 'audio' %}"
+    "{{ '<|audio_bos|><|AUDIO|><|audio_eos|>' }}"
+    "{% elif content['type'] == 'text' %}"
+    "{{ content['text'] }}"
+    "{% endif %}"
+    "{% endfor %}"
+    "{% endif %}"
+    "{{ '<|im_end|>\n' }}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}"
+    "{{ '<|im_start|>assistant\n' }}"
+    "{% endif %}"
+)
+
+
+def _build_processor() -> Qwen3OmniProcessor:
+    return Qwen3OmniProcessor(
+        image_processor=Qwen2VLImageProcessor(min_pixels=_PIXEL_BOUND, max_pixels=_PIXEL_BOUND, patch_size=16),
+        video_processor=Qwen2VLVideoProcessor(min_pixels=_PIXEL_BOUND, max_pixels=_PIXEL_BOUND),
+        feature_extractor=WhisperFeatureExtractor(feature_size=16),
+        tokenizer=_build_tokenizer(),
+        chat_template=_CHAT_TEMPLATE,
+    )
+
+
+def generate(output_dir: Union[str, Path]) -> None:
+    model = Qwen3OmniForConditionalGeneration(_build_config())
+    model.eval()
+    model.save_pretrained(output_dir)
+    _build_processor().save_pretrained(output_dir)

--- a/tests/openvino/test_audit_fixes.py
+++ b/tests/openvino/test_audit_fixes.py
@@ -1,0 +1,570 @@
+#  Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""
+Tests for audit finding fixes:
+- Pipeline dispatch routing for qwen3_omni (accelerator_utils.py)
+- OVTalkerDecoder null guard on _infer_request
+- Batch size validation in _run_talker_generation
+- OVModelForMultimodalLM __init__ attribute initialization
+- Per-component device/ov_config override plumbing
+- OVCode2Wav chunk stitching
+- Projection / audio LRU cache helpers
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import torch
+from transformers import PretrainedConfig
+
+from optimum.intel.openvino import OVModelForMultimodalLM
+from optimum.intel.pipelines.accelerator_utils import OV_TASKS_MAPPING, get_openvino_model_class
+
+
+def _bind_run_talker_generation(model):
+    from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+    return _OVQwen3OmniForCausalLM._run_talker_generation.__get__(model)
+
+
+class TestQwen3OmniDispatch(unittest.TestCase):
+    """Verify get_openvino_model_class routes qwen3_omni to OVModelForMultimodalLM for all supported tasks."""
+
+    def _make_omni_config(self):
+        config = PretrainedConfig()
+        config.model_type = "qwen3_omni"
+        config.architectures = ["Qwen3OmniForConditionalGeneration"]
+        return config
+
+    def _make_non_omni_config(self, model_type="llava"):
+        config = PretrainedConfig()
+        config.model_type = model_type
+        config.architectures = ["LlavaForConditionalGeneration"]
+        return config
+
+    def test_qwen3_omni_dispatch_asr(self):
+        config = self._make_omni_config()
+        cls = get_openvino_model_class("automatic-speech-recognition", config=config)
+        assert cls is OVModelForMultimodalLM, f"Expected OVModelForMultimodalLM, got {cls}"
+
+    def test_qwen3_omni_dispatch_image_text(self):
+        config = self._make_omni_config()
+        cls = get_openvino_model_class("image-text-to-text", config=config)
+        assert cls is OVModelForMultimodalLM, f"Expected OVModelForMultimodalLM, got {cls}"
+
+    def test_qwen3_omni_dispatch_text_audio(self):
+        config = self._make_omni_config()
+        cls = get_openvino_model_class("text-to-audio", config=config)
+        assert cls is OVModelForMultimodalLM, f"Expected OVModelForMultimodalLM, got {cls}"
+
+    def test_asr_non_omni_does_not_get_omni(self):
+        config = self._make_non_omni_config("whisper")
+        config.architectures = ["WhisperForConditionalGeneration"]
+        cls = get_openvino_model_class("automatic-speech-recognition", config=config)
+        assert cls is not OVModelForMultimodalLM
+
+    def test_asr_ctc_model_dispatched_correctly(self):
+        config = PretrainedConfig()
+        config.model_type = "wav2vec2"
+        config.architectures = ["Wav2Vec2ForCTC"]
+        cls = get_openvino_model_class("automatic-speech-recognition", config=config)
+        assert cls is OV_TASKS_MAPPING["automatic-speech-recognition"][0]
+
+    def test_image_text_non_omni_dispatched_to_first(self):
+        config = self._make_non_omni_config("llava")
+        cls = get_openvino_model_class("image-text-to-text", config=config)
+        first_class = OV_TASKS_MAPPING["image-text-to-text"][0]
+        assert cls is first_class
+
+    def test_text_audio_non_omni_dispatched_to_first(self):
+        config = self._make_non_omni_config("speecht5")
+        cls = get_openvino_model_class("text-to-audio", config=config)
+        first_class = OV_TASKS_MAPPING["text-to-audio"][0]
+        assert cls is first_class
+
+    def test_omni_present_in_all_expected_task_tuples(self):
+        expected_tasks = {"automatic-speech-recognition", "image-text-to-text", "text-to-audio"}
+        for task in expected_tasks:
+            assert (
+                OVModelForMultimodalLM in OV_TASKS_MAPPING[task]
+            ), f"OVModelForMultimodalLM missing from OV_TASKS_MAPPING['{task}']"
+
+    def test_unsupported_task_raises(self):
+        config = self._make_omni_config()
+        with pytest.raises(KeyError, match="not supported by OpenVINO"):
+            get_openvino_model_class("nonexistent-task", config=config)
+
+    def test_text_generation_unaffected_by_omni_config(self):
+        config = self._make_omni_config()
+        cls = get_openvino_model_class("text-generation", config=config)
+        assert cls is OV_TASKS_MAPPING["text-generation"][0]
+
+    def test_translation_prefix_normalization(self):
+        cls = get_openvino_model_class("translation_en_to_de")
+        assert cls is OV_TASKS_MAPPING["translation"][0]
+
+
+class TestTalkerNullGuard(unittest.TestCase):
+    """Verify OVTalkerDecoder.forward raises ValueError when _infer_request is None."""
+
+    def _build_talker_stub(self):
+        """Build a minimal OVTalkerDecoder-like object that exercises the null guard."""
+        from optimum.intel.openvino.modeling_visual_language import OVTalkerDecoder
+
+        mock_model = MagicMock()
+        mock_model.inputs = [MagicMock()]
+        mock_model.inputs[0].get_any_name.return_value = "inputs_embeds"
+        mock_model.outputs = [
+            MagicMock(),
+            MagicMock(),
+        ]
+        mock_model.outputs[0].get_any_name.return_value = "logits"
+        mock_model.outputs[1].get_any_name.return_value = "hidden_states"
+        for inp in mock_model.inputs:
+            inp.get_element_type.return_value.get_type_name.return_value = "f32"
+        for out in mock_model.outputs:
+            out.get_element_type.return_value.get_type_name.return_value = "f32"
+
+        parent = MagicMock()
+        parent._device = "CPU"
+        parent.ov_config = {}
+        parent._compile_only = False
+        parent.model_save_dir = "/tmp"
+        parent.config = PretrainedConfig()
+        parent.device = torch.device("cpu")
+
+        talker = OVTalkerDecoder(mock_model, parent)
+        # Override compile to be a no-op so _infer_request stays None
+        talker.compile = lambda: None
+        return talker
+
+    def test_talker_null_guard_raises(self):
+        talker = self._build_talker_stub()
+        assert talker._infer_request is None
+
+        inputs_embeds = torch.randn(1, 5, 64)
+        with pytest.raises(ValueError, match="Talker model not loaded or compilation failed"):
+            talker.forward(inputs_embeds=inputs_embeds)
+
+    def test_talker_null_guard_not_triggered_when_request_exists(self):
+        talker = self._build_talker_stub()
+
+        mock_request = MagicMock()
+        mock_logits = MagicMock()
+        mock_logits.data = np.zeros((1, 5, 10), dtype=np.float32)
+        mock_hidden = MagicMock()
+        mock_hidden.data = np.zeros((1, 5, 64), dtype=np.float32)
+
+        def get_tensor(name):
+            if name == "logits":
+                return mock_logits
+            return mock_hidden
+
+        mock_request.get_tensor = get_tensor
+        talker._infer_request = mock_request
+
+        inputs_embeds = torch.randn(1, 5, 64)
+        logits, hidden = talker.forward(inputs_embeds=inputs_embeds)
+        assert logits.shape == (1, 5, 10)
+        assert hidden.shape == (1, 5, 64)
+
+
+class TestBatchSizeValidation(unittest.TestCase):
+    """Verify _run_talker_generation raises ValueError when batch_size > 1."""
+
+    def test_batch_size_2_raises(self):
+        model = MagicMock()
+        model._run_talker_generation = _bind_run_talker_generation(model)
+
+        talker_input_embeds = torch.randn(2, 10, 64)
+        trailing = torch.randn(2, 5, 64)
+        pad = torch.randn(1, 1, 64)
+
+        with pytest.raises(ValueError, match="only supports batch_size=1, got 2"):
+            model._run_talker_generation(talker_input_embeds, trailing, pad, {})
+
+    def test_batch_size_3_raises(self):
+        model = MagicMock()
+        model._run_talker_generation = _bind_run_talker_generation(model)
+
+        talker_input_embeds = torch.randn(3, 10, 64)
+        trailing = torch.randn(3, 5, 64)
+        pad = torch.randn(1, 1, 64)
+
+        with pytest.raises(ValueError, match="only supports batch_size=1, got 3"):
+            model._run_talker_generation(talker_input_embeds, trailing, pad, {})
+
+    def test_batch_size_0_raises(self):
+        model = MagicMock()
+        model._run_talker_generation = _bind_run_talker_generation(model)
+
+        talker_input_embeds = torch.randn(0, 10, 64)
+        trailing = torch.randn(0, 5, 64)
+        pad = torch.randn(1, 1, 64)
+
+        with pytest.raises(ValueError, match="only supports batch_size=1, got 0"):
+            model._run_talker_generation(talker_input_embeds, trailing, pad, {})
+
+    def test_batch_size_1_passes_guard(self):
+        model = MagicMock()
+        model._run_talker_generation = _bind_run_talker_generation(model)
+
+        talker_config = MagicMock()
+        talker_config.codec_eos_token_id = 0
+        talker_config.code_predictor_config.num_code_groups = 1
+        model.config = MagicMock()
+        model.config.talker_config = talker_config
+
+        logits = torch.zeros(1, 10, 256)
+        logits[0, -1, 0] = 100.0
+        model.talker = MagicMock(return_value=(logits, torch.randn(1, 10, 64)))
+
+        talker_input_embeds = torch.randn(1, 10, 64)
+        trailing = torch.randn(1, 5, 64)
+        pad = torch.randn(1, 1, 64)
+
+        result = model._run_talker_generation(
+            talker_input_embeds, trailing, pad, {"max_new_tokens": 1, "temperature": 0}
+        )
+        assert result is None or isinstance(result, torch.Tensor)
+
+
+class TestOVModelForMultimodalLMInit(unittest.TestCase):
+    """Verify OVModelForMultimodalLM.__init__ correctly mirrors _inner attributes and sets GenerationMixin state."""
+
+    def _build_mock_inner(self):
+        inner = MagicMock()
+        inner.config = PretrainedConfig()
+        inner.config.model_type = "qwen3_omni"
+        inner.model_save_dir = "/tmp/model"
+        inner._device = "CPU"
+        inner.ov_config = {"KEY": "VAL"}
+        inner._compile_only = False
+        inner.use_cache = True
+        inner.preprocessors = [MagicMock()]
+        inner.generation_config = MagicMock()
+        inner.is_dynamic = True
+        inner._openvino_config = MagicMock()
+        inner.language_model = MagicMock()
+        inner.vision_embeddings = MagicMock()
+        inner.has_talker = True
+        inner.audio_encoder = MagicMock()
+        inner.talker = MagicMock()
+        inner.talker_text_embeddings = MagicMock()
+        inner.talker_projections = MagicMock()
+        inner.code_predictor = MagicMock()
+        inner.code2wav = MagicMock()
+        inner.components = {"language_model": inner.language_model}
+        inner._component_names = ["language_model"]
+        inner._ov_model_names = ["lm_model"]
+        inner.ov_models = {"lm_model": MagicMock()}
+        return inner
+
+    def test_config_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.config is inner.config
+
+    def test_model_save_dir_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.model_save_dir is inner.model_save_dir
+
+    def test_device_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model._device is inner._device
+
+    def test_ov_config_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.ov_config is inner.ov_config
+
+    def test_use_cache_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.use_cache is inner.use_cache
+
+    def test_generation_mixin_attributes_set(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model._supports_cache_class is False
+        assert model.main_input_name == "input_ids"
+
+    def test_generation_config_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.generation_config is inner.generation_config
+
+    def test_openvino_config_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model._openvino_config is inner._openvino_config
+
+    def test_openvino_config_none_when_inner_lacks_it(self):
+        inner = self._build_mock_inner()
+        del inner._openvino_config
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model._openvino_config is None
+
+    def test_inner_stored_via_object_setattr(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model._inner is inner
+
+    def test_property_delegation_language_model(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.language_model is inner.language_model
+
+    def test_property_delegation_vision_embeddings(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.vision_embeddings is inner.vision_embeddings
+
+    def test_property_delegation_has_talker(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.has_talker is inner.has_talker
+
+    def test_property_delegation_audio_encoder(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.audio_encoder is inner.audio_encoder
+
+    def test_property_delegation_talker(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.talker is inner.talker
+
+    def test_property_delegation_code_predictor(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.code_predictor is inner.code_predictor
+
+    def test_property_delegation_code2wav(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.code2wav is inner.code2wav
+
+    def test_property_delegation_components(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.components is inner.components
+
+    def test_generate_delegates_to_inner(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        model.generate("test_arg", key="val")
+        inner.generate.assert_called_once_with("test_arg", key="val")
+
+    def test_compile_delegates_to_inner(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        model.compile()
+        inner.compile.assert_called_once()
+
+    def test_preprocessors_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.preprocessors is inner.preprocessors
+
+    def test_is_dynamic_mirrored(self):
+        inner = self._build_mock_inner()
+        model = OVModelForMultimodalLM(_inner=inner)
+        assert model.is_dynamic is inner.is_dynamic
+
+
+class TestTalkerConfigGuard(unittest.TestCase):
+    """Verify _run_talker_generation raises ValueError when talker_config is missing."""
+
+    def test_missing_talker_config_raises(self):
+        model = MagicMock()
+        model._run_talker_generation = _bind_run_talker_generation(model)
+
+        config = MagicMock()
+        config.talker_config = None
+        model.config = config
+
+        talker_input_embeds = torch.randn(1, 10, 64)
+        trailing = torch.randn(1, 5, 64)
+        pad = torch.randn(1, 1, 64)
+
+        with pytest.raises(ValueError, match="talker_config is required"):
+            model._run_talker_generation(talker_input_embeds, trailing, pad, {})
+
+
+class TestPerComponentDeviceOverrides(unittest.TestCase):
+    """Verify _split_component_overrides correctly separates per-component keys from ov_config."""
+
+    def test_device_override_uppercased(self):
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        dev, _, _ = _OVQwen3OmniForCausalLM._split_component_overrides({"talker.device": "gpu"})
+        assert dev == {"talker": "GPU"}
+
+    def test_whitelisted_components_extracted(self):
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        dev, cfg, base = _OVQwen3OmniForCausalLM._split_component_overrides(
+            {
+                "audio_encoder.device": "GPU",
+                "talker.device": "CPU",
+                "talker.ov_config": {"PERFORMANCE_HINT": "LATENCY"},
+                "code_predictor.device": "NPU",
+                "CACHE_DIR": "/tmp/x",
+            }
+        )
+        assert dev == {"audio_encoder": "GPU", "talker": "CPU", "code_predictor": "NPU"}
+        assert cfg == {"talker": {"PERFORMANCE_HINT": "LATENCY"}}
+        assert base == {"CACHE_DIR": "/tmp/x"}
+
+    def test_unknown_component_stays_in_base(self):
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        dev, cfg, base = _OVQwen3OmniForCausalLM._split_component_overrides(
+            {"unknown_component.device": "GPU", "PERFORMANCE_HINT": "LATENCY"}
+        )
+        assert dev == {}
+        assert cfg == {}
+        assert base == {"unknown_component.device": "GPU", "PERFORMANCE_HINT": "LATENCY"}
+
+    def test_non_dict_ov_config_value_stays_in_base(self):
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        dev, cfg, base = _OVQwen3OmniForCausalLM._split_component_overrides({"talker.ov_config": "not_a_dict"})
+        assert cfg == {}
+        assert base == {"talker.ov_config": "not_a_dict"}
+
+    def test_empty_ov_config(self):
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        dev, cfg, base = _OVQwen3OmniForCausalLM._split_component_overrides({})
+        assert dev == {} and cfg == {} and base == {}
+
+
+class TestCode2WavChunking(unittest.TestCase):
+    """Verify OVCode2Wav chunk stitching and guards."""
+
+    def _make_mock_code2wav(self, samples_per_step=40):
+        from optimum.intel.openvino.modeling_visual_language import OVCode2Wav
+
+        class Mock(OVCode2Wav):
+            def __init__(self, spp):
+                self.chunk_size = 25
+                self.chunk_overlap = 5
+                self._async_infer_requests = []
+                self.request = None
+                self._spp = spp
+
+            def _run_single(self, chunk_np):
+                samples = chunk_np.shape[-1] * self._spp
+                return np.ones((1, samples), dtype=np.float32) * float(chunk_np[0, 0, 0])
+
+            def _ensure_infer_pool(self, size):
+                return
+
+        return Mock(samples_per_step)
+
+    def test_chunked_produces_2d_waveform(self):
+        m = self._make_mock_code2wav()
+        codes = torch.ones(1, 16, 60)
+        wave = m._run_chunked(codes, 25, 5)
+        assert wave.ndim == 2
+        assert wave.shape[0] == 1
+
+    def test_chunk_overlap_ge_chunk_size_raises(self):
+        m = self._make_mock_code2wav()
+        codes = torch.ones(1, 16, 60)
+        with pytest.raises(ValueError, match="chunk_overlap"):
+            m._run_chunked(codes, 25, 25)
+        with pytest.raises(ValueError, match="chunk_overlap"):
+            m._run_chunked(codes, 25, 30)
+
+    def test_batch_size_gt_1_raises(self):
+        m = self._make_mock_code2wav()
+        codes = torch.ones(2, 16, 60)
+        with pytest.raises(ValueError, match="batch_size=1"):
+            m._run_chunked(codes, 25, 5)
+
+    def test_wrong_ndim_raises(self):
+        m = self._make_mock_code2wav()
+        codes = torch.ones(16, 60)
+        with pytest.raises(ValueError, match=r"\(B, G, T\)"):
+            m._run_chunked(codes, 25, 5)
+
+    def test_estimate_samples_per_step(self):
+        from optimum.intel.openvino.modeling_visual_language import OVCode2Wav
+
+        assert OVCode2Wav._estimate_samples_per_step(25, 5000) == 200
+        assert OVCode2Wav._estimate_samples_per_step(0, 100) == 0
+        assert OVCode2Wav._estimate_samples_per_step(10, 0) == 0
+
+
+class TestCaches(unittest.TestCase):
+    """Verify projection + audio LRU helpers on _OVQwen3OmniForCausalLM."""
+
+    def test_lru_get_miss_returns_none(self):
+        from collections import OrderedDict
+
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        cache = OrderedDict()
+        assert _OVQwen3OmniForCausalLM._lru_get(cache, b"x") is None
+
+    def test_lru_put_evicts_lru(self):
+        from collections import OrderedDict
+
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        cache = OrderedDict()
+        _OVQwen3OmniForCausalLM._lru_put(cache, b"a", 1, capacity=2)
+        _OVQwen3OmniForCausalLM._lru_put(cache, b"b", 2, capacity=2)
+        _OVQwen3OmniForCausalLM._lru_put(cache, b"c", 3, capacity=2)
+        assert b"a" not in cache
+        assert list(cache.keys()) == [b"b", b"c"]
+
+    def test_lru_get_promotes_to_end(self):
+        from collections import OrderedDict
+
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        cache = OrderedDict()
+        _OVQwen3OmniForCausalLM._lru_put(cache, b"a", 1, capacity=3)
+        _OVQwen3OmniForCausalLM._lru_put(cache, b"b", 2, capacity=3)
+        assert _OVQwen3OmniForCausalLM._lru_get(cache, b"a") == 1
+        # "a" should now be most-recently-used, so "b" evicts first.
+        _OVQwen3OmniForCausalLM._lru_put(cache, b"c", 3, capacity=2)
+        assert b"b" not in cache
+        assert b"a" in cache and b"c" in cache
+
+    def test_tensor_bytes_stable_across_calls(self):
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        t = torch.arange(6).reshape(2, 3)
+        assert _OVQwen3OmniForCausalLM._tensor_bytes(t) == _OVQwen3OmniForCausalLM._tensor_bytes(t)
+
+    def test_tensor_bytes_distinct_for_different_values(self):
+        from optimum.intel.openvino.modeling_visual_language import _OVQwen3OmniForCausalLM
+
+        a = torch.tensor([1, 2, 3])
+        b = torch.tensor([1, 2, 4])
+        assert _OVQwen3OmniForCausalLM._tensor_bytes(a) != _OVQwen3OmniForCausalLM._tensor_bytes(b)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -294,6 +294,8 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
             "gemma4_unified_text",
             "qwen3_omni_moe_text",
             "qwen3_omni_moe_talker_text",
+            "qwen3_omni_text",
+            "qwen3_omni_talker_text",
         }
 
         supported_architectures -= ONNX_SUPPORTED_ARCHITECTURES

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -27,6 +27,7 @@ from utils_tests import (
     SDPA_ARCHS_ONNX_EXPORT_NOT_SUPPORTED,
     TEST_NAME_TO_MODEL_TYPE,
     get_supported_model_for_library,
+    is_qwen3_omni_available,
 )
 
 from optimum.exporters.openvino import export_from_model, main_export
@@ -129,6 +130,11 @@ class ExportModelTest(unittest.TestCase):
         in get_supported_model_for_library("transformers") | get_supported_model_for_library("diffusers")
     }
 
+    # Dense Qwen3-Omni only exists in transformers builds that ship the qwen3_omni module, so it can't
+    # live in the statically-filtered dict above.
+    if is_qwen3_omni_available():
+        SUPPORTED_ARCHITECTURES.update({"qwen3_omni": OVModelForMultimodalLM})
+
     EXPECTED_DIFFUSERS_SCALE_FACTORS = {
         "stable-diffusion-xl": {"vae_encoder": "128.0", "vae_decoder": "128.0"},
         "stable-diffusion-3": {"text_encoder_3": "8.0"},
@@ -191,6 +197,10 @@ class ExportModelTest(unittest.TestCase):
             # rotary embedding. The CLI export backfills it; mirror that here for the direct model load.
             loading_kwargs["config"] = _ensure_qwen3_omni_rope_scaling(AutoConfig.from_pretrained(model_name))
             model = Qwen3OmniMoeForConditionalGeneration.from_pretrained(model_name, **loading_kwargs)
+        elif model_type == "qwen3_omni":
+            from transformers import Qwen3OmniForConditionalGeneration
+
+            model = Qwen3OmniForConditionalGeneration.from_pretrained(model_name, **loading_kwargs)
         else:
             model = auto_model.auto_model_class.from_pretrained(model_name, **loading_kwargs)
 
@@ -372,6 +382,32 @@ class ExportModelTest(unittest.TestCase):
             for behavior in Qwen3OmniMoeConfigBehavior:
                 model_path = Path(tmpdir) / f"openvino_{behavior.value}_model.xml"
                 self.assertTrue(model_path.exists(), f"Missing {behavior.value}_model for task={task}")
+
+    QWEN3_OMNI_EXPECTED_PARTS = (
+        "language_model",
+        "text_embeddings_model",
+        "vision_embeddings_model",
+        "vision_embeddings_pos_model",
+        "audio_encoder_model",
+        "talker_model",
+        "talker_text_embeddings_model",
+        "talker_projections_model",
+        "code_predictor_model",
+        "code2wav_model",
+    )
+
+    @parameterized.expand(["text-to-audio", "automatic-speech-recognition"])
+    @unittest.skipUnless(is_qwen3_omni_available(), "dense qwen3_omni is not available in this transformers build")
+    def test_qwen3_omni_export_task(self, task):
+        model_name = MODEL_NAMES["qwen3_omni"]
+        from transformers import Qwen3OmniForConditionalGeneration
+
+        model = Qwen3OmniForConditionalGeneration.from_pretrained(model_name, attn_implementation="eager")
+        with TemporaryDirectory() as tmpdir:
+            export_from_model(model, tmpdir, task=task, stateful=True)
+            for part_name in self.QWEN3_OMNI_EXPECTED_PARTS:
+                model_path = Path(tmpdir) / f"openvino_{part_name}.xml"
+                self.assertTrue(model_path.exists(), f"Missing {part_name} for task={task}")
 
     def test_compare_openvino_onnx_supported_architectures(self):
         onnx_architectures = set()

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -37,6 +37,7 @@ from utils_tests import (
     get_num_quantized_nodes,
     get_supported_model_for_library,
     is_model_type_transformers_compatible,
+    is_qwen3_omni_available,
 )
 
 from optimum.exporters.openvino.__main__ import main_export
@@ -142,6 +143,24 @@ class OVCLIExportTestCase(unittest.TestCase):
         if TEST_NAME_TO_MODEL_TYPE.get(model_type, model_type)
         in get_supported_model_for_library("transformers") | get_supported_model_for_library("diffusers")
     ]
+
+    # Qwen3-Omni-MoE requires Transformers 5.0+ (fused-experts / router API).
+    if is_transformers_version(">=", "5.0"):
+        SUPPORTED_ARCHITECTURES.extend(
+            [
+                ("text-to-audio", "qwen3_omni_moe"),
+                ("automatic-speech-recognition", "qwen3_omni_moe"),
+            ]
+        )
+
+    # Dense Qwen3-Omni only exists in transformers builds that ship the qwen3_omni module.
+    if is_qwen3_omni_available():
+        SUPPORTED_ARCHITECTURES.extend(
+            [
+                ("text-to-audio", "qwen3_omni"),
+                ("automatic-speech-recognition", "qwen3_omni"),
+            ]
+        )
 
     EXPECTED_NUMBER_OF_TOKENIZER_MODELS = {
         "gpt2": 2,
@@ -825,9 +844,9 @@ class OVCLIExportTestCase(unittest.TestCase):
             )
 
     def _load_exported_ov_model(self, model_type: str, task: str, tmpdir: str, model_kwargs: Dict):
-        # qwen3_omni_moe spans multiple tasks but always loads via OVModelForMultimodalLM,
-        # the dedicated omni-modal wrapper (talker/audio_encoder/code2wav) for this architecture.
-        if model_type == "qwen3_omni_moe":
+        # qwen3_omni(_moe) spans multiple tasks but always loads via OVModelForMultimodalLM,
+        # the dedicated omni-modal wrapper (talker/audio_encoder/code2wav) for these architectures.
+        if model_type in ("qwen3_omni_moe", "qwen3_omni"):
             from optimum.intel.openvino import OVModelForMultimodalLM
 
             return OVModelForMultimodalLM.from_pretrained(tmpdir, **model_kwargs)

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -89,6 +89,7 @@ from utils_tests import (
     check_compression_state_per_model,
     get_supported_model_for_library,
     is_model_type_transformers_compatible,
+    is_qwen3_omni_available,
     TEST_NAME_TO_MODEL_TYPE,
     OPENVINO_DEVICE,
     HUB_MODEL_NAMES,
@@ -502,6 +503,38 @@ class OVQuantizerTest(unittest.TestCase):
         for config in SUPPORTED_ARCHITECTURES_OV_MODEL_WITH_AUTO_DATASET
         if TEST_NAME_TO_MODEL_TYPE.get(config[1], config[1]) in get_supported_model_for_library("transformers")
     ]
+
+    # Dense Qwen3-Omni only exists in transformers builds that ship the qwen3_omni module.
+    if is_qwen3_omni_available():
+        SUPPORTED_ARCHITECTURES_OV_MODEL_WITH_AUTO_DATASET.extend(
+            [
+                (
+                    OVModelForVisualCausalLM,
+                    "qwen3_omni",
+                    OVQuantizationConfig(
+                        bits=8,
+                        dataset="contextual",
+                        num_samples=1,
+                    ),
+                    {
+                        "lm_model": 14,
+                        "text_embeddings_model": 0,
+                        "vision_embeddings_model": 1,
+                        "vision_embeddings_merger_model": 44,
+                        "vision_embeddings_pos_model": 0,
+                        "audio_encoder_model": 0,
+                    },
+                    {
+                        "lm_model": {"int8": 15},
+                        "text_embeddings_model": {"int8": 1},
+                        "vision_embeddings_model": {"int8": 1},
+                        "vision_embeddings_merger_model": {"int8": 32},
+                        "vision_embeddings_pos_model": {"int8": 1},
+                        "audio_encoder_model": {"int8": 10},
+                    },
+                ),
+            ]
+        )
 
     @staticmethod
     def get_calibration_dataset(
@@ -1028,6 +1061,27 @@ class OVWeightCompressionTest(unittest.TestCase):
         ),
         (
             OVModelForVisualCausalLM,
+            "qwen3_omni",
+            False,
+            dict(
+                bits=4,
+                group_size=8,
+                dataset="contextual",
+                ratio=0.8,
+                sensitivity_metric="mean_activation_magnitude",
+                num_samples=1,
+            ),
+            {
+                "lm_model": {"int8": 12, "int4": 18},
+                "text_embeddings_model": {"int8": 1},
+                "vision_embeddings_model": {"int8": 1},
+                "vision_embeddings_merger_model": {"int8": 32},
+                "vision_embeddings_pos_model": {"int8": 1},
+                "audio_encoder_model": {"int8": 10},
+            },
+        ),
+        (
+            OVModelForVisualCausalLM,
             "phi3_v",
             True,
             dict(
@@ -1194,6 +1248,11 @@ class OVWeightCompressionTest(unittest.TestCase):
         if TEST_NAME_TO_MODEL_TYPE.get(config[1], config[1]) in get_supported_model_for_library("transformers")
     ]
 
+    # Dense Qwen3-Omni only exists in transformers builds that ship the qwen3_omni module, so it can't
+    # live in the statically-filtered list above.
+    if is_qwen3_omni_available():
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "qwen3_omni", False))
+
     SUPPORTED_ARCHITECTURES_WITH_HYBRID_QUANTIZATION = [
         (OVStableDiffusionPipeline, "stable-diffusion", 72, 195),
         (OVStableDiffusionXLPipeline, "stable-diffusion-xl", 84, 331),
@@ -1342,6 +1401,9 @@ class OVWeightCompressionTest(unittest.TestCase):
             )
             if not is_model_type_transformers_compatible(model_type)
         }
+        # Dense Qwen3-Omni is filtered out on builds that don't ship the qwen3_omni module.
+        if not is_qwen3_omni_available():
+            expected.add("qwen3_omni")
         if is_transformers_version(">=", "5"):
             expected.update({"llama4", "llava_next_video", "minicpmv", "internvl_chat", "exaone4"})
 

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -54,6 +54,7 @@ from utils_tests import (
     TEST_NAME_TO_MODEL_TYPE,
     Timer,
     get_supported_model_for_library,
+    is_qwen3_omni_available,
 )
 
 from optimum.exporters.openvino.stateful import model_has_state
@@ -77,6 +78,7 @@ from optimum.intel.openvino.modeling_text2speech import (
 from optimum.intel.openvino.modeling_visual_language import (
     MODEL_PARTS_CLS_MAPPING,
     MODEL_TYPE_TO_CLS_MAPPING,
+    _OVQwen3OmniForCausalLM,
     _OVQwen3OmniMoeForCausalLM,
 )
 from optimum.intel.pipelines import pipeline as optimum_pipeline
@@ -623,6 +625,13 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         if TEST_NAME_TO_MODEL_TYPE.get(arch, arch) in get_supported_model_for_library("transformers")
     ]
 
+    # Dense Qwen3-Omni only exists in transformers builds that ship the qwen3_omni module, so it can't
+    # live in the statically-filtered list above.
+    if is_qwen3_omni_available():
+        SUPPORTED_ARCHITECTURES += ["qwen3_omni"]
+        SUPPORT_AUDIO.append("qwen3_omni")
+        SUPPORT_AUDIO_OUTPUT.append("qwen3_omni")
+
     REMOTE_CODE_MODELS = [
         "internvl_chat",
         "minicpmv",
@@ -646,6 +655,10 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
             from transformers import Qwen3OmniMoeForConditionalGeneration
 
             return Qwen3OmniMoeForConditionalGeneration
+        if model_arch == "qwen3_omni":
+            from transformers import Qwen3OmniForConditionalGeneration
+
+            return Qwen3OmniForConditionalGeneration
         if model_arch in [
             "llava",
             "llava_next",
@@ -725,9 +738,9 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         ):
             self.skipTest("CVS-185350: OpenVINO 2026.1.0 inference results mismatch")
 
-        if model_arch == "qwen3_omni_moe":
-            # Qwen3OmniMoeForConditionalGeneration has a custom generate() interface incompatible with this flow
-            self.skipTest("qwen3_omni_moe comparison tested via dedicated test methods")
+        if model_arch in ("qwen3_omni_moe", "qwen3_omni"):
+            # Qwen3Omni(Moe)ForConditionalGeneration has a custom generate() interface incompatible with this flow
+            self.skipTest(f"{model_arch} comparison tested via dedicated test methods")
 
         def compare_outputs(inputs, ov_model, transformers_model, generation_config):
             transformers_inputs = copy.deepcopy(inputs)
@@ -1127,6 +1140,47 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         del model
         gc.collect()
 
+    @unittest.skipUnless(is_qwen3_omni_available(), "dense qwen3_omni is not available in this transformers build")
+    def test_qwen3_omni_video_not_supported(self):
+        model_id = MODEL_NAMES["qwen3_omni"]
+        model = self.OVMODEL_CLASS.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
+        preprocessors = self.get_preprocessors("qwen3_omni")
+        dummy_video = np.random.rand(2, 224, 224, 3).astype(np.uint8)
+        with self.assertRaises(ValueError):
+            model.preprocess_inputs(**preprocessors, text="Describe", video=dummy_video)
+        del model
+        gc.collect()
+
+    @unittest.skipUnless(is_qwen3_omni_available(), "dense qwen3_omni is not available in this transformers build")
+    def test_qwen3_omni_sequential_generation(self):
+        model_id = MODEL_NAMES["qwen3_omni"]
+        model = self.OVMODEL_CLASS.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
+        preprocessors = self.get_preprocessors("qwen3_omni")
+
+        for _ in range(3):
+            inputs = model.preprocess_inputs(**preprocessors, text="Hello", image=self.IMAGE.resize((224, 224)))
+            output = model.generate(**inputs, max_new_tokens=5)
+            self.assertIsInstance(output, torch.Tensor)
+            self.assertGreater(output.shape[1], inputs["input_ids"].shape[1])
+
+        del model
+        gc.collect()
+
+    @parameterized.expand(["text-to-audio", "automatic-speech-recognition"])
+    @unittest.skipUnless(is_qwen3_omni_available(), "dense qwen3_omni is not available in this transformers build")
+    def test_qwen3_omni_any2any_task_registration(self, task):
+        model_id = MODEL_NAMES["qwen3_omni"]
+        model = self.OVMODEL_CLASS.from_pretrained(model_id, export=True, task=task, device=OPENVINO_DEVICE)
+        self.assertIsNotNone(model.language_model)
+
+        preprocessors = self.get_preprocessors("qwen3_omni")
+        inputs = model.preprocess_inputs(**preprocessors, text="Hello")
+        output = model.generate(**inputs, max_new_tokens=5)
+        self.assertIsInstance(output, torch.Tensor)
+        self.assertGreater(output.shape[1], inputs["input_ids"].shape[1])
+        del model
+        gc.collect()
+
     def get_preprocessors(self, model_arch):
         model_id = MODEL_NAMES[model_arch]
         config = AutoConfig.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
@@ -1144,6 +1198,52 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
             preprocessors = {"processor": None, "tokenizer": tokenizer, "config": config}
+        elif model_arch == "qwen3_omni":
+            # qwen3_omni is not yet registered in AutoImageProcessor/AutoProcessor
+            import json
+            import pathlib
+
+            from transformers import Qwen2VLImageProcessor, Qwen2VLVideoProcessor, WhisperFeatureExtractor
+            from transformers.models.qwen3_omni.processing_qwen3_omni import Qwen3OmniProcessor
+
+            tokenizer = AutoTokenizer.from_pretrained(model_id)
+            # Qwen2TokenizerFast doesn't persist custom token attrs, restore from tokenizer_config.json
+            tok_cfg = json.loads((pathlib.Path(model_id) / "tokenizer_config.json").read_text())
+            for attr in (
+                "image_token",
+                "audio_token",
+                "video_token",
+                "vision_bos_token",
+                "vision_eos_token",
+                "audio_bos_token",
+                "audio_eos_token",
+            ):
+                if attr in tok_cfg:
+                    setattr(tokenizer, attr, tok_cfg[attr])
+            vision_cfg = getattr(getattr(config, "thinker_config", config), "vision_config", None)
+            patch_size = getattr(vision_cfg, "patch_size", 16) if vision_cfg else 16
+            spatial_merge = getattr(vision_cfg, "spatial_merge_size", 2) if vision_cfg else 2
+            min_px = patch_size * spatial_merge * 28 * 28
+            image_processor = Qwen2VLImageProcessor(min_pixels=min_px, max_pixels=min_px, patch_size=patch_size)
+            video_processor = Qwen2VLVideoProcessor(min_pixels=min_px, max_pixels=min_px)
+            feature_extractor = WhisperFeatureExtractor.from_pretrained(model_id)
+            chat_template = None
+            for ct_name in ("chat_template.jinja", "chat_template.json"):
+                ct_path = pathlib.Path(model_id) / ct_name
+                if ct_path.exists():
+                    if ct_name.endswith(".jinja"):
+                        chat_template = ct_path.read_text()
+                    else:
+                        chat_template = json.loads(ct_path.read_text()).get("chat_template")
+                    break
+            processor = Qwen3OmniProcessor(
+                image_processor=image_processor,
+                video_processor=video_processor,
+                feature_extractor=feature_extractor,
+                tokenizer=tokenizer,
+                chat_template=chat_template,
+            )
+            preprocessors = {"processor": processor, "tokenizer": None, "config": config}
         else:
             processor = AutoProcessor.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
@@ -1172,30 +1272,89 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
             self.assertIsInstance(ov_restored_model, type(ov_model))
 
 
-@pytest.mark.skipif(is_transformers_version("<", "5.0"), reason="OVModelForMultimodalLM requires transformers >= 5.0")
-class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
-    def _generate_random_audio_data(self):
-        np.random.seed(10)
-        sampling_rate = 16000
-        t = np.linspace(0, 5.0, int(5.0 * sampling_rate), endpoint=False)
-        audio_data = 0.5 * np.sin(2 * np.pi * 220 * t)
-        return (audio_data, sampling_rate)
+def _build_qwen3_omni_moe_preprocessors():
+    model_id = MODEL_NAMES["qwen3_omni_moe"]
+    return {"processor": AutoProcessor.from_pretrained(model_id), "tokenizer": None, "config": None}
 
-    def _get_preprocessors(self, model_id):
-        return {"processor": AutoProcessor.from_pretrained(model_id), "tokenizer": None, "config": None}
+
+def _build_qwen3_omni_preprocessors():
+    # The dense tiny fixture is generated locally and may not round-trip through AutoProcessor,
+    # so assemble the processor from its components explicitly.
+    import json
+    import pathlib
+
+    from transformers import Qwen2VLImageProcessor, Qwen2VLVideoProcessor, WhisperFeatureExtractor
+    from transformers.models.qwen3_omni.processing_qwen3_omni import Qwen3OmniProcessor
+
+    model_id = MODEL_NAMES["qwen3_omni"]
+    config = AutoConfig.from_pretrained(model_id)
+    tokenizer = AutoTokenizer.from_pretrained(model_id)
+    tok_cfg = json.loads((pathlib.Path(model_id) / "tokenizer_config.json").read_text())
+    for attr in (
+        "image_token",
+        "audio_token",
+        "video_token",
+        "vision_bos_token",
+        "vision_eos_token",
+        "audio_bos_token",
+        "audio_eos_token",
+    ):
+        if attr in tok_cfg:
+            setattr(tokenizer, attr, tok_cfg[attr])
+    vision_cfg = getattr(getattr(config, "thinker_config", config), "vision_config", None)
+    patch_size = getattr(vision_cfg, "patch_size", 16) if vision_cfg else 16
+    spatial_merge = getattr(vision_cfg, "spatial_merge_size", 2) if vision_cfg else 2
+    min_px = patch_size * spatial_merge * 28 * 28
+    image_processor = Qwen2VLImageProcessor(min_pixels=min_px, max_pixels=min_px, patch_size=patch_size)
+    video_processor = Qwen2VLVideoProcessor(min_pixels=min_px, max_pixels=min_px)
+    feature_extractor = WhisperFeatureExtractor.from_pretrained(model_id)
+    chat_template = None
+    for ct_name in ("chat_template.jinja", "chat_template.json"):
+        ct_path = pathlib.Path(model_id) / ct_name
+        if ct_path.exists():
+            if ct_name.endswith(".jinja"):
+                chat_template = ct_path.read_text()
+            else:
+                chat_template = json.loads(ct_path.read_text()).get("chat_template")
+            break
+    processor = Qwen3OmniProcessor(
+        image_processor=image_processor,
+        video_processor=video_processor,
+        feature_extractor=feature_extractor,
+        tokenizer=tokenizer,
+        chat_template=chat_template,
+    )
+    return {"processor": processor, "tokenizer": None, "config": config}
+
+
+def _generate_random_audio_data():
+    np.random.seed(10)
+    sampling_rate = 16000
+    t = np.linspace(0, 5.0, int(5.0 * sampling_rate), endpoint=False)
+    audio_data = 0.5 * np.sin(2 * np.pi * 220 * t)
+    return (audio_data, sampling_rate)
+
+
+class OVModelForMultimodalLMIntegrationTestMixin:
+    # Set by each architecture-specific subclass below.
+    MODEL_ARCH = None
+    INNER_CLS = None
+
+    def _build_preprocessors(self):
+        raise NotImplementedError
 
     def test_from_pretrained_export(self):
-        model_id = MODEL_NAMES["qwen3_omni_moe"]
+        model_id = MODEL_NAMES[self.MODEL_ARCH]
         model = OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
         self.assertIsInstance(model, OVModelForMultimodalLM)
-        self.assertIsInstance(model._inner, _OVQwen3OmniMoeForCausalLM)
+        self.assertIsInstance(model._inner, self.INNER_CLS)
         self.assertIsNotNone(model.config)
         self.assertIsNotNone(model.language_model)
         del model
         gc.collect()
 
     def test_save_and_reload(self):
-        model_id = MODEL_NAMES["qwen3_omni_moe"]
+        model_id = MODEL_NAMES[self.MODEL_ARCH]
         model = OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
         with TemporaryDirectory() as save_dir:
             model.save_pretrained(save_dir)
@@ -1203,15 +1362,15 @@ class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
             self.assertIsInstance(restored, OVModelForMultimodalLM)
             self.assertIsNotNone(restored.config)
             self.assertIsNotNone(restored.language_model)
-            self.assertEqual(restored.config.model_type, "qwen3_omni_moe")
+            self.assertEqual(restored.config.model_type, self.MODEL_ARCH)
             del restored
         del model
         gc.collect()
 
     def test_text_only_generation(self):
-        model_id = MODEL_NAMES["qwen3_omni_moe"]
+        model_id = MODEL_NAMES[self.MODEL_ARCH]
         model = OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
-        preprocessors = self._get_preprocessors(model_id)
+        preprocessors = self._build_preprocessors()
         inputs = model.preprocess_inputs(text="Hello", **preprocessors)
         output = model.generate(**inputs, max_new_tokens=5)
         self.assertIsInstance(output, torch.Tensor)
@@ -1220,10 +1379,10 @@ class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
         gc.collect()
 
     def test_audio_input_generation(self):
-        model_id = MODEL_NAMES["qwen3_omni_moe"]
+        model_id = MODEL_NAMES[self.MODEL_ARCH]
         model = OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
-        preprocessors = self._get_preprocessors(model_id)
-        audio_data = self._generate_random_audio_data()
+        preprocessors = self._build_preprocessors()
+        audio_data = _generate_random_audio_data()
         inputs = model.preprocess_inputs(text="Translate", audio=[audio_data], **preprocessors)
         output = model.generate(**inputs, max_new_tokens=5)
         self.assertIsInstance(output, torch.Tensor)
@@ -1231,9 +1390,9 @@ class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
         gc.collect()
 
     def test_audio_output_generation(self):
-        model_id = MODEL_NAMES["qwen3_omni_moe"]
+        model_id = MODEL_NAMES[self.MODEL_ARCH]
         model = OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
-        preprocessors = self._get_preprocessors(model_id)
+        preprocessors = self._build_preprocessors()
         inputs = model.preprocess_inputs(text="Say hello", **preprocessors)
         text_result, audio_result = model.generate(
             **inputs, max_new_tokens=10, return_audio=True, talker_max_new_tokens=20
@@ -1249,7 +1408,7 @@ class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
         gc.collect()
 
     def test_has_talker_property(self):
-        model_id = MODEL_NAMES["qwen3_omni_moe"]
+        model_id = MODEL_NAMES[self.MODEL_ARCH]
         model = OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
         self.assertIsInstance(model.has_talker, bool)
         self.assertEqual(model.has_talker, (model.talker is not None and model.code2wav is not None))
@@ -1257,7 +1416,7 @@ class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
         gc.collect()
 
     def test_component_access(self):
-        model_id = MODEL_NAMES["qwen3_omni_moe"]
+        model_id = MODEL_NAMES[self.MODEL_ARCH]
         model = OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
         self.assertIsNotNone(model.language_model)
         self.assertIsNotNone(model.vision_embeddings)
@@ -1272,10 +1431,10 @@ class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
 
     @parameterized.expand(["text-to-audio", "automatic-speech-recognition"])
     def test_task_alias_loading(self, task):
-        model_id = MODEL_NAMES["qwen3_omni_moe"]
+        model_id = MODEL_NAMES[self.MODEL_ARCH]
         model = OVModelForMultimodalLM.from_pretrained(model_id, export=True, task=task, device=OPENVINO_DEVICE)
         self.assertIsNotNone(model.language_model)
-        preprocessors = self._get_preprocessors(model_id)
+        preprocessors = self._build_preprocessors()
         inputs = model.preprocess_inputs(text="Hello", **preprocessors)
         output = model.generate(**inputs, max_new_tokens=5)
         self.assertIsInstance(output, torch.Tensor)
@@ -1287,6 +1446,24 @@ class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
         model_id = MODEL_NAMES["llava"]
         with self.assertRaises(ValueError):
             OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
+
+
+@unittest.skipUnless(is_transformers_version(">=", "5.0"), "OVModelForMultimodalLM requires transformers >= 5.0")
+class OVModelForMultimodalLMMoeIntegrationTest(OVModelForMultimodalLMIntegrationTestMixin, unittest.TestCase):
+    MODEL_ARCH = "qwen3_omni_moe"
+    INNER_CLS = _OVQwen3OmniMoeForCausalLM
+
+    def _build_preprocessors(self):
+        return _build_qwen3_omni_moe_preprocessors()
+
+
+@unittest.skipUnless(is_qwen3_omni_available(), "dense qwen3_omni is not available in this transformers build")
+class OVModelForMultimodalLMDenseIntegrationTest(OVModelForMultimodalLMIntegrationTestMixin, unittest.TestCase):
+    MODEL_ARCH = "qwen3_omni"
+    INNER_CLS = _OVQwen3OmniForCausalLM
+
+    def _build_preprocessors(self):
+        return _build_qwen3_omni_preprocessors()
 
 
 class OVModelForTextToSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -30,6 +30,21 @@ from optimum.exporters.tasks import TasksManager
 from optimum.intel.utils.import_utils import is_transformers_version
 
 
+def is_qwen3_omni_available() -> bool:
+    """Whether the dense Qwen3-Omni architecture can actually be exercised.
+
+    A version check alone is not enough: the dense ``qwen3_omni`` architecture only ships in the
+    4.57.0 dev line of transformers, and other builds that satisfy ``>=4.57.0.dev0`` (e.g. 5.0.0)
+    carry the MoE variant instead, without ``transformers.models.qwen3_omni``. Tests that load or
+    export a dense model must gate on this helper so they skip cleanly on such builds.
+    """
+    import importlib.util
+
+    return is_transformers_version(">=", "4.57.0.dev0") and (
+        importlib.util.find_spec("transformers.models.qwen3_omni") is not None
+    )
+
+
 def _create_tiny_kokoro_model():
     """Generate a tiny random Kokoro TTS model for testing and return its local path.
 
@@ -301,6 +316,9 @@ HUB_MODEL_NAMES = {
     "qwen3_vl": "optimum-intel-internal-testing/tiny-random-qwen3-vl",
     "qwen3_vl_embedding": "optimum-intel-internal-testing/tiny-random-qwen3-vl-embedding",
     "qwen3_omni_moe": "optimum-intel-internal-testing/tiny-random-qwen3-omni",
+    # qwen3_omni (dense) is generated locally and injected into MODEL_NAMES by the
+    # qwen3_omni_model_path fixture in conftest.py; this hub id is only a fallback.
+    "qwen3_omni": "optimum-intel-internal-testing/tiny-random-qwen3-omni",
     "qwen3_next": "optimum-intel-internal-testing/tiny-random-qwen3-next",
     "qwen3_5": "optimum-intel-internal-testing/tiny-random-qwen3.5",
     "qwen3_5_moe": "optimum-intel-internal-testing/tiny-random-qwen3.5-moe",
@@ -544,6 +562,18 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "talker_projections_model": 4,
         "code_predictor_model": 16,
         "code2wav_model": 53,
+    },
+    "qwen3_omni": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 34,
+        "vision_embeddings_pos_model": 1,
+        "audio_encoder_model": 10,
+        "talker_model": 30,
+        "talker_text_embeddings_model": 1,
+        "talker_projections_model": 5,
+        "code_predictor_model": 18,
+        "code2wav_model": 68,
     },
     "sana": {
         "transformer": 58,


### PR DESCRIPTION
### What does this PR do?
Adds OpenVINO export and inference support for the Qwen3-Omni dense multimodal model (text + vision + audio).

The model is exported as 6 sub-models: language model, text embeddings, vision patch embeddings, vision merger (with deepstack features), vision position embeddings, and audio encoder. Inference supports text-only, image, audio, and combined image+audio inputs through OVModelForVisualCausalLM.

Key implementation details:

Language model exports hidden_states alongside logits for correct stateful transformation
4D position IDs for Qwen3-Omni's multimodal RoPE (vs 3D in Qwen3-VL)
Audio inference replicates the original model's windowed chunking pipeline before calling the exported audio encoder
Vision merger uses InputEmbeddingPatcher for the position embedding sub-model to work around inspect.signature resolution issues after prior exports
Note: Requires transformers from commit 3d1a4f5e for Qwen3-Omni dense variant support (not yet in a stable release). The Talker subsystem (speech synthesis) is not present in the dense 4B variant and is not supported.

[CVS-174395](https://jira.devtools.intel.com/browse/CVS-174395)

### Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ]  Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?