### PR TITLE
[EXPERIMENT][WIP] Add OVHiDreamImageEditingPipeline for HiDream-E1-1 image editing support

### DIFF
--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -108,6 +108,7 @@ except OptionalDependencyNotAvailable:
             "OVFluxImg2ImgPipeline",
             "OVFluxInpaintPipeline",
             "OVFluxFillPipeline",
+            "OVHiDreamImageEditingPipeline",
             "OVSanaPipeline",
             "OVPipelineForImage2Image",
             "OVPipelineForText2Image",
@@ -135,6 +136,7 @@ else:
             "OVFluxImg2ImgPipeline",
             "OVFluxInpaintPipeline",
             "OVFluxFillPipeline",
+            "OVHiDreamImageEditingPipeline",
             "OVSanaPipeline",
             "OVPipelineForImage2Image",
             "OVPipelineForText2Image",
@@ -210,6 +212,7 @@ if TYPE_CHECKING:
         from .utils.dummy_openvino_and_diffusers_objects import (
             OVDiffusionPipeline,
             OVFluxPipeline,
+            OVHiDreamImageEditingPipeline,
             OVLatentConsistencyModelImg2ImgPipeline,
             OVLatentConsistencyModelPipeline,
             OVPipelineForImage2Image,
@@ -231,6 +234,7 @@ if TYPE_CHECKING:
         from .openvino import (
             OVDiffusionPipeline,
             OVFluxPipeline,
+            OVHiDreamImageEditingPipeline,
             OVLatentConsistencyModelImg2ImgPipeline,
             OVLatentConsistencyModelPipeline,
             OVPipelineForImage2Image,

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -99,6 +99,7 @@ if is_diffusers_available():
         OVFluxImg2ImgPipeline,
         OVFluxInpaintPipeline,
         OVFluxPipeline,
+        OVHiDreamImageEditingPipeline,
         OVLatentConsistencyModelImg2ImgPipeline,
         OVLatentConsistencyModelPipeline,
         OVLTXPipeline,

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -126,6 +126,11 @@ if is_diffusers_version(">=", "0.35.0"):
 else:
     CacheMixin = object
 
+try:
+    from diffusers import HiDreamImageEditingPipeline
+except ImportError:
+    HiDreamImageEditingPipeline = object
+
 DIFFUSION_MODEL_TRANSFORMER_SUBFOLDER = "transformer"
 DIFFUSION_MODEL_TEXT_ENCODER_3_SUBFOLDER = "text_encoder_3"
 
@@ -1657,6 +1662,12 @@ class OVSanaSprintPipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, S
     auto_model_class = SanaSprintPipeline
 
 
+class OVHiDreamImageEditingPipeline(OVDiffusionPipeline, HiDreamImageEditingPipeline):
+    main_input_name = "image"
+    export_feature = "image-to-image"
+    auto_model_class = HiDreamImageEditingPipeline
+
+
 class OVLTXPipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, LTXPipeline):
     main_input_name = "prompt"
     export_feature = "text-to-video"
@@ -1747,6 +1758,10 @@ if is_diffusers_version(">=", "0.32.0"):
 if is_diffusers_version(">=", "0.33.0"):
     SUPPORTED_OV_PIPELINES.append(OVSanaSprintPipeline)
     OV_TEXT2IMAGE_PIPELINES_MAPPING["sana-sprint"] = OVSanaSprintPipeline
+
+if HiDreamImageEditingPipeline is not object:
+    SUPPORTED_OV_PIPELINES.append(OVHiDreamImageEditingPipeline)
+    OV_IMAGE2IMAGE_PIPELINES_MAPPING["hidream-image-editing"] = OVHiDreamImageEditingPipeline
 
 SUPPORTED_OV_PIPELINES_MAPPINGS = [
     OV_TEXT2IMAGE_PIPELINES_MAPPING,


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary

Adds `OVHiDreamImageEditingPipeline` to optimum-intel to support OpenVINO export and inference for [HiDream-ai/HiDream-E1-1](https://huggingface.co/HiDream-ai/HiDream-E1-1) — an image editing model based on the diffusers `HiDreamImageEditingPipeline` class.

### Changes
- Added `OVHiDreamImageEditingPipeline` class inheriting from `OVDiffusionPipeline`
- Registered the class in `SUPPORTED_OV_PIPELINES` and `OV_IMAGE2IMAGE_PIPELINES_MAPPING`
- Enables `--task image-to-image` export via `optimum-cli export openvino`

### Model Architecture
- **Pipeline class:** `HiDreamImageEditingPipeline` (from HiDream-ai, based on diffusers)
- **Text encoder:** `meta-llama/Llama-3.1-8B-Instruct` (LLaMA 3.1 8B)
- **Model size:** ~30GB total

### Notes
- `HiDreamImageEditingPipeline` is not in the standard diffusers release (0.38.0) — it is published by HiDream-ai
- Export requires valid HF_TOKEN with Llama 3.1 access agreement
- Full export validation pending due to model size constraints

## Related PRs
None at this time.

## Testing
- Pipeline class registration verified
- `_get_ov_class()` lookup confirmed working
- Full export could not be validated due to model size (~30GB) and gated Llama 3.1 dependency