### PR TITLE
[EXPERIMENT][WIP] Fix Qwen3.6 linear attention reshape for OpenVINO export

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -141,6 +141,8 @@ Here is the list of the supported architectures :
 - Qwen3.5-MoE
 - Qwen3.6
 - Qwen3-Next
+
+Qwen3.5/Qwen3.6 text generation export uses an OpenVINO-friendly causal-mask path to keep stateful OpenVINO GenAI inference compatible with dynamic prompt lengths.
 - RemBERT
 - ResNet
 - RoBERTa

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -335,6 +335,20 @@ def main_export(
             patch_qwenvl_configs()
 
         model_type = config.model_type
+        if (
+            task.startswith("text-generation")
+            and model_type in {"qwen3_5", "qwen3_5_moe"}
+            and hasattr(config, "text_config")
+            and getattr(config.text_config, "model_type", None) in TasksManager._SUPPORTED_MODEL_TYPE
+        ):
+            text_model_type = config.text_config.model_type
+            text_model_tasks = TasksManager.get_supported_tasks_for_model_type(
+                text_model_type, exporter="openvino", library_name=library_name
+            )
+            if task in text_model_tasks:
+                loading_kwargs.setdefault("config", config.text_config)
+                model_type = text_model_type
+
         if model_type not in TasksManager._SUPPORTED_MODEL_TYPE:
             if custom_export_configs is None:
                 raise ValueError(

--- a/optimum/exporters/openvino/_ov_ops.py
+++ b/optimum/exporters/openvino/_ov_ops.py
@@ -104,10 +104,13 @@ def convert_recurrent_attention_cell(context):
     core_attn_out_new = loop.get_iter_value(core_attn_out_res.output(0), -1)
     last_recurrent_state_new = loop.get_iter_value(last_recurrent_state_res.output(0), -1)
 
-    flatten_shape = ops.constant([-1], dtype=np.int32)
-    core_attn_out_new = ops.reshape(core_attn_out_new, flatten_shape, False)
-    last_recurrent_state_new = ops.reshape(last_recurrent_state_new, flatten_shape, False)
-
-    final_output = ops.concat([core_attn_out_new, last_recurrent_state_new], 0)
+    # Concatenate along axis 2 (seq/key-head-dim axis) instead of flattening to 1D.
+    # core_attn_out_new: (B, H, T, D2), last_recurrent_state_new: (B, H, D1, D2)
+    # Combined output: (B, H, T+D1, D2)
+    #
+    # This avoids flattening+reshape which would require a reshape with two dynamic
+    # dimensions (batch and seq) — invalid in OpenVINO (only one -1 allowed per reshape).
+    # The downstream code splits using static negative indexing with the known D1=head_k_dim.
+    final_output = ops.concat([core_attn_out_new, last_recurrent_state_new], 2)
 
     return [final_output.output(0)]

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -5999,7 +5999,7 @@ class Qwen3_5TextOpenVINOConfig(Qwen3VLTextOpenVINOConfig):
     DUMMY_PKV_GENERATOR_CLASS = Qwen3_5DummyPastKeyValuesGenerator
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
     MIN_TRANSFORMERS_VERSION = "5.2.0"
-    MAX_TRANSFORMERS_VERSION = "5.2.99"
+    MAX_TRANSFORMERS_VERSION = "5.99.99"
     _MODEL_PATCHER = Qwen3_5ModelPatcher
 
     def add_past_key_values(self, inputs_or_outputs: Dict[str, Dict[int, str]], direction: str):
@@ -6060,6 +6060,18 @@ class Qwen3_5TextOpenVINOConfig(Qwen3VLTextOpenVINOConfig):
                     f'Could not generate dummy input for "{input_name}". Try adding a proper dummy input generator to the model ONNX config.'
                 )
 
+        if self.use_past_in_inputs and self.num_full_attn_layers > 0 and "attention_mask" in dummy_inputs:
+            past_present_length = (
+                dummy_inputs["input_ids"].shape[1]
+                + dummy_inputs["cache_params"][2 * self.num_linear_attn_layers].shape[2]
+            )
+            dummy_inputs["attention_mask"] = DummyInputGenerator.pad_input_on_dim(
+                dummy_inputs["attention_mask"],
+                desired_length=past_present_length,
+                dim=1,
+                dtype=dummy_inputs["attention_mask"].dtype,
+            )
+
         return dummy_inputs
 
 
@@ -6072,7 +6084,7 @@ class Qwen3_5OpenVINOConfig(Qwen3VLOpenVINOConfig):
     SUPPORTED_BEHAVIORS = [model_type.value for model_type in QwenVLConfigBehavior]
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3VLVisionEmbedInputGenerator,)
     MIN_TRANSFORMERS_VERSION = "5.2.0"
-    MAX_TRANSFORMERS_VERSION = "5.2.99"
+    MAX_TRANSFORMERS_VERSION = "5.99.99"
 
     def __init__(
         self,

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -8602,7 +8602,9 @@ def qwen3_next_gated_delta_net_forward(
         # NOTE: attention mask is a 2D boolean tensor
         if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
             dtype = hidden_states.dtype
-            hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
+            # Use unsqueeze instead of fancy indexing [:, :, None] to avoid OpenVINO conversion issues
+            # The fancy indexing creates complex Gather operations that fail with dynamic shapes
+            hidden_states = (hidden_states * attention_mask.unsqueeze(-1)).to(dtype)
 
         return hidden_states
 
@@ -8644,9 +8646,9 @@ def qwen3_next_gated_delta_net_forward(
         ],
         dim=-1,
     )
-    query = query.reshape(query.shape[0], query.shape[1], -1, self.head_k_dim)
-    key = key.reshape(key.shape[0], key.shape[1], -1, self.head_k_dim)
-    value = value.reshape(value.shape[0], value.shape[1], -1, self.head_v_dim)
+    query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
 
     beta = b.sigmoid()
     # If the model is loaded in fp16, without the .float() here, A might be -inf
@@ -8772,13 +8774,13 @@ class Qwen3NextModelPatcher(OVDecoderModelPatcher):
         model: "PreTrainedModel",
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
-        from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextDynamicCache
+        from transformers.cache_utils import DynamicCache
 
         from openvino.frontend.pytorch import ConversionExtension, ModuleExtension
 
         super().__init__(config, model, model_kwargs)
 
-        class Qwen3NextDynamicCacheWrap(Qwen3NextDynamicCache):
+        class Qwen3NextDynamicCacheWrap(DynamicCache):
             def __init__(self, config, conv_states, recurrent_states, key_cache, value_cache):
                 # Call parent constructor with all required arguments
                 super().__init__(config=config)
@@ -8789,15 +8791,19 @@ class Qwen3NextModelPatcher(OVDecoderModelPatcher):
                 self.value_cache = value_cache
                 self.full_attn_mapping = {}
                 self.linear_attn_mapping = {}
+                self.transformer_layers = list(range(len(config.layer_types)))
+                self.last_linear_layer = None
+                
                 full_attn_layer_idx = 0
                 linear_attn_layer_idx = 0
                 for i in range(len(config.layer_types)):
-                    if self.layer_types[i] == "full_attention":
+                    if config.layer_types[i] == "full_attention":
                         self.full_attn_mapping[i] = full_attn_layer_idx
                         full_attn_layer_idx += 1
-                    elif self.layer_types[i] == "linear_attention":
+                    elif config.layer_types[i] == "linear_attention":
                         self.linear_attn_mapping[i] = linear_attn_layer_idx
                         linear_attn_layer_idx += 1
+                        self.last_linear_layer = i
 
             def update(
                 self,
@@ -8821,12 +8827,18 @@ class Qwen3NextModelPatcher(OVDecoderModelPatcher):
                 """Returns the sequence length of the cached states. A layer index can be optionally passed."""
                 # take any layer that contains cache and not empty tensor
                 layer_idx = self.transformer_layers[0] if layer_idx not in self.transformer_layers else layer_idx
+                # Find first full attention layer
+                if layer_idx not in self.full_attn_mapping:
+                    # If the given layer is not a full attention layer, find the first full attention layer
+                    for idx in self.transformer_layers:
+                        if idx in self.full_attn_mapping:
+                            layer_idx = idx
+                            break
                 layer_idx = self.full_attn_mapping[layer_idx]
                 if len(self.key_cache) <= layer_idx or self.key_cache[layer_idx] is None:
                     return 0
                 return self.key_cache[layer_idx].shape[-2]
 
-            @property
             def has_previous_state(self):
                 """We have a previous state if the last linear (conv) layer was already updated."""
                 layer_idx = self.linear_attn_mapping[self.last_linear_layer]
@@ -8898,10 +8910,6 @@ class Qwen3NextModelPatcher(OVDecoderModelPatcher):
         self.conversion_extensions = [
             ConversionExtension("RecurrentAttentionCellOp", convert_recurrent_attention_cell),
         ]
-
-        from transformers.models.qwen3_5 import modeling_qwen3_5
-
-        self._orig_qwen3_5_create_causal_mask = modeling_qwen3_5.create_causal_mask
 
     def __enter__(self):
         from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextSparseMoeBlock
@@ -9171,7 +9179,9 @@ def qwen3_5_gated_delta_net_forward(
         # NOTE: attention mask is a 2D boolean tensor
         if attention_mask is not None and attention_mask.shape[1] > 1 and attention_mask.shape[0] > 1:
             dtype = hidden_states.dtype
-            hidden_states = (hidden_states * attention_mask[:, :, None]).to(dtype)
+            # Use unsqueeze instead of fancy indexing [:, :, None] to avoid OpenVINO conversion issues
+            # The fancy indexing creates complex Gather operations that fail with dynamic shapes
+            hidden_states = (hidden_states * attention_mask.unsqueeze(-1)).to(dtype)
 
         return hidden_states
 
@@ -9214,9 +9224,9 @@ def qwen3_5_gated_delta_net_forward(
         ],
         dim=-1,
     )
-    query = query.reshape(query.shape[0], query.shape[1], -1, self.head_k_dim)
-    key = key.reshape(key.shape[0], key.shape[1], -1, self.head_k_dim)
-    value = value.reshape(value.shape[0], value.shape[1], -1, self.head_v_dim)
+    query = query.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    key = key.reshape(batch_size, seq_len, -1, self.head_k_dim)
+    value = value.reshape(batch_size, seq_len, -1, self.head_v_dim)
 
     beta = b.sigmoid()
     # If the model is loaded in fp16, without the .float() here, A might be -inf
@@ -9258,7 +9268,7 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
         model: "PreTrainedModel",
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
-        from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5DynamicCache
+        from transformers.cache_utils import DynamicCache
 
         from openvino.frontend.pytorch import ConversionExtension, ModuleExtension
 
@@ -9275,7 +9285,7 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
             self._text_model = self._model.model
             self._text_config = self._model.model.config
 
-        class Qwen3_5DynamicCacheWrap(Qwen3_5DynamicCache):
+        class Qwen3_5DynamicCacheWrap(DynamicCache):
             def __init__(self, config, conv_states, recurrent_states, key_cache, value_cache):
                 # Call parent constructor with all required arguments
                 super().__init__(config=config)
@@ -9286,15 +9296,19 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
                 self.value_cache = value_cache
                 self.full_attn_mapping = {}
                 self.linear_attn_mapping = {}
+                self.transformer_layers = list(range(len(config.layer_types)))
+                self.last_linear_layer = None
+
                 full_attn_layer_idx = 0
                 linear_attn_layer_idx = 0
                 for i in range(len(config.layer_types)):
-                    if self.layer_types[i] == "full_attention":
+                    if config.layer_types[i] == "full_attention":
                         self.full_attn_mapping[i] = full_attn_layer_idx
                         full_attn_layer_idx += 1
-                    elif self.layer_types[i] == "linear_attention":
+                    elif config.layer_types[i] == "linear_attention":
                         self.linear_attn_mapping[i] = linear_attn_layer_idx
                         linear_attn_layer_idx += 1
+                        self.last_linear_layer = i
 
             def update(
                 self,
@@ -9318,15 +9332,26 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
                 """Returns the sequence length of the cached states. A layer index can be optionally passed."""
                 # take any layer that contains cache and not empty tensor
                 layer_idx = self.transformer_layers[0] if layer_idx not in self.transformer_layers else layer_idx
+                # Find first full attention layer
+                if layer_idx not in self.full_attn_mapping:
+                    # If the given layer is not a full attention layer, find the first full attention layer
+                    for idx in self.transformer_layers:
+                        if idx in self.full_attn_mapping:
+                            layer_idx = idx
+                            break
                 layer_idx = self.full_attn_mapping[layer_idx]
                 if len(self.key_cache) <= layer_idx or self.key_cache[layer_idx] is None:
                     return 0
                 return self.key_cache[layer_idx].shape[-2]
 
-            @property
-            def has_previous_state(self):
-                """We have a previous state if the last linear (conv) layer was already updated."""
-                layer_idx = self.linear_attn_mapping[self.last_linear_layer]
+            def get_mask_sizes(self, query_length: int, layer_idx: int) -> tuple[int, int]:
+                return self.get_seq_length(layer_idx) + query_length, 0
+
+            def has_previous_state(self, layer_idx: Optional[int] = None):
+                """We have a previous state if the requested linear layer cache is already populated."""
+                if layer_idx is None:
+                    layer_idx = self.last_linear_layer
+                layer_idx = self.linear_attn_mapping[layer_idx]
                 return self.conv_states[layer_idx] is not None
 
         # the patch is needed to include KV-cache, Conv, and SSM states in the inputs and outputs.
@@ -9379,6 +9404,7 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
                 causal_lm_output = self.model_orig_forward(
                     input_ids=input_ids,
                     attention_mask=attention_mask,
+                    position_ids=position_ids,
                     past_key_values=wrapped_cache_params,
                     use_cache=use_cache,
                 )
@@ -9412,6 +9438,10 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
         self.conversion_extensions = [
             ConversionExtension("RecurrentAttentionCellOp", convert_recurrent_attention_cell),
         ]
+
+        from transformers.models.qwen3_5 import modeling_qwen3_5
+
+        self._orig_qwen3_5_create_causal_mask = modeling_qwen3_5.create_causal_mask
 
     def __enter__(self):
         super().__enter__()

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -162,6 +162,64 @@ def patch_update_causal_mask(
             inner_model._update_causal_mask = types.MethodType(patch_fn, inner_model)
 
 
+def _create_causal_mask_ov_compatible(
+    config=None,
+    input_embeds=None,
+    inputs_embeds=None,
+    attention_mask=None,
+    cache_position=None,
+    past_key_values=None,
+    position_ids=None,
+    **kwargs,
+):
+    inputs_embeds = inputs_embeds if inputs_embeds is not None else input_embeds
+    if inputs_embeds is None:
+        raise ValueError("inputs_embeds or input_embeds must be provided")
+
+    batch_size, sequence_length = inputs_embeds.shape[:2]
+    dtype, device = inputs_embeds.dtype, inputs_embeds.device
+    min_dtype = torch.tensor(torch.finfo(torch.float16).min, device=device, dtype=dtype)
+
+    if cache_position is None:
+        if position_ids is not None:
+            if position_ids.ndim == 3:
+                cache_position = position_ids[0]
+            else:
+                cache_position = position_ids
+        else:
+            past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+            cache_position = torch.arange(
+                past_seen_tokens, past_seen_tokens + sequence_length, device=device, dtype=torch.long
+            )
+
+    if cache_position.ndim == 1:
+        cache_position = cache_position.unsqueeze(0).expand(batch_size, -1)
+    elif cache_position.ndim == 3:
+        cache_position = cache_position[0]
+
+    past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+    target_length = (
+        attention_mask.shape[-1] if isinstance(attention_mask, torch.Tensor) else past_seen_tokens + sequence_length
+    )
+
+    key_positions = torch.arange(target_length, device=device, dtype=cache_position.dtype).view(1, 1, -1)
+    query_positions = cache_position[:, :, None]
+    blocked = key_positions > query_positions
+    causal_mask = torch.where(
+        blocked[:, None, :, :],
+        min_dtype,
+        torch.zeros((batch_size, 1, sequence_length, target_length), dtype=dtype, device=device),
+    )
+
+    if attention_mask is not None:
+        if attention_mask.shape[-1] < target_length:
+            attention_mask = F.pad(attention_mask, (0, target_length - attention_mask.shape[-1]), value=0)
+        padding_mask = attention_mask[:, None, None, :target_length].to(torch.bool)
+        causal_mask = torch.where(padding_mask, causal_mask, min_dtype)
+
+    return causal_mask
+
+
 # adopted from https://github.com/huggingface/transformers/blob/f4014e75db0190792b3feeccfc5dc5b5f9f0ce7b/src/transformers/models/llama/modeling_llama.py#L1036
 def _update_causal_mask_patched(
     self,
@@ -8841,6 +8899,10 @@ class Qwen3NextModelPatcher(OVDecoderModelPatcher):
             ConversionExtension("RecurrentAttentionCellOp", convert_recurrent_attention_cell),
         ]
 
+        from transformers.models.qwen3_5 import modeling_qwen3_5
+
+        self._orig_qwen3_5_create_causal_mask = modeling_qwen3_5.create_causal_mask
+
     def __enter__(self):
         from transformers.models.qwen3_next.modeling_qwen3_next import Qwen3NextSparseMoeBlock
 
@@ -9355,6 +9417,10 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
         super().__enter__()
         setattr(self._model, self.orig_forward_name, self.patched_forward)
 
+        from transformers.models.qwen3_5 import modeling_qwen3_5
+
+        modeling_qwen3_5.create_causal_mask = _create_causal_mask_ov_compatible
+
         for idx, decoder_layer in enumerate(self._text_model.layers):
             layer_type = self._text_config.layer_types[idx]
             if layer_type == "linear_attention":
@@ -9367,6 +9433,11 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
         setattr(self._model, self.orig_forward_name, self.model_orig_forward)
+
+        from transformers.models.qwen3_5 import modeling_qwen3_5
+
+        modeling_qwen3_5.create_causal_mask = self._orig_qwen3_5_create_causal_mask
+
         for idx, decoder_layer in enumerate(self._text_model.layers):
             layer_type = self._text_config.layer_types[idx]
             if layer_type == "linear_attention":

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -8505,9 +8505,14 @@ def patched_recurrent_gated_delta_rule(
         last_recurrent_state,  # (B, H, D1, D2)
     )
 
-    num_elems = value.numel()
-    core_attn_out = output_cell[:num_elems].reshape(value.shape)
-    last_recurrent_state = output_cell[num_elems:].reshape(last_recurrent_state.shape)
+    # output_cell has shape (B, H, T+D1, D2) where D1=k_head_dim is a static Python int.
+    # Use static negative indexing to split without any reshape operation:
+    #   core_attn_out:        output_cell[:, :, :-D1, :] -> (B, H, T,  D2)
+    #   last_recurrent_state: output_cell[:, :, -D1:,  :] -> (B, H, D1, D2)
+    # This avoids the previously invalid reshape([-1, H, -1, D2]) with two dynamic dims.
+    head_k_dim = k_head_dim
+    core_attn_out = output_cell[:, :, :-head_k_dim, :]
+    last_recurrent_state = output_cell[:, :, -head_k_dim:, :]
 
     if not output_final_state:
         last_recurrent_state = None
@@ -8694,7 +8699,11 @@ class RecurrentAttentionCell(torch.nn.Module):
         # This is a workaround to ensure a single output from the torch.nn.Module.
         # The OpenVINO ModuleExtension mechanism has a limitation and expects
         # the module to produce only one output.
-        output_cell = torch.cat([core_attn_out.flatten(), last_recurrent_state.flatten()], dim=0)
+        # Concatenate along dim 2 (sequence/key-head-dim axis) rather than flattening
+        # to 1D. This avoids downstream reshape with two dynamic dims (batch + seq).
+        # core_attn_out: (B, H, T, D2), last_recurrent_state: (B, H, D1, D2)
+        # Combined: (B, H, T+D1, D2) - split downstream using static -D1 indexing.
+        output_cell = torch.cat([core_attn_out, last_recurrent_state], dim=2)
         return output_cell
 
 

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -1429,12 +1429,17 @@ class OVModelWithMambaForCausalLM(OVModelForCausalLM):
         self, outputs: ModelOutput, model_kwargs: Dict[str, Any], num_new_tokens: int = 1, **kwargs
     ) -> Dict[str, Any]:
         model_kwargs["cache_params"] = outputs.get("cache_params", None)
-        if (
-            model_kwargs.get("use_cache", True)
-            and "cache_position" in model_kwargs
-            and model_kwargs["cache_position"] is not None
-        ):
-            model_kwargs["cache_position"] = model_kwargs["cache_position"][-1:] + num_new_tokens
+        if model_kwargs.get("use_cache", True):
+            cache_position = model_kwargs.get("cache_position")
+            if cache_position is not None:
+                model_kwargs["cache_position"] = cache_position[-1:] + num_new_tokens
+            elif "attention_mask" in model_kwargs:
+                attention_mask = model_kwargs["attention_mask"]
+                model_kwargs["cache_position"] = torch.tensor(
+                    [attention_mask.shape[-1] + num_new_tokens - 1],
+                    device=attention_mask.device,
+                    dtype=torch.long,
+                )
 
         if "attention_mask" in model_kwargs:
             attention_mask = model_kwargs["attention_mask"]
@@ -1457,14 +1462,15 @@ class OVModelWithMambaForCausalLM(OVModelForCausalLM):
         # Overwitten -- uses `cache_params` as opposed to `past_key_values`
 
         if self.use_cache:
-            # `cache_position` should have been initialized in `generate`
+            cache_has_previous_state = False
+            if cache_params is not None and hasattr(cache_params, "has_previous_state"):
+                cache_has_previous_state = cache_params.has_previous_state()
+
             if cache_position is None:
-                raise ValueError(
-                    "`cache_position` should not be None as it should have been initialized in "
-                    "`model.generate`, you are responsible for passing in a valid `cache_position` if "
-                    "you are calling `prepare_inputs_for_generation` directly with `use_cache=True`"
-                )
-            if cache_position[0] > 0:
+                prompt_length = attention_mask.shape[-1] if attention_mask is not None else input_ids.shape[-1]
+                cache_position = torch.arange(prompt_length, device=input_ids.device, dtype=torch.long)
+
+            if cache_position[0] > 0 or cache_has_previous_state:
                 # decoding stage so it takes the last token
                 input_ids = input_ids[:, -1].unsqueeze(-1)
 
@@ -1473,8 +1479,6 @@ class OVModelWithMambaForCausalLM(OVModelForCausalLM):
                     "lfm2_moe",
                     "granitemoehybrid",
                     "qwen3_next",
-                    "qwen3_5_text",
-                    "qwen3_5_moe_text",
                 ]:
                     # LFM2, GraniteMoeHybrid (Granite-4.0), and Qwen3-Next require the attention mask
                     # to be the length of the full context, so default mask from OVModelForCausalLM needs to be used.
@@ -1482,7 +1486,7 @@ class OVModelWithMambaForCausalLM(OVModelForCausalLM):
                     # for the decoding step after the first token so use attention mask of ones.
                     attention_mask = torch.ones_like(input_ids, dtype=torch.int64)
 
-            else:
+            elif "cache_position" in self.input_names:
                 # we initialize the `cache_position` to full size of `conv_states` at prefill stage
                 # considering padding will be applied when input length is shorter, and truncation
                 # will be applied when it is longer, so it will be equivalent to always have it match

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -324,6 +324,23 @@ class ExportModelTest(unittest.TestCase):
                     ov_model.model.get_rt_info()["optimum"]["transformers_version"], _transformers_version
                 )
 
+    @unittest.skipUnless(is_transformers_version(">=", "5.2.0"), "Qwen3.5 export requires Transformers >= 5.2.0")
+    def test_main_export_qwen3_5_text_generation(self):
+        model_name = MODEL_NAMES["qwen3_5"]
+
+        with TemporaryDirectory() as tmpdirname:
+            main_export(
+                model_name_or_path=model_name,
+                output=Path(tmpdirname),
+                task="text-generation-with-past",
+                model_loading_kwargs={"attn_implementation": "eager"},
+            )
+
+            ov_model = OVModelForCausalLM.from_pretrained(tmpdirname, use_cache=True)
+            self.assertIsInstance(ov_model, OVBaseModel)
+            self.assertEqual(ov_model.config.model_type, "qwen3_5_text")
+            self.assertTrue(ov_model.use_cache)
+
     def test_compare_openvino_onnx_supported_architectures(self):
         onnx_architectures = set()
         openvino_architectures = set()

--- a/tests/openvino/test_qwen_causal_mask.py
+++ b/tests/openvino/test_qwen_causal_mask.py
@@ -1,0 +1,27 @@
+import torch
+
+from optimum.exporters.openvino.model_patcher import _create_causal_mask_ov_compatible
+
+
+class _TraceWrapper(torch.nn.Module):
+    def forward(self, inputs_embeds, attention_mask, position_ids):
+        return _create_causal_mask_ov_compatible(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+        )
+
+
+def test_qwen3_5_causal_mask_trace_avoids_aten_index():
+    inputs_embeds = torch.zeros(1, 17, 8)
+    attention_mask = torch.ones(1, 17, dtype=torch.bool)
+    position_ids = torch.arange(17, dtype=torch.long).view(1, 1, 17).expand(4, 1, 17)
+
+    traced = torch.jit.trace(_TraceWrapper(), (inputs_embeds, attention_mask, position_ids))
+    graph_text = str(traced.graph)
+    mask = traced(inputs_embeds, attention_mask, position_ids)
+
+    assert mask.shape == (1, 1, 17, 17)
+    assert "aten::index" not in graph_text
+    assert mask[0, 0, 0, 0].item() == 0
+    assert mask[0, 0, 0, 1].item() < 0


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY MEAT AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

# What does this PR do?

Fix Qwen3.6 linear-attention export for OpenVINO by removing invalid recurrent-attention reshapes and replacing the traced Qwen3.5 causal-mask path with an OpenVINO-friendly implementation.

## Installation instructions

```bash
pip install git+https://github.com/huggingface/transformers.git
pip install git+https://github.com/mlukasze/optimum-intel.git@fix/qwen3-6-27b-reshape-inference
pip install --pre -U openvino openvino-tokenizers nncf --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
```

## Exporting cmd-line

```bash
optimum-cli export openvino -m /path/to/Qwen3.6-27B --task text-generation-with-past --weight-format int4 output_dir
```

## Inference script

```python
import openvino_genai as ov_genai
pipe = ov_genai.LLMPipeline('output_dir', 'CPU')
result = pipe.generate('What is OpenVINO?', max_new_tokens=50)
print(result)
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
