### PR TITLE
[OpenVINO] Enable Gemma 4 model support with hybrid reasoning

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -335,6 +335,8 @@ def main_export(
             patch_qwenvl_configs()
 
         model_type = config.model_type
+        if task == "any-to-any" and model_type in MULTI_MODAL_TEXT_GENERATION_MODELS:
+            task = "image-text-to-text"
         if model_type not in TasksManager._SUPPORTED_MODEL_TYPE:
             if custom_export_configs is None:
                 raise ValueError(
@@ -651,7 +653,7 @@ def _main_quantize(
             trust_remote_code=trust_remote_code,
         )
         model_type = config.model_type
-        if model_type in ["phi4mm", "phi4_multimodal"]:
+        if model_type in ["phi4mm", "phi4_multimodal", "gemma4"]:
             task = "image-text-to-text"
 
     # Step 1. Obtain the correct OpenVINO model class

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -148,6 +148,8 @@ from .model_patcher import (
     FluxTransfromerModelPatcher,
     Gemma2ModelPatcher,
     Gemma3LMModelPatcher,
+    Gemma4ImageEmbeddingModelPatcher,
+    Gemma4LMModelPatcher,
     GptJModelPatcher,
     GptNeoModelPatcher,
     GptNeoxModelPatcher,
@@ -261,6 +263,10 @@ def init_model_configs():
     TasksManager._CUSTOM_CLASSES[("pt", "gemma3", "image-text-to-text")] = (
         "transformers",
         "Gemma3ForConditionalGeneration",
+    )
+    TasksManager._CUSTOM_CLASSES[("pt", "gemma4", "image-text-to-text")] = (
+        "transformers",
+        "Gemma4ForConditionalGeneration",
     )
     TasksManager._CUSTOM_CLASSES[("pt", "idefics3", "image-text-to-text")] = (
         "transformers",
@@ -1481,6 +1487,89 @@ class Gemma3TextOpenVINOConfig(Gemma2OpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "4.50.0"
 
 
+class Gemma4DummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedTextConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        sequence_length: int = DEFAULT_DUMMY_SHAPES["sequence_length"],
+        random_batch_size_range: Optional[Tuple[int, int]] = None,
+        random_sequence_length_range: Optional[Tuple[int, int]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            task=task,
+            normalized_config=normalized_config,
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            random_batch_size_range=random_batch_size_range,
+            random_sequence_length_range=random_sequence_length_range,
+        )
+        config = normalized_config.config
+        self.num_key_value_heads = config.num_key_value_heads
+        cache_layer_types = list(getattr(config, "layer_types", []))
+        num_kv_shared_layers = getattr(config, "num_kv_shared_layers", 0)
+        if num_kv_shared_layers:
+            cache_layer_types = cache_layer_types[:-num_kv_shared_layers]
+        self.head_dims_per_layer = [
+            config.global_head_dim
+            if layer_type == "full_attention" and getattr(config, "global_head_dim", None) is not None
+            else config.head_dim
+            for layer_type in cache_layer_types
+        ]
+        self.num_layers = len(self.head_dims_per_layer) if self.head_dims_per_layer else self.num_layers
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        past_key_values = []
+        for head_dim in self.head_dims_per_layer:
+            shape = (self.batch_size, self.num_key_value_heads, self.sequence_length, head_dim)
+            past_key_values.append(
+                (
+                    self.random_float_tensor(shape, framework=framework, dtype=float_dtype),
+                    self.random_float_tensor(shape, framework=framework, dtype=float_dtype),
+                )
+            )
+        return past_key_values
+
+
+@register_in_tasks_manager(
+    "gemma4_text",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text-classification",
+    ],
+    library_name="transformers",
+)
+class Gemma4TextOpenVINOConfig(Gemma2OpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "5.0.0"
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, Gemma4DummyPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = Gemma4DummyPastKeyValuesGenerator
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        inputs = dict(super().inputs)
+        num_cache_layers = self._config.num_hidden_layers - getattr(self._config, "num_kv_shared_layers", 0)
+        return {
+            name: axes
+            for name, axes in inputs.items()
+            if not name.startswith("past_key_values.") or int(name.split(".")[1]) < num_cache_layers
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        outputs = dict(super().outputs)
+        num_cache_layers = self._config.num_hidden_layers - getattr(self._config, "num_kv_shared_layers", 0)
+        return {
+            name: axes
+            for name, axes in outputs.items()
+            if not name.startswith("present.") or int(name.split(".")[1]) < num_cache_layers
+        }
+
+
 class DeciDummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
     def __init__(
         self,
@@ -1725,6 +1814,27 @@ class LMInputEmbedsConfigHelper(TextDecoderWithPositionIdsOnnxConfig):
         return dummy_inputs
 
 
+class Gemma4LMInputEmbedsConfigHelper(LMInputEmbedsConfigHelper):
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        inputs = dict(super().inputs)
+        inputs["per_layer_inputs"] = {0: "batch_size", 1: "sequence_length"}
+        return inputs
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
+        dummy_inputs = super().generate_dummy_inputs(framework, **kwargs)
+        inputs_embeds = dummy_inputs["inputs_embeds"]
+        dummy_inputs["per_layer_inputs"] = self.orig_export_config.DUMMY_INPUT_GENERATOR_CLASSES[0].random_float_tensor(
+            (
+                inputs_embeds.shape[0],
+                inputs_embeds.shape[1],
+                self._config.num_hidden_layers,
+                self._config.hidden_size_per_layer_input,
+            )
+        )
+        return dummy_inputs
+
+
 class InputEmbedOpenvVINOConfig(TextDecoderOnnxConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
     _MODEL_PATCHER = InputEmbeddingPatcher
@@ -1741,6 +1851,12 @@ class InputEmbedOpenvVINOConfig(TextDecoderOnnxConfig):
         model_inputs = {}
         model_inputs["input"] = inputs["input_ids"]
         return model_inputs
+
+
+class Gemma4PerLayerInputEmbedOpenvVINOConfig(InputEmbedOpenvVINOConfig):
+    @property
+    def outputs(self):
+        return {"last_hidden_state": {0: "batch_size", 1: "sequence_length"}}
 
 
 def get_vlm_internal_text_generation_config(model_type, model_config, int_dtype, float_dtype):
@@ -1776,6 +1892,19 @@ def get_vlm_text_embeddings_config(model_type, model_config, int_dtype, float_dt
         float_dtype=float_dtype,
     )
     return export_config
+
+
+def get_gemma4_per_layer_embeddings_config(model_config, int_dtype, float_dtype):
+    internal_export_config = get_vlm_internal_text_generation_config(
+        model_config.model_type, model_config, int_dtype, float_dtype
+    )
+    Gemma4PerLayerInputEmbedOpenvVINOConfig.NORMALIZED_CONFIG_CLASS = internal_export_config.NORMALIZED_CONFIG_CLASS
+    return Gemma4PerLayerInputEmbedOpenvVINOConfig(
+        model_config,
+        task="feature-extraction",
+        int_dtype=int_dtype,
+        float_dtype=float_dtype,
+    )
 
 
 def get_vlm_text_generation_config(
@@ -4169,6 +4298,191 @@ class Gemma3OpenVINOConfig(BaseVLMOpenVINOConfig):
                 inputs_update={"token_type_ids": {0: "batch_size", 1: "sequence_length"}},
             )
         return super().with_behavior(behavior)
+
+
+class Gemma4ConfigBehavior(str, enum.Enum):
+    LANGUAGE = "language"
+    PER_LAYER_EMBEDDINGS = "per_layer_embeddings"
+    TEXT_EMBEDDINGS = "text_embeddings"
+    VISION_EMBEDDINGS = "vision_embeddings"
+
+
+class Gemma4DummyVisionInputGenerator(DummyVisionInputGenerator):
+    SUPPORTED_INPUT_NAMES = ("pixel_values", "image_position_ids")
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        width: int = DEFAULT_DUMMY_SHAPES["width"],
+        height: int = DEFAULT_DUMMY_SHAPES["height"],
+        **kwargs,
+    ):
+        super().__init__(task, normalized_config, batch_size, num_channels, width, height, **kwargs)
+        self.hidden_size = normalized_config.config.hidden_size
+        # Match the default Gemma4 processor layout: 2520 patch slots with 2340 valid patches and 180 padding slots.
+        self.num_patches_h = 39
+        self.num_patches_w = 60
+        self.num_patches = 2520
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "pixel_values":
+            return self.random_float_tensor(
+                [self.batch_size, self.num_patches, self.hidden_size], framework=framework, dtype=float_dtype
+            )
+        if input_name == "image_position_ids":
+            import torch
+
+            x_coords = torch.arange(self.num_patches_w, dtype=DTYPE_MAPPER.pt(int_dtype))
+            y_coords = torch.arange(self.num_patches_h, dtype=DTYPE_MAPPER.pt(int_dtype))
+            grid_y, grid_x = torch.meshgrid(y_coords, x_coords, indexing="ij")
+            valid_position_ids = torch.stack((grid_x.reshape(-1), grid_y.reshape(-1)), dim=-1)
+            padding = torch.full(
+                (self.num_patches - valid_position_ids.shape[0], 2),
+                -1,
+                dtype=DTYPE_MAPPER.pt(int_dtype),
+            )
+            position_ids = torch.cat((valid_position_ids, padding), dim=0)
+            return position_ids.unsqueeze(0).repeat(self.batch_size, 1, 1)
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+@register_in_tasks_manager("gemma4", *["image-text-to-text"], library_name="transformers")
+class Gemma4OpenVINOConfig(BaseVLMOpenVINOConfig):
+    SUPPORTED_BEHAVIORS = [model_type.value for model_type in Gemma4ConfigBehavior]
+    DUMMY_INPUT_GENERATOR_CLASSES = (Gemma4DummyVisionInputGenerator,)
+    MIN_TRANSFORMERS_VERSION = "5.0.0"
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: Gemma4ConfigBehavior = Gemma4ConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self._behavior = behavior
+        self._orig_config = config
+        if self._behavior == Gemma4ConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            self._config = config.vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior != Gemma4ConfigBehavior.VISION_EMBEDDINGS:
+            return {}
+        return {
+            "pixel_values": {0: "batch_size"},
+            "image_position_ids": {0: "batch_size"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior != Gemma4ConfigBehavior.VISION_EMBEDDINGS:
+            return super().outputs
+        return {"last_hidden_state": {}}
+
+    def with_behavior(
+        self,
+        behavior: Union[str, Gemma4ConfigBehavior],
+    ):
+        if isinstance(behavior, str) and not isinstance(behavior, Gemma4ConfigBehavior):
+            behavior = Gemma4ConfigBehavior(behavior)
+
+        if behavior == Gemma4ConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config(
+                self._orig_config.text_config.model_type,
+                self._orig_config.text_config,
+                self.int_dtype,
+                self.float_dtype,
+            )
+
+        if behavior == Gemma4ConfigBehavior.LANGUAGE:
+            internal_export_config = get_vlm_internal_text_generation_config(
+                self._orig_config.text_config.model_type,
+                self._orig_config.text_config,
+                self.int_dtype,
+                self.float_dtype,
+            )
+            export_config = Gemma4LMInputEmbedsConfigHelper(
+                internal_export_config,
+                patcher_cls=Gemma4LMModelPatcher,
+            )
+            export_config._normalized_config = internal_export_config._normalized_config
+            return export_config
+
+        if behavior == Gemma4ConfigBehavior.PER_LAYER_EMBEDDINGS:
+            return get_gemma4_per_layer_embeddings_config(
+                self._orig_config.text_config,
+                self.int_dtype,
+                self.float_dtype,
+            )
+
+        return self.__class__(
+            self._orig_config,
+            task=self.task,
+            int_dtype=self.int_dtype,
+            float_dtype=self.float_dtype,
+            behavior=behavior,
+            preprocessors=self._preprocessors,
+        )
+
+    def get_model_for_behavior(self, model, behavior: Union[str, Gemma4ConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, Gemma4ConfigBehavior):
+            behavior = Gemma4ConfigBehavior(behavior)
+
+        if behavior == Gemma4ConfigBehavior.LANGUAGE:
+            return model
+
+        if behavior == Gemma4ConfigBehavior.VISION_EMBEDDINGS:
+            return model
+
+        if behavior == Gemma4ConfigBehavior.TEXT_EMBEDDINGS:
+            text_embedding = model.model.language_model.get_input_embeddings()
+            text_embedding.config = model.model.language_model.config
+            return text_embedding
+
+        if behavior == Gemma4ConfigBehavior.PER_LAYER_EMBEDDINGS:
+            import torch
+
+            class Gemma4PerLayerEmbeddingsModel(torch.nn.Module):
+                def __init__(self, language_model):
+                    super().__init__()
+                    self.embed_tokens_per_layer = language_model.embed_tokens_per_layer
+                    self.num_hidden_layers = language_model.config.num_hidden_layers
+                    self.hidden_size_per_layer_input = language_model.config.hidden_size_per_layer_input
+                    self.config = language_model.config
+
+                def forward(self, input_ids):
+                    return self.embed_tokens_per_layer(input_ids).reshape(
+                        *input_ids.shape,
+                        self.num_hidden_layers,
+                        self.hidden_size_per_layer_input,
+                    )
+
+            return Gemma4PerLayerEmbeddingsModel(model.model.language_model)
+
+    def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
+        model_kwargs = model_kwargs or {}
+        if self._behavior != Gemma4ConfigBehavior.VISION_EMBEDDINGS:
+            return super().patch_model_for_export(model, model_kwargs)
+        return Gemma4ImageEmbeddingModelPatcher(self, model, model_kwargs)
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
+        if self._behavior == Gemma4ConfigBehavior.VISION_EMBEDDINGS:
+            kwargs["batch_size"] = 1
+        return super().generate_dummy_inputs(framework, **kwargs)
 
 
 class DummyVisionPositionIdsInputGenerator(DummyVisionInputGenerator):

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -54,12 +54,7 @@ from optimum.exporters.onnx.model_patcher import (
     override_arguments,
     sdpa_mask_without_vmap,
 )
-from optimum.intel.utils.import_utils import (
-    is_diffusers_version,
-    is_openvino_version,
-    is_torch_version,
-    is_transformers_version,
-)
+from optimum.intel.utils.import_utils import is_diffusers_version, is_torch_version, is_transformers_version
 
 from ._ov_ops import convert_recurrent_attention_cell
 
@@ -232,6 +227,15 @@ def patch_cos_sin_cached_fp32(model):
 def eager_mask_without_vmap(*args, **kwargs) -> Optional[torch.Tensor]:
     kwargs.pop("allow_is_causal_skip", None)
     dtype = kwargs.get("dtype", torch.float32)
+    if "cache_position" not in kwargs and "q_length" in kwargs:
+        q_length = kwargs.pop("q_length")
+        q_offset = kwargs.pop("q_offset", 0)
+        device = kwargs.get("device", "cpu")
+        if isinstance(q_offset, torch.Tensor):
+            cache_position = torch.arange(q_length, device=device) + q_offset
+        else:
+            cache_position = torch.arange(q_offset, q_offset + q_length, device=device)
+        kwargs["cache_position"] = cache_position
     mask = sdpa_mask_without_vmap(*args, allow_is_causal_skip=False, **kwargs)
     # we use torch.finfo(torch.float16).min instead torch.finfo(dtype).min to avoid an overflow but not
     # sure this is the right way to handle this, we are basically pretending that -65,504 is -inf
@@ -4752,6 +4756,137 @@ class Gemma3LMModelPatcher(OVDecoderModelPatcher):
             del self._model.model._orig_update_causual_mask
 
 
+class Gemma4ImageEmbeddingModelPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        def get_image_features(self, pixel_values, image_position_ids=None):
+            return self.model.get_image_features(
+                pixel_values=pixel_values,
+                image_position_ids=image_position_ids,
+                return_dict=True,
+            ).pooler_output
+
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(get_image_features, model)
+
+        vision_tower = model.model.vision_tower
+        vision_tower.__orig_attn_implementation = getattr(vision_tower.config, "_attn_implementation", None)
+        vision_tower.config._attn_implementation = "eager"
+
+        super().__init__(config, model, model_kwargs)
+
+    def __enter__(self):
+        super().__enter__()
+        if is_transformers_version(">=", "4.53.0"):
+            ALL_MASK_ATTENTION_FUNCTIONS.register("eager", eager_mask_without_vmap)
+            ALL_MASK_ATTENTION_FUNCTIONS.register("sdpa", eager_mask_without_vmap)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if is_transformers_version(">=", "4.53"):
+            ALL_MASK_ATTENTION_FUNCTIONS.register("sdpa", sdpa_mask)
+            ALL_MASK_ATTENTION_FUNCTIONS.register("eager", eager_mask)
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+        vision_tower = self._model.model.vision_tower
+        vision_tower.config._attn_implementation = vision_tower.__orig_attn_implementation
+        del vision_tower.__orig_attn_implementation
+
+
+def _gemma4_legacy_cache_to_dynamic(past_key_values, text_config):
+    cache = DynamicCache(config=text_config)
+    cache.shared_layers = {}
+    if past_key_values is None:
+        return cache
+    if isinstance(past_key_values, Cache):
+        return past_key_values
+
+    if len(past_key_values) > 0 and isinstance(past_key_values[0], torch.Tensor):
+        past_key_values = list(zip(past_key_values[0::2], past_key_values[1::2]))
+
+    cache_layer_types = list(getattr(text_config, "layer_types", []))
+    num_kv_shared_layers = getattr(text_config, "num_kv_shared_layers", 0)
+    if num_kv_shared_layers:
+        cache_layer_types = cache_layer_types[:-num_kv_shared_layers]
+
+    last_cache_layer_per_type = {}
+    for layer_idx, (key_states, value_states) in enumerate(past_key_values):
+        cache.update(key_states, value_states, layer_idx)
+        if layer_idx < len(cache_layer_types):
+            last_cache_layer_per_type[cache_layer_types[layer_idx]] = layer_idx
+
+    for layer_idx in last_cache_layer_per_type.values():
+        layer = cache.layers[layer_idx]
+        cache.shared_layers[layer_idx] = (layer.keys, layer.values)
+
+    return cache
+
+
+def _gemma4_dynamic_cache_to_legacy(past_key_values):
+    if past_key_values is None:
+        return None
+    return tuple((layer.keys, layer.values) for layer in past_key_values.layers)
+
+
+class Gemma4LMModelPatcher(OVDecoderModelPatcher):
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        def lm_forward(
+            self,
+            attention_mask,
+            position_ids,
+            past_key_values,
+            inputs_embeds,
+            per_layer_inputs=None,
+            use_cache=True,
+        ):
+            text_model = self.model.language_model
+            text_config = text_model.config
+            pkv = _gemma4_legacy_cache_to_dynamic(past_key_values, text_config)
+            outputs = text_model(
+                input_ids=None,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=pkv,
+                inputs_embeds=inputs_embeds,
+                per_layer_inputs=per_layer_inputs,
+                use_cache=use_cache,
+                return_dict=True,
+            )
+            logits = self.lm_head(outputs.last_hidden_state)
+            if (final_logit_softcapping := getattr(text_config, "final_logit_softcapping", None)) is not None:
+                logits = logits / final_logit_softcapping
+                logits = torch.tanh(logits)
+                logits = logits * final_logit_softcapping
+            return logits, _gemma4_dynamic_cache_to_legacy(outputs.past_key_values)
+
+        def get_per_layer_inputs(self, input_ids, inputs_embeds):
+            return None
+
+        language_model = model.model.language_model
+        language_model.__orig_get_per_layer_inputs = language_model.get_per_layer_inputs
+        language_model.get_per_layer_inputs = types.MethodType(get_per_layer_inputs, language_model)
+
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(lm_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+        language_model = self._model.model.language_model
+        language_model.get_per_layer_inputs = language_model.__orig_get_per_layer_inputs
+        del language_model.__orig_get_per_layer_inputs
+
+
 class Idefics3ImageEmbeddingsModelPatcher(ModelPatcher):
     def __init__(
         self,
@@ -7583,10 +7718,10 @@ def afmoe_moe_forward_patched(self, hidden_states):
     act_fn = self.experts[0].act_fn
 
     # compute experts outputs in a vectorized form
-    gate = torch.bmm(hidden_states, self.gate_projs.transpose(1, 2))
-    up = torch.bmm(hidden_states, self.up_projs.transpose(1, 2))
+    gate = torch.bmm(hidden_states, self.gate_projs)
+    up = torch.bmm(hidden_states, self.up_projs)
     gate_up = act_fn(gate) * up
-    next_states = torch.bmm(gate_up, self.down_projs.transpose(1, 2))
+    next_states = torch.bmm(gate_up, self.down_projs)
     next_states = next_states.view(num_experts, batch_size, -1, hidden_dim)
     next_states = next_states * new_routing_weights.transpose(0, 1).view(num_experts, batch_size, -1)[..., None]
     next_states = next_states.sum(dim=0)
@@ -7612,22 +7747,29 @@ class AfmoeModelPatcher(OVDecoderModelPatcher):
                 # with bf16 weights that leads to operands types mismatch in torch.bmm during TorchScript tracing
                 # Now we align with hidden_states (that will be always fp32 due to patching
                 # above for embedding layer during tracing)
-                afmoe_moe.down_projs = torch.concat(
-                    tuple(afmoe_moe.experts[i].down_proj.weight.unsqueeze(0) for i in range(num_experts)),
-                    dim=0,
+                afmoe_moe.down_projs = (
+                    torch.concat(
+                        tuple(afmoe_moe.experts[i].down_proj.weight.unsqueeze(0) for i in range(num_experts)),
+                        dim=0,
+                    )
+                    .transpose(1, 2)
+                    .float()
                 )
-                afmoe_moe.gate_projs = torch.concat(
-                    tuple(afmoe_moe.experts[i].gate_proj.weight.unsqueeze(0) for i in range(num_experts)),
-                    dim=0,
+                afmoe_moe.gate_projs = (
+                    torch.concat(
+                        tuple(afmoe_moe.experts[i].gate_proj.weight.unsqueeze(0) for i in range(num_experts)),
+                        dim=0,
+                    )
+                    .transpose(1, 2)
+                    .float()
                 )
-                afmoe_moe.up_projs = torch.concat(
-                    tuple(afmoe_moe.experts[i].up_proj.weight.unsqueeze(0) for i in range(num_experts)), dim=0
+                afmoe_moe.up_projs = (
+                    torch.concat(
+                        tuple(afmoe_moe.experts[i].up_proj.weight.unsqueeze(0) for i in range(num_experts)), dim=0
+                    )
+                    .transpose(1, 2)
+                    .float()
                 )
-
-                if is_openvino_version("<", "2026.1.0"):
-                    afmoe_moe.down_projs = afmoe_moe.down_projs.float()
-                    afmoe_moe.gate_projs = afmoe_moe.gate_projs.float()
-                    afmoe_moe.up_projs = afmoe_moe.up_projs.float()
 
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -297,6 +297,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "qwen3_vl",
     "got_ocr2",
     "gemma3",
+    "gemma4",
     "idefics3",
     "smolvlm",
     "phi4mm",

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -25,7 +25,10 @@ from openvino._offline_transformations import apply_moc_transformations, compres
 from transformers import GenerationConfig, PretrainedConfig
 from transformers.file_utils import add_start_docstrings
 from transformers.generation import GenerationMixin
-from transformers.utils import is_offline_mode
+try:
+    from transformers.utils import is_offline_mode
+except ImportError:
+    from transformers.utils.hub import is_offline_mode
 from transformers.utils.hub import cached_file
 
 from optimum.exporters.base import ExportConfig
@@ -263,8 +266,11 @@ class OVBaseModel(OptimizedModel, OVModelHostMixin):
 
             # some model configs may have issues with loading without parameters initialization
             try:
-                misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
-            except (KeyError, TypeError):
+                if hasattr(self.config, "_get_non_default_generation_parameters"):
+                    misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
+                else:
+                    misplaced_generation_parameters = self.config._get_generation_parameters()
+            except (AttributeError, KeyError, TypeError):
                 misplaced_generation_parameters = {}
             if len(misplaced_generation_parameters) > 0:
                 logger.warning(

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -31,7 +31,11 @@ from transformers.generation.logits_process import LogitsProcessorList
 from transformers.generation.stopping_criteria import StoppingCriteriaList
 from transformers.generation.utils import GenerateOutput, GenerationMode
 from transformers.modeling_outputs import CausalLMOutputWithPast, ModelOutput
-from transformers.models.mamba.modeling_mamba import MambaCache
+try:
+    from transformers.models.mamba.modeling_mamba import MambaCache
+except ImportError:
+    class MambaCache:  # transformers>=5.5 removed this symbol
+        pass
 from transformers.utils.hub import PushToHubMixin
 
 from optimum.utils.normalized_config import NormalizedConfigManager

--- a/optimum/intel/openvino/modeling_open_clip.py
+++ b/optimum/intel/openvino/modeling_open_clip.py
@@ -31,7 +31,10 @@ from transformers import (
 from transformers.file_utils import add_start_docstrings
 from transformers.modeling_outputs import ModelOutput
 from transformers.models.clip.modeling_clip import CLIPOutput
-from transformers.utils import is_offline_mode
+try:
+    from transformers.utils import is_offline_mode
+except ImportError:
+    from transformers.utils.hub import is_offline_mode
 
 from optimum.exporters.tasks import TasksManager
 

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -27,12 +27,15 @@ from transformers import (
     AutoConfig,
     AutoModelForSeq2SeqLM,
     AutoModelForSpeechSeq2Seq,
-    AutoModelForVision2Seq,
     GenerationConfig,
     Pix2StructForConditionalGeneration,
     PretrainedConfig,
     WhisperForConditionalGeneration,
 )
+try:
+    from transformers import AutoModelForVision2Seq
+except ImportError:
+    from transformers import AutoModelForImageTextToText as AutoModelForVision2Seq
 from transformers.file_utils import add_start_docstrings, add_start_docstrings_to_model_forward
 from transformers.generation import GenerationMixin
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -214,6 +214,9 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
                 token_type_ids = np.zeros(inputs_embeds.shape[:2], dtype=int)
             inputs["token_type_ids"] = token_type_ids
 
+        if "per_layer_inputs" in self.input_names and kwargs.get("per_layer_inputs") is not None:
+            inputs["per_layer_inputs"] = kwargs["per_layer_inputs"]
+
         if "beam_idx" in self.input_names:
             inputs["beam_idx"] = (
                 self.next_beam_idx if self.next_beam_idx is not None else np.arange(batch_size, dtype=int)
@@ -344,6 +347,14 @@ class OVAudioEncoder(OVModelPart):
         return self.request({"audio_feature": audio_feature, "audio_mask": audio_mask})[0]
 
 
+class OVPerLayerEmbeddings(OVModelPart):
+    _model_name = "per_layer_embeddings"
+
+    def forward(self, input_ids):
+        self.compile()
+        return self.request(input_ids, share_inputs=True)[0]
+
+
 MODEL_PARTS_CLS_MAPPING = {
     "resampler": OVResampler,
     "language_model": OVModelWithEmbedForCausalLM,
@@ -356,6 +367,7 @@ MODEL_PARTS_CLS_MAPPING = {
     "audio_embeddings": OVAudioEmbeddings,
     "audio_forward_embeddings": OVAudioEmbeddings,
     "audio_encoder": OVAudioEncoder,
+    "per_layer_embeddings": OVPerLayerEmbeddings,
     "audio_vision_projection": OVAudioEmbeddings,
     "audio_speech_projection": OVAudioEmbeddings,
 }
@@ -3937,6 +3949,149 @@ class _OVGemma3ForCausalLM(OVModelForVisualCausalLM):
         return model_kwargs
 
 
+class _OVGemma4ForCausalLM(OVModelForVisualCausalLM):
+    additional_parts = ["per_layer_embeddings"]
+
+    def forward(self, *args, image_position_ids=None, mm_token_type_ids=None, **kwargs):
+        if kwargs.get("per_layer_inputs") is None:
+            input_ids = kwargs.get("input_ids", args[0] if args else None)
+            if input_ids is not None and input_ids.shape[1] > 0:
+                kwargs["per_layer_inputs"] = self.get_per_layer_inputs(
+                    self._clean_input_ids_for_per_layer_inputs(input_ids, mm_token_type_ids)
+                )
+        return super().forward(*args, image_position_ids=image_position_ids, mm_token_type_ids=mm_token_type_ids, **kwargs)
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        pixel_values=None,
+        image_sizes=None,
+        attention_mask=None,
+        image_position_ids=None,
+        mm_token_type_ids=None,
+        **kwargs,
+    ):
+        model_inputs = super().prepare_inputs_for_generation(
+            input_ids=input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            image_sizes=image_sizes,
+            attention_mask=attention_mask,
+            image_position_ids=image_position_ids,
+            mm_token_type_ids=mm_token_type_ids,
+            **kwargs,
+        )
+
+        current_input_ids = model_inputs.get("input_ids")
+        if mm_token_type_ids is not None and current_input_ids is not None and mm_token_type_ids.shape[1] != current_input_ids.shape[1]:
+            mm_token_type_ids = mm_token_type_ids[:, -current_input_ids.shape[1] :]
+
+        model_inputs["image_position_ids"] = image_position_ids
+        model_inputs["mm_token_type_ids"] = mm_token_type_ids
+        if mm_token_type_ids is not None and model_inputs.get("token_type_ids") is None:
+            model_inputs["token_type_ids"] = mm_token_type_ids
+        return model_inputs
+
+    def get_per_layer_inputs(self, input_ids):
+        return self.per_layer_embeddings(input_ids)
+
+    def _clean_input_ids_for_per_layer_inputs(self, input_ids, mm_token_type_ids=None):
+        if isinstance(input_ids, np.ndarray):
+            input_ids = torch.from_numpy(input_ids)
+        cleaned_input_ids = input_ids.clone()
+        text_config = self.config.get_text_config() if hasattr(self.config, "get_text_config") else self.config.text_config
+        pad_token_id = text_config.pad_token_id
+
+        if mm_token_type_ids is not None:
+            if isinstance(mm_token_type_ids, np.ndarray):
+                mm_token_type_ids = torch.from_numpy(mm_token_type_ids)
+            if mm_token_type_ids.shape[1] != cleaned_input_ids.shape[1]:
+                mm_token_type_ids = mm_token_type_ids[:, -cleaned_input_ids.shape[1] :]
+            cleaned_input_ids[mm_token_type_ids != InputMode.LANGUAGE.value] = pad_token_id
+            return cleaned_input_ids
+
+        for token_name in (
+            "image_token_id",
+            "image_token_index",
+            "video_token_id",
+            "video_token_index",
+            "audio_token_id",
+            "audio_token_index",
+        ):
+            token_id = getattr(self.config, token_name, None)
+            if token_id is not None:
+                cleaned_input_ids[cleaned_input_ids == token_id] = pad_token_id
+        return cleaned_input_ids
+
+    def get_vision_embeddings(self, pixel_values, input_ids=None, **kwargs):
+        if input_ids is not None and input_ids.shape[1] == 1:
+            return None
+        image_position_ids = kwargs.get("image_position_ids")
+        if pixel_values is not None and pixel_values.dtype != torch.float32:
+            pixel_values = pixel_values.to(torch.float32)
+        vision_inputs = {"pixel_values": pixel_values}
+        if image_position_ids is not None:
+            vision_inputs["image_position_ids"] = image_position_ids
+        return self.vision_embeddings(**vision_inputs).last_hidden_state
+
+    def merge_vision_text_embeddings(
+        self, vision_embeds, inputs_embeds, input_ids=None, attention_mask=None, position_ids=None, **kwargs
+    ):
+        image_features = torch.from_numpy(vision_embeds) if isinstance(vision_embeds, np.ndarray) else vision_embeds
+        inputs_embeds = torch.from_numpy(inputs_embeds) if isinstance(inputs_embeds, np.ndarray) else inputs_embeds
+        if input_ids is None:
+            return inputs_embeds, attention_mask, position_ids
+
+        image_token_id = getattr(self.config, "image_token_id", 258880)
+        special_image_mask = (input_ids == image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+        inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
+        return inputs_embeds, attention_mask, position_ids
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None:
+            raise ValueError("Processor is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        conversation = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": text},
+                ],
+            }
+        ]
+        if image is not None:
+            conversation[0]["content"].insert(0, {"type": "image"})
+
+        text_prompt = processor.apply_chat_template(conversation, add_generation_prompt=True, tokenize=False)
+
+        orig_add_bos_token = processor.tokenizer.add_bos_token
+        if "bos_token" in processor.tokenizer.chat_template:
+            processor.tokenizer.add_bos_token = False
+
+        inputs = processor(images=image, text=text_prompt, return_tensors="pt")
+        inputs.pop("mm_token_type_ids", None)
+
+        processor.tokenizer.add_bos_token = orig_add_bos_token
+        return inputs
+
+
 class _OVGotOCR2ForCausalLM(OVModelForVisualCausalLM):
     def get_vision_embeddings(self, pixel_values, input_ids, **kwargs):
         if input_ids is not None and input_ids.shape[1] == 1 and kwargs.get("past_key_values") is not None:
@@ -4817,6 +4972,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen2_5_vl_text": _OVQwen2_5_VLForCausalLM,
     "got_ocr2": _OVGotOCR2ForCausalLM,
     "gemma3": _OVGemma3ForCausalLM,
+    "gemma4": _OVGemma4ForCausalLM,
     "idefics3": _OVIdefics3ForCausalLM,
     "smolvlm": _OVSmolVLForCasualLM,
     "phi4mm": _OVPhi4MMForCausalLM,

--- a/optimum/intel/utils/modeling_utils.py
+++ b/optimum/intel/utils/modeling_utils.py
@@ -23,7 +23,12 @@ from pathlib import Path
 from typing import Dict, List, Optional, Type, Union
 
 import torch
-from huggingface_hub import HfApi, HfFolder, hf_hub_download
+try:
+    from huggingface_hub import HfApi, HfFolder, hf_hub_download
+except ImportError:
+    from huggingface_hub import HfApi, get_token, hf_hub_download
+
+    HfFolder = None
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from huggingface_hub.hf_api import file_exists
 from transformers import CLIPConfig, PretrainedConfig, PreTrainedModel
@@ -115,7 +120,7 @@ def _find_files_matching_pattern(
     model_path = Path(model_name_or_path) if not isinstance(model_name_or_path, Path) else model_name_or_path
 
     if isinstance(use_auth_token, bool):
-        token = HfFolder().get_token()
+        token = HfFolder().get_token() if HfFolder is not None else get_token()
     else:
         token = use_auth_token
 


### PR DESCRIPTION
Add full OpenVINO export and inference support for Gemma 4 E4B (model_type=gemma4), a tri-modal (text+vision+audio) model from Google.

Use transformer version 5.5.0

Core enablement (5-file pattern):
- Register gemma4 in MULTI_MODAL_TEXT_GENERATION_MODELS
- Add any-to-any -> image-text-to-text task remapping for new transformers 5.5.0 multimodal task type
- Add Gemma4OpenVINOConfig with 4 export behaviors: vision_embeddings, text_embeddings, language, and per_layer_embeddings
- Add Gemma4DummyPastKeyValuesGenerator handling 24 cache layers (42 total - 18 KV-shared) with mixed head_dims (256 sliding/512 full)
- Add Gemma4LMModelPatcher preserving per-layer inputs (PLE) as explicit LM input, DynamicCache conversion with sliding window layer support
- Add Gemma4ImageEmbeddingModelPatcher for vision export with image_position_ids and eager attention mask registration
- Add _OVGemma4ForCausalLM inference class with per-layer embeddings runtime, vision/text merge via masked_scatter, and prepare_inputs_for_generation preserving image_position_ids

Exports 4 OpenVINO submodels:
- openvino_language_model (stateful, 24 KV cache layers)
- openvino_vision_embeddings_model
- openvino_text_embeddings_model
- openvino_per_layer_embeddings_model (new, for PLE)

Tested: FP16, INT8, INT4 exports + inference evaluation all passing. Supports text-only, image+text, and thinking/reasoning mode.

Sample test script with 5 multi-turn conversation using following chat.py file,

```python
#!/usr/bin/env python3
"""Multi-turn chat with Gemma-4-E4B-it INT4 OpenVINO model (up to 5 turns).

Usage:
    python3 chat.py                 # Normal mode
    python3 chat.py --reasoning     # Thinking/reasoning mode
"""

import sys
import argparse
from optimum.intel.openvino import OVModelForVisualCausalLM
from transformers import AutoProcessor

MODEL_PATH = "/workspace/gemma-4-E4B-it/gemma4-int4"
MAX_NEW_TOKENS = 512
MAX_TURNS = 5

parser = argparse.ArgumentParser(description="Chat with Gemma-4-E4B-it")
parser.add_argument("--reasoning", action="store_true", help="Enable thinking/reasoning mode")
parser.add_argument("--model", default=MODEL_PATH, help="Path to OV model directory")
parser.add_argument("--max-tokens", type=int, default=MAX_NEW_TOKENS, help="Max new tokens per response")
args = parser.parse_args()

print(f"Loading model from {args.model}...")
model = OVModelForVisualCausalLM.from_pretrained(args.model, device="CPU")
processor = AutoProcessor.from_pretrained(args.model)

mode = "REASONING" if args.reasoning else "NORMAL"
print(f"Model loaded. Mode: {mode}. Type your message (or 'quit' to exit).\n")
if args.reasoning:
    print("💭 Thinking mode enabled — model will reason step-by-step before answering.\n")

conversation = []

for turn in range(1, MAX_TURNS + 1):
    try:
        user_input = input(f"[{turn}/{MAX_TURNS}] You: ").strip()
    except (EOFError, KeyboardInterrupt):
        print("\nBye!")
        sys.exit(0)

    if user_input.lower() in ("quit", "exit", "q"):
        print("Bye!")
        break

    if not user_input:
        print("(empty input, skipping)")
        continue

    conversation.append({
        "role": "user",
        "content": [{"type": "text", "text": user_input}],
    })

    text = processor.apply_chat_template(
        conversation,
        tokenize=False,
        add_generation_prompt=True,
        enable_thinking=args.reasoning,
    )
    inputs = processor(text=text, return_tensors="pt")

    output = model.generate(**inputs, max_new_tokens=args.max_tokens)
    raw_reply = processor.decode(output[0][inputs["input_ids"].shape[1]:], skip_special_tokens=False)

    # Parse thinking vs final answer
    if args.reasoning and "<|channel>thought" in raw_reply:
        # Split thinking from answer
        parts = raw_reply.split("<channel|>", 1)
        thinking = parts[0].replace("<|channel>thought\n", "").strip()
        answer = parts[1].strip() if len(parts) > 1 else ""
        # Clean special tokens from answer
        for tok in ["<eos>", "<end_of_turn>", "<turn|>", "</s>"]:
            answer = answer.replace(tok, "")
        answer = answer.strip()

        print(f"\n💭 Thinking: {thinking}")
        print(f"\n✅ Answer: {answer}\n")
        # Only keep the final answer in conversation history (per model card best practice)
        reply_for_history = answer
    else:
        # Normal mode — strip special tokens
        reply = raw_reply
        for tok in ["<eos>", "<end_of_turn>", "<turn|>", "</s>"]:
            reply = reply.replace(tok, "")
        reply = reply.strip()
        print(f"\nAssistant: {reply}\n")
        reply_for_history = reply

    conversation.append({
        "role": "assistant",
        "content": [{"type": "text", "text": reply_for_history}],
    })

print("Chat ended.")

```

