### PR TITLE
[OpenVINO] Fix beam_idx wiring in patch_stateful_hybrid_ssm for hybrid SSM/attention models

### DIFF
--- a/optimum/exporters/openvino/stateful.py
+++ b/optimum/exporters/openvino/stateful.py
@@ -301,7 +301,9 @@ def patch_stateful_hybrid_ssm(ov_model: ov.Model):
     # hybrid models can contain transformer blocks as well
     # so KV tensors must be handled properly
     batch_dim = 0
-    fuse_cache_reorder(ov_model, not_cache_inputs, cache_inputs, batch_dim)
+    # Only KV tensors need beam-search reorder; SSM states are not per-beam
+    if kv_input_names:
+        fuse_cache_reorder(ov_model, not_cache_inputs, kv_input_names, batch_dim)
     make_stateful(ov_model, not_cache_inputs, cache_inputs, cache_outputs, batch_dim)
 
 


### PR DESCRIPTION
Hello team!

I believe I found a bug in hybrid_ssm. I was experimenting converting Qwen 3.6 models to IR (stripping off visual layer) and running them on OVMS and here is a small patch that addresses the issue

# What does this PR do?

Fixes `fuse_cache_reorder` usage: SSM states are recurrent accumulators, not per-beam caches — gathering them by `beam_idx` breaks the IR after `make_stateful` hides those SSM parameters as internal variables. So `kv_input_names` would be the correct subset to pass

With an additional check for VLM dispatch https://github.com/huggingface/optimum-intel/pull/1689/changes#diff-bd6225d5672fbb5fa75d6a97bffe1a23ace426dd21e0bc07376a6d29e5a7aaea this bug will most likely be reproducedon new Qwen models.


# Root cause:
`fuse_cache_reorder`: When the original code passes SSM tensors to fuse_cache_reorder for hybrid models, it inserts Gather ops on SSM input edges. After `make_stateful` subsequently hides those SSM tensors as internal variables, the resulting IR graph has Gather ops referring to beam_idx in ways inconsistent with the final input parameter list. OVMS rejects the IR with:

```
Model references undeclared parameters: opset1::Parameter beam_idx () -> (i32[?])
```

This bug doesn't surface for pure-SSM models (mamba, falcon_mamba) because they have no K/V tensors, so the for-loop in fuse_cache_reorder iterates zero times and the Gather ops are never inserted. It only surfaces for hybrid models with both attention and SSM layers (e.g., qwen3_5_text, also recently merged lfm2 family).

# Repro for the original bug:
Convert any model whose inner architecture is in SSM_MODELS and contains both attention and SSM layers. With current main branch (or #1689 branch):
- Export: succeeds
- OVMS load: fails with "Model references undeclared parameters: beam_idx"

With this PR:

- Export: succeeds
- OVMS load: succeeds


Relates to #1689 so @rkazants this might be relevant for your `patch_stateful` change

UPD:
This fixes the `beam_idx` wiring bug for hybrid SSM models. Note: separate issues exist for LFM2 family related to `attention_mask` handling. This PR addresses the `beam_idx` issue specifically (so far)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

