### PR TITLE
[EXPERIMENT][WIP] Add OpenVINO export support for mistral3 model type

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -108,7 +108,9 @@ Here is the list of the supported architectures :
 - MiniCPM3
 - MiniCPM-o
 - MiniCPM-V
+- Ministral3
 - Mistral
+- Mistral3
 - Mixtral
 - MobileBERT
 - MobileNet v1

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -484,7 +484,9 @@ def main_export(
             task_model_loading = task
             if library_name == "transformers":
                 has_remote_code = hasattr(config, "auto_map")
-                if has_remote_code and trust_remote_code and task == "image-text-to-text":
+                if config.model_type == "mistral3" and task.startswith("text-generation"):
+                    task_model_loading = "image-text-to-text"
+                elif has_remote_code and trust_remote_code and task == "image-text-to-text":
                     task_model_loading = "text-generation"
 
             model = TasksManager.get_model_from_task(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -185,6 +185,7 @@ from .model_patcher import (
     MiniCPMModelPatcher,
     MiniCPMVImageEmbeddingsModelPatcher,
     MiniCPMVResamplerModelPatcher,
+    Mistral3ImageEmbeddingsModelPatcher,
     MistralModelPatcher,
     MixtralModelPatcher,
     MPTModelPatcher,
@@ -1457,6 +1458,21 @@ class MistralOpenVINOConfig(MistralOnnxConfig):
     ) + TextDecoderOnnxConfig.DUMMY_INPUT_GENERATOR_CLASSES
     DUMMY_PKV_GENERATOR_CLASS = OVMistralDummyPastKeyValuesGenerator
     _MODEL_PATCHER = MistralModelPatcher
+
+
+@register_in_tasks_manager(
+    "ministral3",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text-classification",
+    ],
+    library_name="transformers",
+)
+class Ministral3OpenVINOConfig(MistralOpenVINOConfig):
+    pass
 
 
 @register_in_tasks_manager(
@@ -4286,6 +4302,46 @@ class GotOCR2OpenVINOConfig(BaseVLMOpenVINOConfig):
         if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
             self._config = config.vision_config
             self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+
+
+@register_in_tasks_manager(
+    "mistral3", *["image-text-to-text", "text-generation", "text-generation-with-past"], library_name="transformers"
+)
+class Mistral3OpenVINOConfig(BaseVLMOpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "5.0.0"
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self._orig_config = config
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            self._config = config.vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+
+    def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
+        model_kwargs = model_kwargs or {}
+        if self._behavior != VLMConfigBehavior.VISION_EMBEDDINGS:
+            return super().patch_model_for_export(model, model_kwargs)
+        return Mistral3ImageEmbeddingsModelPatcher(self, model, model_kwargs)
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs) -> Dict:
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and self._config.model_type == "pixtral":
+            kwargs["batch_size"] = 1
+        return super().generate_dummy_inputs(framework, **kwargs)
 
 
 @register_in_tasks_manager("gemma3", *["image-text-to-text"], library_name="transformers")

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -3407,6 +3407,51 @@ def maira_vision_embed_forward(self, pixel_values):
     return self.get_image_features(pixel_values, vision_feature_layer, vision_feature_select_strategy)
 
 
+def mistral3_vision_embed_forward(self, pixel_values):
+    import torch
+
+    batch_size = pixel_values.shape[0]
+    image_sizes = torch.tensor(
+        [[pixel_values.shape[-2], pixel_values.shape[-1]]] * batch_size, dtype=torch.int64, device=pixel_values.device
+    )
+    outputs = self.get_image_features(pixel_values=pixel_values, image_sizes=image_sizes, return_dict=True)
+    return outputs.pooler_output if hasattr(outputs, "pooler_output") else outputs
+
+
+def mistral3_patch_merger_forward(self, image_features: torch.Tensor, image_sizes: torch.Tensor) -> torch.Tensor:
+    image_size = image_sizes[0]
+    h = image_size[0] // self.patch_size
+    w = image_size[1] // self.patch_size
+    d = image_features.shape[-1]
+    image_grid = image_features.view(h, w, d).permute(2, 0, 1).unsqueeze(0)
+    grid = torch.nn.functional.unfold(image_grid, kernel_size=self.spatial_merge_size, stride=self.spatial_merge_size)
+    grid = grid.view(d * self.spatial_merge_size**2, -1).t()
+    return self.merging_layer(grid)
+
+
+class Mistral3ImageEmbeddingsModelPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Dict[str, Any],
+    ):
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(mistral3_vision_embed_forward, model)
+        model.model.multi_modal_projector.patch_merger.__orig_forward = model.model.multi_modal_projector.patch_merger.forward
+        model.model.multi_modal_projector.patch_merger.forward = types.MethodType(
+            mistral3_patch_merger_forward, model.model.multi_modal_projector.patch_merger
+        )
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+        self._model.model.multi_modal_projector.patch_merger.forward = (
+            self._model.model.multi_modal_projector.patch_merger.__orig_forward
+        )
+
+
 class LlavaImageEmbeddingModelPatcher(ModelPatcher):
     def __init__(
         self,

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -304,6 +304,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "phi4_multimodal",
     "llama4",
     "minicpmo",
+    "mistral3",
 ]
 
 SSM_MODELS = ["mamba", "falcon_mamba", "zamba2", "lfm2", "lfm2_moe", "granitemoehybrid", "qwen3_next"]

--- a/tests/openvino/test_mistral3_export.py
+++ b/tests/openvino/test_mistral3_export.py
@@ -1,0 +1,88 @@
+# Copyright 2025 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from optimum.exporters.openvino.__main__ import main_export
+from optimum.exporters.openvino.model_configs import Mistral3OpenVINOConfig, Ministral3OpenVINOConfig
+from optimum.exporters.openvino.model_patcher import Mistral3ImageEmbeddingsModelPatcher
+from optimum.exporters.openvino.utils import MULTI_MODAL_TEXT_GENERATION_MODELS
+from optimum.exporters.tasks import TasksManager
+
+
+class Mistral3OpenVINORegistrationTest(unittest.TestCase):
+    def test_mistral3_tasks_manager_registration(self):
+        supported_tasks = TasksManager.get_supported_tasks_for_model_type(
+            "mistral3", exporter="openvino", library_name="transformers"
+        )
+
+        self.assertEqual(
+            sorted(supported_tasks.keys()),
+            ["image-text-to-text", "text-generation", "text-generation-with-past"],
+        )
+        self.assertIs(supported_tasks["image-text-to-text"].func, Mistral3OpenVINOConfig)
+        self.assertIs(supported_tasks["text-generation"].func, Mistral3OpenVINOConfig)
+        self.assertIs(supported_tasks["text-generation-with-past"].func, Mistral3OpenVINOConfig)
+
+    def test_ministral3_tasks_manager_registration(self):
+        supported_tasks = TasksManager.get_supported_tasks_for_model_type(
+            "ministral3", exporter="openvino", library_name="transformers"
+        )
+
+        self.assertEqual(
+            sorted(supported_tasks.keys()),
+            [
+                "feature-extraction",
+                "feature-extraction-with-past",
+                "text-classification",
+                "text-generation",
+                "text-generation-with-past",
+            ],
+        )
+        self.assertIs(supported_tasks["text-generation-with-past"].func, Ministral3OpenVINOConfig)
+
+    def test_mistral3_image_embeddings_patcher_is_importable(self):
+        self.assertIs(Mistral3ImageEmbeddingsModelPatcher, Mistral3ImageEmbeddingsModelPatcher)
+
+    def test_mistral3_is_marked_as_multimodal_text_generation_model(self):
+        self.assertIn("mistral3", MULTI_MODAL_TEXT_GENERATION_MODELS)
+
+    def test_main_export_uses_image_text_loader_for_mistral3_text_generation(self):
+        config = SimpleNamespace(
+            model_type="mistral3",
+            torch_dtype=None,
+            architectures=["Mistral3ForConditionalGeneration"],
+        )
+        sentinel = RuntimeError("stop after checking task redirection")
+
+        for task in ("text-generation", "text-generation-with-past"):
+            with self.subTest(task=task), patch(
+                "optimum.exporters.openvino.__main__.AutoConfig.from_pretrained", return_value=config
+            ), patch(
+                "optimum.exporters.openvino.__main__.TasksManager.get_model_from_task", side_effect=sentinel
+            ) as get_model_from_task:
+                with self.assertRaises(RuntimeError) as caught:
+                    main_export(
+                        model_name_or_path="stub-model",
+                        output=Path("tests/openvino/mistral3-export-stub"),
+                        task=task,
+                        library_name="transformers",
+                        local_files_only=True,
+                    )
+
+                self.assertIs(caught.exception, sentinel)
+                self.assertEqual(get_model_from_task.call_args.args[0], "image-text-to-text")

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -141,6 +141,7 @@ MODEL_NAMES = {
     "minicpmv": "optimum-intel-internal-testing/tiny-random-minicpmv-2_6",
     "minicpmo": "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
     "mistral": "optimum-intel-internal-testing/tiny-random-mistral",
+    "mistral3": "optimum-intel-internal-testing/tiny-random-mistral3",
     "mistral-nemo": "optimum-intel-internal-testing/tiny-random-mistral-nemo",
     "mixtral": "optimum-intel-internal-testing/tiny-mixtral",
     "mixtral_awq": "optimum-intel-internal-testing/tiny-mixtral-AWQ-4bit",


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

# What does this PR do?

Adds OpenVINO export support for `model_type=mistral3` and `model_type=ministral3` (`Mistral3ForConditionalGeneration`) in optimum-intel. This enables exporting and running `mistralai/Ministral-3-3B-Reasoning-2512` and similar Mistral3 family models with OpenVINO.

**Problem:** `mistralai/Ministral-3-3B-Reasoning-2512` uses `model_type=mistral3` which was previously unsupported in optimum-intel's OpenVINO export pipeline, resulting in:
```
ValueError: Trying to export a mistral3 model, that is a custom or unsupported architecture
```

**Solution:**
- Added `mistral3` and `ministral3` to the OV export task registry (mapping to existing mistral causal LM configs)
- Added model patcher support for the `Mistral3ForConditionalGeneration` class
- Updated documentation to list Mistral3/Ministral3 in supported models list

## Installation instructions

```bash
pip install git+https://github.com/mlukasze/optimum-intel.git@feat/add-mistral3-ov-export
```

## Exporting cmd-line

```bash
optimum-cli export openvino --model mistralai/Ministral-3-3B-Reasoning-2512 --task text-generation-with-past ./Ministral-3-3B-ov/
```

## Inference script

```python
from optimum.intel import OVModelForCausalLM
from transformers import AutoTokenizer

model = OVModelForCausalLM.from_pretrained("./Ministral-3-3B-ov/", device="CPU")
tokenizer = AutoTokenizer.from_pretrained("mistralai/Ministral-3-3B-Reasoning-2512")

inputs = tokenizer("What is OpenVINO?", return_tensors="pt")
output = model.generate(**inputs, max_new_tokens=100)
print(tokenizer.decode(output[0], skip_special_tokens=True))
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
