### PR TITLE
Add OpenVINO export support for glm4_moe_lite (GLM-4.7-Flash)

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -62,6 +62,7 @@ Here is the list of the supported architectures :
 - Falcon-Mamba
 - FlauBERT
 - GLM-4
+- GLM-4.7-Flash (Glm4MoeLite)
 - GLM-Edge
 - GPT-2
 - GPT-BigCode

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -147,6 +147,7 @@ from .model_patcher import (
     FalconModelPatcher,
     FluxTransfromerModelPatcher,
     Gemma2ModelPatcher,
+    Glm4MoeLitePatcher,
     Gemma3LMModelPatcher,
     GptJModelPatcher,
     GptNeoModelPatcher,
@@ -3972,6 +3973,26 @@ class GLMOpenVINOConfig(LlamaOpenVINOConfig):
 )
 class GLM4OpenVINOConfig(LlamaOpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "4.51.3"
+
+
+@register_in_tasks_manager(
+    "glm4_moe_lite",
+    *["text-generation", "text-generation-with-past"],
+    library_name="transformers",
+)
+class Glm4MoeLiteOpenVINOConfig(MiniCPM3OpenVINOConfig):
+    """OpenVINO export config for GLM-4.7-Flash / Glm4MoeLiteForCausalLM.
+
+    The model uses Multi-head Latent Attention (MLA) with separate key/value
+    head dimensions, identical to MiniCPM3, so we reuse its dummy PKV
+    generator.  The only additional requirement is patching the
+    ``Glm4MoeLiteNaiveMoe`` forward method to replace its dynamic expert loop
+    with a vectorized implementation.
+    """
+
+    MIN_TRANSFORMERS_VERSION = "5.0.0"
+    MAX_TRANSFORMERS_VERSION = None  # No upper bound for this newer model
+    _MODEL_PATCHER = Glm4MoeLitePatcher
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -3881,6 +3881,67 @@ class MiniCPM3Patcher(OVDecoderModelPatcher):
             block.self_attn.forward = block.self_attn._orig_forward
 
 
+def glm4_moe_lite_naive_moe_forward(
+    self,
+    hidden_states: torch.Tensor,
+    top_k_index: torch.Tensor,
+    top_k_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Vectorized forward for Glm4MoeLiteNaiveMoe that avoids dynamic control flow.
+
+    Replaces the original loop-over-experts implementation with batched matrix
+    multiplications, enabling stable torch.jit.trace for OpenVINO export.
+    """
+    num_tokens = hidden_states.shape[0]
+    num_experts = self.num_experts
+
+    # Build a dense routing weights matrix of shape (num_tokens, num_experts)
+    routing_weights = torch.zeros(num_tokens, num_experts, dtype=hidden_states.dtype, device=hidden_states.device)
+    routing_weights.scatter_(1, top_k_index, top_k_weights.to(hidden_states.dtype))
+
+    # Expand hidden states for all experts: (num_experts, num_tokens, hidden_dim)
+    hidden_expanded = hidden_states.unsqueeze(0).expand(num_experts, -1, -1)
+
+    # gate_up_proj: (num_experts, 2 * intermediate_dim, hidden_dim)
+    # hidden_expanded @ gate_up_proj.T => (num_experts, num_tokens, 2 * intermediate_dim)
+    gate_up = torch.bmm(hidden_expanded, self.gate_up_proj.transpose(1, 2))
+    gate, up = gate_up.chunk(2, dim=-1)
+
+    # Apply activation and element-wise multiply: (num_experts, num_tokens, intermediate_dim)
+    activated = self.act_fn(gate) * up
+
+    # down_proj: (num_experts, hidden_dim, intermediate_dim)
+    # activated @ down_proj.T => (num_experts, num_tokens, hidden_dim)
+    expert_out = torch.bmm(activated, self.down_proj.transpose(1, 2))
+
+    # Weight each expert's output by the routing weight and sum over experts
+    # routing_weights.T: (num_experts, num_tokens) -> unsqueeze -> (num_experts, num_tokens, 1)
+    weighted_out = expert_out * routing_weights.T.unsqueeze(-1)
+    return weighted_out.sum(dim=0)
+
+
+class Glm4MoeLitePatcher(OVDecoderModelPatcher):
+    """Model patcher for Glm4MoeLiteForCausalLM.
+
+    Patches the ``Glm4MoeLiteNaiveMoe`` forward method with a vectorized
+    (batched matrix-multiplication) implementation to ensure stable graph
+    generation during torch.jit.trace.
+    """
+
+    def __enter__(self):
+        super().__enter__()
+        for block in self._model.model.layers:
+            if hasattr(block.mlp, "experts"):
+                block.mlp.experts._orig_forward = block.mlp.experts.forward
+                block.mlp.experts.forward = types.MethodType(glm4_moe_lite_naive_moe_forward, block.mlp.experts)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        for block in self._model.model.layers:
+            if hasattr(block.mlp, "experts") and hasattr(block.mlp.experts, "_orig_forward"):
+                block.mlp.experts.forward = block.mlp.experts._orig_forward
+
+
 class DeepseekPatcher(OVDecoderModelPatcher):
     def __enter__(self):
         super().__enter__()

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -148,6 +148,9 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
     if is_transformers_version(">=", "4.57.0"):
         SUPPORTED_ARCHITECTURES += ("hunyuan_v1_dense",)
 
+    if is_transformers_version(">=", "5.0.0"):
+        SUPPORTED_ARCHITECTURES += ("glm4_moe_lite",)
+
     if is_transformers_version("<", "4.56.0"):
         SUPPORTED_ARCHITECTURES += ("qwen", "chatglm", "chatglm4")
 
@@ -243,6 +246,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "mixtral_awq": 2,
         "gemma3_text": 2,
         "glm4": 2,
+        "glm4_moe_lite": 2,
         "qwen3": 2,
         "qwen3_moe": 2,
         "mamba": 0,

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -113,6 +113,9 @@ class ExportModelTest(unittest.TestCase):
     if is_transformers_version(">=", "4.57.0"):
         SUPPORTED_ARCHITECTURES.update({"hunyuan_v1_dense": OVModelForCausalLM})
 
+    if is_transformers_version(">=", "5.0.0"):
+        SUPPORTED_ARCHITECTURES.update({"glm4_moe_lite": OVModelForCausalLM})
+
     if is_transformers_version(">=", "4.57.0") and is_transformers_version("<", "5"):
         SUPPORTED_ARCHITECTURES.update({"qwen3_next": OVModelForCausalLM})
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -172,6 +172,13 @@ class OVCLIExportTestCase(unittest.TestCase):
             ]
         )
 
+    if is_transformers_version(">=", "5.0.0"):
+        SUPPORTED_ARCHITECTURES.extend(
+            [
+                ("text-generation-with-past", "glm4_moe_lite"),
+            ]
+        )
+
     if is_transformers_version(">=", "4.57.0") and is_transformers_version("<", "5"):
         SUPPORTED_ARCHITECTURES.extend(
             [

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1081,6 +1081,9 @@ class OVWeightCompressionTest(unittest.TestCase):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "qwen3_vl", False))
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForCausalLM, "hunyuan_v1_dense", False))
 
+    if is_transformers_version(">=", "5.0.0"):
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForCausalLM, "glm4_moe_lite", False))
+
     if is_transformers_version("<", "5"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.extend(
             [

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -218,6 +218,7 @@ MODEL_NAMES = {
     "xglm": "optimum-intel-internal-testing/tiny-random-XGLMForCausalLM",
     "xverse": "optimum-intel-internal-testing/tiny-random-xverse",
     "glm4": "optimum-intel-internal-testing/tiny-random-glm4",
+    "glm4_moe_lite": "/tmp/model_enabler/tiny_model/GLM-4.7-Flash-tiny",
     "glm": "optimum-intel-internal-testing/tiny-random-glm-edge",
     "open-clip": "optimum-intel-internal-testing/tiny-open-clip-model",
     "open-clip-ov": "optimum-intel-internal-testing/tiny-open-clip-model",
@@ -234,6 +235,7 @@ EAGLE3_MODELS = {"qwen3_eagle3": ("AngelSlim/Qwen3-1.7B_eagle3", "Qwen/Qwen3-1.7
 
 _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "afmoe": {"model": 16},
+    "glm4_moe_lite": {"model": 42},
     "bert": {"model": 68 if is_transformers_version("<", "5") else 70},
     "roberta": {"model": 68},
     "albert": {"model": 84},


### PR DESCRIPTION
# What does this PR do?

Adds native OpenVINO IR export support for the `glm4_moe_lite` model type, which powers the **GLM-4.7-Flash** family of models (e.g. `THUDM/GLM-4.7-Flash`).

## Architecture overview

`Glm4MoeLiteForCausalLM` is a decoder-only transformer (available in Transformers ≥ 5.0) that combines:

- **Multi-head Latent Attention (MLA)** — same LoRA-compressed KV projection used in MiniCPM3/DeepSeek, with separate `qk_nope_head_dim`/`qk_rope_head_dim` key dimensions and a smaller `v_head_dim`
- **Hybrid MLP layers** — alternating dense (`Glm4MoeLiteMLP`) and sparse Mixture-of-Experts (`Glm4MoeLiteMoE` / `Glm4MoeLiteNaiveMoe`) layers

## Changes

### `optimum/exporters/openvino/model_configs.py`
- Import `Glm4MoeLitePatcher`
- Add `Glm4MoeLiteOpenVINOConfig` registered under `glm4_moe_lite` for `text-generation` and `text-generation-with-past` tasks. Inherits from `MiniCPM3OpenVINOConfig` to reuse `OVMiniCPM3DummyPastKeyValuesGenerator` (which correctly handles MLA-style KV cache shapes: `k_head_dim = qk_nope_head_dim + qk_rope_head_dim`, `v_head_dim`).

### `optimum/exporters/openvino/model_patcher.py`
- Add `glm4_moe_lite_naive_moe_forward` — a fully vectorized replacement for `Glm4MoeLiteNaiveMoe.forward`. The original implementation uses a `nonzero()`-driven Python `for` loop over active experts, which is incompatible with `torch.jit.trace` (loop count varies per input). The patch replaces it with batched matrix multiplications (`torch.bmm`) over all experts simultaneously, producing a consistent graph regardless of routing decisions.
- Add `Glm4MoeLitePatcher` — patches the `experts` sub-module inside every sparse MoE layer during export and restores the original on exit.

### Tests
- `tests/openvino/utils_tests.py` — model ID entry for `glm4_moe_lite` and expected INT8 node count (42)
- `tests/openvino/test_decoder.py` — add `glm4_moe_lite` to `SUPPORTED_ARCHITECTURES` (Transformers ≥ 5.0) and `EXPECTED_NUM_SDPA`
- `tests/openvino/test_export.py` — add `glm4_moe_lite` export test (Transformers ≥ 5.0)
- `tests/openvino/test_exporters_cli.py` — add CLI export test for `text-generation-with-past`
- `tests/openvino/test_quantization.py` — add to `SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION`

### Docs
- `docs/source/openvino/models.mdx` — list Glm4MoeLite (GLM-4.7-Flash) as a supported model

## Before submitting
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
