### PR TITLE
[EXPERIMENT][WIP] Add Mistral3ForConditionalGeneration OpenVINO export support

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -4256,6 +4256,68 @@ class DummyVisionPositionIdsInputGenerator(DummyVisionInputGenerator):
         return super().generate(input_name, framework, int_dtype, float_dtype)
 
 
+
+@register_in_tasks_manager(
+    "mistral3", *["image-text-to-text", "text-generation", "text-generation-with-past"],
+    library_name="transformers"
+)
+class Mistral3OpenVINOConfig(BaseVLMOpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "4.52.0"
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self._orig_config = config
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            self._config = config.vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+
+    def with_behavior(self, behavior: Union[str, VLMConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            model_type = self._orig_config.text_config.model_type
+            return get_vlm_text_generation_config(
+                model_type, self._orig_config.text_config, self.int_dtype, self.float_dtype
+            )
+
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            model_type = self._orig_config.text_config.model_type
+            return get_vlm_text_embeddings_config(
+                model_type, self._orig_config.text_config, self.int_dtype, self.float_dtype
+            )
+
+        return super().with_behavior(behavior)
+
+    def get_model_for_behavior(self, model, behavior: Union[str, VLMConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            return model
+
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            text_embedding = model.get_input_embeddings()
+            text_embedding.config = model.model.language_model.config
+            return text_embedding
+
+        return model
+
 @register_in_tasks_manager("idefics3", *["image-text-to-text"], library_name="transformers")
 class Idefics3OpenVINOConfig(BaseVLMOpenVINOConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator, DummyVisionPositionIdsInputGenerator)

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -303,6 +303,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "phi4_multimodal",
     "llama4",
     "minicpmo",
+    "mistral3",
 ]
 
 SSM_MODELS = ["mamba", "falcon_mamba", "zamba2", "lfm2", "lfm2_moe", "granitemoehybrid", "qwen3_next"]

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -399,3 +399,51 @@ class CustomExportModelTest(unittest.TestCase):
         ov_outputs = ov_model(**tokens)
         self.assertTrue(torch.allclose(ov_outputs.token_embeddings, model_outputs.token_embeddings, atol=1e-4))
         self.assertTrue(torch.allclose(ov_outputs.sentence_embedding, model_outputs.sentence_embedding, atol=1e-4))
+
+
+class Mistral3OpenVINORegistrationTest(unittest.TestCase):
+    """Tests for mistral3 OpenVINO support registration - no model downloads required."""
+
+    def test_mistral3_tasks_registered_in_tasks_manager(self):
+        """Test that mistral3 is registered for the expected tasks in TasksManager."""
+        from optimum.exporters.tasks import TasksManager
+
+        supported_model_types = TasksManager._SUPPORTED_MODEL_TYPE
+        self.assertIn("mistral3", supported_model_types, "mistral3 not found in TasksManager._SUPPORTED_MODEL_TYPE")
+
+        mistral3_exporters = supported_model_types["mistral3"]
+        self.assertIn("openvino", mistral3_exporters, "mistral3 missing 'openvino' exporter key")
+
+        openvino_tasks = mistral3_exporters["openvino"]
+        for task in ("image-text-to-text", "text-generation", "text-generation-with-past"):
+            self.assertIn(task, openvino_tasks, f"mistral3 missing task '{task}' in openvino exporter")
+
+    def test_mistral3_in_multi_modal_text_generation_models(self):
+        """Test that mistral3 is listed in MULTI_MODAL_TEXT_GENERATION_MODELS."""
+        from optimum.exporters.openvino.utils import MULTI_MODAL_TEXT_GENERATION_MODELS
+
+        self.assertIn(
+            "mistral3",
+            MULTI_MODAL_TEXT_GENERATION_MODELS,
+            "mistral3 not found in MULTI_MODAL_TEXT_GENERATION_MODELS",
+        )
+
+    @unittest.skipIf(
+        not is_transformers_version(">=", "4.52.0"),
+        "Mistral3OpenVINOConfig requires transformers >= 4.52.0",
+    )
+    def test_mistral3_openvino_config_importable(self):
+        """Test that Mistral3OpenVINOConfig can be imported from model_configs."""
+        from optimum.exporters.openvino.model_configs import Mistral3OpenVINOConfig
+
+        self.assertTrue(issubclass(Mistral3OpenVINOConfig, object))
+
+    @unittest.skipIf(
+        not is_transformers_version(">=", "4.52.0"),
+        "Mistral3OpenVINOConfig requires transformers >= 4.52.0",
+    )
+    def test_mistral3_openvino_config_min_transformers_version(self):
+        """Test that Mistral3OpenVINOConfig declares the correct minimum transformers version."""
+        from optimum.exporters.openvino.model_configs import Mistral3OpenVINOConfig
+
+        self.assertEqual(Mistral3OpenVINOConfig.MIN_TRANSFORMERS_VERSION, "4.52.0")

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -140,6 +140,7 @@ MODEL_NAMES = {
     "minicpmo": "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
     "mistral": "optimum-intel-internal-testing/tiny-random-mistral",
     "mistral-nemo": "optimum-intel-internal-testing/tiny-random-mistral-nemo",
+    "mistral3": "optimum-intel-internal-testing/tiny-random-mistral3",
     "mixtral": "optimum-intel-internal-testing/tiny-mixtral",
     "mixtral_awq": "optimum-intel-internal-testing/tiny-mixtral-AWQ-4bit",
     "mobilebert": "optimum-intel-internal-testing/tiny-random-MobileBertModel",


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary

Adds OpenVINO export support for `Mistral3ForConditionalGeneration` (`mistral3` model type) used by `mistralai/Mistral-Medium-3.5-128B`.

## Changes

- Adds `Mistral3OpenVINOConfig` to `model_configs.py` inheriting from `BaseVLMOpenVINOConfig`
- Registers `mistral3` for `image-text-to-text`, `text-generation`, `text-generation-with-past` tasks
- Adds `mistral3` to `MULTI_MODAL_TEXT_GENERATION_MODELS` in `utils.py`
- VLM split: vision (pixtral) → text embeddings (mistral) → language model (mistral)
- Language sub-model delegates to existing `MistralOpenVINOConfig` via `text_config.model_type = 'mistral'`

## Testing

```python
from optimum.exporters.tasks import TasksManager
export_config_class = TasksManager.get_exporter_config_constructor(
    exporter='openvino', model_type='mistral3', task='text-generation-with-past'
)
# Returns Mistral3OpenVINOConfig → SUCCESS
```

## Related

- MEAT pipeline issue: 849