### PR TITLE
[EXPERIMENT][WIP] Add OpenVINO export and inference support for FLUX.2-klein-4B (Flux2KleinPipeline)

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -737,6 +737,22 @@ def export_from_model(
             elif hasattr(subcomponent, "config") and hasattr(subcomponent.config, "save_pretrained"):
                 subcomponent.config.save_pretrained(output / model_name)
 
+        # For Flux2KleinPipeline, save the VAE batch-norm running statistics so that
+        # OVFlux2KleinPipeline can normalize latents correctly without the original model.
+        if getattr(model, "__class__", None) and model.__class__.__name__ == "Flux2KleinPipeline":
+            import numpy as _np
+
+            _vae = getattr(model, "vae", None)
+            if _vae is not None and hasattr(_vae, "bn"):
+                _bn_path = output / "vae_decoder" / "bn_stats.npz"
+                _bn_path.parent.mkdir(parents=True, exist_ok=True)
+                _np.savez(
+                    str(_bn_path),
+                    running_mean=_vae.bn.running_mean.float().numpy(),
+                    running_var=_vae.bn.running_var.float().numpy(),
+                )
+                logger.info(f"Saved VAE batch-norm statistics to {_bn_path}")
+
         files_subpaths = [os.path.join(name_dir, OV_XML_FILE_NAME) for name_dir in models_and_export_configs]
 
         # Saving the additional components needed to perform inference.
@@ -1011,7 +1027,8 @@ def get_diffusion_models_for_export_ext(
 ):
     is_sdxl = pipeline.__class__.__name__.startswith("StableDiffusionXL")
     is_sd3 = pipeline.__class__.__name__.startswith("StableDiffusion3")
-    is_flux = pipeline.__class__.__name__.startswith("Flux")
+    is_flux2_klein = pipeline.__class__.__name__ == "Flux2KleinPipeline"
+    is_flux = pipeline.__class__.__name__.startswith("Flux") and not is_flux2_klein
     is_sana = pipeline.__class__.__name__.startswith("Sana")
     is_ltx_video = pipeline.__class__.__name__.startswith("LTX")
     is_sd = pipeline.__class__.__name__.startswith("StableDiffusion") and not is_sd3
@@ -1033,6 +1050,8 @@ def get_diffusion_models_for_export_ext(
 
     elif is_sd3:
         models_for_export = get_sd3_models_for_export(pipeline, exporter, int_dtype, float_dtype)
+    elif is_flux2_klein:
+        models_for_export = get_flux2_klein_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     elif is_flux:
         models_for_export = get_flux_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     elif is_sana:
@@ -1366,6 +1385,124 @@ def get_flux_models_for_export(pipeline, exporter, int_dtype, float_dtype):
         )
         export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
         models_for_export["text_encoder_2"] = (text_encoder_2, export_config)
+
+    return models_for_export
+
+
+import torch as _torch  # noqa: E402 — used by Qwen3TextEncoderForFlux2Klein
+
+
+class Qwen3TextEncoderForFlux2Klein(_torch.nn.Module):
+    """Wrapper around Qwen3ForCausalLM that stacks hidden states from specific
+    intermediate layers and returns the concatenated embeddings.
+
+    This matches the behaviour of ``Flux2KleinPipeline._get_qwen3_prompt_embeds``.
+    The output tensor has shape ``(batch, seq_len, num_layers * hidden_dim)`` and
+    is exported as ``last_hidden_state`` for compatibility with ``OVModelTextEncoder``.
+    """
+
+    HIDDEN_STATE_LAYERS = (9, 18, 27)
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        # Expose config so that the export tooling can inspect it
+        self.config = model.config
+
+    def forward(self, input_ids, attention_mask, **kwargs):
+        output = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            output_hidden_states=True,
+            use_cache=False,
+        )
+        # Stack selected intermediate layers: shape (B, num_layers, seq_len, hidden_dim)
+        out = _torch.stack([output.hidden_states[k] for k in self.HIDDEN_STATE_LAYERS], dim=1)
+        batch_size, num_channels, seq_len, hidden_dim = out.shape
+        # Reshape to (B, seq_len, num_layers * hidden_dim)
+        return out.permute(0, 2, 1, 3).reshape(batch_size, seq_len, num_channels * hidden_dim)
+
+
+def get_flux2_klein_models_for_export(pipeline, exporter, int_dtype, float_dtype):
+    """Build the ``models_for_export`` dict for ``Flux2KleinPipeline``.
+
+    Handles three sub-models:
+    - ``text_encoder``: ``Qwen3ForCausalLM`` wrapped in
+      ``Qwen3TextEncoderForFlux2Klein`` so the hidden-state stacking is baked into
+      the exported IR.
+    - ``transformer``: ``Flux2Transformer2DModel``, exported with the
+      ``flux2-klein-transformer`` config.
+    - ``vae_encoder`` / ``vae_decoder``: ``AutoencoderKLFlux2``, exported with the
+      standard vae configs (same API as ``AutoencoderKL``).
+    """
+    models_for_export = {}
+
+    # --- Text encoder ---
+    text_encoder = getattr(pipeline, "text_encoder", None)
+    if text_encoder is not None:
+        wrapped_encoder = Qwen3TextEncoderForFlux2Klein(text_encoder)
+        text_encoder_config_constructor = TasksManager.get_exporter_config_constructor(
+            model=wrapped_encoder,
+            exporter=exporter,
+            library_name="diffusers",
+            task="feature-extraction",
+            model_type="qwen3-text-encoder",
+        )
+        text_encoder_export_config = text_encoder_config_constructor(
+            text_encoder.config, int_dtype=int_dtype, float_dtype=float_dtype
+        )
+        text_encoder_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+        models_for_export["text_encoder"] = (wrapped_encoder, text_encoder_export_config)
+
+    # --- Transformer ---
+    transformer = pipeline.transformer
+    transformer.config.text_encoder_projection_dim = transformer.config.joint_attention_dim
+    transformer.config.requires_aesthetics_score = False
+    transformer.config.time_cond_proj_dim = None
+    export_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=transformer,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="flux2-klein-transformer",
+    )
+    transformer_export_config = export_config_constructor(
+        pipeline.transformer.config, int_dtype=int_dtype, float_dtype=float_dtype
+    )
+    transformer_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["transformer"] = (transformer, transformer_export_config)
+
+    # --- VAE Encoder ---
+    vae_encoder = copy.deepcopy(pipeline.vae)
+    vae_encoder.forward = lambda sample: {"latent_parameters": vae_encoder.encode(x=sample)["latent_dist"].parameters}
+    vae_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=vae_encoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="vae-encoder",
+    )
+    vae_encoder_export_config = vae_config_constructor(
+        vae_encoder.config, int_dtype=int_dtype, float_dtype=float_dtype
+    )
+    vae_encoder_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_encoder"] = (vae_encoder, vae_encoder_export_config)
+
+    # --- VAE Decoder ---
+    vae_decoder = copy.deepcopy(pipeline.vae)
+    vae_decoder.forward = lambda latent_sample: vae_decoder.decode(z=latent_sample)
+    vae_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=vae_decoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="vae-decoder",
+    )
+    vae_decoder_export_config = vae_config_constructor(
+        vae_decoder.config, int_dtype=int_dtype, float_dtype=float_dtype
+    )
+    vae_decoder_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_decoder"] = (vae_decoder, vae_decoder_export_config)
 
     return models_for_export
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -200,6 +200,7 @@ from .model_patcher import (
     Qwen2MoEPatcher,
     Qwen2VLLanguageModelPatcher,
     Qwen2VLVisionEmbMergerPatcher,
+    Qwen3DiffusionTextEncoderModelPatcher,
     Qwen3MoeModelPatcher,
     Qwen3NextModelPatcher,
     Qwen3VLLanguageModelPatcher,
@@ -313,6 +314,11 @@ def init_model_configs():
     if is_diffusers_available() and "text-to-video" not in TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS:
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-video"] = {}
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-video"]["ltx-video"] = "LTXPipeline"
+
+    if is_diffusers_available() and "text-to-image" in TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS:
+        TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["text-to-image"]["flux2-klein"] = "Flux2KleinPipeline"
+        if "text-to-image" not in TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS:
+            TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS["text-to-image"] = ("AutoPipelineForText2Image",)
 
     supported_model_types = [
         "_SUPPORTED_MODEL_TYPE",
@@ -2671,6 +2677,104 @@ class FluxTransformerOpenVINOConfig(SD3TransformerOpenVINOConfig):
         if getattr(self._normalized_config, "guidance_embeds", False):
             common_inputs["guidance"] = {0: "batch_size"}
         return common_inputs
+
+
+class DummyFlux2KleinTransformerInputGenerator(DummyFluxTransformerInputGenerator):
+    """Dummy input generator for Flux2Transformer2DModel.
+
+    Differences from standard FLUX:
+    - ``img_ids`` and ``txt_ids`` are 4D (T, H, W, L) instead of 3D (H, W, C).
+    - No ``pooled_projections`` input.
+    """
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "img_ids":
+            img_ids_height = self.height // 2
+            img_ids_width = self.width // 2
+            return self.random_int_tensor(
+                [self.batch_size, img_ids_height * img_ids_width, 4],
+                min_value=0,
+                max_value=min(img_ids_height, img_ids_width),
+                framework=framework,
+                dtype=float_dtype,
+            )
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+class DummyFlux2KleinTextInputGenerator(DummyFluxTextInputGenerator):
+    """Dummy input generator for Flux2Klein text inputs.
+
+    ``txt_ids`` has shape ``(batch, sequence_length, 4)`` instead of ``(sequence_length, 3)``.
+    """
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "txt_ids":
+            import torch
+
+            shape = [self.batch_size, self.sequence_length, 4]
+            dtype = DTYPE_MAPPER.pt(float_dtype)
+            return torch.full(shape, 0, dtype=dtype)
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+@register_in_tasks_manager("flux2-klein-transformer", *["semantic-segmentation"], library_name="diffusers")
+class Flux2KleinTransformerOpenVINOConfig(FluxTransformerOpenVINOConfig):
+    """Export config for Flux2Transformer2DModel used in Flux2KleinPipeline.
+
+    Key differences from standard FluxTransformerOpenVINOConfig:
+    - No ``pooled_projections`` input (Flux2Klein uses a single Qwen3 text encoder).
+    - ``img_ids`` and ``txt_ids`` are 4D tensors of shape ``(B, seq_len, 4)``.
+    """
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        DummyTransformerTimestpsInputGenerator,
+        DummyFlux2KleinTransformerInputGenerator,
+        DummyFlux2KleinTextInputGenerator,
+    )
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        image_size="sample_size",
+        num_channels="in_channels",
+        hidden_size="joint_attention_dim",
+        vocab_size="attention_head_dim",
+        allow_new=True,
+    )
+
+    @property
+    def inputs(self):
+        common_inputs = {}
+        common_inputs["hidden_states"] = {0: "batch_size", 1: "packed_height_width"}
+        common_inputs["encoder_hidden_states"] = {0: "batch_size", 1: "sequence_length"}
+        common_inputs["timestep"] = {0: "batch_size"}
+        common_inputs["txt_ids"] = {0: "batch_size", 1: "sequence_length"}
+        common_inputs["img_ids"] = {0: "batch_size", 1: "packed_height_width"}
+        if getattr(self._normalized_config, "guidance_embeds", False):
+            common_inputs["guidance"] = {0: "batch_size"}
+        return common_inputs
+
+
+@register_in_tasks_manager("qwen3-text-encoder", *["feature-extraction"], library_name="diffusers")
+class Qwen3TextEncoderForDiffusionOpenVINOConfig(CLIPTextOpenVINOConfig):
+    """Export config for Qwen3ForCausalLM used as text encoder in Flux2KleinPipeline.
+
+    The model is wrapped in a ``Qwen3TextEncoderForFlux2Klein`` instance that stacks
+    hidden states from layers 9, 18, and 27 and returns the concatenated embeddings
+    as ``last_hidden_state``.
+    """
+
+    _MODEL_PATCHER = Qwen3DiffusionTextEncoderModelPatcher
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "input_ids": {0: "batch_size", 1: "sequence_length"},
+            "attention_mask": {0: "batch_size", 1: "sequence_length"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "last_hidden_state": {0: "batch_size", 1: "sequence_length"},
+        }
 
 
 class LTXVaeDummyInputGenerator(DummyVisionInputGenerator):

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -4683,6 +4683,26 @@ class OVSeq2SeqModelPatcher(ModelPatcher):
             ALL_MASK_ATTENTION_FUNCTIONS.register("eager", eager_mask)
 
 
+class Qwen3DiffusionTextEncoderModelPatcher(OVDecoderModelPatcher):
+    """Patcher for ``Qwen3TextEncoderForFlux2Klein`` wrapper used in Flux2Klein diffusion pipeline.
+
+    The wrapper has a ``.model`` attribute pointing to the inner ``Qwen3ForCausalLM``.
+    We keep ``self._model`` as the wrapper throughout so that the base-class
+    ``__enter__`` patches the wrapper's ``forward`` (not the inner model's ``forward``).
+    The inner Qwen3 is a sub-module of the wrapper, so all module-level patches
+    (RoPE, attention, causal mask) are applied correctly when iterating
+    ``self._model.modules()``.
+
+    Keeping the wrapper's ``forward`` as the patched entry-point avoids an infinite
+    recursion that would otherwise occur if both the wrapper's ``forward`` (which calls
+    ``self.model``) and the inner model's ``forward`` (set to the same
+    ``ts_patched_forward``) end up calling each other.
+    """
+
+    # No __enter__/__exit__ overrides needed — OVDecoderModelPatcher operates on
+    # the wrapper, whose modules() iterator covers all inner Qwen3 layers.
+
+
 class SanaTextEncoderModelPatcher(ModelPatcher):
     def __enter__(self):
         super().__enter__()

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -19,6 +19,7 @@ import os
 import shutil
 from abc import abstractmethod
 from collections import OrderedDict
+from contextlib import contextmanager
 from pathlib import Path
 from tempfile import gettempdir
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -119,6 +120,12 @@ if is_diffusers_version(">=", "0.33.0"):
     from diffusers import SanaSprintPipeline
 else:
     SanaSprintPipeline = object
+
+
+try:
+    from diffusers import Flux2KleinPipeline
+except ImportError:
+    Flux2KleinPipeline = object
 
 
 if is_diffusers_version(">=", "0.35.0"):
@@ -1307,6 +1314,14 @@ class OVModelTransformer(OVPipelinePart):
 
         return ModelOutput(**model_outputs)
 
+    @contextmanager
+    def cache_context(self, name: str):
+        """No-op stub so that ``Flux2KleinPipeline.__call__`` can call
+        ``self.transformer.cache_context(...)`` without error.  The OV
+        transformer does not support KV caching for reference-image editing.
+        """
+        yield
+
 
 class OVModelVaeEncoder(OVPipelinePart):
     def __init__(self, *args, **kwargs):
@@ -1645,6 +1660,152 @@ class OVFluxFillPipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, Flu
     auto_model_class = FluxFillPipeline
 
 
+class OVFlux2KleinPipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, Flux2KleinPipeline):
+    """OpenVINO pipeline for ``Flux2KleinPipeline`` (text-to-image and image editing).
+
+    Overrides ``_get_qwen3_prompt_embeds`` so the OV text encoder — which already
+    stacks the Qwen3 hidden states — is called correctly.  Also loads the VAE
+    batch-norm running statistics saved at export time and attaches them to
+    ``self.vae`` so that ``Flux2KleinPipeline.__call__`` can normalise latents.
+    """
+
+    main_input_name = "prompt"
+    export_feature = "text-to-image"
+    auto_model_class = Flux2KleinPipeline
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._attach_vae_bn_stats()
+
+    def _attach_vae_bn_stats(self):
+        """Load VAE batch-norm stats saved at export time and attach a proxy
+        ``bn`` object to ``self.vae`` so that ``Flux2KleinPipeline.__call__``
+        can normalise latents without the original ``AutoencoderKLFlux2``.
+        """
+        import numpy as _np
+        import types as _types
+
+        bn_path = Path(self.model_save_dir) / "vae_decoder" / "bn_stats.npz"
+        if not bn_path.is_file():
+            logger.warning(
+                f"VAE batch-norm stats file not found at {bn_path}. "
+                "Latent normalisation will use zeros/ones. Re-export with updated optimum-intel to fix this."
+            )
+            running_mean = torch.zeros(128)
+            running_var = torch.ones(128)
+        else:
+            data = _np.load(str(bn_path))
+            running_mean = torch.from_numpy(data["running_mean"])
+            running_var = torch.from_numpy(data["running_var"])
+
+        bn_proxy = _types.SimpleNamespace(running_mean=running_mean, running_var=running_var)
+        self.vae.bn = bn_proxy
+
+    @staticmethod
+    def _get_qwen3_prompt_embeds(
+        text_encoder,
+        tokenizer,
+        prompt,
+        dtype=None,
+        device=None,
+        max_sequence_length: int = 512,
+        hidden_states_layers=None,  # unused for OV; stacking is done at export time
+    ):
+        """Encode a prompt using the OV Qwen3 text encoder.
+
+        The exported IR already bakes in the hidden-state stacking, so we simply
+        tokenise the prompt, run a forward pass, and return ``last_hidden_state``.
+        """
+        import torch
+
+        if isinstance(prompt, str):
+            prompt = [prompt]
+
+        all_input_ids = []
+        all_attention_masks = []
+
+        for single_prompt in prompt:
+            messages = [{"role": "user", "content": single_prompt}]
+            text = tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+                enable_thinking=False,
+            )
+            inputs = tokenizer(
+                text,
+                return_tensors="pt",
+                padding="max_length",
+                truncation=True,
+                max_length=max_sequence_length,
+            )
+            all_input_ids.append(inputs["input_ids"])
+            all_attention_masks.append(inputs["attention_mask"])
+
+        input_ids = torch.cat(all_input_ids, dim=0)
+        attention_mask = torch.cat(all_attention_masks, dim=0)
+
+        if device is not None:
+            input_ids = input_ids.to(device)
+            attention_mask = attention_mask.to(device)
+
+        output = text_encoder(input_ids=input_ids, attention_mask=attention_mask)
+        # The OV text encoder returns the stacked embeddings directly as last_hidden_state
+        prompt_embeds = output.last_hidden_state
+
+        if dtype is not None:
+            prompt_embeds = prompt_embeds.to(dtype=dtype)
+
+        return prompt_embeds
+
+    def _reshape_transformer(
+        self,
+        model: "openvino.Model",
+        batch_size: int = -1,
+        height: int = -1,
+        width: int = -1,
+        num_images_per_prompt: int = -1,
+        tokenizer_max_length: int = -1,
+        num_frames: int = -1,
+    ):
+        """Override to handle Flux2Klein's 4D img_ids/txt_ids (T,H,W,L coords)."""
+        if batch_size == -1 or num_images_per_prompt == -1:
+            batch_size = -1
+        else:
+            batch_size *= num_images_per_prompt
+
+        height = height // self.vae_scale_factor if height > 0 else height
+        width = width // self.vae_scale_factor if width > 0 else width
+        packed_height = height // 2 if height > 0 else height
+        packed_width = width // 2 if width > 0 else width
+        packed_height_width = packed_width * packed_height if height > 0 and width > 0 else -1
+
+        shapes = {}
+        for inputs in model.inputs:
+            shapes[inputs] = inputs.get_partial_shape()
+            name = inputs.get_any_name()
+            if name in ["timestep", "guidance"]:
+                shapes[inputs][0] = batch_size
+            elif name == "hidden_states":
+                in_channels = self.transformer.config.get("in_channels", None)
+                if in_channels is None:
+                    in_channels = shapes[inputs][2]
+                shapes[inputs] = [batch_size, packed_height_width, in_channels]
+            elif name == "encoder_hidden_states":
+                shapes[inputs] = [batch_size, -1, shapes[inputs][2]]
+            elif name == "img_ids":
+                # Flux2Klein uses (B, H*W, 4) — batch-major 4-coord ids
+                shapes[inputs] = [batch_size, packed_height_width, 4]
+            elif name == "txt_ids":
+                # Flux2Klein uses (B, seq_len, 4)
+                shapes[inputs] = [batch_size, -1, 4]
+            else:
+                shapes[inputs][0] = batch_size
+                shapes[inputs][1] = -1
+        model.reshape(shapes)
+        return model
+
+
 class OVSanaPipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, SanaPipeline):
     main_input_name = "prompt"
     export_feature = "text-to-image"
@@ -1747,6 +1908,10 @@ if is_diffusers_version(">=", "0.32.0"):
 if is_diffusers_version(">=", "0.33.0"):
     SUPPORTED_OV_PIPELINES.append(OVSanaSprintPipeline)
     OV_TEXT2IMAGE_PIPELINES_MAPPING["sana-sprint"] = OVSanaSprintPipeline
+
+if Flux2KleinPipeline is not object:
+    SUPPORTED_OV_PIPELINES.append(OVFlux2KleinPipeline)
+    OV_TEXT2IMAGE_PIPELINES_MAPPING["flux2-klein"] = OVFlux2KleinPipeline
 
 SUPPORTED_OV_PIPELINES_MAPPINGS = [
     OV_TEXT2IMAGE_PIPELINES_MAPPING,


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.


## Summary

Adds full OpenVINO IR export and inference support for `black-forest-labs/FLUX.2-klein-4B` (`Flux2KleinPipeline` from diffusers ≥ 0.38).

> **Note**: `Flux2KleinPipeline` requires `diffusers` installed from git (`pip install git+https://github.com/huggingface/diffusers.git`) as it is not yet in a PyPI release.

## Model Architecture

| Component | Class | Notes |
|-----------|-------|-------|
| Text encoder | `Qwen3ForCausalLM` | Hidden states from layers 9, 18, 27 stacked → shape `(B, seq, 7680)` |
| Transformer | `Flux2Transformer2DModel` | No `pooled_projections`; 4-D `img_ids`/`txt_ids` (T,H,W,L coords) |
| VAE | `AutoencoderKLFlux2` | Requires `bn.running_mean`/`running_var` for latent normalisation |

## Files Changed

### `optimum/exporters/openvino/model_patcher.py`
- **`Qwen3DiffusionTextEncoderModelPatcher`** — extends `OVDecoderModelPatcher` with no `__enter__`/`__exit__` overrides.  The wrapper exposes its inner `Qwen3ForCausalLM` as `.model`, so `modules()` iteration covers all inner layers.  Overriding `__enter__` to swap `self._model` caused infinite recursion (wrapper's forward → inner Qwen3's patched forward → wrapper's forward …).

### `optimum/exporters/openvino/model_configs.py`
- **`DummyFlux2KleinTransformerInputGenerator`** — generates 4-D `img_ids`/`txt_ids`.
- **`Flux2KleinTransformerOpenVINOConfig`** — registered as `flux2-klein-transformer`.
- **`Qwen3TextEncoderForDiffusionOpenVINOConfig`** — registered as `qwen3-text-encoder`.
- `init_model_configs` updated to register the `flux2-klein` pipeline mapping.

### `optimum/exporters/openvino/convert.py`
- **`Qwen3TextEncoderForFlux2Klein`** wrapper — stacks hidden states from layers 9/18/27 into `last_hidden_state` of shape `(B, seq, 7680)`.
- **`get_flux2_klein_models_for_export`** — builds the models dict and saves `vae_decoder/bn_stats.npz` (VAE batch-norm running stats needed at inference).
- `get_diffusion_models_for_export_ext` — routes `Flux2KleinPipeline` before the generic `is_flux` check.

### `optimum/intel/openvino/modeling_diffusion.py`
- **`OVFlux2KleinPipeline`** — `OVDiffusionPipeline` subclass with:
  - `_get_qwen3_prompt_embeds` override (OV encoder returns stacked embeddings as `last_hidden_state`).
  - `_reshape_transformer` override (handles `img_ids`/`txt_ids` as `(B, hw, 4)`).
  - `_attach_vae_bn_stats` — loads `bn_stats.npz` and proxies `self.vae.bn`.
- **`cache_context`** no-op context-manager stub on `OVModelTransformer` (called by `Flux2KleinPipeline.__call__`).
- Registered in `SUPPORTED_OV_PIPELINES` and `OV_TEXT2IMAGE_PIPELINES_MAPPING`.

## Usage

```bash
pip install git+https://github.com/huggingface/diffusers.git
optimum-cli export openvino -m black-forest-labs/FLUX.2-klein-4B --task text-to-image ./flux2-klein-ir
```

```python
from optimum.intel import OVDiffusionPipeline
pipeline = OVDiffusionPipeline.from_pretrained('./flux2-klein-ir')
image = pipeline(prompt='a cat sitting on a table', height=512, width=512).images[0]
```

## Testing

Export and inference tested locally on CPU.  Inference produces a valid PIL image at 256×256 and 512×512 resolutions with `num_inference_steps=2`.

Tracking issue: 853