### PR TITLE
Add support for DeepSeek-V4 (deepseek_v4) model

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -51,6 +51,7 @@ Here is the list of the supported architectures :
 - DeepSeek
 - DeepSeek-V2
 - DeepSeek-V3
+- DeepSeek-V4
 - DistilBERT
 - ERNIE 4.5
 - ELECTRA

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -144,6 +144,7 @@ from .model_patcher import (
     DBRXModelPatcher,
     DeciLMModelPatcher,
     DeepseekPatcher,
+    DeepseekV4Patcher,
     FalconModelPatcher,
     FluxTransfromerModelPatcher,
     Gemma2ModelPatcher,
@@ -4099,6 +4100,54 @@ class MBartOpenVINOConfig(BartOpenVINOConfig):
 )
 class M2M100OpenVINOConfig(BartOpenVINOConfig):
     pass
+
+
+class OVDeepseekV4DummyPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
+    """Custom PKV generator for DeepseekV4 which stores k/v with num_attention_heads dimension."""
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedTextConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        sequence_length: int = DEFAULT_DUMMY_SHAPES["sequence_length"],
+        random_batch_size_range: Optional[Tuple[int, int]] = None,
+        random_sequence_length_range: Optional[Tuple[int, int]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            task=task,
+            normalized_config=normalized_config,
+            batch_size=batch_size,
+            sequence_length=sequence_length,
+            random_batch_size_range=random_batch_size_range,
+            random_sequence_length_range=random_sequence_length_range,
+        )
+        self.head_dim = normalized_config.head_dim
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        shape = (
+            self.batch_size,
+            self.num_attention_heads,
+            self.sequence_length,
+            self.head_dim,
+        )
+        return [
+            (
+                self.random_float_tensor(shape, framework=framework, dtype=float_dtype),
+                self.random_float_tensor(shape, framework=framework, dtype=float_dtype),
+            )
+            for _ in range(self.num_layers)
+        ]
+
+
+@register_in_tasks_manager("deepseek_v4", *["text-generation", "text-generation-with-past"], library_name="transformers")
+class DeepseekV4OpenVINOConfig(TextDecoderWithPositionIdsOnnxConfig):
+    DEFAULT_ONNX_OPSET = 14
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, OVDeepseekV4DummyPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = OVDeepseekV4DummyPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+    _MODEL_PATCHER = DeepseekV4Patcher
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -4176,6 +4176,58 @@ def deepseek_moe_infer(self, x, topk_ids, topk_weight):
     return final_out
 
 
+def deepseek_v4_moe_forward(self, x, token_ids=None):
+    """Vectorized MoE forward for DeepseekV4 that replaces dynamic for-loop with mask to be compatible with tracing."""
+    bsz, seq, d = x.shape
+    flat = x.view(-1, d)
+    n_tokens = flat.shape[0]
+    n_experts = self.n_experts
+
+    weights, indices = self.gate(flat, token_ids)  # [tokens, topk], [tokens, topk]
+
+    # Build a dense routing matrix [tokens, n_experts]
+    routing_weights = torch.zeros(n_tokens, n_experts, device=flat.device, dtype=weights.dtype)
+    routing_weights.scatter_(1, indices, weights)
+
+    # Use pre-stacked expert weights (set in patcher's __enter__)
+    # gate_w: [E, inter, d], up_w: [E, inter, d], down_w: [E, d, inter]
+    flat_exp = flat.unsqueeze(0).expand(n_experts, -1, -1)  # [E, tokens, d]
+
+    gate_out = torch.bmm(flat_exp, self._gate_w.transpose(1, 2))  # [E, tokens, inter]
+    up_out = torch.bmm(flat_exp, self._up_w.transpose(1, 2))  # [E, tokens, inter]
+    gate_up = F.silu(gate_out) * up_out  # [E, tokens, inter]
+    expert_outs = torch.bmm(gate_up, self._down_w.transpose(1, 2))  # [E, tokens, d]
+
+    # Weighted sum over experts: routing_weights.T [E, tokens, 1] * expert_outs [E, tokens, d]
+    out = (expert_outs * routing_weights.T.unsqueeze(-1)).sum(0)  # [tokens, d]
+
+    out = out + self.shared_expert(flat)
+    return out.view(bsz, seq, d)
+
+
+class DeepseekV4Patcher(OVDecoderModelPatcher):
+    def __enter__(self):
+        super().__enter__()
+        device = next(self._model.parameters()).device
+        for block in self._model.model.layers:
+            # Pre-compute cos/sin before tracing so they become frozen constants in the graph
+            block.self_attn._get_cos_sin(device, torch.float32)
+            # Pre-stack expert weights to avoid torch.stack inside traced forward
+            mlp = block.mlp
+            mlp._gate_w = torch.stack([e.gate_proj.weight.data for e in mlp.experts]).to(device)
+            mlp._up_w = torch.stack([e.up_proj.weight.data for e in mlp.experts]).to(device)
+            mlp._down_w = torch.stack([e.down_proj.weight.data for e in mlp.experts]).to(device)
+            # Patch MoE forward to remove data-dependent for-loop with conditional
+            mlp._orig_forward = mlp.forward
+            mlp.forward = types.MethodType(deepseek_v4_moe_forward, mlp)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        for block in self._model.model.layers:
+            block.mlp.forward = block.mlp._orig_forward
+            del block.mlp._gate_w, block.mlp._up_w, block.mlp._down_w
+
+
 class Qwen2VLLanguageModelPatcher(OVDecoderModelPatcher):
     def __init__(
         self,

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -146,7 +146,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         SUPPORTED_ARCHITECTURES += ("gpt_oss", "gpt_oss_mxfp4", "afmoe")
 
     if is_transformers_version(">=", "4.57.0"):
-        SUPPORTED_ARCHITECTURES += ("hunyuan_v1_dense",)
+        SUPPORTED_ARCHITECTURES += ("hunyuan_v1_dense", "deepseek_v4")
 
     if is_transformers_version("<", "4.56.0"):
         SUPPORTED_ARCHITECTURES += ("qwen", "chatglm", "chatglm4")

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -111,7 +111,7 @@ class ExportModelTest(unittest.TestCase):
         SUPPORTED_ARCHITECTURES.update({"afmoe": OVModelForCausalLM})
 
     if is_transformers_version(">=", "4.57.0"):
-        SUPPORTED_ARCHITECTURES.update({"hunyuan_v1_dense": OVModelForCausalLM})
+        SUPPORTED_ARCHITECTURES.update({"hunyuan_v1_dense": OVModelForCausalLM, "deepseek_v4": OVModelForCausalLM})
 
     if is_transformers_version(">=", "4.57.0") and is_transformers_version("<", "5"):
         SUPPORTED_ARCHITECTURES.update({"qwen3_next": OVModelForCausalLM})

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1080,6 +1080,7 @@ class OVWeightCompressionTest(unittest.TestCase):
     if is_transformers_version(">=", "4.57.0"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "qwen3_vl", False))
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForCausalLM, "hunyuan_v1_dense", False))
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForCausalLM, "deepseek_v4", True))
 
     if is_transformers_version("<", "5"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.extend(

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -70,6 +70,7 @@ MODEL_NAMES = {
     "deberta-v2": "optimum-intel-internal-testing/tiny-random-DebertaV2Model",
     "decilm": "optimum-intel-internal-testing/tiny-random-decilm",
     "deepseek": "optimum-intel-internal-testing/tiny-random-deepseek-v3",
+    "deepseek_v4": "/home/rkazants/.copilot/workspace/tiny-deepseek-v4-flash",
     "deit": "optimum-intel-internal-testing/tiny-random-DeiTModel",
     "convnext": "optimum-intel-internal-testing/tiny-random-convnext",
     "convnextv2": "optimum-intel-internal-testing/tiny-random-ConvNextV2Model",
@@ -234,6 +235,7 @@ EAGLE3_MODELS = {"qwen3_eagle3": ("AngelSlim/Qwen3-1.7B_eagle3", "Qwen/Qwen3-1.7
 
 _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "afmoe": {"model": 16},
+    "deepseek_v4": {"model": 80},
     "bert": {"model": 68 if is_transformers_version("<", "5") else 70},
     "roberta": {"model": 68},
     "albert": {"model": 84},
@@ -397,6 +399,7 @@ REMOTE_CODE_MODELS = (
     "decilm",
     "minicpm3",
     "deepseek",
+    "deepseek_v4",
     "qwen3_eagle3",
 )
 


### PR DESCRIPTION
## What does this PR do?

This PR adds OpenVINO export support for the **DeepSeek-V4** (`deepseek_v4`) model architecture, as introduced in the `tiny-deepseek-v4-flash` reference model.

### Changes

**`optimum/exporters/openvino/model_configs.py`**
- Add `OVDeepseekV4DummyPastKeyValuesGenerator`: custom PKV dummy input generator that generates key/value tensors with shape `[batch, num_attention_heads, seq, head_dim]`. This differs from the standard MiniCPM3/DeepSeek-V2/V3 generator because DeepSeek-V4 uses an MQA-style single shared KV vector that is expanded to `num_attention_heads` before caching.
- Add `DeepseekV4OpenVINOConfig`: registers the `deepseek_v4` model type for `text-generation` and `text-generation-with-past` tasks.

**`optimum/exporters/openvino/model_patcher.py`**
- Add `deepseek_v4_moe_forward`: a vectorized replacement for the original MoE forward that used a Python for-loop with a data-dependent `if not mask.any(): continue` conditional — incompatible with `torch.jit.trace`. The patched version uses batched matrix multiplication (`torch.bmm`) over pre-stacked expert weight matrices, eliminating dynamic control flow.
- Add `DeepseekV4Patcher`:
  - Pre-stacks all expert MLP weights (`gate_proj`, `up_proj`, `down_proj`) before tracing so they become frozen constants rather than dynamic `aten::stack` graph nodes.
  - Pre-computes RoPE cosine/sine tables via `_get_cos_sin()` before tracing, so they are frozen as constants in the exported graph instead of being recomputed at every forward pass.
  - Patches each MoE layer's `forward` with the vectorized implementation.

**Tests**
- `tests/openvino/utils_tests.py`: add `deepseek_v4` model ID, expected INT8 node count (80), and include in `REMOTE_CODE_MODELS`.
- `tests/openvino/test_decoder.py`: add `deepseek_v4` to `SUPPORTED_ARCHITECTURES` (gated on transformers >= 4.57.0).
- `tests/openvino/test_export.py`: add `deepseek_v4` to `SUPPORTED_ARCHITECTURES`.
- `tests/openvino/test_quantization.py`: add `deepseek_v4` to `SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION`.

**Documentation**
- `docs/source/openvino/models.mdx`: add DeepSeek-V4 to the supported models list.

### Validation

Export and inference were validated locally:
```bash
optimum-cli export openvino \
  --model /path/to/tiny-deepseek-v4-flash \
  --task text-generation-with-past \
  --trust-remote-code \
  output_dir
```

Inference with `OVModelForCausalLM` produces correct output.

## Before submitting
- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?