### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: 3.9
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,9 +22,9 @@ jobs:
             echo "branch=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
           fi
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{env.branch}}
           fetch-depth: ${{env.depth}}
       - name: Scan for secrets
-        uses: trufflesecurity/trufflehog@main
+        uses: trufflesecurity/trufflehog@6bd2d14f7a4bc1e569fa3550efa7ec632a4fa67b  # main

--- a/.github/workflows/style_bot.yml
+++ b/.github/workflows/style_bot.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   style:
-    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@main
+    uses: huggingface/huggingface_hub/.github/workflows/style-bot-action.yml@e000c1c89c65aee188041723456ac3a479416d4c  # main
     with:
       python_quality_dependencies: "[quality]"
       style_command_type: "style_only"

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -46,13 +46,13 @@ jobs:
     steps:
       - name: Free Disk Space (Ubuntu)
         if: matrix.runs-on == 'ubuntu-22.04'
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # main
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5
         with:
           python-version: "3.10"
 

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       package_name: optimum-intel
     secrets:


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `quality.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `quality.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `upload_pr_documentation.yml` | `huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml` | `main` | `main` | `90b4ee2c10b8…` |
| `style_bot.yml` | `huggingface/huggingface_hub/.github/workflows/style-bot-action.yml` | `main` | `main` | `e000c1c89c65…` |
| `test_openvino_slow.yml` | `jlumbroso/free-disk-space` | `main` | `main` | `54081f138730…` |
| `test_openvino_slow.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `test_openvino_slow.yml` | `actions/setup-python` | `v5` | `v5` | `a26af69be951…` |
| `security.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `security.yml` | `trufflesecurity/trufflehog` | `main` | `main` | `6bd2d14f7a4b…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#230