### PR TITLE
Compression configs for Qwen/Qwen3.5-35B-A3B and Qwen/Qwen3.6-35B-A3B

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -613,18 +613,12 @@ _DEFAULT_IGNORED_SCOPE_CONFIGS = {
     },
     "Qwen/Qwen3.5-35B-A3B": {
         "lm_model": {
-            "patterns": [
-                ".*shared_expert.*",
-                ".*attn.*"
-            ],
+            "patterns": [".*shared_expert.*", ".*attn.*"],
         },
     },
     "Qwen/Qwen3.6-35B-A3B": {
         "lm_model": {
-            "patterns": [
-                ".*shared_expert.*",
-                ".*attn.*"
-            ],
+            "patterns": [".*shared_expert.*", ".*attn.*"],
         },
     },
 }

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -449,19 +449,25 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "group_size_fallback": "adjust",
     },
     "Qwen/Qwen3.5-35B-A3B": {
-        "lm_model": {
-            "patterns": [
-                ".*shared_expert.*",
-                ".*attn.*"
-            ],
+        "quantization_configs": {
+            "lm_model": {
+                "bits": 4,
+                "sym": False,
+                "group_size": 128,
+            },
+            "text_embeddings_model": {"bits": 8, "sym": True, "weight_only": True},
+            "vision_embeddings_merger_model": {"bits": 8, "sym": True, "weight_only": True},
         },
     },
     "Qwen/Qwen3.6-35B-A3B": {
-        "lm_model": {
-            "patterns": [
-                ".*shared_expert.*",
-                ".*attn.*"
-            ],
+        "quantization_configs": {
+            "lm_model": {
+                "bits": 4,
+                "sym": False,
+                "group_size": 128,
+            },
+            "text_embeddings_model": {"bits": 8, "sym": True, "weight_only": True},
+            "vision_embeddings_merger_model": {"bits": 8, "sym": True, "weight_only": True},
         },
     },
 }

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -448,6 +448,28 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "group_size": 64,
         "group_size_fallback": "adjust",
     },
+    "Qwen/Qwen3.5-35B-A3B": {
+        "quantization_configs": {
+            "lm_model": {
+                "bits": 4,
+                "sym": False,
+                "group_size": 128,
+            },
+            "text_embeddings_model": {"bits": 8, "sym": True, "weight_only": True},
+            "vision_embeddings_merger_model": {"bits": 8, "sym": True, "weight_only": True},
+        },
+    },
+    "Qwen/Qwen3.6-35B-A3B": {
+        "quantization_configs": {
+            "lm_model": {
+                "bits": 4,
+                "sym": False,
+                "group_size": 128,
+            },
+            "text_embeddings_model": {"bits": 8, "sym": True, "weight_only": True},
+            "vision_embeddings_merger_model": {"bits": 8, "sym": True, "weight_only": True},
+        },
+    },
 }
 
 _DEFAULT_8BIT_WQ_CONFIGS = {
@@ -587,6 +609,22 @@ _DEFAULT_IGNORED_SCOPE_CONFIGS = {
     "google/gemma-4-26B-A4B": {
         "lm_model": {
             "patterns": [".*router.*"],
+        },
+    },
+    "Qwen/Qwen3.5-35B-A3B": {
+        "lm_model": {
+            "patterns": [
+                ".*shared_expert.*",
+                ".*attn.*"
+            ],
+        },
+    },
+    "Qwen/Qwen3.6-35B-A3B": {
+        "lm_model": {
+            "patterns": [
+                ".*shared_expert.*",
+                ".*attn.*"
+            ],
         },
     },
 }

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -449,25 +449,19 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "group_size_fallback": "adjust",
     },
     "Qwen/Qwen3.5-35B-A3B": {
-        "quantization_configs": {
-            "lm_model": {
-                "bits": 4,
-                "sym": False,
-                "group_size": 128,
-            },
-            "text_embeddings_model": {"bits": 8, "sym": True, "weight_only": True},
-            "vision_embeddings_merger_model": {"bits": 8, "sym": True, "weight_only": True},
+        "lm_model": {
+            "patterns": [
+                ".*shared_expert.*",
+                ".*attn.*"
+            ],
         },
     },
     "Qwen/Qwen3.6-35B-A3B": {
-        "quantization_configs": {
-            "lm_model": {
-                "bits": 4,
-                "sym": False,
-                "group_size": 128,
-            },
-            "text_embeddings_model": {"bits": 8, "sym": True, "weight_only": True},
-            "vision_embeddings_merger_model": {"bits": 8, "sym": True, "weight_only": True},
+        "lm_model": {
+            "patterns": [
+                ".*shared_expert.*",
+                ".*attn.*"
+            ],
         },
     },
 }


### PR DESCRIPTION
# What does this PR do?

Added compression configs for Qwen/Qwen3.5-35B-A3B and Qwen/Qwen3.6-35B-A3B significantly improving the accuracy for int8 and int4 versions.

Fixes # (issue): 181271, 181280, 182003


## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

