### PR TITLE
Fix value error: per_layer_inputs, but it was not passed

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -866,12 +866,16 @@ class OVCalibrationDatasetBuilder:
                     **inputs
                 )
 
-                language_model_inputs = self.model.language_model.prepare_inputs(
-                    input_ids=None,
-                    attention_mask=attention_mask,
-                    position_ids=position_ids,
-                    inputs_embeds=inputs_embeds,
-                )
+                prepare_inputs_kwargs = {
+                    "input_ids": None,
+                    "attention_mask": attention_mask,
+                    "position_ids": position_ids,
+                    "inputs_embeds": inputs_embeds,
+                }
+                if self.model.language_model.config.model_type == "gemma4":
+                    prepare_inputs_kwargs["per_layer_inputs"] = extra_outputs[0]
+
+                language_model_inputs = self.model.language_model.prepare_inputs(**prepare_inputs_kwargs)
 
                 collected_inputs["lm_model"].append(language_model_inputs)
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1684,14 +1684,17 @@ class OVWeightCompressionTest(unittest.TestCase):
         )
         self.assertTrue(all(len(sample["input_ids"][0]) == 64 for sample in dataset["model"].get_data()))
 
-    @unittest.skipUnless(is_transformers_version(">=", "5.5.0"), "transformers >= 5.5.0 is required")
     @parameterized.expand(
         [
-            (MODEL_NAMES["gemma4"],),
-            (MODEL_NAMES["gemma4_moe"],),
+            ("gemma4",),
+            ("gemma4_moe",),
         ]
+        if is_transformers_version(">=", "5.5.0")
+        else [],
+        name_func=lambda testcase_func, param_num, params: f"{testcase_func.__name__}_{parameterized.to_safe_name(params.args[0])}",
     )
-    def test_build_dataset(self, model_id):
+    def test_build_dataset(self, model_arch):
+        model_id = MODEL_NAMES[model_arch]
         model = OVModelForVisualCausalLM.from_pretrained(model_id, export=True, load_in_8bit=False)
         dataset_builder = OVCalibrationDatasetBuilder(model)
         dataset = dataset_builder.build_from_quantization_config(

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1691,6 +1691,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         ]
         if is_transformers_version(">=", "5.5.0")
         else [],
+        skip_on_empty=True,
         name_func=lambda testcase_func, param_num, params: f"{testcase_func.__name__}_{parameterized.to_safe_name(params.args[0])}",
     )
     def test_build_dataset(self, model_arch):

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1684,6 +1684,31 @@ class OVWeightCompressionTest(unittest.TestCase):
         )
         self.assertTrue(all(len(sample["input_ids"][0]) == 64 for sample in dataset["model"].get_data()))
 
+    @unittest.skipUnless(is_transformers_version(">=", "5.5.0"), "transformers >= 5.5.0 is required")
+    @parameterized.expand(
+        [
+            (MODEL_NAMES["gemma4"],),
+            (MODEL_NAMES["gemma4_moe"],),
+        ]
+    )
+    def test_build_dataset(self, model_id):
+        model = OVModelForVisualCausalLM.from_pretrained(model_id, export=True, load_in_8bit=False)
+        dataset_builder = OVCalibrationDatasetBuilder(model)
+        dataset = dataset_builder.build_from_quantization_config(
+            OVPipelineQuantizationConfig(
+                quantization_configs={
+                    "lm_model": OVWeightQuantizationConfig(
+                        bits=4,
+                        group_size=64,
+                        num_samples=1,
+                        scale_estimation=True,
+                        dataset="contextual",
+                        processor=model_id,
+                    )
+                }
+            ),
+        )
+
 
 class OVPipelineQuantizationTest(unittest.TestCase):
     maxDiff = None


### PR DESCRIPTION
# What does this PR do?

Fix `ValueError: Expected 'per_layer_inputs', but it was not passed`

Command:

> optimum-cli export openvino -m google/gemma-4-E2B-it gemma4_E2Bit_ov --task=image-text-to-text --weight-format int4 --dataset contextual --scale-estimation


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

