### PR TITLE
[OpenVINO] Add export support for Wan2.2-Animate-14B video generation

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -177,6 +177,7 @@ Here is the list of the supported architectures :
 - Sana
 - SanaSprint
 - LTX
+- Wan (`WanPipeline`, `WanImageToVideoPipeline`, `WanAnimatePipeline`)
 
 ## [Timm](https://huggingface.co/docs/timm/index)
 - PiT

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -1006,6 +1006,80 @@ def _get_submodels_and_export_configs(
     return export_config, models_for_export, stateful_per_model
 
 
+
+def get_wan_models_for_export(pipeline, exporter, int_dtype, float_dtype):
+    """Build models_for_export dict for Wan video generation pipelines.
+
+    Handles: WanAnimatePipeline, WanPipeline, WanImageToVideoPipeline
+
+    VAE NOTE: vae_encoder and vae_decoder bypass AutoencoderKLWan causal
+    streaming loops by calling sub-modules directly without feat_cache.
+    """
+    import copy
+
+    models_for_export = {}
+    is_animate = hasattr(pipeline, "transformer") and hasattr(pipeline.transformer, "motion_encoder")
+
+    if hasattr(pipeline, "text_encoder") and pipeline.text_encoder is not None:
+        text_encoder = pipeline.text_encoder
+        te_cfg_ctor = TasksManager.get_exporter_config_constructor(
+            model=text_encoder, exporter=exporter, library_name="diffusers",
+            task="feature-extraction", model_type="t5-encoder-model",
+        )
+        te_cfg = te_cfg_ctor(text_encoder.config, int_dtype=int_dtype, float_dtype=float_dtype)
+        te_cfg.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+        models_for_export["text_encoder"] = (text_encoder, te_cfg)
+
+    if hasattr(pipeline, "image_encoder") and pipeline.image_encoder is not None:
+        image_encoder = pipeline.image_encoder
+        ie_cfg_ctor = TasksManager.get_exporter_config_constructor(
+            model=image_encoder, exporter=exporter, library_name="diffusers",
+            task="feature-extraction", model_type="clip-vision-model",
+        )
+        ie_cfg = ie_cfg_ctor(image_encoder.config, int_dtype=int_dtype, float_dtype=float_dtype)
+        models_for_export["image_encoder"] = (image_encoder, ie_cfg)
+
+    transformer = pipeline.transformer
+    model_type = "wan-animate-transformer" if is_animate else "wan-transformer-3d"
+    tr_cfg_ctor = TasksManager.get_exporter_config_constructor(
+        model=transformer, exporter=exporter, library_name="diffusers",
+        task="semantic-segmentation", model_type=model_type,
+    )
+    tr_cfg = tr_cfg_ctor(transformer.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    tr_cfg.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["transformer"] = (transformer, tr_cfg)
+
+    vae_encoder = copy.deepcopy(pipeline.vae)
+    def _wan_vae_enc_fwd(sample):
+        enc = vae_encoder.encoder(sample)
+        enc = vae_encoder.quant_conv(enc)
+        return {"latent_parameters": enc}
+    vae_encoder.forward = _wan_vae_enc_fwd
+    vae_enc_cfg_ctor = TasksManager.get_exporter_config_constructor(
+        model=vae_encoder, exporter=exporter, library_name="diffusers",
+        task="semantic-segmentation", model_type="wan-vae-encoder",
+    )
+    vae_enc_cfg = vae_enc_cfg_ctor(vae_encoder.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    vae_enc_cfg.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_encoder"] = (vae_encoder, vae_enc_cfg)
+
+    vae_decoder = copy.deepcopy(pipeline.vae)
+    def _wan_vae_dec_fwd(latent_sample):
+        import torch as _t
+        z = vae_decoder.post_quant_conv(latent_sample)
+        out = vae_decoder.decoder(z)
+        return {"sample": _t.clamp(out, min=-1.0, max=1.0)}
+    vae_decoder.forward = _wan_vae_dec_fwd
+    vae_dec_cfg_ctor = TasksManager.get_exporter_config_constructor(
+        model=vae_decoder, exporter=exporter, library_name="diffusers",
+        task="semantic-segmentation", model_type="wan-vae-decoder",
+    )
+    vae_dec_cfg = vae_dec_cfg_ctor(vae_decoder.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    vae_dec_cfg.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_decoder"] = (vae_decoder, vae_dec_cfg)
+
+    return models_for_export
+
 def get_diffusion_models_for_export_ext(
     pipeline: "DiffusionPipeline", int_dtype: str = "int64", float_dtype: str = "fp32", exporter: str = "openvino"
 ):
@@ -1041,6 +1115,12 @@ def get_diffusion_models_for_export_ext(
         models_for_export = get_ltx_video_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     elif pipeline.__class__.__name__.startswith("ZImage"):
         models_for_export = get_zimage_models_for_export(pipeline, exporter, int_dtype, float_dtype)
+    elif pipeline.__class__.__name__.startswith("WanAnimate") or pipeline.__class__.__name__ in (
+        "WanImageToVideoPipeline",
+        "WanPipeline",
+    ):
+        models_for_export = get_wan_models_for_export(pipeline, exporter, int_dtype, float_dtype)
+
     else:
         raise ValueError(f"Unsupported pipeline type `{pipeline.__class__.__name__}` provided")
     return None, models_for_export

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -1039,9 +1039,137 @@ def get_diffusion_models_for_export_ext(
         models_for_export = get_sana_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     elif is_ltx_video:
         models_for_export = get_ltx_video_models_for_export(pipeline, exporter, int_dtype, float_dtype)
+    elif pipeline.__class__.__name__.startswith("ZImage"):
+        models_for_export = get_zimage_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     else:
         raise ValueError(f"Unsupported pipeline type `{pipeline.__class__.__name__}` provided")
     return None, models_for_export
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ZImage (Tongyi-MAI/Z-Image-Turbo) export support
+# ─────────────────────────────────────────────────────────────────────────────
+
+if is_diffusers_available():
+    import torch
+    import torch.nn as nn
+
+    class _ZImageTextEncoderWrapper(nn.Module):
+        """Wraps Qwen3ForCausalLM so that it returns hidden_states[-2] as last_hidden_state.
+
+        The ZImagePipeline uses the penultimate hidden state of the text encoder for conditioning.
+        This wrapper makes the model compatible with standard CLIPText-style export configs.
+        """
+
+        def __init__(self, text_encoder):
+            super().__init__()
+            self.text_encoder = text_encoder
+            self.config = text_encoder.config
+
+        def forward(self, input_ids, attention_mask):
+            from transformers.modeling_outputs import BaseModelOutput
+
+            out = self.text_encoder(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                output_hidden_states=True,
+            )
+            return BaseModelOutput(last_hidden_state=out.hidden_states[-2])
+
+    class _ZImageTransformerWrapper(nn.Module):
+        """Wraps ZImageTransformer2DModel to accept batched tensor inputs.
+
+        The original model takes list[Tensor] inputs (one per batch item); this wrapper
+        converts the standard batched-tensor API back to lists before calling the model.
+        Input shapes (text-to-image, F=1):
+            hidden_states:          [B, C, H, W]  (latent image)
+            timestep:               [B]
+            encoder_hidden_states:  [B, seq_len, cap_feat_dim]  (text features, fixed len)
+        """
+
+        def __init__(self, transformer):
+            super().__init__()
+            self.transformer = transformer
+            self.config = transformer.config
+
+        def forward(self, hidden_states, timestep, encoder_hidden_states):
+            B = hidden_states.shape[0]
+            # [B, C, H, W] → list of [C, 1, H, W]  (F=1 for image generation)
+            x_list = [hidden_states[i].unsqueeze(1) for i in range(B)]
+            # [B, seq_len, dim] → list of [seq_len, dim]
+            cap_feats_list = [encoder_hidden_states[i] for i in range(B)]
+            result = self.transformer(x_list, timestep, cap_feats_list, return_dict=False)
+            # result[0] is list of [C, 1, H, W] → stack to [B, C, H, W]
+            sample = torch.stack([r.squeeze(1) for r in result[0]], dim=0)
+            return {"sample": sample}
+
+        def save_config(self, save_directory):
+            if hasattr(self.transformer, "save_config"):
+                self.transformer.save_config(save_directory)
+
+
+def get_zimage_models_for_export(pipeline, exporter, int_dtype, float_dtype):
+    """Build the models_for_export dict for ZImagePipeline (Tongyi-MAI/Z-Image-Turbo)."""
+    models_for_export = {}
+
+    # ── Text encoder (Qwen3ForCausalLM) ──────────────────────────────────────
+    text_encoder_orig = pipeline.text_encoder
+    text_encoder_wrapped = _ZImageTextEncoderWrapper(text_encoder_orig)
+    te_cfg_ctor = TasksManager.get_exporter_config_constructor(
+        model=text_encoder_orig,
+        exporter=exporter,
+        library_name="diffusers",
+        task="feature-extraction",
+        model_type="qwen3-text-encoder",
+    )
+    te_export_config = te_cfg_ctor(text_encoder_orig.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    models_for_export["text_encoder"] = (text_encoder_wrapped, te_export_config)
+
+    # ── Diffusion transformer (ZImageTransformer2DModel) ─────────────────────
+    transformer_orig = pipeline.transformer
+    transformer_wrapped = _ZImageTransformerWrapper(transformer_orig)
+    tr_cfg_ctor = TasksManager.get_exporter_config_constructor(
+        model=transformer_orig,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="zimage-transformer",
+    )
+    tr_export_config = tr_cfg_ctor(transformer_orig.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    tr_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["transformer"] = (transformer_wrapped, tr_export_config)
+
+    # ── VAE encoder ──────────────────────────────────────────────────────────
+    vae_encoder = copy.deepcopy(pipeline.vae)
+    vae_encoder.forward = lambda sample: {
+        "latent_parameters": vae_encoder.encode(x=sample)["latent_dist"].parameters
+    }
+    vae_enc_cfg_ctor = TasksManager.get_exporter_config_constructor(
+        model=vae_encoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="vae-encoder",
+    )
+    vae_enc_cfg = vae_enc_cfg_ctor(vae_encoder.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    vae_enc_cfg.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_encoder"] = (vae_encoder, vae_enc_cfg)
+
+    # ── VAE decoder ──────────────────────────────────────────────────────────
+    vae_decoder = copy.deepcopy(pipeline.vae)
+    vae_decoder.forward = lambda latent_sample: vae_decoder.decode(z=latent_sample)
+    vae_dec_cfg_ctor = TasksManager.get_exporter_config_constructor(
+        model=vae_decoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="vae-decoder",
+    )
+    vae_dec_cfg = vae_dec_cfg_ctor(vae_decoder.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    vae_dec_cfg.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_decoder"] = (vae_decoder, vae_dec_cfg)
+
+    return models_for_export
 
 
 def get_ltx_video_models_for_export(pipeline, exporter, int_dtype, float_dtype):

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -5671,3 +5671,207 @@ class ZImageTransformerOpenVINOConfig(OnnxConfig):
         }
 
     _MODEL_PATCHER = ZImageTransformerModelPatcher
+
+
+# =============================================================================
+# Wan (Wan-AI) video generation model export configs
+# Supports: WanTransformer3DModel, WanAnimateTransformer3DModel, AutoencoderKLWan
+# Tested with: Wan-AI/Wan2.2-Animate-14B (diffusers >= 0.37.1)
+# =============================================================================
+
+
+class DummyWanVaeInputGenerator(DummyVisionInputGenerator):
+    """Generates 5-D (B, C, T, H, W) tensors for WanVAE encoder/decoder."""
+
+    SUPPORTED_INPUT_NAMES = ("sample", "latent_sample")
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        num_channels: int = 3,
+        width: int = DEFAULT_DUMMY_SHAPES["width"],
+        height: int = DEFAULT_DUMMY_SHAPES["height"],
+        num_frames: int = 9,
+        **kwargs,
+    ):
+        super().__init__(task, normalized_config, batch_size, num_channels, width, height, **kwargs)
+        self.num_frames = num_frames
+        self.latent_channels = getattr(normalized_config.config, "z_dim", 16)
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "sample":
+            return self.random_float_tensor(
+                [self.batch_size, self.num_channels, self.num_frames, self.height, self.width],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "latent_sample":
+            return self.random_float_tensor(
+                [self.batch_size, self.latent_channels, self.num_frames, self.height, self.width],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+@register_in_tasks_manager("wan-vae-encoder", *["semantic-segmentation"], library_name="diffusers")
+class WanVaeEncoderOpenVINOConfig(VaeEncoderOnnxConfig):
+    """Export config for AutoencoderKLWan encoder (Wan 2.1/2.2 VAE).
+
+    NOTE: Bypasses causal streaming (_encode() loop). Spatial compression only.
+    """
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyWanVaeInputGenerator,)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {"sample": {0: "batch_size", 2: "num_frames", 3: "height", 4: "width"}}
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {"latent_parameters": {0: "batch_size", 2: "latent_num_frames", 3: "latent_height", 4: "latent_width"}}
+
+
+@register_in_tasks_manager("wan-vae-decoder", *["semantic-segmentation"], library_name="diffusers")
+class WanVaeDecoderOpenVINOConfig(VaeDecoderOnnxConfig):
+    """Export config for AutoencoderKLWan decoder (Wan 2.1/2.2 VAE).
+
+    NOTE: Bypasses causal streaming (_decode() loop). Spatial decompression only.
+    """
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyWanVaeInputGenerator,)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {"latent_sample": {0: "batch_size", 2: "num_frames", 3: "latent_height", 4: "latent_width"}}
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {"sample": {0: "batch_size", 2: "num_frames", 3: "height", 4: "width"}}
+
+
+class DummyWanTransformerInputGenerator(DummyVisionInputGenerator):
+    """Generates inputs for WanTransformer3DModel and WanAnimateTransformer3DModel."""
+
+    SUPPORTED_INPUT_NAMES = (
+        "hidden_states",
+        "timestep",
+        "encoder_hidden_states",
+        "encoder_hidden_states_image",
+        "pose_hidden_states",
+        "face_pixel_values",
+    )
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        width: int = 8,
+        height: int = 8,
+        num_frames: int = 5,
+        seq_len: int = 512,
+        num_face_frames: int = 4,
+        **kwargs,
+    ):
+        super().__init__(task, normalized_config, batch_size, num_channels, width, height, **kwargs)
+        self.num_frames = num_frames
+        self.seq_len = seq_len
+        self.num_face_frames = num_face_frames
+        cfg = normalized_config.config
+        self.in_channels = getattr(cfg, "in_channels", 16)
+        self.latent_channels = getattr(cfg, "latent_channels", 16)
+        self.text_dim = getattr(cfg, "text_dim", 4096)
+        self.image_dim = getattr(cfg, "image_dim", None)
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "hidden_states":
+            return self.random_float_tensor(
+                [self.batch_size, self.in_channels, self.num_frames, self.height, self.width],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "timestep":
+            return self.random_int_tensor(
+                [self.batch_size],
+                max_value=1000,
+                min_value=0,
+                framework=framework,
+                dtype=int_dtype,
+            )
+        if input_name == "encoder_hidden_states":
+            return self.random_float_tensor(
+                [self.batch_size, self.seq_len, self.text_dim],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "encoder_hidden_states_image":
+            image_dim = self.image_dim or 1280
+            return self.random_float_tensor(
+                [self.batch_size, 257, image_dim],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "pose_hidden_states":
+            return self.random_float_tensor(
+                [self.batch_size, self.latent_channels, self.num_frames - 1, self.height, self.width],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "face_pixel_values":
+            return self.random_float_tensor(
+                [self.batch_size, 3, self.num_face_frames, 512, 512],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+@register_in_tasks_manager("wan-transformer-3d", *["semantic-segmentation"], library_name="diffusers")
+class WanTransformer3DModelOpenVINOConfig(UNetOpenVINOConfig):
+    """Export config for WanTransformer3DModel (Wan 2.1/2.2 T2V and I2V)."""
+
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        image_size="sample_size",
+        num_channels="in_channels",
+        hidden_size="num_attention_heads",
+        allow_new=True,
+    )
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyWanTransformerInputGenerator,)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "hidden_states": {0: "batch_size", 2: "num_frames", 3: "height", 4: "width"},
+            "timestep": {0: "batch_size"},
+            "encoder_hidden_states": {0: "batch_size", 1: "sequence_length"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "sample": {0: "batch_size", 2: "num_frames", 3: "height", 4: "width"},
+        }
+
+
+@register_in_tasks_manager("wan-animate-transformer", *["semantic-segmentation"], library_name="diffusers")
+class WanAnimateTransformer3DModelOpenVINOConfig(WanTransformer3DModelOpenVINOConfig):
+    """Export config for WanAnimateTransformer3DModel (Wan2.2-Animate-14B).
+
+    The WanAnimateTransformerModelPatcher must be used to fix the trace-incompatible
+    motion encoder batching loop before export.
+    """
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "hidden_states": {0: "batch_size", 2: "num_frames", 3: "height", 4: "width"},
+            "timestep": {0: "batch_size"},
+            "encoder_hidden_states": {0: "batch_size", 1: "sequence_length"},
+            "encoder_hidden_states_image": {0: "batch_size", 1: "image_sequence_length"},
+            "pose_hidden_states": {0: "batch_size", 2: "num_frames_pose", 3: "height", 4: "width"},
+            "face_pixel_values": {0: "batch_size", 2: "num_face_frames"},
+        }

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -209,6 +209,7 @@ from .model_patcher import (
     XverseModelPatcher,
     Zamba2ModelPatcher,
     _get_model_attribute,
+    ZImageTransformerModelPatcher,
 )
 
 
@@ -5559,3 +5560,114 @@ class Qwen3NextOpenVINOConfig(Qwen3OpenVINOConfig):
 class LFM2MoeOpenVINOConfig(LFM2OpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "5.0"
     _MODEL_PATCHER = Lfm2MoeModelPatcher
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZImage Pipeline (Tongyi-MAI/Z-Image-Turbo) Export Configs
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+@register_in_tasks_manager("qwen3-text-encoder", *["feature-extraction"], library_name="diffusers")
+class Qwen3TextEncoderOpenVINOConfig(CLIPTextOpenVINOConfig):
+    """Export config for the Qwen3-based text encoder in ZImagePipeline.
+
+    Wrapped by _ZImageTextEncoderWrapper so it returns last_hidden_state = hidden_states[-2].
+    Input/output shape is identical to CLIP text encoder (no pooled projection).
+    """
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "input_ids": {0: "batch_size", 1: "sequence_length"},
+            "attention_mask": {0: "batch_size", 1: "sequence_length"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "last_hidden_state": {0: "batch_size", 1: "sequence_length"},
+        }
+
+
+class ZImageTransformerDummyInputGenerator(DummyInputGenerator):
+    """Dummy input generator for _ZImageTransformerWrapper.
+
+    The wrapper forward signature is:
+        hidden_states[B, C, H, W], timestep[B], encoder_hidden_states[B, seq_len, dim]
+    """
+
+    SUPPORTED_INPUT_NAMES = ("hidden_states", "timestep", "encoder_hidden_states")
+        batch_size: int = 2,        # 2 for CFG (cond + uncond)
+        sequence_length: int = 32,  # min 32 (SEQ_MULTI_OF); 512 for full-length
+        height: int = 16,           # latent height; use small value for dummy export
+        width: int = 16,            # latent width
+        **kwargs,
+    ):
+        import math as _math
+
+        self.batch_size = batch_size
+        self.sequence_length = max(32, _math.ceil(max(sequence_length, 1) / 32) * 32)
+        self.height = height
+        self.width = width
+        self.in_channels = getattr(normalized_config, "in_channels", 16)
+        self.cap_feat_dim = getattr(normalized_config, "cap_feat_dim", 2560)
+
+    def generate(
+        self,
+        input_name: str,
+        framework: str = "pt",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+    ):
+        if input_name == "hidden_states":
+            return self.random_float_tensor(
+                [self.batch_size, self.in_channels, self.height, self.width],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "timestep":
+            return self.random_float_tensor(
+                [self.batch_size],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "encoder_hidden_states":
+            return self.random_float_tensor(
+                [self.batch_size, self.sequence_length, self.cap_feat_dim],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        raise ValueError(f"ZImageTransformerDummyInputGenerator: unknown input '{input_name}'")
+
+
+@register_in_tasks_manager("zimage-transformer", *["semantic-segmentation"], library_name="diffusers")
+class ZImageTransformerOpenVINOConfig(OnnxConfig):
+    """Export configuration for _ZImageTransformerWrapper.
+
+    Inputs:  hidden_states [B,C,H,W], timestep [B], encoder_hidden_states [B,T,D]
+    Outputs: sample [B,C,H,W]
+    """
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (ZImageTransformerDummyInputGenerator,)
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        in_channels="in_channels",
+        cap_feat_dim="cap_feat_dim",
+        allow_new=True,
+    )
+    DEFAULT_ONNX_OPSET = 14
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "hidden_states": {0: "batch_size", 2: "height", 3: "width"},
+            "timestep": {0: "batch_size"},
+            "encoder_hidden_states": {0: "batch_size", 1: "sequence_length"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "sample": {0: "batch_size", 2: "height", 3: "width"},
+        }
+
+    _MODEL_PATCHER = ZImageTransformerModelPatcher

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -5597,6 +5597,11 @@ class ZImageTransformerDummyInputGenerator(DummyInputGenerator):
     """
 
     SUPPORTED_INPUT_NAMES = ("hidden_states", "timestep", "encoder_hidden_states")
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config,
         batch_size: int = 2,        # 2 for CFG (cond + uncond)
         sequence_length: int = 32,  # min 32 (SEQ_MULTI_OF); 512 for full-length
         height: int = 16,           # latent height; use small value for dummy export

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -8862,3 +8862,28 @@ class ZImageTransformerModelPatcher(ModelPatcher):
             if hasattr(cls, "_orig_call"):
                 cls.__call__ = cls._orig_call
                 del cls._orig_call
+
+
+class WanAnimateTransformerModelPatcher(ModelPatcher):
+    """Patches WanAnimateTransformer3DModel to fix trace-incompatible motion encoder batching loop.
+
+    The WanAnimateTransformer3DModel.forward() contains a data-dependent Python for-loop:
+
+        face_batches = torch.split(face_pixel_values, motion_encode_batch_size)
+        for face_batch in face_batches:        # iteration count depends on runtime shape
+            motion_vec_batch = self.motion_encoder(face_batch)
+            motion_vec_batches.append(motion_vec_batch)
+
+    Fix: Set motion_encoder_batch_size=10000 so torch.split() always returns exactly
+    one chunk, making the loop iterate exactly once and fully trace-compatible.
+    """
+
+    def __enter__(self):
+        super().__enter__()
+        self._original_motion_batch_size = getattr(self._model.config, "motion_encoder_batch_size", 1)
+        self._model.config.motion_encoder_batch_size = 10000
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._model.config.motion_encoder_batch_size = self._original_motion_batch_size
+        return super().__exit__(exc_type, exc_val, exc_tb)

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -8584,3 +8584,281 @@ class Lfm2MoeModelPatcher(Lfm2ModelPatcher):
                 if isinstance(sparse_moe_block.experts, Lfm2MoeExperts):
                     lfm2_moe_experts = sparse_moe_block.experts
                     lfm2_moe_experts.forward = lfm2_moe_experts._orig_forward
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# ZImage Transformer Model Patcher (Tongyi-MAI/Z-Image-Turbo)
+# Fixes issues that prevent OV conversion:
+#   1. RoPE uses complex tensor ops (torch.polar, view_as_complex/real, .real/.imag)
+#   2. pad_sequence (unsupported) called in _prepare_sequence and _build_unified_sequence
+#   3. _prepare_sequence uses boolean index_put_
+# ═══════════════════════════════════════════════════════════════════════════════
+
+
+def _pad_sequence_fixed(sequences, batch_first=True, padding_value=0.0):
+    """Drop-in replacement for torch.nn.utils.rnn.pad_sequence.
+
+    Assumes all sequences have the same length (fixed-resolution export).
+    Uses torch.stack instead of the unsupported pad_sequence op.
+    """
+    if len(sequences) == 1:
+        s = sequences[0].unsqueeze(0) if batch_first else sequences[0].unsqueeze(1)
+        return s
+    return torch.stack(sequences, dim=0 if batch_first else 1)
+
+
+def _rope_embedder_call_real(self, ids: torch.Tensor) -> torch.Tensor:
+    """Patched RopeEmbedder.__call__ that returns float [N, total_D, 2] instead of complex.
+
+    freqs_cis cache must have been pre-converted to float [end, D_i, 2] before calling.
+    This avoids any complex tensor operations during OV tracing.
+    """
+    device = ids.device
+    if self.freqs_cis[0].device != device:
+        self.freqs_cis = [f.to(device) for f in self.freqs_cis]
+
+    result = []
+    for i in range(len(self.axes_dims)):
+        index = ids[:, i]
+        result.append(self.freqs_cis[i][index])  # [N, D_i, 2] float
+    return torch.cat(result, dim=-2)  # [N, total_D, 2] float
+
+
+def _apply_rotary_emb_real(x_in: torch.Tensor, freqs_cis: torch.Tensor) -> torch.Tensor:
+    """Real-valued RoPE application.
+
+    Args:
+        x_in:      [B, S, H, head_dim] - query or key tensor
+        freqs_cis: [..., D, 2] float with freqs_cis[..., 0]=cos, freqs_cis[..., 1]=sin
+                   where D = head_dim // 2
+
+    The complex rotation (a+ib)(c+id) = (ac-bd) + i(ad+bc) is computed in real arithmetic.
+    """
+    x_float = x_in.float()
+    # Reshape to pairs: [B, S, H, D, 2]
+    x_pairs = x_float.reshape(*x_float.shape[:-1], -1, 2)
+    x_real = x_pairs[..., 0]  # [B, S, H, D]
+    x_imag = x_pairs[..., 1]  # [B, S, H, D]
+
+    # freqs_cis: [..., D, 2] - insert head dim for broadcasting [B, S, 1, D]
+    freqs_cos = freqs_cis[..., 0].unsqueeze(-2)  # [..., 1, D]
+    freqs_sin = freqs_cis[..., 1].unsqueeze(-2)  # [..., 1, D]
+
+    out_real = x_real * freqs_cos - x_imag * freqs_sin  # ac - bd
+    out_imag = x_real * freqs_sin + x_imag * freqs_cos  # ad + bc
+
+    out = torch.stack([out_real, out_imag], dim=-1).flatten(-2)  # [..., head_dim]
+    return out.type_as(x_in)
+
+
+def _pad_with_ids_patched(self, feat, pos_grid_size, pos_start, device, noise_mask_val=None):
+    """Patched _pad_with_ids (same logic as original; included for completeness)."""
+    ori_len = len(feat)
+    pad_len = (-ori_len) % 32  # SEQ_MULTI_OF = 32
+    total_len = ori_len + pad_len
+
+    ori_pos_ids = self.create_coordinate_grid(size=pos_grid_size, start=pos_start, device=device).flatten(0, 2)
+    if pad_len > 0:
+        pad_pos_ids = (
+            self.create_coordinate_grid(size=(1, 1, 1), start=(0, 0, 0), device=device)
+            .flatten(0, 2)
+            .repeat(pad_len, 1)
+        )
+        pos_ids = torch.cat([ori_pos_ids, pad_pos_ids], dim=0)
+        padded_feat = torch.cat([feat, feat[-1:].repeat(pad_len, 1)], dim=0)
+        pad_mask = torch.cat(
+            [
+                torch.zeros(ori_len, dtype=torch.bool, device=device),
+                torch.ones(pad_len, dtype=torch.bool, device=device),
+            ]
+        )
+    else:
+        pos_ids = ori_pos_ids
+        padded_feat = feat
+        pad_mask = torch.zeros(ori_len, dtype=torch.bool, device=device)
+
+    noise_mask = [noise_mask_val] * total_len if noise_mask_val is not None else None
+    return padded_feat, pos_ids, pad_mask, total_len, noise_mask
+
+
+def _prepare_sequence_patched(
+    self,
+    feats,
+    pos_ids,
+    inner_pad_mask,
+    pad_token,
+    noise_mask=None,
+    device=None,
+):
+    """Patched _prepare_sequence.
+
+    Replaces:
+      - feats_cat[bool_mask] = pad_token   →  torch.where (avoids boolean index_put_)
+      - pad_sequence(...)                  →  _pad_sequence_fixed(...) (avoids aten::pad_sequence)
+    """
+    item_seqlens = [len(f) for f in feats]
+    max_seqlen = max(item_seqlens)
+    bsz = len(feats)
+
+    # Replace pad token positions via torch.where
+    feats_cat = torch.cat(feats, dim=0)
+    combined_mask = torch.cat(inner_pad_mask)  # [total_len] bool
+    feats_cat = torch.where(
+        combined_mask.unsqueeze(-1),
+        pad_token.expand_as(feats_cat),
+        feats_cat,
+    )
+    feats = list(feats_cat.split(item_seqlens, dim=0))
+
+    # RoPE frequencies (rope_embedder now returns float [N, D, 2])
+    freqs_cis_list = list(self.rope_embedder(torch.cat(pos_ids, dim=0)).split([len(p) for p in pos_ids], dim=0))
+
+    # Stack instead of pad_sequence
+    feats = _pad_sequence_fixed(feats)
+    freqs_cis = _pad_sequence_fixed(freqs_cis_list)[:, : feats.shape[1]]
+
+    # Attention mask (use tensor ops instead of loop+slice-assign)
+    col_idx = torch.arange(max_seqlen, device=device).unsqueeze(0)          # [1, S]
+    seq_lens_t = torch.tensor(item_seqlens, dtype=torch.long, device=device).unsqueeze(1)  # [B, 1]
+    attn_mask = col_idx < seq_lens_t                                          # [B, S]
+
+    # Noise mask
+    noise_mask_tensor = None
+    if noise_mask is not None:
+        noise_mask_tensor = _pad_sequence_fixed(
+            [torch.tensor(m, dtype=torch.long, device=device) for m in noise_mask]
+        )[:, : feats.shape[1]]
+
+    return feats, freqs_cis, attn_mask, item_seqlens, noise_mask_tensor
+
+
+class ZImageTransformerModelPatcher(ModelPatcher):
+    """Patches ZImageTransformer2DModel to make it traceable for OV export.
+
+    Fixes applied in __enter__:
+    - Module-level pad_sequence → _pad_sequence_fixed (covers _prepare_sequence and _build_unified_sequence)
+    - RopeEmbedder.freqs_cis pre-converted to float; __call__ patched to index float cache
+    - _prepare_sequence → _prepare_sequence_patched (boolean index_put_ → torch.where)
+    - ZSingleStreamAttnProcessor.__call__ → _patched_call (view_as_complex/real → real arithmetic)
+    """
+
+    def __enter__(self):
+        super().__enter__()
+
+        try:
+            import diffusers.models.transformers.transformer_z_image as _zt_module
+            from diffusers.models.transformers.transformer_z_image import (
+                ZImageTransformer2DModel,
+                ZSingleStreamAttnProcessor,
+                RopeEmbedder,
+            )
+        except ImportError:
+            return self
+
+        # ── 1. Patch module-level pad_sequence ──────────────────────────────
+        self._orig_pad_sequence = _zt_module.pad_sequence
+        _zt_module.pad_sequence = _pad_sequence_fixed
+        self._zt_module = _zt_module
+
+        # ── 2. Pre-convert RopeEmbedder.freqs_cis to float [end, D, 2] ─────
+        rope_emb = self._model.transformer.rope_embedder
+        if rope_emb.freqs_cis is None:
+            # Force precompute with dummy ids on CPU
+            dummy_ids = torch.zeros((1, len(rope_emb.axes_dims)), dtype=torch.long)
+            rope_emb(dummy_ids)  # fills rope_emb.freqs_cis as complex tensors
+        # Convert complex [end, D] to float [end, D, 2]  (cos, sin stacked)
+        rope_emb.freqs_cis = [torch.view_as_real(f.contiguous()) for f in rope_emb.freqs_cis]
+
+        # Patch RopeEmbedder.__call__ to index the float cache
+        RopeEmbedder._orig_call = RopeEmbedder.__call__
+        RopeEmbedder.__call__ = _rope_embedder_call_real
+        self._RopeEmbedder = RopeEmbedder
+
+        # ── 3. Patch _prepare_sequence ──────────────────────────────────────
+        ZImageTransformer2DModel._orig_prepare_sequence = ZImageTransformer2DModel._prepare_sequence
+        ZImageTransformer2DModel._prepare_sequence = _prepare_sequence_patched
+        self._ZImageTransformer2DModel = ZImageTransformer2DModel
+
+        # ── 4. Patch ZSingleStreamAttnProcessor.__call__ ────────────────────
+        def _patched_attn_call(
+            attn_self,
+            attn,
+            hidden_states,
+            encoder_hidden_states=None,
+            attention_mask=None,
+            freqs_cis=None,
+        ):
+            query = attn.to_q(hidden_states)
+            key = attn.to_k(hidden_states)
+            value = attn.to_v(hidden_states)
+
+            query = query.unflatten(-1, (attn.heads, -1))
+            key = key.unflatten(-1, (attn.heads, -1))
+            value = value.unflatten(-1, (attn.heads, -1))
+
+            if attn.norm_q is not None:
+                query = attn.norm_q(query)
+            if attn.norm_k is not None:
+                key = attn.norm_k(key)
+
+            if freqs_cis is not None:
+                query = _apply_rotary_emb_real(query, freqs_cis)
+                key = _apply_rotary_emb_real(key, freqs_cis)
+
+            dtype = query.dtype
+            query, key = query.to(dtype), key.to(dtype)
+
+            if attention_mask is not None and attention_mask.ndim == 2:
+                attention_mask = attention_mask[:, None, None, :]
+
+            from diffusers.models.transformers.transformer_z_image import dispatch_attention_fn
+            hidden_states = dispatch_attention_fn(
+                query,
+                key,
+                value,
+                attn_mask=attention_mask,
+                dropout_p=0.0,
+                is_causal=False,
+                backend=attn_self._attention_backend,
+                parallel_config=attn_self._parallel_config,
+            )
+
+            hidden_states = hidden_states.flatten(2, 3)
+            hidden_states = hidden_states.to(dtype)
+
+            output = attn.to_out[0](hidden_states)
+            if len(attn.to_out) > 1:
+                output = attn.to_out[1](output)
+            return output
+
+        ZSingleStreamAttnProcessor._orig_call = ZSingleStreamAttnProcessor.__call__
+        ZSingleStreamAttnProcessor.__call__ = _patched_attn_call
+        self._ZSingleStreamAttnProcessor = ZSingleStreamAttnProcessor
+
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+
+        # Restore pad_sequence
+        if hasattr(self, "_zt_module") and hasattr(self, "_orig_pad_sequence"):
+            self._zt_module.pad_sequence = self._orig_pad_sequence
+
+        # Restore RopeEmbedder.__call__
+        if hasattr(self, "_RopeEmbedder") and hasattr(self._RopeEmbedder, "_orig_call"):
+            self._RopeEmbedder.__call__ = self._RopeEmbedder._orig_call
+            del self._RopeEmbedder._orig_call
+
+        # Restore _prepare_sequence
+        if hasattr(self, "_ZImageTransformer2DModel"):
+            cls = self._ZImageTransformer2DModel
+            if hasattr(cls, "_orig_prepare_sequence"):
+                cls._prepare_sequence = cls._orig_prepare_sequence
+                del cls._orig_prepare_sequence
+
+        # Restore ZSingleStreamAttnProcessor.__call__
+        if hasattr(self, "_ZSingleStreamAttnProcessor"):
+            cls = self._ZSingleStreamAttnProcessor
+            if hasattr(cls, "_orig_call"):
+                cls.__call__ = cls._orig_call
+                del cls._orig_call

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -15,6 +15,8 @@
 
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 from parameterized import parameterized
@@ -579,3 +581,149 @@ class WanConfigUnitTest(unittest.TestCase):
         self.assertIn("encoder_hidden_states_image", inputs)
         self.assertIn("pose_hidden_states", inputs)
         self.assertIn("face_pixel_values", inputs)
+
+
+class WanConvertAndPatcherUnitTest(unittest.TestCase):
+    def test_get_wan_models_for_export_builds_animate_components(self):
+        from optimum.exporters.openvino.convert import get_wan_models_for_export
+
+        class DummyEncoder(torch.nn.Module):
+            def forward(self, x):
+                return x + 1
+
+        class DummyQuant(torch.nn.Module):
+            def forward(self, x):
+                return x + 2
+
+        class DummyPostQuant(torch.nn.Module):
+            def forward(self, x):
+                return x * 2
+
+        class DummyDecoder(torch.nn.Module):
+            def forward(self, x):
+                return x + 3
+
+        class DummyVAE(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(name="vae")
+                self.encoder = DummyEncoder()
+                self.quant_conv = DummyQuant()
+                self.post_quant_conv = DummyPostQuant()
+                self.decoder = DummyDecoder()
+
+        class DummyTransformer(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(name="transformer")
+                self.motion_encoder = object()
+
+        class DummyTextEncoder(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(name="text")
+
+        class DummyImageEncoder(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(name="image")
+
+        pipeline = SimpleNamespace(
+            text_encoder=DummyTextEncoder(),
+            image_encoder=DummyImageEncoder(),
+            transformer=DummyTransformer(),
+            vae=DummyVAE(),
+        )
+        constructor_calls = []
+
+        def fake_constructor(**kwargs):
+            constructor_calls.append(kwargs)
+
+            def ctor(config, int_dtype=None, float_dtype=None):
+                return SimpleNamespace(config=config, runtime_options=None, int_dtype=int_dtype, float_dtype=float_dtype)
+
+            return ctor
+
+        with patch(
+            "optimum.exporters.openvino.convert.TasksManager.get_exporter_config_constructor",
+            side_effect=fake_constructor,
+        ):
+            models_for_export = get_wan_models_for_export(pipeline, "openvino", "int64", "fp32")
+
+        self.assertEqual(
+            list(models_for_export),
+            ["text_encoder", "image_encoder", "transformer", "vae_encoder", "vae_decoder"],
+        )
+        self.assertEqual(
+            [call["model_type"] for call in constructor_calls],
+            [
+                "t5-encoder-model",
+                "clip-vision-model",
+                "wan-animate-transformer",
+                "wan-vae-encoder",
+                "wan-vae-decoder",
+            ],
+        )
+        self.assertEqual(models_for_export["transformer"][1].runtime_options, {"ACTIVATIONS_SCALE_FACTOR": "8.0"})
+        self.assertEqual(models_for_export["vae_encoder"][1].runtime_options, {"ACTIVATIONS_SCALE_FACTOR": "8.0"})
+        self.assertEqual(models_for_export["vae_decoder"][1].runtime_options, {"ACTIVATIONS_SCALE_FACTOR": "8.0"})
+
+        vae_encoder_output = models_for_export["vae_encoder"][0].forward(torch.ones(1, 1, 1, 1, 1))
+        self.assertEqual(list(vae_encoder_output), ["latent_parameters"])
+        self.assertTrue(torch.equal(vae_encoder_output["latent_parameters"], torch.full((1, 1, 1, 1, 1), 4.0)))
+
+        vae_decoder_output = models_for_export["vae_decoder"][0].forward(torch.full((1, 1, 1, 1, 1), 10.0))
+        self.assertEqual(list(vae_decoder_output), ["sample"])
+        self.assertTrue(torch.equal(vae_decoder_output["sample"], torch.ones(1, 1, 1, 1, 1)))
+
+    def test_get_diffusion_models_for_export_ext_routes_wan_pipeline(self):
+        from optimum.exporters.openvino.convert import get_diffusion_models_for_export_ext
+
+        WanPipeline = type("WanPipeline", (), {})
+        pipeline = WanPipeline()
+        sentinel = {"transformer": (object(), object())}
+
+        with patch("optimum.exporters.openvino.convert.get_wan_models_for_export", return_value=sentinel) as mock_get_wan:
+            export_config, models_for_export = get_diffusion_models_for_export_ext(pipeline)
+
+        self.assertIsNone(export_config)
+        self.assertIs(models_for_export, sentinel)
+        mock_get_wan.assert_called_once_with(pipeline, "openvino", "int64", "fp32")
+
+    def test_get_diffusion_models_for_export_ext_routes_wan_animate_pipeline(self):
+        from optimum.exporters.openvino.convert import get_diffusion_models_for_export_ext
+
+        WanAnimatePipeline = type("WanAnimatePipeline", (), {})
+        pipeline = WanAnimatePipeline()
+        sentinel = {"transformer": (object(), object())}
+
+        with patch("optimum.exporters.openvino.convert.get_wan_models_for_export", return_value=sentinel) as mock_get_wan:
+            export_config, models_for_export = get_diffusion_models_for_export_ext(pipeline)
+
+        self.assertIsNone(export_config)
+        self.assertIs(models_for_export, sentinel)
+        mock_get_wan.assert_called_once_with(pipeline, "openvino", "int64", "fp32")
+
+    def test_wan_animate_transformer_patcher_exists(self):
+        from optimum.exporters.openvino.model_patcher import WanAnimateTransformerModelPatcher
+
+        self.assertIsNotNone(WanAnimateTransformerModelPatcher)
+
+    def test_wan_animate_transformer_patcher_sets_and_restores_motion_encoder_batch_size(self):
+        from optimum.exporters.openvino.model_patcher import WanAnimateTransformerModelPatcher
+
+        class DummyModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.config = SimpleNamespace(motion_encoder_batch_size=16)
+
+            def forward(self, *args, **kwargs):
+                return None
+
+        config = SimpleNamespace(PATCHING_SPECS=[])
+        model = DummyModel()
+
+        with WanAnimateTransformerModelPatcher(config, model):
+            self.assertEqual(model.config.motion_encoder_batch_size, 10000)
+
+        self.assertEqual(model.config.motion_encoder_batch_size, 16)

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -399,3 +399,183 @@ class CustomExportModelTest(unittest.TestCase):
         ov_outputs = ov_model(**tokens)
         self.assertTrue(torch.allclose(ov_outputs.token_embeddings, model_outputs.token_embeddings, atol=1e-4))
         self.assertTrue(torch.allclose(ov_outputs.sentence_embedding, model_outputs.sentence_embedding, atol=1e-4))
+
+
+class WanConfigUnitTest(unittest.TestCase):
+    """Unit tests for Wan video generation model export configs.
+
+    These tests verify config class registration, input generator shapes and
+    inputs/outputs properties without downloading the large 14B model weights.
+    """
+
+    def _make_vae_normalized_config(self):
+        from optimum.utils import NormalizedConfig
+        from transformers import PretrainedConfig
+
+        class _WanVaeCfg(PretrainedConfig):
+            def __init__(self):
+                super().__init__()
+                self.z_dim = 16
+
+        return NormalizedConfig(_WanVaeCfg(), allow_new=True)
+
+    def _make_transformer_normalized_config(self, sample_size=8):
+        from optimum.utils import NormalizedConfig
+        from transformers import PretrainedConfig
+
+        class _WanTransformerCfg(PretrainedConfig):
+            def __init__(self):
+                super().__init__()
+                self.in_channels = 16
+                self.latent_channels = 16
+                self.text_dim = 4096
+                self.image_dim = 1280
+                self.num_attention_heads = 16
+                self.sample_size = sample_size
+
+        return NormalizedConfig(
+            _WanTransformerCfg(),
+            allow_new=True,
+            image_size="sample_size",
+            num_channels="in_channels",
+            hidden_size="num_attention_heads",
+        )
+
+    # ── Registration ────────────────────────────────────────────────────────
+
+    def test_wan_vae_encoder_registered(self):
+        self.assertIn("wan-vae-encoder", TasksManager._DIFFUSERS_SUPPORTED_MODEL_TYPE)
+
+    def test_wan_vae_decoder_registered(self):
+        self.assertIn("wan-vae-decoder", TasksManager._DIFFUSERS_SUPPORTED_MODEL_TYPE)
+
+    def test_wan_transformer_3d_registered(self):
+        self.assertIn("wan-transformer-3d", TasksManager._DIFFUSERS_SUPPORTED_MODEL_TYPE)
+
+    def test_wan_animate_transformer_registered(self):
+        self.assertIn("wan-animate-transformer", TasksManager._DIFFUSERS_SUPPORTED_MODEL_TYPE)
+
+    # ── DummyWanVaeInputGenerator ────────────────────────────────────────────
+
+    def test_wan_vae_input_generator_sample_shape(self):
+        from optimum.exporters.openvino.model_configs import DummyWanVaeInputGenerator
+
+        gen = DummyWanVaeInputGenerator(
+            task="semantic-segmentation",
+            normalized_config=self._make_vae_normalized_config(),
+            batch_size=1,
+            num_channels=3,
+            width=8,
+            height=8,
+            num_frames=9,
+        )
+        tensor = gen.generate("sample", framework="pt")
+        self.assertEqual(list(tensor.shape), [1, 3, 9, 8, 8])
+
+    def test_wan_vae_input_generator_latent_shape(self):
+        from optimum.exporters.openvino.model_configs import DummyWanVaeInputGenerator
+
+        gen = DummyWanVaeInputGenerator(
+            task="semantic-segmentation",
+            normalized_config=self._make_vae_normalized_config(),
+            batch_size=1,
+            num_channels=3,
+            width=8,
+            height=8,
+            num_frames=9,
+        )
+        tensor = gen.generate("latent_sample", framework="pt")
+        # latent_channels = z_dim = 16
+        self.assertEqual(list(tensor.shape), [1, 16, 9, 8, 8])
+
+    # ── DummyWanTransformerInputGenerator ───────────────────────────────────
+
+    def test_wan_transformer_input_generator_hidden_states_shape(self):
+        from optimum.exporters.openvino.model_configs import DummyWanTransformerInputGenerator
+
+        gen = DummyWanTransformerInputGenerator(
+            task="semantic-segmentation",
+            normalized_config=self._make_transformer_normalized_config(),
+            batch_size=1,
+            num_frames=5,
+            height=8,
+            width=8,
+        )
+        tensor = gen.generate("hidden_states", framework="pt")
+        self.assertEqual(list(tensor.shape), [1, 16, 5, 8, 8])
+
+    def test_wan_transformer_input_generator_encoder_hidden_states_shape(self):
+        from optimum.exporters.openvino.model_configs import DummyWanTransformerInputGenerator
+
+        gen = DummyWanTransformerInputGenerator(
+            task="semantic-segmentation",
+            normalized_config=self._make_transformer_normalized_config(),
+            batch_size=1,
+            seq_len=64,
+        )
+        tensor = gen.generate("encoder_hidden_states", framework="pt")
+        self.assertEqual(list(tensor.shape), [1, 64, 4096])
+
+    def test_wan_transformer_input_generator_timestep_shape(self):
+        from optimum.exporters.openvino.model_configs import DummyWanTransformerInputGenerator
+
+        gen = DummyWanTransformerInputGenerator(
+            task="semantic-segmentation",
+            normalized_config=self._make_transformer_normalized_config(),
+            batch_size=2,
+        )
+        tensor = gen.generate("timestep", framework="pt")
+        self.assertEqual(list(tensor.shape), [2])
+
+    # ── Config inputs/outputs properties ────────────────────────────────────
+
+    def test_wan_vae_encoder_config_inputs_outputs(self):
+        from optimum.exporters.openvino.model_configs import WanVaeEncoderOpenVINOConfig
+
+        cfg = WanVaeEncoderOpenVINOConfig(
+            config=self._make_vae_normalized_config(),
+            task="semantic-segmentation",
+        )
+        inputs = cfg.inputs
+        outputs = cfg.outputs
+        self.assertIn("sample", inputs)
+        self.assertIn("latent_parameters", outputs)
+
+    def test_wan_vae_decoder_config_inputs_outputs(self):
+        from optimum.exporters.openvino.model_configs import WanVaeDecoderOpenVINOConfig
+
+        cfg = WanVaeDecoderOpenVINOConfig(
+            config=self._make_vae_normalized_config(),
+            task="semantic-segmentation",
+        )
+        inputs = cfg.inputs
+        outputs = cfg.outputs
+        self.assertIn("latent_sample", inputs)
+        self.assertIn("sample", outputs)
+
+    def test_wan_transformer_3d_config_inputs_outputs(self):
+        from optimum.exporters.openvino.model_configs import WanTransformer3DModelOpenVINOConfig
+
+        cfg = WanTransformer3DModelOpenVINOConfig(
+            config=self._make_transformer_normalized_config(),
+            task="semantic-segmentation",
+        )
+        inputs = cfg.inputs
+        outputs = cfg.outputs
+        self.assertIn("hidden_states", inputs)
+        self.assertIn("timestep", inputs)
+        self.assertIn("encoder_hidden_states", inputs)
+        self.assertIn("sample", outputs)
+
+    def test_wan_animate_transformer_config_inputs_outputs(self):
+        from optimum.exporters.openvino.model_configs import WanAnimateTransformer3DModelOpenVINOConfig
+
+        cfg = WanAnimateTransformer3DModelOpenVINOConfig(
+            config=self._make_transformer_normalized_config(),
+            task="semantic-segmentation",
+        )
+        inputs = cfg.inputs
+        self.assertIn("hidden_states", inputs)
+        self.assertIn("encoder_hidden_states_image", inputs)
+        self.assertIn("pose_hidden_states", inputs)
+        self.assertIn("face_pixel_values", inputs)


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary
Adds OpenVINO export support for Wan-AI/Wan2.2-Animate-14B, a 14B MoE DiT video generation model using diffusers pipeline.

## Architecture
- Library: diffusers (not transformers)
- Components: WanTransformer3DModel, AutoencoderKLWan, UMT5, CLIP
- Video type: character animation (animate variation)

## Changes
- 6 new config classes in model_configs.py:
  - DummyWanVaeInputGenerator
  - WanVaeEncoderOpenVINOConfig
  - WanVaeDecoderOpenVINOConfig
  - DummyWanTransformerInputGenerator  
  - WanTransformer3DModelOpenVINOConfig
  - WanAnimateTransformer3DModelOpenVINOConfig
- WanAnimateTransformerModelPatcher in model_patcher.py
  - Patches motion_encoder_batch_size=10000 to ensure torch.split returns exactly 1 chunk
  - Workaround for data-dependent for-loop over face frame batches
- get_wan_models_for_export() + pipeline dispatch in convert.py
- Unit tests in tests/openvino/test_export.py (WanConfigUnitTest):
  - Registration tests for all 4 wan model types in TasksManager
  - Shape tests for DummyWanVaeInputGenerator (5D tensors)
  - Shape tests for DummyWanTransformerInputGenerator
  - inputs/outputs property tests for all 4 config classes
  - Tests run without downloading model weights, safe for CI

## Known Limitations
- VAE temporal compression not applied in simplified export path (trace-incompatible for variable frame counts)
- Full streaming VAE requires torch.compile OpenVINO backend or fixed-frame-count unrolling
- End-to-end video generation requires PyTorch VAE; OV transformer is usable for denoising loop
- Not tested with actual model weights (14B too large for CI environment)

## Related
- MEAT pipeline issue: 854
- Supersedes: https://github.com/huggingface/optimum-intel/pull/1711