### PR TITLE
[OpenVINO] fix: Respect `trust_remote_code` in  export and improve safety for multimodal configs FIXES #1668

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -112,6 +112,13 @@ def infer_task(
                 )
 
     if library_name == "transformers":
+        if not trust_remote_code:
+            logger.warning(
+                "This model may require executing custom code from its repository. "
+                "For security reasons, this is disabled by default. "
+                "Please review the source and rerun with `--trust-remote-code` if needed."
+            )
+
         config = AutoConfig.from_pretrained(
             model_name_or_path,
             subfolder=subfolder,

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -128,6 +128,13 @@ def infer_task(
                 )
 
     if library_name == "transformers":
+
+        if not trust_remote_code:
+            logger.warning(
+                "This model may require executing custom code from its repository. "
+                "For security reasons, this is disabled by default. "
+                "Please review the source and rerun with `--trust-remote-code` if needed."
+            )
         try:
             config = AutoConfig.from_pretrained(
                 model_name_or_path,
@@ -157,6 +164,7 @@ def infer_task(
                     raise e
             else:
                 raise
+
         if hasattr(config, "export_model_type"):
             model_type = config.export_model_type
         else:

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -684,6 +684,7 @@ def export_from_model(
             _variant="default",
             exporter="openvino",
             stateful=stateful,
+            trust_remote_code=trust_remote_code,
         )
         logging.disable(logging.NOTSET)
 
@@ -916,6 +917,7 @@ def _get_multi_modal_submodels_and_export_configs(
     preprocessors: Optional[List[Any]] = None,
     model_kwargs: Optional[Dict] = None,
     stateful: bool = True,
+    trust_remote_code: bool = False,
 ):
     models_for_export = {}
     stateful_parts = []
@@ -950,7 +952,7 @@ def _get_multi_modal_submodels_and_export_configs(
         model=model, task=task, exporter="openvino", library_name=library_name
     )
     main_config = main_config_cls(
-        model.config, int_dtype=int_dtype, float_dtype=float_dtype, preprocessors=preprocessors
+        model.config, int_dtype=int_dtype, float_dtype=float_dtype, preprocessors=preprocessors, trust_remote_code=trust_remote_code
     )
     for behavior in main_config.SUPPORTED_BEHAVIORS:
         model_id = f"{behavior}_model"
@@ -976,6 +978,7 @@ def _get_submodels_and_export_configs(
     model_kwargs: Optional[Dict] = None,
     exporter: str = "openvino",
     stateful: bool = False,
+    trust_remote_code: bool = False,
 ):
     if (
         not custom_architecture
@@ -983,7 +986,7 @@ def _get_submodels_and_export_configs(
         and model.config.model_type in MULTI_MODAL_TEXT_GENERATION_MODELS
     ):
         return _get_multi_modal_submodels_and_export_configs(
-            model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful
+            model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful, trust_remote_code=trust_remote_code
         )
     elif not custom_architecture and library_name == "transformers" and model.config.model_type == "speecht5":
         return _get_speecht5_tss_model_for_export(

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -78,7 +78,6 @@ from .utils import (
     set_simplified_chat_template,
 )
 
-
 logger = logging.getLogger(__name__)
 
 if is_torch_available():
@@ -998,7 +997,15 @@ def _get_submodels_and_export_configs(
         and model.config.model_type in MULTI_MODAL_TEXT_GENERATION_MODELS
     ):
         return _get_multi_modal_submodels_and_export_configs(
-            model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful, trust_remote_code=trust_remote_code
+            model,
+            task,
+            library_name,
+            int_dtype,
+            float_dtype,
+            preprocessors,
+            model_kwargs,
+            stateful,
+            trust_remote_code=trust_remote_code,
         )
     elif not custom_architecture and library_name == "transformers" and model.config.model_type == "speecht5":
         return _get_speecht5_tss_model_for_export(

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -922,23 +922,24 @@ def _get_multi_modal_submodels_and_export_configs(
     models_for_export = {}
     stateful_parts = []
 
-    model_type = model.config.model_type
+    base_model_type = model.config.model_type
+    export_model_type = getattr(model.config, "export_model_type", None) or base_model_type
 
-    if model_type == "internvl_chat" and preprocessors is not None:
+    if base_model_type == "internvl_chat" and preprocessors is not None:
         model.config.img_context_token_id = preprocessors[0].convert_tokens_to_ids("<IMG_CONTEXT>")
 
-    if model_type == "phi3_v":
+    if base_model_type == "phi3_v":
         model.config.glb_GN = model.model.vision_embed_tokens.glb_GN.tolist()
         model.config.sub_GN = model.model.vision_embed_tokens.sub_GN.tolist()
 
-    if model_type == "phi4mm":
+    if base_model_type == "phi4mm":
         model.config.glb_GN = model.model.embed_tokens_extend.image_embed.glb_GN.tolist()
         model.config.sub_GN = model.model.embed_tokens_extend.image_embed.sub_GN.tolist()
         model.config.num_img_tokens = model.model.embed_tokens_extend.image_embed.num_img_tokens
         model.config.hd_transform_order = model.model.embed_tokens_extend.image_embed.hd_transform_order
         if model.config.img_processor is None:
             model.config.img_processor = model.model.embed_tokens_extend.image_embed.img_processor.config.to_dict()
-    if model_type == "phi4_multimodal":
+    if base_model_type == "phi4_multimodal":
         model.config.glb_GN = model.model.embed_tokens_extend.image_embed.global_img_feature_extensor.tolist()
         model.config.sub_GN = model.model.embed_tokens_extend.image_embed.sub_img_feature_extensor.tolist()
         model.config.num_img_tokens = model.model.embed_tokens_extend.image_embed.num_img_tokens
@@ -951,8 +952,19 @@ def _get_multi_modal_submodels_and_export_configs(
     main_config_cls = TasksManager.get_exporter_config_constructor(
         model=model, task=task, exporter="openvino", library_name=library_name
     )
+
+    config_kwargs = {
+        "int_dtype": int_dtype,
+        "float_dtype": float_dtype,
+        "preprocessors": preprocessors,
+    }
+
+    if export_model_type in {"llava-qwen2", "phi3_v"}:
+        config_kwargs["trust_remote_code"] = trust_remote_code
+
     main_config = main_config_cls(
-        model.config, int_dtype=int_dtype, float_dtype=float_dtype, preprocessors=preprocessors, trust_remote_code=trust_remote_code
+        model.config,
+        **config_kwargs,
     )
     for behavior in main_config.SUPPORTED_BEHAVIORS:
         model_id = f"{behavior}_model"

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -791,6 +791,7 @@ def export_from_model(
             _variant="default",
             exporter="openvino",
             stateful=stateful,
+            trust_remote_code=trust_remote_code,
         )
         logging.disable(logging.NOTSET)
 
@@ -1025,6 +1026,7 @@ def _get_multi_modal_submodels_and_export_configs(
     preprocessors: Optional[List[Any]] = None,
     model_kwargs: Optional[Dict] = None,
     stateful: bool = True,
+    trust_remote_code: bool = False,
 ):
     models_for_export = {}
     stateful_parts = []
@@ -1059,7 +1061,7 @@ def _get_multi_modal_submodels_and_export_configs(
         model=model, task=task, exporter="openvino", library_name=library_name
     )
     main_config = main_config_cls(
-        model.config, int_dtype=int_dtype, float_dtype=float_dtype, preprocessors=preprocessors
+        model.config, int_dtype=int_dtype, float_dtype=float_dtype, preprocessors=preprocessors, trust_remote_code=trust_remote_code
     )
     for behavior in main_config.SUPPORTED_BEHAVIORS:
         model_id = f"{behavior}_model"
@@ -1085,6 +1087,7 @@ def _get_submodels_and_export_configs(
     model_kwargs: Optional[Dict] = None,
     exporter: str = "openvino",
     stateful: bool = False,
+    trust_remote_code: bool = False,
 ):
     if (
         not custom_architecture
@@ -1092,7 +1095,7 @@ def _get_submodels_and_export_configs(
         and model.config.model_type in MULTI_MODAL_TEXT_GENERATION_MODELS
     ):
         return _get_multi_modal_submodels_and_export_configs(
-            model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful
+            model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful, trust_remote_code=trust_remote_code
         )
     elif not custom_architecture and library_name == "transformers" and model.config.model_type == "speecht5":
         return _get_speecht5_tss_model_for_export(

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -1031,23 +1031,24 @@ def _get_multi_modal_submodels_and_export_configs(
     models_for_export = {}
     stateful_parts = []
 
-    model_type = model.config.model_type
+    base_model_type = model.config.model_type
+    export_model_type = getattr(model.config, "export_model_type", None) or base_model_type
 
-    if model_type == "internvl_chat" and preprocessors is not None:
+    if base_model_type == "internvl_chat" and preprocessors is not None:
         model.config.img_context_token_id = preprocessors[0].convert_tokens_to_ids("<IMG_CONTEXT>")
 
-    if model_type == "phi3_v":
+    if base_model_type == "phi3_v":
         model.config.glb_GN = model.model.vision_embed_tokens.glb_GN.tolist()
         model.config.sub_GN = model.model.vision_embed_tokens.sub_GN.tolist()
 
-    if model_type == "phi4mm":
+    if base_model_type == "phi4mm":
         model.config.glb_GN = model.model.embed_tokens_extend.image_embed.glb_GN.tolist()
         model.config.sub_GN = model.model.embed_tokens_extend.image_embed.sub_GN.tolist()
         model.config.num_img_tokens = model.model.embed_tokens_extend.image_embed.num_img_tokens
         model.config.hd_transform_order = model.model.embed_tokens_extend.image_embed.hd_transform_order
         if model.config.img_processor is None:
             model.config.img_processor = model.model.embed_tokens_extend.image_embed.img_processor.config.to_dict()
-    if model_type == "phi4_multimodal":
+    if base_model_type == "phi4_multimodal":
         model.config.glb_GN = model.model.embed_tokens_extend.image_embed.global_img_feature_extensor.tolist()
         model.config.sub_GN = model.model.embed_tokens_extend.image_embed.sub_img_feature_extensor.tolist()
         model.config.num_img_tokens = model.model.embed_tokens_extend.image_embed.num_img_tokens
@@ -1060,8 +1061,19 @@ def _get_multi_modal_submodels_and_export_configs(
     main_config_cls = TasksManager.get_exporter_config_constructor(
         model=model, task=task, exporter="openvino", library_name=library_name
     )
+
+    config_kwargs = {
+        "int_dtype": int_dtype,
+        "float_dtype": float_dtype,
+        "preprocessors": preprocessors,
+    }
+
+    if export_model_type in {"llava-qwen2", "phi3_v"}:
+        config_kwargs["trust_remote_code"] = trust_remote_code
+
     main_config = main_config_cls(
-        model.config, int_dtype=int_dtype, float_dtype=float_dtype, preprocessors=preprocessors, trust_remote_code=trust_remote_code
+        model.config,
+        **config_kwargs,
     )
     for behavior in main_config.SUPPORTED_BEHAVIORS:
         model_id = f"{behavior}_model"

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -80,7 +80,6 @@ from .utils import (
     set_simplified_chat_template,
 )
 
-
 logger = logging.getLogger(__name__)
 
 if is_torch_available():
@@ -1107,7 +1106,15 @@ def _get_submodels_and_export_configs(
         and model.config.model_type in MULTI_MODAL_TEXT_GENERATION_MODELS
     ):
         return _get_multi_modal_submodels_and_export_configs(
-            model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful, trust_remote_code=trust_remote_code
+            model,
+            task,
+            library_name,
+            int_dtype,
+            float_dtype,
+            preprocessors,
+            model_kwargs,
+            stateful,
+            trust_remote_code=trust_remote_code,
         )
     elif not custom_architecture and library_name == "transformers" and model.config.model_type == "speecht5":
         return _get_speecht5_tss_model_for_export(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2189,12 +2189,6 @@ class LlavaQwen2OpenVINOConfig(BaseVLMOpenVINOConfig):
         self._orig_config = config
         self._trust_remote_code = trust_remote_code
         if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "mm_vision_tower"):
-            if not self._trust_remote_code:
-                logger.warning(
-                    "This model may require executing custom code from its repository. "
-                    "For security reasons, this is disabled by default. "
-                    "Please review the source and rerun with `--trust-remote-code` if needed."
-                )
             config = AutoConfig.from_pretrained(config.mm_vision_tower, trust_remote_code=self._trust_remote_code)
             if hasattr(config, "vision_config"):
                 config = config.vision_config
@@ -3087,12 +3081,6 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
         self._orig_config = config
         self._trust_remote_code = trust_remote_code
         if self._behavior == Phi3VisionConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "img_processor"):
-            if not self._trust_remote_code:
-                logger.warning(
-                    "This model may require executing custom code from its repository. "
-                    "For security reasons, this is disabled by default. "
-                    "Please review the source and rerun with `--trust-remote-code` if needed."
-                )
             self._config = AutoConfig.from_pretrained(
                 config.img_processor["model_name"], trust_remote_code=self._trust_remote_code
             ).vision_config

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2183,11 +2183,19 @@ class LlavaQwen2OpenVINOConfig(BaseVLMOpenVINOConfig):
         behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
         preprocessors: Optional[List[Any]] = None,
         use_past: bool = False,
+        trust_remote_code: bool = False,
     ):
         self._behavior = behavior
         self._orig_config = config
-        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
-            config = AutoConfig.from_pretrained(config.mm_vision_tower, trust_remote_code=True)
+        self._trust_remote_code = trust_remote_code
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "mm_vision_tower"):
+            if not self._trust_remote_code:
+                logger.warning(
+                    "This model may require executing custom code from its repository. "
+                    "For security reasons, this is disabled by default. "
+                    "Please review the source and rerun with `--trust-remote-code` if needed."
+                )
+            config = AutoConfig.from_pretrained(config.mm_vision_tower, trust_remote_code=self._trust_remote_code)
             if hasattr(config, "vision_config"):
                 config = config.vision_config
         super().__init__(
@@ -3066,6 +3074,7 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
         float_dtype: str = "fp32",
         behavior: Phi3VisionConfigBehavior = Phi3VisionConfigBehavior.VISION_EMBEDDINGS,
         preprocessors: Optional[List[Any]] = None,
+        trust_remote_code: bool = False,
     ):
         super().__init__(
             config=config,
@@ -3076,9 +3085,16 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
         )
         self._behavior = behavior
         self._orig_config = config
+        self._trust_remote_code = trust_remote_code
         if self._behavior == Phi3VisionConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "img_processor"):
+            if not self._trust_remote_code:
+                logger.warning(
+                    "This model may require executing custom code from its repository. "
+                    "For security reasons, this is disabled by default. "
+                    "Please review the source and rerun with `--trust-remote-code` if needed."
+                )
             self._config = AutoConfig.from_pretrained(
-                config.img_processor["model_name"], trust_remote_code=True
+                config.img_processor["model_name"], trust_remote_code=self._trust_remote_code
             ).vision_config
             self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
             self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2184,6 +2184,7 @@ class LlavaQwen2OpenVINOConfig(BaseVLMOpenVINOConfig):
         preprocessors: Optional[List[Any]] = None,
         use_past: bool = False,
         trust_remote_code: bool = False,
+        **kwargs,
     ):
         self._behavior = behavior
         self._orig_config = config
@@ -3069,6 +3070,7 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
         behavior: Phi3VisionConfigBehavior = Phi3VisionConfigBehavior.VISION_EMBEDDINGS,
         preprocessors: Optional[List[Any]] = None,
         trust_remote_code: bool = False,
+        **kwargs,
     ):
         super().__init__(
             config=config,

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2513,6 +2513,7 @@ class LlavaQwen2OpenVINOConfig(BaseVLMOpenVINOConfig):
                 float_dtype=self.float_dtype,
                 behavior=behavior,
                 preprocessors=self._preprocessors,
+                trust_remote_code=self._trust_remote_code,
             )
 
     def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
@@ -3391,6 +3392,7 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
                 float_dtype=self.float_dtype,
                 behavior=behavior,
                 preprocessors=self._preprocessors,
+                trust_remote_code=self._trust_remote_code,
             )
         if behavior == Phi3VisionConfigBehavior.VISION_PROJECTION:
             return self.__class__(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2443,12 +2443,6 @@ class LlavaQwen2OpenVINOConfig(BaseVLMOpenVINOConfig):
         self._orig_config = config
         self._trust_remote_code = trust_remote_code
         if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "mm_vision_tower"):
-            if not self._trust_remote_code:
-                logger.warning(
-                    "This model may require executing custom code from its repository. "
-                    "For security reasons, this is disabled by default. "
-                    "Please review the source and rerun with `--trust-remote-code` if needed."
-                )
             config = AutoConfig.from_pretrained(config.mm_vision_tower, trust_remote_code=self._trust_remote_code)
             if hasattr(config, "vision_config"):
                 config = config.vision_config
@@ -3345,12 +3339,6 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
         self._orig_config = config
         self._trust_remote_code = trust_remote_code
         if self._behavior == Phi3VisionConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "img_processor"):
-            if not self._trust_remote_code:
-                logger.warning(
-                    "This model may require executing custom code from its repository. "
-                    "For security reasons, this is disabled by default. "
-                    "Please review the source and rerun with `--trust-remote-code` if needed."
-                )
             self._config = AutoConfig.from_pretrained(
                 config.img_processor["model_name"], trust_remote_code=self._trust_remote_code
             ).vision_config

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2437,11 +2437,19 @@ class LlavaQwen2OpenVINOConfig(BaseVLMOpenVINOConfig):
         behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
         preprocessors: Optional[List[Any]] = None,
         use_past: bool = False,
+        trust_remote_code: bool = False,
     ):
         self._behavior = behavior
         self._orig_config = config
-        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
-            config = AutoConfig.from_pretrained(config.mm_vision_tower, trust_remote_code=True)
+        self._trust_remote_code = trust_remote_code
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "mm_vision_tower"):
+            if not self._trust_remote_code:
+                logger.warning(
+                    "This model may require executing custom code from its repository. "
+                    "For security reasons, this is disabled by default. "
+                    "Please review the source and rerun with `--trust-remote-code` if needed."
+                )
+            config = AutoConfig.from_pretrained(config.mm_vision_tower, trust_remote_code=self._trust_remote_code)
             if hasattr(config, "vision_config"):
                 config = config.vision_config
         super().__init__(
@@ -3324,6 +3332,7 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
         float_dtype: str = "fp32",
         behavior: Phi3VisionConfigBehavior = Phi3VisionConfigBehavior.VISION_EMBEDDINGS,
         preprocessors: Optional[List[Any]] = None,
+        trust_remote_code: bool = False,
     ):
         super().__init__(
             config=config,
@@ -3334,9 +3343,16 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
         )
         self._behavior = behavior
         self._orig_config = config
+        self._trust_remote_code = trust_remote_code
         if self._behavior == Phi3VisionConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "img_processor"):
+            if not self._trust_remote_code:
+                logger.warning(
+                    "This model may require executing custom code from its repository. "
+                    "For security reasons, this is disabled by default. "
+                    "Please review the source and rerun with `--trust-remote-code` if needed."
+                )
             self._config = AutoConfig.from_pretrained(
-                config.img_processor["model_name"], trust_remote_code=True
+                config.img_processor["model_name"], trust_remote_code=self._trust_remote_code
             ).vision_config
             self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
             self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2438,6 +2438,7 @@ class LlavaQwen2OpenVINOConfig(BaseVLMOpenVINOConfig):
         preprocessors: Optional[List[Any]] = None,
         use_past: bool = False,
         trust_remote_code: bool = False,
+        **kwargs,
     ):
         self._behavior = behavior
         self._orig_config = config
@@ -3327,6 +3328,7 @@ class Phi3VisionOpenVINOConfig(BaseVLMOpenVINOConfig):
         behavior: Phi3VisionConfigBehavior = Phi3VisionConfigBehavior.VISION_EMBEDDINGS,
         preprocessors: Optional[List[Any]] = None,
         trust_remote_code: bool = False,
+        **kwargs,
     ):
         super().__init__(
             config=config,

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -62,7 +62,6 @@ from optimum.intel.utils.import_utils import _transformers_version, is_transform
 from optimum.utils import logging
 from optimum.utils.save_utils import maybe_load_preprocessors
 
-
 logger = logging.get_logger()
 
 
@@ -146,6 +145,7 @@ class ExportModelTest(unittest.TestCase):
         SUPPORTED_ARCHITECTURES.update({"qwen3": OVModelForFeatureExtraction})
 
     GENERATIVE_MODELS = ("pix2struct", "t5", "bart", "gpt2", "whisper", "llava", "speecht5")
+    OV_MULTIMODAL_REMOTE_CODE_MODELS = ("llava-qwen2", "phi3_v")
 
     def _openvino_export(
         self,
@@ -365,6 +365,29 @@ class ExportModelTest(unittest.TestCase):
             only_onnx = onnx_architectures - openvino_architectures
             if len(only_onnx) > 0:
                 logger.warning(f"The following architectures export {only_onnx} is supported by ONNX but not OpenVINO")
+
+    @parameterized.expand(OV_MULTIMODAL_REMOTE_CODE_MODELS)
+    def test_export_requires_trust_remote_code_for_multimodal_models(self, model_type):
+
+        model = MODEL_NAMES[model_type]
+        task = "image-text-to-text"
+        with TemporaryDirectory() as tmpdirname:
+            with self.assertRaises(ValueError) as ctx:
+                main_export(
+                    model_name_or_path=model,
+                    task=task,
+                    output=Path(tmpdirname),
+                    trust_remote_code=False,
+                )
+
+            self.assertIn("trust_remote_code", str(ctx.exception))
+
+            main_export(
+                model_name_or_path=model,
+                task=task,
+                output=Path(tmpdirname),
+                trust_remote_code=True,
+            )
 
 
 class CustomExportModelTest(unittest.TestCase):

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -121,6 +121,11 @@ class LLMPipelineTestCase(unittest.TestCase):
         "decilm",
         "minicpm3",
         "deepseek",
+        "xglm",
+        "granitemoe",
+        "granite",
+        "llama4",
+        "zamba2",
     )
     NO_CACHE_MODELS = (  # mostly remote that are broken with past key values
         "aquila",

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -172,7 +172,7 @@ class LLMPipelineTestCase(unittest.TestCase):
             optimum_model = OVModelForCausalLM.from_pretrained(
                 tmpdirname, trust_remote_code=trust_remote_code, device=OPENVINO_DEVICE, ov_config=F32_CONFIG
             )
-            genai_model = LLMPipeline(tmpdirname, device=OPENVINO_DEVICE, **F32_CONFIG, trust_remote_code=trust_remote_code)
+            genai_model = LLMPipeline(tmpdirname, device=OPENVINO_DEVICE, **F32_CONFIG)
 
         prompt = "Paris is the capital of"
         tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -156,9 +156,7 @@ class LLMPipelineTestCase(unittest.TestCase):
         echo = model_arch not in self.NO_ECHO_MODELS
         use_cache = model_arch not in self.NO_CACHE_MODELS
         trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
-        # 🔥 DEBUG: force for xglm
-        if model_arch == "xglm":
-            trust_remote_code = True
+
         set_seed(42)
         transformers_model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=trust_remote_code).eval()
 

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -156,7 +156,9 @@ class LLMPipelineTestCase(unittest.TestCase):
         echo = model_arch not in self.NO_ECHO_MODELS
         use_cache = model_arch not in self.NO_CACHE_MODELS
         trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
-
+        # 🔥 DEBUG: force for xglm
+        if model_arch == "xglm":
+            trust_remote_code = True
         set_seed(42)
         transformers_model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=trust_remote_code).eval()
 

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -172,7 +172,7 @@ class LLMPipelineTestCase(unittest.TestCase):
             optimum_model = OVModelForCausalLM.from_pretrained(
                 tmpdirname, trust_remote_code=trust_remote_code, device=OPENVINO_DEVICE, ov_config=F32_CONFIG
             )
-            genai_model = LLMPipeline(tmpdirname, device=OPENVINO_DEVICE, **F32_CONFIG)
+            genai_model = LLMPipeline(tmpdirname, device=OPENVINO_DEVICE, **F32_CONFIG, trust_remote_code=trust_remote_code)
 
         prompt = "Paris is the capital of"
         tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -259,7 +259,9 @@ class LLMPipelineTestCase(unittest.TestCase):
         model_id = MODEL_NAMES[model_arch]
         use_cache = model_arch not in self.NO_CACHE_MODELS
         trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
-
+        # 🔥 DEBUG: force for xglm
+        if model_arch == "xglm":
+            trust_remote_code = True
         set_seed(42)
         transformers_model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=trust_remote_code).eval()
 

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -223,6 +223,11 @@ class LLMPipelineTestCase(unittest.TestCase):
         "decilm",
         "minicpm3",
         "deepseek",
+        "xglm",
+        "granitemoe",
+        "granite",
+        "llama4",
+        "zamba2",
     )
     NO_CACHE_MODELS = (  # mostly remote that are broken with past key values
         "aquila",

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -259,9 +259,7 @@ class LLMPipelineTestCase(unittest.TestCase):
         model_id = MODEL_NAMES[model_arch]
         use_cache = model_arch not in self.NO_CACHE_MODELS
         trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
-        # 🔥 DEBUG: force for xglm
-        if model_arch == "xglm":
-            trust_remote_code = True
+
         set_seed(42)
         transformers_model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=trust_remote_code).eval()
 

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -223,11 +223,6 @@ class LLMPipelineTestCase(unittest.TestCase):
         "decilm",
         "minicpm3",
         "deepseek",
-        "xglm",
-        "granitemoe",
-        "granite",
-        "llama4",
-        "zamba2",
     )
     NO_CACHE_MODELS = (  # mostly remote that are broken with past key values
         "aquila",

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -263,6 +263,7 @@ class LLMPipelineTestCase(unittest.TestCase):
         set_seed(42)
         transformers_model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=trust_remote_code).eval()
 
+
         set_seed(42)
         main_export(
             model_name_or_path=model_id,
@@ -272,6 +273,7 @@ class LLMPipelineTestCase(unittest.TestCase):
             output=self.temp_dir,
         )
         genai_model = LLMPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
+
 
         prompt = "Paris is the capital of"
         tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)


### PR DESCRIPTION
**Summary**
This PR ensures that the trust_remote_code flag is consistently respected across the OpenVINO export pipeline and improves robustness when handling multimodal model configurations.

**Motivation**

Some multimodal models (e.g. LLaVA, Phi-3 Vision, Qwen-VL) rely on custom code from their Hugging Face repositories.

- Previously:

    - `trust_remote_code` was not consistently propagated
    - In some places it was effectively ignored or hardcoded
    - This could lead to:
      - unexpected failures
      - or unintended execution of remote code

-  A warning is  added in `infer_task()` when `trust_remote_code=False` : This informs users that the model may require remote code appears before       Transformers raises an exception

- Defensive handling of multimodal configs
Added check: `hasattr(config, "mm_vision_tower")`
- Reason :
    - config objects may be modified, partially loaded, or differ across checkpoints
    - prevents AttributeError during export
    - ensures more robust handling of multimodal models


**Behavior**

**Without --trust-remote-code**
- Warning is shown  
- Export fails safely (no remote code execution)

```
optimum-cli export openvino \
  --model Qwen/Qwen-VL \
  --task image-text-to-text \
  ./tmpdir

```
Output : 
``` 
2026-04-02 13:18:31.022603: I external/local_xla/xla/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.
2026-04-02 13:18:31.527521: I external/local_xla/xla/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.
2026-04-02 13:18:31.732439: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1775135911.776867   15390 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
E0000 00:00:1775135911.787531   15390 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
W0000 00:00:1775135911.818199   15390 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1775135911.818289   15390 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1775135911.818295   15390 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1775135911.818300   15390 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
2026-04-02 13:18:31.827581: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
WARNING:torchao.kernel.intmm:Warning: Detected no triton, on systems without Triton certain kernels will not work
Multiple distributions found for package optimum. Picked distribution: optimum
Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
/content/optimum-intel/optimum/intel/openvino/modeling_base.py:590: SyntaxWarning: invalid escape sequence '\.'
  pattern=cls._search_pattern if not kwargs.get("from_onnx", False) else ".*\.onnx$",
config.json: 1.16kB [00:00, 4.72MB/s]
```
**This model may require executing custom code from its repository. For security reasons, this is disabled by default. Please review the source and rerun with `--trust-remote-code` if needed.**
```
Traceback (most recent call last):
  File "/usr/local/bin/optimum-cli", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/optimum/commands/optimum_cli.py", line 219, in main
    service.run()
  File "/content/optimum-intel/optimum/commands/export/openvino.py", line 468, in run
    main_export(
  File "/content/optimum-intel/optimum/exporters/openvino/__main__.py", line 291, in main_export
    task = infer_task(
           ^^^^^^^^^^^
  File "/content/optimum-intel/optimum/exporters/openvino/__main__.py", line 122, in infer_task
    config = AutoConfig.from_pretrained(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformers/models/auto/configuration_auto.py", line 1341, in from_pretrained
    trust_remote_code = resolve_trust_remote_code(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/transformers/dynamic_module_utils.py", line 782, in resolve_trust_remote_code
    raise ValueError(
ValueError: The repository Qwen/Qwen-VL contains custom code which must be executed to correctly load the model. You can inspect the repository content at https://hf.co/Qwen/Qwen-VL .
 You can inspect the repository content at https://hf.co/Qwen/Qwen-VL.
Please pass the argument `trust_remote_code=True` to allow custom code to be run.
```
**With --trust-remote-code**

- Model loads correctly
- Export proceeds as expected

``` 
!optimum-cli export openvino \
  --model llava-hf/llava-1.5-7b-hf \
  --task image-text-to-text \
  --trust-remote-code \
  ./tmpdir
```
Output: 
```
2026-04-02 13:22:07.877253: I external/local_xla/xla/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.
2026-04-02 13:22:07.882495: I external/local_xla/xla/tsl/cuda/cudart_stub.cc:32] Could not find cuda drivers on your machine, GPU will not be used.
2026-04-02 13:22:07.897407: E external/local_xla/xla/stream_executor/cuda/cuda_fft.cc:467] Unable to register cuFFT factory: Attempting to register factory for plugin cuFFT when one has already been registered
WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
E0000 00:00:1775136127.921680   16309 cuda_dnn.cc:8579] Unable to register cuDNN factory: Attempting to register factory for plugin cuDNN when one has already been registered
E0000 00:00:1775136127.929257   16309 cuda_blas.cc:1407] Unable to register cuBLAS factory: Attempting to register factory for plugin cuBLAS when one has already been registered
W0000 00:00:1775136127.948168   16309 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1775136127.948254   16309 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1775136127.948261   16309 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
W0000 00:00:1775136127.948266   16309 computation_placer.cc:177] computation placer already registered. Please check linkage and avoid linking the same target more than once.
2026-04-02 13:22:07.954122: I tensorflow/core/platform/cpu_feature_guard.cc:210] This TensorFlow binary is optimized to use available CPU instructions in performance-critical operations.
To enable the following instructions: AVX2 FMA, in other operations, rebuild TensorFlow with the appropriate compiler flags.
WARNING:torchao.kernel.intmm:Warning: Detected no triton, on systems without Triton certain kernels will not work
Multiple distributions found for package optimum. Picked distribution: optimum
Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
Flax classes are deprecated and will be removed in Diffusers v1.0.0. We recommend migrating to PyTorch classes or pinning your version of Diffusers.
config.json: 100% 950/950 [00:00<00:00, 4.38MB/s]
`torch_dtype` is deprecated! Use `dtype` instead!
`torch_dtype` is deprecated! Use `dtype` instead!
model.safetensors.index.json: 70.1kB [00:00, 139MB/s]
Fetching 3 files:   0% 0/3 [00:00<?, ?it/s]
model-00002-of-00003.safetensors:   0% 0.00/4.96G [00:00<?, ?B/s]
model-00002-of-00003.safetensors:  93% 4.63G/4.96G [09:39<00:46, 7.05MB/s]
model-00002-of-00003.safetensors: 100% 4.96G/4.96G [09:42<00:00, 8.51MB/s]
.
.
.
```
[testing_colab_notebook](https://colab.research.google.com/drive/1vHn-6VMb0HlBe2EQMsDPjDSLH9PNGqog?usp=sharing) 
#### All tests relevant tests were passed 
#### Docs already include related info for flag... no need to change 

Fixes #1668