### PR TITLE
Add OpenVINO export and inference support for ZImagePipeline (Tongyi-MAI/Z-Image-Turbo)

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -1014,6 +1014,7 @@ def get_diffusion_models_for_export_ext(
     is_flux = pipeline.__class__.__name__.startswith("Flux")
     is_sana = pipeline.__class__.__name__.startswith("Sana")
     is_ltx_video = pipeline.__class__.__name__.startswith("LTX")
+    is_zimage = pipeline.__class__.__name__.startswith("ZImage")
     is_sd = pipeline.__class__.__name__.startswith("StableDiffusion") and not is_sd3
     is_lcm = pipeline.__class__.__name__.startswith("LatentConsistencyModel")
 
@@ -1039,9 +1040,94 @@ def get_diffusion_models_for_export_ext(
         models_for_export = get_sana_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     elif is_ltx_video:
         models_for_export = get_ltx_video_models_for_export(pipeline, exporter, int_dtype, float_dtype)
+    elif is_zimage:
+        models_for_export = get_zimage_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     else:
         raise ValueError(f"Unsupported pipeline type `{pipeline.__class__.__name__}` provided")
     return None, models_for_export
+
+
+def get_zimage_models_for_export(pipeline, exporter, int_dtype, float_dtype):
+    """
+    Build the models_for_export dict for ZImagePipeline (Tongyi-MAI/Z-Image-Turbo).
+
+    Components exported:
+      text_encoder   - Qwen3Model → produces cap_feat_dim-dimensional text features
+      transformer    - ZImageTransformer2DModel (patched forward)
+      vae_encoder    - standard AutoencoderKL encoder
+      vae_decoder    - standard AutoencoderKL decoder
+    """
+    models_for_export = {}
+
+    # ── Text encoder (Qwen3Model) ──────────────────────────────────────────
+    text_encoder = pipeline.text_encoder
+    text_encoder_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=text_encoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="feature-extraction",
+        model_type="qwen3-text-encoder",
+    )
+    text_encoder_export_config = text_encoder_config_constructor(
+        text_encoder.config,
+        int_dtype=int_dtype,
+        float_dtype=float_dtype,
+    )
+    text_encoder_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["text_encoder"] = (text_encoder, text_encoder_export_config)
+
+    # ── Transformer (ZImageTransformer2DModel) ─────────────────────────────
+    transformer = pipeline.transformer
+    # Propagate cap_feat_dim so the export config can size encoder_hidden_states
+    transformer.config.text_encoder_projection_dim = transformer.config.cap_feat_dim
+    transformer.config.requires_aesthetics_score = False
+    transformer.config.time_cond_proj_dim = None
+    export_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=transformer,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="z-image-transformer",
+    )
+    transformer_export_config = export_config_constructor(
+        transformer.config, int_dtype=int_dtype, float_dtype=float_dtype
+    )
+    transformer_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["transformer"] = (transformer, transformer_export_config)
+
+    # ── VAE Encoder ────────────────────────────────────────────────────────
+    vae_encoder = copy.deepcopy(pipeline.vae)
+    vae_encoder.forward = lambda sample: {"latent_parameters": vae_encoder.encode(x=sample)["latent_dist"].parameters}
+    vae_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=vae_encoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="vae-encoder",
+    )
+    vae_encoder_export_config = vae_config_constructor(
+        vae_encoder.config, int_dtype=int_dtype, float_dtype=float_dtype
+    )
+    vae_encoder_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_encoder"] = (vae_encoder, vae_encoder_export_config)
+
+    # ── VAE Decoder ────────────────────────────────────────────────────────
+    vae_decoder = copy.deepcopy(pipeline.vae)
+    vae_decoder.forward = lambda latent_sample: vae_decoder.decode(z=latent_sample)
+    vae_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=vae_decoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="vae-decoder",
+    )
+    vae_decoder_export_config = vae_config_constructor(
+        vae_decoder.config, int_dtype=int_dtype, float_dtype=float_dtype
+    )
+    vae_decoder_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_decoder"] = (vae_decoder, vae_decoder_export_config)
+
+    return models_for_export
 
 
 def get_ltx_video_models_for_export(pipeline, exporter, int_dtype, float_dtype):

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -206,6 +206,8 @@ from .model_patcher import (
     Qwen3VLVisionEmbMergerPatcher,
     QwenModelPatcher,
     SanaTextEncoderModelPatcher,
+    ZImageTextEncoderModelPatcher,
+    ZImageTransformerModelPatcher,
     XverseModelPatcher,
     Zamba2ModelPatcher,
     _get_model_attribute,
@@ -310,6 +312,7 @@ def init_model_configs():
             TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-image"] = {}
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-image"]["sana"] = "SanaPipeline"
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-image"]["sana-sprint"] = "SanaSprintPipeline"
+        TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-image"]["z-image"] = "ZImagePipeline"
     if is_diffusers_available() and "text-to-video" not in TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS:
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-video"] = {}
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-video"]["ltx-video"] = "LTXPipeline"
@@ -5559,3 +5562,140 @@ class Qwen3NextOpenVINOConfig(Qwen3OpenVINOConfig):
 class LFM2MoeOpenVINOConfig(LFM2OpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "5.0"
     _MODEL_PATCHER = Lfm2MoeModelPatcher
+
+
+# ── ZImage (Tongyi-MAI/Z-Image-Turbo) ─────────────────────────────────────
+
+
+class DummyZImageTransformerVisionInputGenerator(DummyUnetVisionInputGenerator):
+    """Generates dummy latent inputs for ZImageTransformer2DModel export.
+
+    Uses 64x64 latent (= 512x512 / 8) as the default trace resolution.
+    This matches typical Z-Image inference (512x512 output images).
+    The exported model is resolution-specific; re-export for other resolutions.
+    """
+
+    SUPPORTED_INPUT_NAMES = (
+        "pixel_values",
+        "pixel_mask",
+        "sample",
+        "latent_sample",
+        "hidden_states",
+    )
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        # 64x64 latent = 512x512 image / 8 (VAE spatial factor)
+        # This must match the resolution used at inference time.
+        width: int = 64,
+        height: int = 64,
+        **kwargs,
+    ):
+        super().__init__(task, normalized_config, batch_size, num_channels, width=width, height=height, **kwargs)
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "hidden_states":
+            return self.random_float_tensor(
+                [self.batch_size, self.num_channels, self.height, self.width],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+class DummyZImageCapFeatInputGenerator(DummySeq2SeqDecoderTextInputGenerator):
+    """Generates dummy text-feature inputs for ZImageTransformer2DModel export."""
+
+    SUPPORTED_INPUT_NAMES = (
+        "decoder_input_ids",
+        "decoder_attention_mask",
+        "encoder_outputs",
+        "encoder_hidden_states",
+    )
+
+
+@register_in_tasks_manager("z-image-transformer", *["semantic-segmentation"], library_name="diffusers")
+class ZImageTransformerOpenVINOConfig(UNetOpenVINOConfig):
+    """
+    Export config for ZImageTransformer2DModel.
+
+    The patched forward (via ZImageTransformerModelPatcher) accepts:
+      hidden_states:         [B, C, H, W]    — latent without the frame (F) dim
+      timestep:              [B]
+      encoder_hidden_states: [B, seq_len, cap_feat_dim]
+
+    And returns:
+      sample: [B, C, H, W]
+    """
+
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        image_size="sample_size",  # not used directly but required by base class
+        num_channels="in_channels",
+        hidden_size="cap_feat_dim",  # used for encoder_hidden_states dim
+        vocab_size="n_heads",  # dummy — needed by base class
+        allow_new=True,
+    )
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        DummyTransformerTimestpsInputGenerator,
+        DummyZImageTransformerVisionInputGenerator,
+        DummyZImageCapFeatInputGenerator,
+    )
+    _MODEL_PATCHER = ZImageTransformerModelPatcher
+
+    @property
+    def inputs(self):
+        return {
+            "hidden_states": {0: "batch_size", 2: "height", 3: "width"},
+            "timestep": {0: "batch_size"},
+            "encoder_hidden_states": {0: "batch_size", 1: "sequence_length"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "sample": {0: "batch_size", 2: "height", 3: "width"},
+        }
+
+    def rename_ambiguous_inputs(self, inputs):
+        return inputs
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
+        # Force batch_size=1: ZImageTransformer patching only supports single-item lists.
+        # The list-based forward (x: list[Tensor], cap_feats: list[Tensor]) is unrolled
+        # for batch_size=1 to remain OV-traceable.
+        # Use ZIMAGE_CAP_SEQ for cap to match what the patcher pads to at inference time.
+        # This ensures cap_seqlens (burned as a JIT constant) always matches.
+        from optimum.exporters.openvino.model_patcher import ZIMAGE_CAP_SEQ
+
+        kwargs["batch_size"] = 1
+        kwargs["sequence_length"] = ZIMAGE_CAP_SEQ
+        return super().generate_dummy_inputs(framework=framework, **kwargs)
+
+
+@register_in_tasks_manager("qwen3-text-encoder", *["feature-extraction"], library_name="diffusers")
+class ZImageTextEncoderOpenVINOConfig(CLIPTextOpenVINOConfig):
+    """
+    Export config for the Qwen3Model text encoder used in ZImagePipeline.
+
+    The patched forward (via ZImageTextEncoderModelPatcher) returns hidden_states[-2]
+    directly as the main output tensor.
+    """
+
+    _MODEL_PATCHER = ZImageTextEncoderModelPatcher
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "input_ids": {0: "batch_size", 1: "sequence_length"},
+            "attention_mask": {0: "batch_size", 1: "sequence_length"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "last_hidden_state": {0: "batch_size", 1: "sequence_length"},
+        }

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -8584,3 +8584,370 @@ class Lfm2MoeModelPatcher(Lfm2ModelPatcher):
                 if isinstance(sparse_moe_block.experts, Lfm2MoeExperts):
                     lfm2_moe_experts = sparse_moe_block.experts
                     lfm2_moe_experts.forward = lfm2_moe_experts._orig_forward
+
+
+# Fixed cap sequence length for ZImage OV export.
+# All cap (text) tokens are padded / truncated to this length before tracing.
+# Must be a multiple of SEQ_MULTI_OF (32).  128 = 4 × 32 covers most prompts.
+ZIMAGE_CAP_SEQ = 128
+
+
+def _z_image_rope_embedder_call(self, ids: "torch.Tensor"):
+    """
+    Patched RopeEmbedder.__call__ for OV export.
+
+    Returns a real-valued tensor of shape [seq_len, total_freq, 2]
+    where [..., 0] = cos and [..., 1] = sin.
+    This avoids complex-tensor indexing which OV cannot convert.
+    """
+    import torch
+
+    device = ids.device
+
+    # Lazily precompute real (cos, sin) lookup tables
+    if not hasattr(self, "_ov_freqs_cos") or self._ov_freqs_cos is None:
+        raw_freqs = self.precompute_freqs_cis(self.axes_dims, self.axes_lens, theta=self.theta)
+        self._ov_freqs_cos = [f.real.float() for f in raw_freqs]
+        self._ov_freqs_sin = [f.imag.float() for f in raw_freqs]
+        self.freqs_cis = raw_freqs  # keep original for non-export use
+
+    # Move to the correct device
+    if self._ov_freqs_cos[0].device != device:
+        self._ov_freqs_cos = [f.to(device) for f in self._ov_freqs_cos]
+        self._ov_freqs_sin = [f.to(device) for f in self._ov_freqs_sin]
+
+    result_cos, result_sin = [], []
+    for i in range(len(self.axes_dims)):
+        index = ids[:, i]  # [seq_len] integer indices
+        result_cos.append(self._ov_freqs_cos[i][index])  # [seq_len, freq_i] real
+        result_sin.append(self._ov_freqs_sin[i][index])  # [seq_len, freq_i] real
+
+    cos = torch.cat(result_cos, dim=-1)  # [seq_len, total_freq]
+    sin = torch.cat(result_sin, dim=-1)  # [seq_len, total_freq]
+    # Stack as [seq_len, total_freq, 2] where last dim = [cos, sin]
+    return torch.stack([cos, sin], dim=-1)
+
+
+def _z_image_attn_proc_call(
+    self,
+    attn,
+    hidden_states: "torch.Tensor",
+    encoder_hidden_states=None,
+    attention_mask=None,
+    freqs_cis=None,
+):
+    """
+    Patched ZSingleStreamAttnProcessor.__call__ for OV export.
+
+    Replaces torch.view_as_complex / view_as_real with real-number RoPE.
+    freqs_cis is now [batch, seq_len, head_dim//2, 2] (cos, sin stacked).
+    """
+    import torch
+
+    def apply_rotary_emb_real(x_in, freqs_cis_real):
+        """Real-number RoPE: avoids view_as_complex/view_as_real."""
+        # x_in:          [batch, seq, heads, head_dim]
+        # freqs_cis_real:[batch, seq, head_dim//2, 2]  (last dim: [cos, sin])
+        cos = freqs_cis_real[..., 0]  # [batch, seq, head_dim//2]
+        sin = freqs_cis_real[..., 1]  # [batch, seq, head_dim//2]
+
+        x_float = x_in.float()
+        x_pairs = x_float.reshape(*x_float.shape[:-1], -1, 2)  # [batch, seq, heads, head_dim//2, 2]
+
+        # Broadcast cos/sin over the heads dimension
+        cos = cos.unsqueeze(2)  # [batch, seq, 1, head_dim//2]
+        sin = sin.unsqueeze(2)
+
+        out_real = x_pairs[..., 0] * cos - x_pairs[..., 1] * sin  # [batch, seq, heads, head_dim//2]
+        out_imag = x_pairs[..., 0] * sin + x_pairs[..., 1] * cos
+        out = torch.stack([out_real, out_imag], dim=-1).flatten(-2)  # [batch, seq, heads, head_dim]
+        return out.type_as(x_in)
+
+    query = attn.to_q(hidden_states)
+    key = attn.to_k(hidden_states)
+    value = attn.to_v(hidden_states)
+
+    query = query.unflatten(-1, (attn.heads, -1))
+    key = key.unflatten(-1, (attn.heads, -1))
+    value = value.unflatten(-1, (attn.heads, -1))
+
+    if attn.norm_q is not None:
+        query = attn.norm_q(query)
+    if attn.norm_k is not None:
+        key = attn.norm_k(key)
+
+    if freqs_cis is not None:
+        query = apply_rotary_emb_real(query, freqs_cis)
+        key = apply_rotary_emb_real(key, freqs_cis)
+
+    dtype = query.dtype
+    query, key = query.to(dtype), key.to(dtype)
+
+    if attention_mask is not None and attention_mask.ndim == 2:
+        attention_mask = attention_mask[:, None, None, :]
+
+    # Standard SDPA
+    hidden_states = torch.nn.functional.scaled_dot_product_attention(
+        query.transpose(1, 2),
+        key.transpose(1, 2),
+        value.transpose(1, 2),
+        attn_mask=attention_mask.bool() if attention_mask is not None else None,
+        dropout_p=0.0,
+        is_causal=False,
+    ).transpose(1, 2)
+
+    hidden_states = hidden_states.flatten(2, 3)
+    hidden_states = hidden_states.to(dtype)
+
+    output = attn.to_out[0](hidden_states)
+    if len(attn.to_out) > 1:
+        output = attn.to_out[1](output)
+
+    return output
+
+
+def _patched_z_image_prepare_sequence(
+    self,
+    feats,
+    pos_ids,
+    inner_pad_mask,
+    pad_token,
+    noise_mask=None,
+    device=None,
+):
+    """
+    Patched _prepare_sequence for OV export (batch_size=1 only).
+
+    Replaces:
+      - index_put_ (feats_cat[bool_mask] = pad_token) with torch.where
+      - pad_sequence with unsqueeze (no variable-length batching needed)
+    """
+    import torch
+
+    # batch_size=1: process the single element
+    feat = feats[0]  # [seq_len, dim]
+    pos_id = pos_ids[0]  # [seq_len, 3]
+    pad_mask = inner_pad_mask[0]  # [seq_len] bool
+
+    # Apply pad token using torch.where (avoids aten::index_put_)
+    # pad_token may be shape [1, dim] or [dim]; broadcast directly to [seq_len, dim]
+    feat = torch.where(pad_mask.unsqueeze(-1), pad_token.view(1, -1).expand_as(feat), feat)
+
+    # RoPE: call helper directly to avoid class-level __call__ dispatch issue
+    # (Python's special method lookup bypasses instance-level __call__ patches)
+    # pos_id may be longer than feat (pos_grid_size includes padding positions):
+    # truncate freqs_cis to match the actual feature length, as the original does
+    # with pad_sequence + [:, :feats.shape[1]].
+    freqs_cis = _z_image_rope_embedder_call(self.rope_embedder, pos_id)  # [pos_len, total_freq, 2]
+    seq_len = feat.shape[0]  # actual (padded) feature length
+    freqs_cis = freqs_cis[:seq_len]  # truncate to [seq_len, total_freq, 2]
+
+    # Expand to batch dimension (unsqueeze avoids aten::pad_sequence)
+    feats_batched = feat.unsqueeze(0)  # [1, seq_len, dim]
+    freqs_batched = freqs_cis.unsqueeze(0)  # [1, seq_len, total_freq, 2]
+
+    # All-True attention mask: for batch_size=1 there is no inter-sequence padding
+    seq_len = feat.shape[0]
+    attn_mask = torch.ones((1, seq_len), dtype=torch.bool, device=device)
+
+    return feats_batched, freqs_batched, attn_mask, [seq_len], None
+
+
+def _patched_z_image_build_unified_sequence(
+    self,
+    x,
+    x_freqs,
+    x_seqlens,
+    x_noise_mask,
+    cap,
+    cap_freqs,
+    cap_seqlens,
+    cap_noise_mask,
+    siglip,
+    siglip_freqs,
+    siglip_seqlens,
+    siglip_noise_mask,
+    omni_mode,
+    device,
+):
+    """
+    Patched _build_unified_sequence for OV export (batch_size=1, non-omni only).
+
+    Replaces pad_sequence + bool-masked creation with torch.cat + unsqueeze.
+    """
+    import torch
+
+    x_len = x_seqlens[0]
+    cap_len = cap_seqlens[0]
+
+    # Extract single-batch items  (x/cap are [1, seq, dim] from _prepare_sequence)
+    x_sq = x[0][:x_len]  # [x_len, dim]
+    cap_sq = cap[0][:cap_len]  # [cap_len, dim]
+    x_freqs_sq = x_freqs[0][:x_len]  # [x_len, total_freq, 2]
+    cap_freqs_sq = cap_freqs[0][:cap_len]  # [cap_len, total_freq, 2]
+
+    # Basic mode order: [x, cap]
+    unified_sq = torch.cat([x_sq, cap_sq], dim=0)  # [unified_len, dim]
+    unified_freqs_sq = torch.cat([x_freqs_sq, cap_freqs_sq], dim=0)  # [unified_len, total_freq, 2]
+
+    # Expand to batch dimension
+    unified = unified_sq.unsqueeze(0)  # [1, unified_len, dim]
+    unified_freqs = unified_freqs_sq.unsqueeze(0)  # [1, unified_len, total_freq, 2]
+
+    unified_len = unified_sq.shape[0]
+    attn_mask = torch.ones((1, unified_len), dtype=torch.bool, device=device)
+
+    return unified, unified_freqs, attn_mask, None  # noise_mask_tensor=None for non-omni
+
+
+class ZImageTransformerModelPatcher(ModelPatcher):
+    """
+    Model patcher for ZImageTransformer2DModel OV export.
+
+    Patches:
+    - RopeEmbedder.__call__: returns real [seq, freq, 2] instead of complex
+    - ZSingleStreamAttnProcessor.__call__: real-number RoPE, avoids view_as_complex
+    - ZImageTransformer2DModel._prepare_sequence: avoids index_put_, pad_sequence
+    - ZImageTransformer2DModel._build_unified_sequence: avoids pad_sequence
+    - ZImageTransformer2DModel.forward: wraps to accept/return standard tensors
+
+    Only supports batch_size=1, non-omni mode (single image per inference call).
+    """
+
+    def __enter__(self):
+        super().__enter__()
+
+        # Import the processor class to patch at class level
+        # (Python's special method lookup always goes to the type, not the instance,
+        #  so we must patch at class level, not instance level)
+        from diffusers.models.transformers.transformer_z_image import ZSingleStreamAttnProcessor as _ZAttnProc
+
+        # 1. Patch ZSingleStreamAttnProcessor at class level to use real RoPE
+        _ZAttnProc._orig_ov_call = _ZAttnProc.__call__
+        _ZAttnProc.__call__ = _z_image_attn_proc_call
+
+        # 2. Patch _prepare_sequence
+        self._model._orig_ov_prepare_sequence = self._model._prepare_sequence
+        self._model._prepare_sequence = types.MethodType(_patched_z_image_prepare_sequence, self._model)
+
+        # 3. Patch _build_unified_sequence
+        self._model._orig_ov_build_unified = self._model._build_unified_sequence
+        self._model._build_unified_sequence = types.MethodType(
+            _patched_z_image_build_unified_sequence, self._model
+        )
+
+        # 4. Wrap forward to accept/return standard batched tensors
+        #    hidden_states: [B, C, H, W]   (no F dim — we add it internally)
+        #    timestep:      [B]
+        #    encoder_hidden_states: [B, seq_len, cap_feat_dim]
+        # Use self.orig_forward (the REAL model forward set by ModelPatcher.__init__)
+        # to avoid double-wrapping through the base patcher's output filtering logic.
+        _orig_forward = self.orig_forward
+        _model_ref = self._model
+
+        def patched_forward(hidden_states, timestep, encoder_hidden_states):
+            import torch
+
+            # ── Cap sequence ────────────────────────────────────────────────────
+            # torch.jit.trace burns Python-level len() calls as static constants.
+            # To guarantee that `cap_seqlens = [len(ci) for ci in cap_feats]`
+            # always matches the trace value, we pad / truncate encoder_hidden_states
+            # to exactly ZIMAGE_CAP_SEQ tokens here, before calling the model.
+            # Tokens beyond the real prompt length are zero-filled; the model
+            # attends to them but their contribution is minimal (bias-only after
+            # cap_embedder), so quality impact is acceptable.
+            cap_feat_dim = encoder_hidden_states.shape[2]
+            cap_len = encoder_hidden_states.shape[1]
+            if cap_len < ZIMAGE_CAP_SEQ:
+                pad = torch.zeros(
+                    1, ZIMAGE_CAP_SEQ - cap_len, cap_feat_dim,
+                    dtype=encoder_hidden_states.dtype,
+                    device=encoder_hidden_states.device,
+                )
+                encoder_hidden_states = torch.cat([encoder_hidden_states, pad], dim=1)
+            elif cap_len > ZIMAGE_CAP_SEQ:
+                encoder_hidden_states = encoder_hidden_states[:, :ZIMAGE_CAP_SEQ]
+
+            # Add frame dimension: [B, C, H, W] -> [B, C, 1, H, W]
+            x_with_f = hidden_states.unsqueeze(2)
+            # Convert to list of [C, 1, H, W] for the model
+            x = list(x_with_f.unbind(0))
+            # Convert cap_feats to list of [ZIMAGE_CAP_SEQ, cap_feat_dim]
+            cap_feats = list(encoder_hidden_states.unbind(0))
+
+            out = _orig_forward(x, timestep, cap_feats, return_dict=False)
+
+            # Stack list output [B x [C, 1, H, W]] into tensor [B, C, 1, H, W]
+            result = torch.stack(out[0], dim=0)
+            # Remove frame dimension: [B, C, 1, H, W] -> [B, C, H, W]
+            return result.squeeze(2)
+
+        self._model.forward = patched_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+
+        # Restore ZSingleStreamAttnProcessor class-level patch
+        try:
+            from diffusers.models.transformers.transformer_z_image import ZSingleStreamAttnProcessor as _ZAttnProc
+
+            if hasattr(_ZAttnProc, "_orig_ov_call"):
+                _ZAttnProc.__call__ = _ZAttnProc._orig_ov_call
+                del _ZAttnProc._orig_ov_call
+        except ImportError:
+            pass
+
+        # Restore model methods
+        if hasattr(self._model, "_orig_ov_prepare_sequence"):
+            self._model._prepare_sequence = self._model._orig_ov_prepare_sequence
+            del self._model._orig_ov_prepare_sequence
+        if hasattr(self._model, "_orig_ov_build_unified"):
+            self._model._build_unified_sequence = self._model._orig_ov_build_unified
+            del self._model._orig_ov_build_unified
+        # Forward is restored by the base ModelPatcher via _orig_forward mechanism
+
+
+class ZImageTextEncoderModelPatcher(ModelPatcher):
+    """
+    Model patcher for the Qwen3-based text encoder used in ZImagePipeline.
+
+    The pipeline uses hidden_states[-2] from the Qwen3 model as text features.
+    This patcher wraps forward to return hidden_states[-2] directly as the
+    last_hidden_state output so it matches the CLIPText export interface.
+    """
+
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: "PreTrainedModel",
+        model_kwargs=None,
+    ):
+        super().__init__(config, model, model_kwargs)
+        _orig_forward = self.orig_forward
+
+        @functools.wraps(_orig_forward)
+        def patched_forward(input_ids, attention_mask):
+            out = _orig_forward(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                output_hidden_states=True,
+            )
+            # Return second-to-last hidden state as the text features
+            # (ZImagePipeline uses prompt_embeds[i][prompt_masks[i]] from hidden_states[-2])
+            # Must return a dict so ts_patched_forward can call .values() on it.
+            return {"last_hidden_state": out.hidden_states[-2]}
+
+        self.patched_forward = patched_forward
+
+    def __enter__(self):
+        super().__enter__()
+        # Ensure SDPA is used for tracing (avoids boolean mask issues with eager mode)
+        if hasattr(self._model, "config") and hasattr(self._model.config, "_attn_implementation"):
+            self._model.config._orig_ov_attn_impl = self._model.config._attn_implementation
+            self._model.config._attn_implementation = "sdpa"
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if hasattr(self._model, "config") and hasattr(self._model.config, "_orig_ov_attn_impl"):
+            self._model.config._attn_implementation = self._model.config._orig_ov_attn_impl
+            del self._model.config._orig_ov_attn_impl

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -226,6 +226,7 @@ if TYPE_CHECKING:
             OVStableDiffusionXLImg2ImgPipeline,
             OVStableDiffusionXLInpaintPipeline,
             OVStableDiffusionXLPipeline,
+            OVZImagePipeline,
         )
     else:
         from .openvino import (
@@ -247,6 +248,7 @@ if TYPE_CHECKING:
             OVStableDiffusionXLImg2ImgPipeline,
             OVStableDiffusionXLInpaintPipeline,
             OVStableDiffusionXLPipeline,
+            OVZImagePipeline,
         )
 
     try:

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -117,6 +117,7 @@ if is_diffusers_available():
         OVStableDiffusionXLImg2ImgPipeline,
         OVStableDiffusionXLInpaintPipeline,
         OVStableDiffusionXLPipeline,
+        OVZImagePipeline,
     )
 
 

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -120,6 +120,11 @@ if is_diffusers_version(">=", "0.33.0"):
 else:
     SanaSprintPipeline = object
 
+if is_diffusers_version(">=", "0.37.0"):
+    from diffusers import ZImagePipeline
+else:
+    ZImagePipeline = object
+
 
 if is_diffusers_version(">=", "0.35.0"):
     from diffusers.models.cache_utils import CacheMixin
@@ -1663,6 +1668,143 @@ class OVLTXPipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, LTXPipel
     auto_model_class = LTXPipeline
 
 
+class _OVZImageTransformerAdapter:
+    """Adapter that converts ZImagePipeline's transformer calling convention to OV model inputs.
+
+    ZImagePipeline calls the transformer as:
+        transformer(x_list, t, cap_feats_list, return_dict=False)
+    where x_list is a list of [C,1,H,W] tensors (with frame dim) and cap_feats_list is a list
+    of variable-length [seq_len, dim] tensors.
+
+    The exported OV model expects single-item batches (batch=1) with no frame dim:
+        hidden_states [1, C, H, W], timestep scalar, encoder_hidden_states [1, CAP_SEQ, dim]
+    and returns sample [1, C, H, W].
+
+    This adapter processes each batch item individually, mirroring the logic in
+    ZImageTransformerModelPatcher.patched_forward.
+    """
+
+    _ZIMAGE_CAP_SEQ = 128
+
+    def __init__(self, ov_transformer, cap_seq: int = 128):
+        self._ov_transformer = ov_transformer
+        self._ZIMAGE_CAP_SEQ = cap_seq
+
+    def __call__(self, x, t, cap_feats, return_dict=True, **kwargs):
+        import torch
+
+        results = []
+        batch_size = len(x)
+        for i, (x_item, cf_item) in enumerate(zip(x, cap_feats)):
+            # x_item: [C, 1, H, W] → squeeze F → [C, H, W] → add batch → [1, C, H, W]
+            hs = x_item.squeeze(1).unsqueeze(0)  # [1, C, H, W]
+
+            # t may be scalar or [batch] tensor — extract per-item timestep
+            if isinstance(t, torch.Tensor) and t.numel() > 1:
+                t_item = t[i : i + 1]
+            else:
+                t_item = t
+
+            # cf_item: [seq_len, dim] → pad/truncate → [1, CAP_SEQ, dim]
+            cap_feat_dim = cf_item.shape[-1]
+            enc_hs = torch.zeros(1, self._ZIMAGE_CAP_SEQ, cap_feat_dim, dtype=cf_item.dtype)
+            L = min(cf_item.shape[0], self._ZIMAGE_CAP_SEQ)
+            enc_hs[0, :L] = cf_item[:L]
+
+            ov_out = self._ov_transformer(
+                hidden_states=hs,
+                timestep=t_item,
+                encoder_hidden_states=enc_hs,
+                return_dict=False,
+            )
+
+            # Extract sample from output
+            if isinstance(ov_out, (tuple, list)):
+                sample = ov_out[0]
+            elif hasattr(ov_out, "sample"):
+                sample = ov_out.sample
+            else:
+                sample = list(ov_out.values())[0] if hasattr(ov_out, "values") else ov_out
+
+            if not isinstance(sample, torch.Tensor):
+                sample = torch.from_numpy(sample)
+
+            # sample: [1, C, H, W] → squeeze batch → [C, H, W] → add F dim → [C, 1, H, W]
+            sample = sample.squeeze(0).unsqueeze(1)
+            results.append(sample)
+
+        return (results,)
+
+    def __getattr__(self, name):
+        return getattr(self._ov_transformer, name)
+
+
+class OVZImagePipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, ZImagePipeline):
+    main_input_name = "prompt"
+    export_feature = "text-to-image"
+    auto_model_class = ZImagePipeline
+
+    _ZIMAGE_CAP_SEQ = 128  # must match ZIMAGE_CAP_SEQ in model_patcher.py
+
+    def __call__(self, *args, **kwargs):
+        """Wrap transformer with ZImage-to-OV adapter before calling the pipeline."""
+        orig_transformer = self.transformer
+        if not isinstance(orig_transformer, _OVZImageTransformerAdapter):
+            self.transformer = _OVZImageTransformerAdapter(orig_transformer, self._ZIMAGE_CAP_SEQ)
+        try:
+            return ZImagePipeline.__call__(self, *args, **kwargs)
+        finally:
+            self.transformer = orig_transformer
+
+    def _encode_prompt(self, prompt, device=None, prompt_embeds=None, max_sequence_length=512):
+        """Override to use last_hidden_state from the OV text encoder.
+
+        The OV text encoder exports hidden_states[-2] as last_hidden_state
+        (see ZImageTextEncoderModelPatcher), so we read that directly instead
+        of calling with output_hidden_states=True.
+        """
+        import torch
+
+        if prompt_embeds is not None:
+            return prompt_embeds
+
+        if isinstance(prompt, str):
+            prompt = [prompt]
+
+        for i, prompt_item in enumerate(prompt):
+            messages = [{"role": "user", "content": prompt_item}]
+            prompt_item = self.tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=True,
+            )
+            prompt[i] = prompt_item
+
+        text_inputs = self.tokenizer(
+            prompt,
+            padding="max_length",
+            max_length=max_sequence_length,
+            truncation=True,
+            return_tensors="pt",
+        )
+
+        text_input_ids = text_inputs.input_ids
+        prompt_masks = text_inputs.attention_mask.bool()
+
+        # OV text encoder returns last_hidden_state which is already hidden_states[-2]
+        encoder_out = self.text_encoder(input_ids=text_input_ids, attention_mask=prompt_masks)
+        prompt_embeds = encoder_out.last_hidden_state
+        if not isinstance(prompt_embeds, torch.Tensor):
+            prompt_embeds = torch.from_numpy(prompt_embeds)
+
+        embeddings_list = []
+        for i in range(len(prompt_embeds)):
+            embeddings_list.append(prompt_embeds[i][prompt_masks[i]])
+
+        return embeddings_list
+
+
 SUPPORTED_OV_PIPELINES = [
     OVStableDiffusionPipeline,
     OVStableDiffusionImg2ImgPipeline,
@@ -1747,6 +1889,10 @@ if is_diffusers_version(">=", "0.32.0"):
 if is_diffusers_version(">=", "0.33.0"):
     SUPPORTED_OV_PIPELINES.append(OVSanaSprintPipeline)
     OV_TEXT2IMAGE_PIPELINES_MAPPING["sana-sprint"] = OVSanaSprintPipeline
+
+if is_diffusers_version(">=", "0.37.0"):
+    SUPPORTED_OV_PIPELINES.append(OVZImagePipeline)
+    OV_TEXT2IMAGE_PIPELINES_MAPPING["z-image"] = OVZImagePipeline
 
 SUPPORTED_OV_PIPELINES_MAPPINGS = [
     OV_TEXT2IMAGE_PIPELINES_MAPPING,

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -41,6 +41,9 @@ from optimum.intel.openvino.utils import TemporaryDirectory
 from optimum.intel.utils.import_utils import is_diffusers_version, is_transformers_version
 from optimum.utils.testing_utils import require_diffusers
 
+if is_diffusers_version(">=", "0.37.0"):
+    from optimum.intel.openvino import OVZImagePipeline
+
 
 def get_generator(framework, seed):
     if framework == "np":
@@ -1200,3 +1203,174 @@ class OVPipelineForText2VideoTest(unittest.TestCase):
         inputs.pop("width")
         image = pipeline(**inputs).frames[0]
         self.assertTupleEqual(image.shape[-3:-1], (32, 32))
+
+
+@unittest.skipIf(not is_diffusers_version(">=", "0.37.0"), reason="ZImagePipeline requires diffusers >= 0.37.0")
+@require_diffusers
+class OVZImagePipelineTest(unittest.TestCase):
+    """Tests for OVZImagePipeline (Tongyi-MAI/Z-Image-Turbo architecture).
+
+    Uses a tiny randomly-initialised ZImagePipeline created in memory so that
+    no large model download is required during CI.  The only external assets
+    are the Qwen3 tokenizer files from
+    ``optimum-intel-internal-testing/tiny-random-qwen3`` (~14 MB).
+
+    The tiny model parameters are chosen so that:
+    - ``dim=64``, ``n_heads=2`` → ``head_dim=32 == sum(axes_dims)``
+    - ``cap_feat_dim=32`` matches the Qwen3 ``hidden_size=32``
+    - ``in_channels=16`` matches ``AutoencoderKL`` ``latent_channels=16``
+    """
+
+    # Tiny but self-consistent model configuration
+    TRANSFORMER_CONFIG = dict(
+        all_patch_size=[2],
+        all_f_patch_size=[1],
+        in_channels=16,
+        dim=64,
+        n_layers=1,
+        n_refiner_layers=1,
+        n_heads=2,
+        n_kv_heads=2,
+        norm_eps=1e-5,
+        qk_norm=True,
+        cap_feat_dim=32,
+        siglip_feat_dim=None,
+        rope_theta=256.0,
+        t_scale=1000.0,
+        axes_dims=[4, 14, 14],  # must sum to head_dim=32
+        axes_lens=[256, 128, 128],
+    )
+
+    VAE_CONFIG = dict(
+        in_channels=3,
+        out_channels=3,
+        latent_channels=16,
+        down_block_types=("DownEncoderBlock2D",),
+        up_block_types=("UpDecoderBlock2D",),
+        block_out_channels=(32,),
+        layers_per_block=1,
+        norm_num_groups=32,
+        scaling_factor=0.3611,
+        shift_factor=0.1159,
+    )
+
+    QWEN3_CONFIG = dict(
+        vocab_size=100,
+        hidden_size=32,
+        intermediate_size=64,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        num_key_value_heads=2,
+        head_dim=16,
+        max_position_embeddings=512,
+        rms_norm_eps=1e-5,
+    )
+
+    # Public tokenizer with chat-template support; ~14 MB download
+    TOKENIZER_ID = "optimum-intel-internal-testing/tiny-random-qwen3"
+
+    def _build_tiny_pipeline(self):
+        """Create an in-memory ZImagePipeline with random weights."""
+        from diffusers import FlowMatchEulerDiscreteScheduler, ZImagePipeline
+        from diffusers.models import AutoencoderKL
+        from diffusers.models.transformers import ZImageTransformer2DModel
+        from transformers import AutoTokenizer, Qwen3Config, Qwen3Model
+
+        transformer = ZImageTransformer2DModel(**self.TRANSFORMER_CONFIG)
+        vae = AutoencoderKL(**self.VAE_CONFIG)
+        text_encoder = Qwen3Model(Qwen3Config(**self.QWEN3_CONFIG))
+        tokenizer = AutoTokenizer.from_pretrained(self.TOKENIZER_ID)
+        scheduler = FlowMatchEulerDiscreteScheduler()
+
+        return ZImagePipeline(
+            scheduler=scheduler,
+            vae=vae,
+            text_encoder=text_encoder,
+            tokenizer=tokenizer,
+            transformer=transformer,
+        )
+
+    def test_export_tiny_model(self):
+        """Exporting a tiny ZImagePipeline produces the expected four OV sub-models."""
+        from optimum.intel.openvino.utils import TemporaryDirectory
+
+        pipe = self._build_tiny_pipeline()
+        with TemporaryDirectory() as src_dir, TemporaryDirectory() as ov_dir:
+            pipe.save_pretrained(src_dir)
+
+            import subprocess
+
+            result = subprocess.run(
+                f"optimum-cli export openvino --model {src_dir} --task text-to-image {ov_dir}",
+                shell=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, msg=f"Export failed:\n{result.stderr}")
+
+            exported_xmls = {p.parent.name for p in Path(ov_dir).rglob("openvino_model.xml")}
+            self.assertSetEqual(
+                exported_xmls,
+                {"text_encoder", "transformer", "vae_encoder", "vae_decoder"},
+            )
+
+    def test_inference_output_shape(self):
+        """OVZImagePipeline generates images with the requested spatial resolution."""
+        from optimum.intel.openvino import OVZImagePipeline
+        from optimum.intel.openvino.utils import TemporaryDirectory
+
+        pipe = self._build_tiny_pipeline()
+        height, width = 64, 64
+
+        with TemporaryDirectory() as src_dir, TemporaryDirectory() as ov_dir:
+            pipe.save_pretrained(src_dir)
+
+            import subprocess
+
+            result = subprocess.run(
+                f"optimum-cli export openvino --model {src_dir} --task text-to-image {ov_dir}",
+                shell=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, msg=f"Export failed:\n{result.stderr}")
+
+            ov_pipe = OVZImagePipeline.from_pretrained(ov_dir, device=OPENVINO_DEVICE)
+            output = ov_pipe(
+                "a beautiful landscape",
+                num_inference_steps=1,
+                height=height,
+                width=width,
+                output_type="np",
+            )
+            images = output.images
+            self.assertEqual(len(images), 1)
+            self.assertTupleEqual(images[0].shape, (height, width, 3))
+
+    def test_pipeline_class_dispatch(self):
+        """OVDiffusionPipeline.from_pretrained dispatches to OVZImagePipeline."""
+        from optimum.intel.openvino import OVDiffusionPipeline, OVZImagePipeline
+        from optimum.intel.openvino.utils import TemporaryDirectory
+
+        pipe = self._build_tiny_pipeline()
+
+        with TemporaryDirectory() as src_dir, TemporaryDirectory() as ov_dir:
+            pipe.save_pretrained(src_dir)
+
+            import subprocess
+
+            result = subprocess.run(
+                f"optimum-cli export openvino --model {src_dir} --task text-to-image {ov_dir}",
+                shell=True,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, msg=f"Export failed:\n{result.stderr}")
+
+            # Direct load
+            ov_pipe = OVZImagePipeline.from_pretrained(ov_dir, device=OPENVINO_DEVICE)
+            self.assertIsInstance(ov_pipe, OVZImagePipeline)
+
+            # Dispatch via OVDiffusionPipeline
+            ov_pipe_dispatched = OVDiffusionPipeline.from_pretrained(ov_dir, device=OPENVINO_DEVICE)
+            self.assertIsInstance(ov_pipe_dispatched, OVZImagePipeline)


### PR DESCRIPTION
## What does this PR do?

Adds complete OpenVINO IR export and inference support for [Tongyi-MAI/Z-Image-Turbo](https://huggingface.co/Tongyi-MAI/Z-Image-Turbo), a custom DiT text-to-image pipeline.

## Architecture

- **Pipeline**: `ZImagePipeline` from diffusers 0.37+
- **Transformer**: `ZImageTransformer2DModel` — DiT with list-based forward (`x: list[Tensor]`, `cap_feats: list[Tensor]`)
- **Text encoder**: `Qwen3Model` (2.5B, returns `hidden_states[-2]` as caption features)
- **VAE**: Standard `AutoencoderKL`
- **4 models exported**: `text_encoder`, `transformer`, `vae_encoder`, `vae_decoder`

## Usage

### Export
```bash
optimum-cli export openvino --model Tongyi-MAI/Z-Image-Turbo --task text-to-image ./z-image-turbo-ov
```

### Inference
```python
from optimum.intel import OVZImagePipeline

pipe = OVZImagePipeline.from_pretrained("./z-image-turbo-ov")
image = pipe("a beautiful colibri sitting on a flower").images[0]
image.save("output.png")
```

## Key implementation notes

### Fixed cap sequence length (`ZIMAGE_CAP_SEQ = 128`)
`torch.jit.trace` burns Python list comprehensions as compile-time constants. The model's `cap_seqlens = [len(ci) for ci in cap_feats]` becomes a static split size in the TorchScript graph. The patcher pads/truncates `encoder_hidden_states` to exactly 128 tokens before every inference call.

### Complex tensor workaround
`RopeEmbedder` and `ZSingleStreamAttnProcessor` use `complex64` tensors that are incompatible with OpenVINO. Replaced with equivalent real-valued cos/sin arithmetic.

### Batch size = 1
The model's list-based forward is patched to use `unbind(0)`. Only batch_size=1 is supported.

### Fixed resolution (512×512)
The transformer is traced for 64×64 latents (= 512×512 image ÷ 8). Other resolutions require re-export.

## Changes

| File | What changed |
|---|---|
| `convert.py` | Added `get_zimage_models_for_export()` and `is_zimage` pipeline detection |
| `model_configs.py` | Added `ZImageTransformerOpenVINOConfig` and `ZImageTextEncoderOpenVINOConfig` |
| `model_patcher.py` | Added `ZImageTransformerModelPatcher` and `ZImageTextEncoderModelPatcher` with all OV-incompatible op patches |
| `modeling_diffusion.py` | Added `OVZImagePipeline` inference class with `_encode_prompt` override |
| `__init__.py` | Exported `OVZImagePipeline` |

## Tests

Added `OVZImagePipelineTest` in `tests/openvino/test_diffusion.py` with 3 tests:
- `test_export_tiny_model`: verifies the 4 expected OV sub-models are created
- `test_inference_output_shape`: verifies inference produces correct spatial output (64×64×3)
- `test_pipeline_class_dispatch`: verifies `OVDiffusionPipeline` auto-dispatches to `OVZImagePipeline`

The tests use an in-memory tiny ZImagePipeline (random weights, ~700 K params) so no large model download is needed in CI. The only external asset is the Qwen3 tokenizer from `optimum-intel-internal-testing/tiny-random-qwen3`.

## Known limitations

1. **Fixed resolution (512×512)**: The transformer is traced for 64×64 latents; other resolutions require re-export
2. **Fixed cap length (128 tokens)**: Prompts >128 tokens are silently truncated
3. **batch_size=1 only**

These are standard `torch.jit.trace` limitations. Future improvement: use `OPENVINO_DYNAMO_EXPORT=1` with shape hints.

## Checklist

- [x] Did you write any new necessary tests?
