### PR TITLE
[OPENVINO] Fix  : Sentence-transformers compatibility: remove deprecated _text_length usage Fixes #1680

### DIFF
--- a/optimum/intel/openvino/modeling_sentence_transformers.py
+++ b/optimum/intel/openvino/modeling_sentence_transformers.py
@@ -27,7 +27,6 @@ class OVSentenceTransformer(OVModel):
         super().__init__(model, config, **kwargs)
 
         self.encode = MethodType(SentenceTransformer.encode, self)
-        self._text_length = MethodType(SentenceTransformer._text_length, self)
         self.default_prompt_name = None
         self.truncate_dim = None
         self.tokenizer = tokenizer


### PR DESCRIPTION
# What does this PR do?

This PR removes the usage of the `_text_length` attribute from `SentenceTransformer`, which is no longer available in recent versions of the library.

**Details**
- `_text_length` is a private API and has been removed in newer versions of `sentence-transformers`, causing an AttributeError during export.
- The code was binding this method using `MethodType`, but the bound method is not used elsewhere in the class.
- Since this is a **dead binding** and relies on a removed private API, it has been removed.

**Notes**
- While newer versions expose `_input_length`, it is also a private/internal API and not guaranteed to be stable.
- The fix avoids relying on private attribute and keeps the implementation compatible across versions.

**Result**
- Fixes export failure for sentence-transformers models.
- Improves compatibility with newer versions of the library.

Complete Testing [Notebook](https://colab.research.google.com/drive/1m11RYsSgp1eIDZVBN_DD96xIrE2UP7dZ?usp=sharing)

Fixes #1680

