### PR TITLE
Added a new test to check whether some transformations is applied during conversion or completion

### DIFF
--- a/tests/openvino/transformations/arch_to_model_class.py
+++ b/tests/openvino/transformations/arch_to_model_class.py
@@ -1,0 +1,46 @@
+
+# Used by test_transformations.py to dynamically select the right class per architecture
+
+ARCH_TO_MODEL_CLASS = {
+    # text-generation
+    "afmoe":                    "OVModelForCausalLM",
+    "gpt2":                     "OVModelForCausalLM",
+    "llama":                    "OVModelForCausalLM",
+    "mistral":                  "OVModelForCausalLM",
+    "qwen2":                    "OVModelForCausalLM",
+    "qwen3":                    "OVModelForCausalLM",
+    
+
+    # image-text-to-text
+    "llava":                    "OVModelForVisualCausalLM",
+    
+
+    # text-to-image / text-to-video
+    "stable-diffusion":      "OVDiffusionPipeline",
+    
+
+    # automatic-speech-recognition
+    "whisper":          "OVModelForSpeechSeq2Seq",
+  
+
+    # text2text-generation
+   
+    "bart":             "OVModelForSeq2SeqLM",
+    
+
+
+
+    # feature-extraction 
+    "bert":             "OVModelForFeatureExtraction",
+    "electra":          "OVModelForFeatureExtraction",
+ 
+
+   
+
+    # zero-shot-image-classification
+    "clip":             "OVModelForZeroShotImageClassification",
+    "siglip":           "OVModelForZeroShotImageClassification",
+    
+}
+
+

--- a/tests/openvino/transformations/arch_to_model_class.py
+++ b/tests/openvino/transformations/arch_to_model_class.py
@@ -1,46 +1,25 @@
-
 # Used by test_transformations.py to dynamically select the right class per architecture
 
 ARCH_TO_MODEL_CLASS = {
     # text-generation
-    "afmoe":                    "OVModelForCausalLM",
-    "gpt2":                     "OVModelForCausalLM",
-    "llama":                    "OVModelForCausalLM",
-    "mistral":                  "OVModelForCausalLM",
-    "qwen2":                    "OVModelForCausalLM",
-    "qwen3":                    "OVModelForCausalLM",
-    
-
+    "afmoe": "OVModelForCausalLM",
+    "gpt2": "OVModelForCausalLM",
+    "llama": "OVModelForCausalLM",
+    "mistral": "OVModelForCausalLM",
+    "qwen2": "OVModelForCausalLM",
+    "qwen3": "OVModelForCausalLM",
     # image-text-to-text
-    "llava":                    "OVModelForVisualCausalLM",
-    
-
+    "llava": "OVModelForVisualCausalLM",
     # text-to-image / text-to-video
-    "stable-diffusion":      "OVDiffusionPipeline",
-    
-
+    "stable-diffusion": "OVDiffusionPipeline",
     # automatic-speech-recognition
-    "whisper":          "OVModelForSpeechSeq2Seq",
-  
-
+    "whisper": "OVModelForSpeechSeq2Seq",
     # text2text-generation
-   
-    "bart":             "OVModelForSeq2SeqLM",
-    
-
-
-
-    # feature-extraction 
-    "bert":             "OVModelForFeatureExtraction",
-    "electra":          "OVModelForFeatureExtraction",
- 
-
-   
-
+    "bart": "OVModelForSeq2SeqLM",
+    # feature-extraction
+    "bert": "OVModelForFeatureExtraction",
+    "electra": "OVModelForFeatureExtraction",
     # zero-shot-image-classification
-    "clip":             "OVModelForZeroShotImageClassification",
-    "siglip":           "OVModelForZeroShotImageClassification",
-    
+    "clip": "OVModelForZeroShotImageClassification",
+    "siglip": "OVModelForZeroShotImageClassification",
 }
-
-

--- a/tests/openvino/transformations/expected_transformations.txt
+++ b/tests/openvino/transformations/expected_transformations.txt
@@ -2,5 +2,5 @@
 # Format: arch_name: Transformation1, Transformation2
 
 
-afmoe: MoEMatMulsFusion,ConvertToCPUSpecificOpset
+afmoe: MoEMatMulsFusion,FullyConnectedBiasFusion
 gpt2: ConvertToCPUSpecificOpset,MatMulToFCFusion

--- a/tests/openvino/transformations/expected_transformations.txt
+++ b/tests/openvino/transformations/expected_transformations.txt
@@ -1,0 +1,6 @@
+
+# Format: arch_name: Transformation1, Transformation2
+
+
+afmoe: MoEMatMulsFusion,ConvertToCPUSpecificOpset
+gpt2: ConvertToCPUSpecificOpset,MatMulToFCFusion

--- a/tests/openvino/transformations/test_transformations.py
+++ b/tests/openvino/transformations/test_transformations.py
@@ -17,6 +17,7 @@ import re
 
 from parameterized import parameterized
 from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS
+from arch_to_model_class import ARCH_TO_MODEL_CLASS
 
 # Maps architecture name -> list of  transformation needed to be applied , as per expected_transformations.txt
 def _load_expected_transformations(path):
@@ -39,16 +40,16 @@ _CONFIG_PATH = os.path.join(
 ARCH_TO_EXPECTED_TRANSFORMATIONS = _load_expected_transformations(_CONFIG_PATH)
 
 
-def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code):
+def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code, model_class="OVModelForCausalLM"):
     #  Runs model loading in a subprocess to reliably capture OpenVINO C++ logs.
 
     code = textwrap.dedent(f"""
         import os
         os.environ["OV_ENABLE_PROFILE_PASS"] = "1"
 
-        from optimum.intel import OVModelForCausalLM
+        from optimum.intel import {model_class}
 
-        OVModelForCausalLM.from_pretrained(
+        {model_class}.from_pretrained(
             "{model_id}",
             export=True,
             compile=True,
@@ -130,11 +131,13 @@ class OVTransformationTest(unittest.TestCase):
     ):
         model_id = MODEL_NAMES[model_arch]
         trust_remote_code = model_arch in REMOTE_CODE_MODELS
+        model_class = ARCH_TO_MODEL_CLASS.get(model_arch)
 
         log_output = _capture_stderr_during(
             model_id,
             OPENVINO_DEVICE,
-            trust_remote_code
+            trust_remote_code,
+            model_class,
         )
 
         result = check_failed_transformations(

--- a/tests/openvino/transformations/test_transformations.py
+++ b/tests/openvino/transformations/test_transformations.py
@@ -1,18 +1,17 @@
-
-
-
-
 import os
-
 import sys
-
 import unittest
-
 
 os.environ["OV_ENABLE_PROFILE_PASS"] = "1"
 
-# we are adding this , so the parent directory (tests/openvino/) is in the python search path for utils.py to be imported
+# we are adding this , so the parent directory (tests/openvino/) is in the python search path for utils_test.py to be imported
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+import subprocess
+import textwrap
+import re
+from difflib import get_close_matches
 
 from parameterized import parameterized
 from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS
@@ -20,8 +19,8 @@ from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS
 
 
 
-# Maps architecture name -> list of  transformation needed to be applied , as per expected_transformations.txt
 
+# Maps architecture name -> list of  transformation needed to be applied , as per expected_transformations.txt
 def _load_expected_transformations(path):
     result = {}
     with open(path) as f:
@@ -30,21 +29,19 @@ def _load_expected_transformations(path):
             if not line or line.startswith("#"):
                 continue
             arch, _, transforms_str = line.partition(":")
-            result[arch.strip()] = [t.strip() for t in transforms_str.split(",") if t.strip()]
+            result[arch.strip()] = [
+                t.strip() for t in transforms_str.split(",") if t.strip()
+            ]
     return result
 
 
-_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "expected_transformations.txt")
+_CONFIG_PATH = os.path.join(
+    os.path.dirname(__file__), "expected_transformations.txt"
+)
 ARCH_TO_EXPECTED_TRANSFORMATIONS = _load_expected_transformations(_CONFIG_PATH)
 
 
-import subprocess
-import sys
-import textwrap
-
-
 def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code):
-    
     #  Runs model loading in a subprocess to reliably capture OpenVINO C++ logs.
 
     code = textwrap.dedent(f"""
@@ -68,41 +65,36 @@ def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code):
         text=True,
     )
 
-  
     return result.stdout
 
 
-import re
-from difflib import get_close_matches
-
-
- # Remove separators and lowercase for fuzzy comparison.
+# Remove separators and lowercase for fuzzy comparison.
 def normalize(name: str) -> str:
     return re.sub(r'[\s_\-]', '', name).lower()
 
+
 # Extract transformation name — always last token before NUMBERms +/-
 def extract_transform_name(line: str) -> str | None:
-    match = re.search(r'([A-Za-z][A-Za-z0-9_]*)\s+\d+ms\s*[+-]\s*$', line.strip())
+    match = re.search(
+        r'([A-Za-z][A-Za-z0-9_]*)\s+\d+ms\s*[+-]\s*$',
+        line.strip()
+    )
     return match.group(1) if match else None
 
 
-
-#Algo to identify tranformations present with '+' in the log.
-def check_failed_transformations(
-    log: str,
-    words: list[str]
-) -> dict:
-    applied_raw = []     
-    applied_norm = []   
+# Algo to identify tranformations present with '+' in the log.
+def check_failed_transformations(log: str, words: list[str]) -> dict:
+    applied_raw = []
+    applied_norm = []
 
     for line in log.splitlines():
         stripped = line.strip()
+
         if not stripped:
             continue
 
         if not stripped.endswith('+'):  #  neglect '-' because those transformations are not applied
             continue
-        
 
         name = extract_transform_name(stripped)
         if name:
@@ -111,51 +103,71 @@ def check_failed_transformations(
 
     remaining = {normalize(w): w for w in words}
 
-    
-
     for key in list(remaining.keys()):
         if any(key in a for a in applied_norm):
             del remaining[key]
 
-   
     hints = {}
     for key, original in remaining.items():
         matches = get_close_matches(key, applied_norm, n=2, cutoff=0.8)
+
         if matches:
-           
-            readable = [applied_raw[applied_norm.index(m)] for m in matches]
+            readable = [
+                applied_raw[applied_norm.index(m)]
+                for m in matches
+            ]
             hints[original] = readable
 
     return {
         "not_found": list(remaining.values()),
-        "hints": hints 
+        "hints": hints
     }
 
 
-
 class OVTransformationTest(unittest.TestCase):
-    @parameterized.expand(list(ARCH_TO_EXPECTED_TRANSFORMATIONS.items()))
-    def test_transformations_applied(self, model_arch, expected_transforms):
+
+    @parameterized.expand(
+        list(ARCH_TO_EXPECTED_TRANSFORMATIONS.items())
+    )
+    def test_transformations_applied(
+        self,
+        model_arch,
+        expected_transforms
+    ):
         model_id = MODEL_NAMES[model_arch]
         trust_remote_code = model_arch in REMOTE_CODE_MODELS
-        
-        
 
-        log_output = _capture_stderr_during(model_id,OPENVINO_DEVICE,trust_remote_code)
+        log_output = _capture_stderr_during(
+            model_id,
+            OPENVINO_DEVICE,
+            trust_remote_code
+        )
 
-        result=check_failed_transformations(log_output,expected_transforms)
+        result = check_failed_transformations(
+            log_output,
+            expected_transforms
+        )
+
         if result["not_found"]:
             not_found = ", ".join(result["not_found"])
             hints = result["hints"]
+
             hint_lines = ""
+
             if hints:
-                 hint_lines = "\nPossible matches in log:\n" + "\n".join(
-                            f"  '{wrong}' → did you mean '{', '.join(suggestions)}'?"
-                           for wrong, suggestions in hints.items()
-                            )
+                hint_lines = (
+                    "\nPossible matches in log:\n"
+                    + "\n".join(
+                        f"  '{wrong}' → did you mean '{', '.join(suggestions)}'?"
+                        for wrong, suggestions in hints.items()
+                    )
+                )
+
             raise AssertionError(
-                            f"The following transformations were not applied for '{model_arch}' architecture: "
-                                 f"{not_found}{hint_lines}"
-                     )
+                f"The following transformations were not applied for '{model_arch}' architecture: "
+                f"{not_found}{hint_lines}"
+            )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/openvino/transformations/test_transformations.py
+++ b/tests/openvino/transformations/test_transformations.py
@@ -2,7 +2,7 @@ import os
 import sys
 import unittest
 
-os.environ["OV_ENABLE_PROFILE_PASS"] = "1"
+
 
 # we are adding this , so the parent directory (tests/openvino/) is in the python search path for utils_test.py to be imported
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -61,7 +61,8 @@ def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code):
 
     result = subprocess.run(
         [sys.executable, "-c", code],
-        capture_output=True,
+        stdout=subprocess.PIPE, 
+       stderr=subprocess.STDOUT, 
         text=True,
     )
 
@@ -104,7 +105,7 @@ def check_failed_transformations(log: str, words: list[str]) -> dict:
     remaining = {normalize(w): w for w in words}
 
     for key in list(remaining.keys()):
-        if any(key in a for a in applied_norm):
+        if key in applied_norm:
             del remaining[key]
 
     hints = {}

--- a/tests/openvino/transformations/test_transformations.py
+++ b/tests/openvino/transformations/test_transformations.py
@@ -1,0 +1,161 @@
+
+
+
+
+import os
+
+import sys
+
+import unittest
+
+
+os.environ["OV_ENABLE_PROFILE_PASS"] = "1"
+
+# we are adding this , so the parent directory (tests/openvino/) is in the python search path for utils.py to be imported
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from parameterized import parameterized
+from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS
+
+
+
+
+# Maps architecture name -> list of  transformation needed to be applied , as per expected_transformations.txt
+
+def _load_expected_transformations(path):
+    result = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            arch, _, transforms_str = line.partition(":")
+            result[arch.strip()] = [t.strip() for t in transforms_str.split(",") if t.strip()]
+    return result
+
+
+_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "expected_transformations.txt")
+ARCH_TO_EXPECTED_TRANSFORMATIONS = _load_expected_transformations(_CONFIG_PATH)
+
+
+import subprocess
+import sys
+import textwrap
+
+
+def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code):
+    
+    #  Runs model loading in a subprocess to reliably capture OpenVINO C++ logs.
+
+    code = textwrap.dedent(f"""
+        import os
+        os.environ["OV_ENABLE_PROFILE_PASS"] = "1"
+
+        from optimum.intel import OVModelForCausalLM
+
+        OVModelForCausalLM.from_pretrained(
+            "{model_id}",
+            export=True,
+            compile=True,
+            device="{OPENVINO_DEVICE}",
+            trust_remote_code={trust_remote_code},
+        )
+    """)
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+
+  
+    return result.stdout
+
+
+import re
+from difflib import get_close_matches
+
+
+ # Remove separators and lowercase for fuzzy comparison.
+def normalize(name: str) -> str:
+    return re.sub(r'[\s_\-]', '', name).lower()
+
+# Extract transformation name — always last token before NUMBERms +/-
+def extract_transform_name(line: str) -> str | None:
+    match = re.search(r'([A-Za-z][A-Za-z0-9_]*)\s+\d+ms\s*[+-]\s*$', line.strip())
+    return match.group(1) if match else None
+
+
+
+#Algo to identify tranformations present with '+' in the log.
+def check_failed_transformations(
+    log: str,
+    words: list[str]
+) -> dict:
+    applied_raw = []     
+    applied_norm = []   
+
+    for line in log.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+
+        if not stripped.endswith('+'):  #  neglect '-' because those transformations are not applied
+            continue
+        
+
+        name = extract_transform_name(stripped)
+        if name:
+            applied_raw.append(name)
+            applied_norm.append(normalize(name))
+
+    remaining = {normalize(w): w for w in words}
+
+    
+
+    for key in list(remaining.keys()):
+        if any(key in a for a in applied_norm):
+            del remaining[key]
+
+   
+    hints = {}
+    for key, original in remaining.items():
+        matches = get_close_matches(key, applied_norm, n=2, cutoff=0.8)
+        if matches:
+           
+            readable = [applied_raw[applied_norm.index(m)] for m in matches]
+            hints[original] = readable
+
+    return {
+        "not_found": list(remaining.values()),
+        "hints": hints 
+    }
+
+
+
+class OVTransformationTest(unittest.TestCase):
+    @parameterized.expand(list(ARCH_TO_EXPECTED_TRANSFORMATIONS.items()))
+    def test_transformations_applied(self, model_arch, expected_transforms):
+        model_id = MODEL_NAMES[model_arch]
+        trust_remote_code = model_arch in REMOTE_CODE_MODELS
+        
+        
+
+        log_output = _capture_stderr_during(model_id,OPENVINO_DEVICE,trust_remote_code)
+
+        result=check_failed_transformations(log_output,expected_transforms)
+        if result["not_found"]:
+            not_found = ", ".join(result["not_found"])
+            hints = result["hints"]
+            hint_lines = ""
+            if hints:
+                 hint_lines = "\nPossible matches in log:\n" + "\n".join(
+                            f"  '{wrong}' → did you mean '{', '.join(suggestions)}'?"
+                           for wrong, suggestions in hints.items()
+                            )
+            raise AssertionError(
+                            f"The following transformations were not applied for '{model_arch}' architecture: "
+                                 f"{not_found}{hint_lines}"
+                     )
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/openvino/transformations/test_transformations.py
+++ b/tests/openvino/transformations/test_transformations.py
@@ -2,23 +2,21 @@ import os
 import sys
 import unittest
 
-
+#This code is for eliminating unnecessary code text from the output
+import pytest
+@pytest.fixture(autouse=True, scope="session")
+def set_tb_style(pytestconfig):
+    pytestconfig.option.tbstyle = "line"
 
 # we are adding this , so the parent directory (tests/openvino/) is in the python search path for utils_test.py to be imported
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-
 import subprocess
 import textwrap
 import re
-from difflib import get_close_matches
 
 from parameterized import parameterized
 from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS
-
-
-
-
 
 # Maps architecture name -> list of  transformation needed to be applied , as per expected_transformations.txt
 def _load_expected_transformations(path):
@@ -74,7 +72,7 @@ def normalize(name: str) -> str:
     return re.sub(r'[\s_\-]', '', name).lower()
 
 
-# Extract transformation name — always last token before NUMBERms +/-
+# Extract transformation name — always last token before NUMBER ms +/-
 def extract_transform_name(line: str) -> str | None:
     match = re.search(
         r'([A-Za-z][A-Za-z0-9_]*)\s+\d+ms\s*[+-]\s*$',
@@ -85,48 +83,43 @@ def extract_transform_name(line: str) -> str | None:
 
 # Algo to identify tranformations present with '+' in the log.
 def check_failed_transformations(log: str, words: list[str]) -> dict:
-    applied_raw = []
-    applied_norm = []
+    applied_norm_plus = []
+    applied_norm_minus = []
+    found_not_applied=[]
 
     for line in log.splitlines():
         stripped = line.strip()
 
         if not stripped:
             continue
-
-        if not stripped.endswith('+'):  #  neglect '-' because those transformations are not applied
-            continue
-
         name = extract_transform_name(stripped)
+        
         if name:
-            applied_raw.append(name)
-            applied_norm.append(normalize(name))
+            if stripped.endswith('+'):
+                applied_norm_plus.append(normalize(name))
+            elif stripped.endswith('-'):
+                applied_norm_minus.append(normalize(name))
 
     remaining = {normalize(w): w for w in words}
 
     for key in list(remaining.keys()):
-        if key in applied_norm:
+        if key in applied_norm_plus:
+            del remaining[key]
+        elif key in applied_norm_minus:
+            found_not_applied.append(remaining[key])
             del remaining[key]
 
-    hints = {}
-    for key, original in remaining.items():
-        matches = get_close_matches(key, applied_norm, n=2, cutoff=0.8)
-
-        if matches:
-            readable = [
-                applied_raw[applied_norm.index(m)]
-                for m in matches
-            ]
-            hints[original] = readable
+   
 
     return {
         "not_found": list(remaining.values()),
-        "hints": hints
+        "not_applied":found_not_applied
     }
 
 
-class OVTransformationTest(unittest.TestCase):
 
+class OVTransformationTest(unittest.TestCase):
+    
     @parameterized.expand(
         list(ARCH_TO_EXPECTED_TRANSFORMATIONS.items())
     )
@@ -149,25 +142,32 @@ class OVTransformationTest(unittest.TestCase):
             expected_transforms
         )
 
-        if result["not_found"]:
-            not_found = ", ".join(result["not_found"])
-            hints = result["hints"]
-
-            hint_lines = ""
-
-            if hints:
-                hint_lines = (
-                    "\nPossible matches in log:\n"
-                    + "\n".join(
-                        f"  '{wrong}' → did you mean '{', '.join(suggestions)}'?"
-                        for wrong, suggestions in hints.items()
-                    )
-                )
-
-            raise AssertionError(
-                f"The following transformations were not applied for '{model_arch}' architecture: "
-                f"{not_found}{hint_lines}"
-            )
+        errors=[]
+        not_found = ", ".join(result["not_found"])
+        not_applied = ", ".join(result["not_applied"])
+        if not_applied:
+            err = (
+               f"These transformations were not 'applied' for '{model_arch}' architecture: "
+                + not_applied
+                  )
+            errors.append(err)
+           
+        if not_found:
+            err=   (
+                       f"These transformations were not 'found' in the '{model_arch}'  transformation set: "
+                          + not_found
+                      )
+            errors.append(err)
+        
+        RED = "\033[91m"
+        RESET = "\033[0m"
+        if errors:
+            # raise AssertionError("\n".join(errors))
+            raise AssertionError(f"{RED}" + "\n".join(errors) + f"{RESET}")
+    
+    
+            
+   
 
 
 if __name__ == "__main__":

--- a/tests/openvino/transformations/test_transformations.py
+++ b/tests/openvino/transformations/test_transformations.py
@@ -2,11 +2,14 @@ import os
 import sys
 import unittest
 
-#This code is for eliminating unnecessary code text from the output
+# This code is for eliminating unnecessary code text from the output
 import pytest
+
+
 @pytest.fixture(autouse=True, scope="session")
 def set_tb_style(pytestconfig):
     pytestconfig.option.tbstyle = "line"
+
 
 # we are adding this , so the parent directory (tests/openvino/) is in the python search path for utils_test.py to be imported
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -18,6 +21,7 @@ import re
 from parameterized import parameterized
 from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS
 from arch_to_model_class import ARCH_TO_MODEL_CLASS
+
 
 # Maps architecture name -> list of  transformation needed to be applied , as per expected_transformations.txt
 def _load_expected_transformations(path):
@@ -34,13 +38,13 @@ def _load_expected_transformations(path):
     return result
 
 
-_CONFIG_PATH = os.path.join(
-    os.path.dirname(__file__), "expected_transformations.txt"
-)
+_CONFIG_PATH = os.path.join(os.path.dirname(__file__), "expected_transformations.txt")
 ARCH_TO_EXPECTED_TRANSFORMATIONS = _load_expected_transformations(_CONFIG_PATH)
 
 
-def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code, model_class="OVModelForCausalLM"):
+def _capture_stderr_during(
+    model_id, OPENVINO_DEVICE, trust_remote_code, model_class="OVModelForCausalLM"
+):
     #  Runs model loading in a subprocess to reliably capture OpenVINO C++ logs.
 
     code = textwrap.dedent(f"""
@@ -60,8 +64,8 @@ def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code, model_c
 
     result = subprocess.run(
         [sys.executable, "-c", code],
-        stdout=subprocess.PIPE, 
-       stderr=subprocess.STDOUT, 
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         text=True,
     )
 
@@ -70,15 +74,12 @@ def _capture_stderr_during(model_id, OPENVINO_DEVICE, trust_remote_code, model_c
 
 # Remove separators and lowercase for fuzzy comparison.
 def normalize(name: str) -> str:
-    return re.sub(r'[\s_\-]', '', name).lower()
+    return re.sub(r"[\s_\-]", "", name).lower()
 
 
 # Extract transformation name — always last token before NUMBER ms +/-
 def extract_transform_name(line: str) -> str | None:
-    match = re.search(
-        r'([A-Za-z][A-Za-z0-9_]*)\s+\d+ms\s*[+-]\s*$',
-        line.strip()
-    )
+    match = re.search(r"([A-Za-z][A-Za-z0-9_]*)\s+\d+ms\s*[+-]\s*$", line.strip())
     return match.group(1) if match else None
 
 
@@ -86,7 +87,7 @@ def extract_transform_name(line: str) -> str | None:
 def check_failed_transformations(log: str, words: list[str]) -> dict:
     applied_norm_plus = []
     applied_norm_minus = []
-    found_not_applied=[]
+    found_not_applied = []
 
     for line in log.splitlines():
         stripped = line.strip()
@@ -94,11 +95,11 @@ def check_failed_transformations(log: str, words: list[str]) -> dict:
         if not stripped:
             continue
         name = extract_transform_name(stripped)
-        
+
         if name:
-            if stripped.endswith('+'):
+            if stripped.endswith("+"):
                 applied_norm_plus.append(normalize(name))
-            elif stripped.endswith('-'):
+            elif stripped.endswith("-"):
                 applied_norm_minus.append(normalize(name))
 
     remaining = {normalize(w): w for w in words}
@@ -110,25 +111,13 @@ def check_failed_transformations(log: str, words: list[str]) -> dict:
             found_not_applied.append(remaining[key])
             del remaining[key]
 
-   
-
-    return {
-        "not_found": list(remaining.values()),
-        "not_applied":found_not_applied
-    }
-
+    return {"not_found": list(remaining.values()), "not_applied": found_not_applied}
 
 
 class OVTransformationTest(unittest.TestCase):
-    
-    @parameterized.expand(
-        list(ARCH_TO_EXPECTED_TRANSFORMATIONS.items())
-    )
-    def test_transformations_applied(
-        self,
-        model_arch,
-        expected_transforms
-    ):
+
+    @parameterized.expand(list(ARCH_TO_EXPECTED_TRANSFORMATIONS.items()))
+    def test_transformations_applied(self, model_arch, expected_transforms):
         model_id = MODEL_NAMES[model_arch]
         trust_remote_code = model_arch in REMOTE_CODE_MODELS
         model_class = ARCH_TO_MODEL_CLASS.get(model_arch)
@@ -140,37 +129,30 @@ class OVTransformationTest(unittest.TestCase):
             model_class,
         )
 
-        result = check_failed_transformations(
-            log_output,
-            expected_transforms
-        )
+        result = check_failed_transformations(log_output, expected_transforms)
 
-        errors=[]
+        errors = []
         not_found = ", ".join(result["not_found"])
         not_applied = ", ".join(result["not_applied"])
         if not_applied:
             err = (
-               f"These transformations were not 'applied' for '{model_arch}' architecture: "
+                f"These transformations were not 'applied' for '{model_arch}' architecture: "
                 + not_applied
-                  )
+            )
             errors.append(err)
-           
+
         if not_found:
-            err=   (
-                       f"These transformations were not 'found' in the '{model_arch}'  transformation set: "
-                          + not_found
-                      )
+            err = (
+                f"These transformations were not 'found' in the '{model_arch}'  transformation set: "
+                + not_found
+            )
             errors.append(err)
-        
+
         RED = "\033[91m"
         RESET = "\033[0m"
         if errors:
             # raise AssertionError("\n".join(errors))
             raise AssertionError(f"{RED}" + "\n".join(errors) + f"{RESET}")
-    
-    
-            
-   
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

This checks whether a specific set of transformations has been applied during conversion or compilation for particular architectures

- **The set of transformations** that needed to be checked for a particular architecture can be defined in a separate file called `expected_transformations.txt`
- **The test case runs for each architecture**
- **The model is loaded and compiled in a separate subprocess** so that the logs can be captured effectively
- **If a transformation is applied during conversion**, then the log definitely contains its name along with time and '+' symbol
- **We run a scan of the logs using an algorithm** to check if the transformations are applied based on that logic
- **Sometimes we may misspell the name of the transformation**, so I used `get_close_matches` library which does fuzzy search and returns the possible matches

Closes #1645

**Please review and let me know if any further improvements are needed.**