### PR TITLE
[EXPERIMENT][WIP][OpenVINO] Add export support for Qwen/Qwen-Image-Edit

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -181,6 +181,7 @@ Here is the list of the supported architectures :
 - Sana
 - SanaSprint
 - LTX
+- Qwen-Image-Edit
 
 ## [Timm](https://huggingface.co/docs/timm/index)
 - PiT

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -746,6 +746,10 @@ def export_from_model(
         if feature_extractor is not None:
             feature_extractor.save_pretrained(output.joinpath("feature_extractor"))
 
+        processor = getattr(model, "processor", None)
+        if processor is not None:
+            processor.save_pretrained(output.joinpath("processor"))
+
         tokenizer = getattr(model, "tokenizer", None)
         if tokenizer is not None:
             tokenizer.save_pretrained(output.joinpath("tokenizer"))
@@ -1012,6 +1016,7 @@ def get_diffusion_models_for_export_ext(
     is_sdxl = pipeline.__class__.__name__.startswith("StableDiffusionXL")
     is_sd3 = pipeline.__class__.__name__.startswith("StableDiffusion3")
     is_flux = pipeline.__class__.__name__.startswith("Flux")
+    is_qwen_image_edit = pipeline.__class__.__name__.startswith("QwenImageEdit")
     is_sana = pipeline.__class__.__name__.startswith("Sana")
     is_ltx_video = pipeline.__class__.__name__.startswith("LTX")
     is_sd = pipeline.__class__.__name__.startswith("StableDiffusion") and not is_sd3
@@ -1035,6 +1040,8 @@ def get_diffusion_models_for_export_ext(
         models_for_export = get_sd3_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     elif is_flux:
         models_for_export = get_flux_models_for_export(pipeline, exporter, int_dtype, float_dtype)
+    elif is_qwen_image_edit:
+        models_for_export = get_qwen_image_edit_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     elif is_sana:
         models_for_export = get_sana_models_for_export(pipeline, exporter, int_dtype, float_dtype)
     elif is_ltx_video:
@@ -1369,6 +1376,121 @@ def get_flux_models_for_export(pipeline, exporter, int_dtype, float_dtype):
 
     return models_for_export
 
+
+class _QwenImageTransformerExportWrapper(nn.Module):
+    def __init__(self, transformer):
+        super().__init__()
+        self.transformer = transformer
+        self.config = transformer.config
+
+    def forward(self, hidden_states, encoder_hidden_states, encoder_hidden_states_mask, timestep, img_shapes, guidance=None):
+        img_shapes_list = [tuple(int(v) for v in shape.tolist()) for shape in img_shapes]
+        outputs = self.transformer(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states_mask=encoder_hidden_states_mask,
+            timestep=timestep,
+            img_shapes=img_shapes_list,
+            guidance=guidance,
+            return_dict=False,
+        )
+        return {"sample": outputs[0]}
+
+
+class _QwenImageVaeEncoderExportWrapper(nn.Module):
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+        self.config = vae.config
+
+    def forward(self, sample):
+        return {"latent_parameters": self.vae.encode(x=sample).latent_dist.parameters}
+
+
+class _QwenImageVaeDecoderExportWrapper(nn.Module):
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+        self.config = vae.config
+
+    def forward(self, latent_sample):
+        return {"sample": self.vae.decode(z=latent_sample).sample}
+
+
+class _QwenImageTextEncoderExportWrapper(nn.Module):
+    def __init__(self, text_encoder):
+        super().__init__()
+        self.text_encoder = text_encoder
+        self.config = text_encoder.config
+
+    def forward(self, input_ids, attention_mask, pixel_values, image_grid_thw):
+        outputs = self.text_encoder(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            pixel_values=pixel_values,
+            image_grid_thw=image_grid_thw,
+            output_hidden_states=True,
+            return_dict=True,
+        )
+        return {"last_hidden_state": outputs.hidden_states[-1]}
+
+
+def get_qwen_image_edit_models_for_export(pipeline, exporter, int_dtype, float_dtype):
+    models_for_export = {}
+
+    transformer = _QwenImageTransformerExportWrapper(pipeline.transformer)
+    export_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=transformer,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="qwen-image-transformer",
+    )
+    transformer_export_config = export_config_constructor(
+        pipeline.transformer.config, int_dtype=int_dtype, float_dtype=float_dtype
+    )
+    transformer_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["transformer"] = (transformer, transformer_export_config)
+
+    vae_encoder = _QwenImageVaeEncoderExportWrapper(pipeline.vae)
+    vae_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=vae_encoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="qwen-image-vae-encoder",
+    )
+    vae_encoder_export_config = vae_config_constructor(pipeline.vae.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    vae_encoder_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_encoder"] = (vae_encoder, vae_encoder_export_config)
+
+    vae_decoder = _QwenImageVaeDecoderExportWrapper(pipeline.vae)
+    vae_config_constructor = TasksManager.get_exporter_config_constructor(
+        model=vae_decoder,
+        exporter=exporter,
+        library_name="diffusers",
+        task="semantic-segmentation",
+        model_type="qwen-image-vae-decoder",
+    )
+    vae_decoder_export_config = vae_config_constructor(pipeline.vae.config, int_dtype=int_dtype, float_dtype=float_dtype)
+    vae_decoder_export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+    models_for_export["vae_decoder"] = (vae_decoder, vae_decoder_export_config)
+
+    text_encoder = getattr(pipeline, "text_encoder", None)
+    if text_encoder is not None:
+        text_encoder_wrapper = _QwenImageTextEncoderExportWrapper(text_encoder)
+        export_config_constructor = TasksManager.get_exporter_config_constructor(
+            model=text_encoder_wrapper,
+            exporter=exporter,
+            library_name="transformers",
+            task="feature-extraction",
+            model_type="qwen-image-text-encoder",
+        )
+        export_config = export_config_constructor(text_encoder.config, int_dtype=int_dtype, float_dtype=float_dtype)
+        export_config.runtime_options = {"ACTIVATIONS_SCALE_FACTOR": "8.0"}
+        models_for_export["text_encoder"] = (text_encoder_wrapper, export_config)
+
+    return models_for_export
 
 def _get_encoder_decoder_stateful_models_for_export(
     model: "PreTrainedModel",

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -211,6 +211,7 @@ from .model_patcher import (
     Qwen3NextModelPatcher,
     Qwen3VLLanguageModelPatcher,
     Qwen3VLVisionEmbMergerPatcher,
+    QwenImageVAEPatcher,
     QwenModelPatcher,
     SanaTextEncoderModelPatcher,
     XverseModelPatcher,
@@ -6221,3 +6222,212 @@ class Qwen3_5MoeOpenVINOConfig(Qwen3_5OpenVINOConfig):
                 "qwen3_5_moe_text", self._orig_config.text_config, self.int_dtype, self.float_dtype
             ).outputs
         return super().outputs
+
+
+
+class DummyQwenImageTransformerInputGenerator(DummyVisionInputGenerator):
+    SUPPORTED_INPUT_NAMES = (
+        "hidden_states",
+        "encoder_hidden_states",
+        "encoder_hidden_states_mask",
+        "timestep",
+        "img_shapes",
+        "guidance",
+    )
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        width: int = DEFAULT_DUMMY_SHAPES["width"] // 16,
+        height: int = DEFAULT_DUMMY_SHAPES["height"] // 16,
+        sequence_length: int = DEFAULT_DUMMY_SHAPES["sequence_length"],
+        **kwargs,
+    ):
+        super().__init__(task, normalized_config, batch_size, num_channels, width, height, **kwargs)
+        self.num_channels = getattr(normalized_config.config, "in_channels", num_channels)
+        self.hidden_size = getattr(normalized_config.config, "joint_attention_dim", 4096)
+        self.sequence_length = sequence_length
+        self.packed_height = max(1, self.height // 2)
+        self.packed_width = max(1, self.width // 2)
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        import torch
+
+        if input_name == "hidden_states":
+            return self.random_float_tensor(
+                [self.batch_size, self.packed_height * self.packed_width, self.num_channels],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "encoder_hidden_states":
+            return self.random_float_tensor(
+                [self.batch_size, self.sequence_length, self.hidden_size], framework=framework, dtype=float_dtype
+            )
+        if input_name == "encoder_hidden_states_mask":
+            return self.constant_tensor(
+                [self.batch_size, self.sequence_length], framework=framework, value=1, dtype=DTYPE_MAPPER.pt(int_dtype)
+            )
+        if input_name == "timestep":
+            return self.random_float_tensor([self.batch_size], framework=framework, dtype=float_dtype)
+        if input_name == "guidance":
+            return self.random_float_tensor([self.batch_size], framework=framework, dtype=float_dtype)
+        if input_name == "img_shapes":
+            return torch.tensor(
+                [[1, self.packed_height, self.packed_width] for _ in range(self.batch_size)],
+                dtype=DTYPE_MAPPER.pt(int_dtype),
+            )
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+@register_in_tasks_manager("qwen-image-transformer", *["semantic-segmentation"], library_name="diffusers")
+@register_in_tasks_manager("qwen-image-transformer-2d", *["semantic-segmentation"], library_name="diffusers")
+class QwenImageTransformerOpenVINOConfig(OnnxConfig):
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
+        image_size="sample_size",
+        num_channels="in_channels",
+        hidden_size="joint_attention_dim",
+        allow_new=True,
+    )
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwenImageTransformerInputGenerator,)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        common_inputs = OrderedDict(
+            [
+                ("hidden_states", {0: "batch_size", 1: "image_sequence_length"}),
+                ("encoder_hidden_states", {0: "batch_size", 1: "sequence_length"}),
+                ("encoder_hidden_states_mask", {0: "batch_size", 1: "sequence_length"}),
+                ("timestep", {0: "batch_size"}),
+                ("img_shapes", {0: "batch_size"}),
+            ]
+        )
+        if getattr(self._normalized_config.config, "guidance_embeds", False):
+            common_inputs["guidance"] = {0: "batch_size"}
+        return common_inputs
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return OrderedDict([("sample", {0: "batch_size", 1: "image_sequence_length"})])
+
+
+class DummyQwenImageVaeInputGenerator(DummyVisionInputGenerator):
+    SUPPORTED_INPUT_NAMES = ("sample", "latent_sample")
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        width: int = DEFAULT_DUMMY_SHAPES["width"] // 8,
+        height: int = DEFAULT_DUMMY_SHAPES["height"] // 8,
+        num_frames: int = 1,
+        **kwargs,
+    ):
+        super().__init__(task, normalized_config, batch_size, num_channels, width, height, **kwargs)
+        self.sample_channels = getattr(normalized_config.config, "input_channels", num_channels)
+        self.latent_channels = getattr(normalized_config.config, "z_dim", 16)
+        self.num_frames = num_frames
+        self.spatial_compression_ratio = getattr(normalized_config.config, "spatial_compression_ratio", 8)
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "sample":
+            return self.random_float_tensor(
+                [self.batch_size, self.sample_channels, self.num_frames, self.height, self.width],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "latent_sample":
+            return self.random_float_tensor(
+                [
+                    self.batch_size,
+                    self.latent_channels,
+                    self.num_frames,
+                    max(1, self.height // self.spatial_compression_ratio),
+                    max(1, self.width // self.spatial_compression_ratio),
+                ],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+@register_in_tasks_manager("qwen-image-vae-encoder", *["semantic-segmentation"], library_name="diffusers")
+class AutoencoderKLQwenImageEncoderOpenVINOConfig(VaeEncoderOnnxConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwenImageVaeInputGenerator,)
+    _MODEL_PATCHER = QwenImageVAEPatcher
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "sample": {0: "batch_size", 2: "num_frames", 3: "height", 4: "width"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "latent_parameters": {0: "batch_size", 2: "num_frames", 3: "height_latent", 4: "width_latent"},
+        }
+
+
+@register_in_tasks_manager("qwen-image-vae-decoder", *["semantic-segmentation"], library_name="diffusers")
+class AutoencoderKLQwenImageDecoderOpenVINOConfig(VaeDecoderOnnxConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwenImageVaeInputGenerator,)
+    _MODEL_PATCHER = QwenImageVAEPatcher
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "latent_sample": {0: "batch_size", 2: "num_frames", 3: "height_latent", 4: "width_latent"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "sample": {0: "batch_size", 2: "num_frames", 3: "height", 4: "width"},
+        }
+
+
+@register_in_tasks_manager("qwen-image-text-encoder", *["feature-extraction"], library_name="transformers")
+class QwenImageTextEncoderOpenVINOConfig(OnnxConfig):
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return OrderedDict(
+            [
+                ("input_ids", {0: "batch_size", 1: "sequence_length"}),
+                ("attention_mask", {0: "batch_size", 1: "sequence_length"}),
+                ("pixel_values", {0: "patch_sequence_length", 1: "patch_hidden_size"}),
+                ("image_grid_thw", {0: "num_images"}),
+            ]
+        )
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return OrderedDict([("last_hidden_state", {0: "batch_size", 1: "sequence_length"})])
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs):
+        import torch
+
+        vision_config = getattr(self._config, "vision_config", self._config)
+        patch_size = getattr(vision_config, "patch_size", 14)
+        temporal_patch_size = getattr(vision_config, "temporal_patch_size", 2)
+        in_channels = getattr(vision_config, "in_channels", 3)
+        vision_start_token_id = getattr(self._config, "vision_start_token_id", 151652)
+        image_token_id = getattr(self._config, "image_token_id", 151655)
+        image_grid_thw = torch.tensor([[1, 2, 2]], dtype=torch.long)
+        patch_sequence_length = int(image_grid_thw.prod().item())
+        patch_hidden_size = in_channels * temporal_patch_size * patch_size * patch_size
+
+        input_ids = torch.tensor([[vision_start_token_id, image_token_id, 1, 1]], dtype=torch.long)
+        attention_mask = torch.ones_like(input_ids)
+        pixel_values = torch.randn(patch_sequence_length, patch_hidden_size)
+
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": pixel_values,
+            "image_grid_thw": image_grid_thw,
+        }

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9464,3 +9464,36 @@ class Qwen3_5MoeModelPatcher(Qwen3_5ModelPatcher):
             if isinstance(decoder_layer.mlp, Qwen3_5MoeSparseMoeBlock):
                 sparse_moe_block = decoder_layer.mlp
                 sparse_moe_block.forward = sparse_moe_block._orig_forward
+
+
+
+def _qwen_image_causal_conv3d_forward_patched(self, x, cache_x=None):
+    padding = list(self._padding)
+    if cache_x is None and self._padding[4] > 0:
+        cache_x = x.new_zeros(x.shape[0], x.shape[1], self._padding[4], x.shape[3], x.shape[4])
+
+    if cache_x is not None and self._padding[4] > 0:
+        x = torch.cat([cache_x.to(x.device), x], dim=2)
+        padding[4] = max(padding[4] - cache_x.shape[2], 0)
+
+    x = F.pad(x, padding)
+    return nn.Conv3d.forward(self, x)
+
+
+class QwenImageVAEPatcher(ModelPatcher):
+    def __enter__(self):
+        super().__enter__()
+        self._original_forwards = {}
+        for name, module in self._model.named_modules():
+            if type(module).__name__ == 'QwenImageCausalConv3d':
+                self._original_forwards[name] = module.forward
+                module.forward = types.MethodType(_qwen_image_causal_conv3d_forward_patched, module)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        for name, module in self._model.named_modules():
+            if name in getattr(self, '_original_forwards', {}):
+                module.forward = self._original_forwards[name]
+        if hasattr(self, '_original_forwards'):
+            self._original_forwards.clear()
+        super().__exit__(exc_type, exc_value, traceback)

--- a/optimum/exporters/openvino/qwen_image_edit_export.py
+++ b/optimum/exporters/openvino/qwen_image_edit_export.py
@@ -1,0 +1,257 @@
+"""Custom OpenVINO export support for Qwen/Qwen-Image-Edit."""
+
+import gc
+import logging
+import time
+from pathlib import Path
+from typing import Union
+
+import torch
+from huggingface_hub import snapshot_download
+
+logger = logging.getLogger(__name__)
+
+
+class TextEncoderWrapper(torch.nn.Module):
+    def __init__(self, model):
+        super().__init__()
+        self.model = model.model if hasattr(model, "model") else model
+
+    def forward(self, input_ids: torch.Tensor, attention_mask: torch.Tensor) -> torch.Tensor:
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            use_cache=False,
+            output_hidden_states=False,
+            return_dict=False,
+        )
+        return outputs[0] if isinstance(outputs, (tuple, list)) else outputs.last_hidden_state
+
+
+class VAEEncoderWrapper(torch.nn.Module):
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        posterior = self.vae.encode(x, return_dict=False)[0]
+        return posterior.mode() if hasattr(posterior, "mode") else posterior
+
+
+class VAEDecoderWrapper(torch.nn.Module):
+    def __init__(self, vae):
+        super().__init__()
+        self.vae = vae
+
+    def forward(self, z: torch.Tensor) -> torch.Tensor:
+        outputs = self.vae.decode(z, return_dict=False)
+        return outputs[0] if isinstance(outputs, tuple) else outputs.sample
+
+
+class TransformerWrapper(torch.nn.Module):
+    def __init__(self, model, img_shapes):
+        super().__init__()
+        self.model = model
+        self.img_shapes = img_shapes
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: torch.Tensor,
+        encoder_hidden_states_mask: torch.Tensor,
+        timestep: torch.Tensor,
+    ) -> torch.Tensor:
+        outputs = self.model(
+            hidden_states=hidden_states,
+            encoder_hidden_states=encoder_hidden_states,
+            encoder_hidden_states_mask=encoder_hidden_states_mask,
+            timestep=timestep,
+            img_shapes=self.img_shapes,
+            return_dict=False,
+        )
+        return outputs[0] if isinstance(outputs, (tuple, list)) else outputs.sample
+
+
+def _try_ov_export(model, example_input):
+    import openvino as ov
+
+    return ov.convert_model(model, example_input=example_input)
+
+
+def _try_torch_export(model, example_input):
+    import openvino as ov
+
+    with torch.no_grad():
+        if isinstance(example_input, dict):
+            exported = torch.export.export(model, args=(), kwargs=example_input, strict=False)
+        elif isinstance(example_input, tuple):
+            exported = torch.export.export(model, args=example_input, strict=False)
+        else:
+            exported = torch.export.export(model, args=(example_input,), strict=False)
+    return ov.convert_model(exported)
+
+
+def _try_jit_trace(model, example_input):
+    import openvino as ov
+
+    with torch.no_grad():
+        if isinstance(example_input, dict):
+            keys = list(example_input.keys())
+            values = tuple(example_input.values())
+
+            class _DictWrapper(torch.nn.Module):
+                def __init__(self, wrapped, names):
+                    super().__init__()
+                    self.wrapped = wrapped
+                    self.names = names
+
+                def forward(self, *args):
+                    return self.wrapped(**dict(zip(self.names, args)))
+
+            traced = torch.jit.trace(_DictWrapper(model, keys), values, strict=False)
+            return ov.convert_model(traced, example_input=values)
+        if isinstance(example_input, tuple):
+            traced = torch.jit.trace(model, example_input, strict=False)
+            return ov.convert_model(traced, example_input=example_input)
+        traced = torch.jit.trace(model, (example_input,), strict=False)
+        return ov.convert_model(traced, example_input=(example_input,))
+
+
+def _export_component(model, example_input, out_path: Path, name: str) -> bool:
+    import openvino as ov
+
+    for strategy_name, strategy in (
+        ("ov.convert_model", _try_ov_export),
+        ("torch.export", _try_torch_export),
+        ("torch.jit.trace", _try_jit_trace),
+    ):
+        logger.info("[%s] Trying %s", name, strategy_name)
+        try:
+            start = time.time()
+            ov_model = strategy(model, example_input)
+            ov.save_model(ov_model, str(out_path))
+            logger.info(
+                "[%s] SUCCESS via %s in %.1fs (%.1f MB)",
+                name,
+                strategy_name,
+                time.time() - start,
+                out_path.stat().st_size / 1e6,
+            )
+            return True
+        except Exception as error:
+            logger.warning("[%s] %s failed: %s: %s", name, strategy_name, type(error).__name__, str(error)[:300])
+
+    logger.error("[%s] All strategies failed", name)
+    return False
+
+
+def _load_components(model_id: str, dtype: torch.dtype):
+    from diffusers import AutoencoderKLQwenImage, QwenImageTransformer2DModel
+    from transformers import Qwen2_5_VLForConditionalGeneration
+
+    model_dir = Path(snapshot_download(model_id))
+    logger.info("Loading components from %s", model_dir)
+
+    text_encoder = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+        model_dir / "text_encoder",
+        torch_dtype=dtype,
+        low_cpu_mem_usage=True,
+    )
+    transformer = QwenImageTransformer2DModel.from_pretrained(
+        model_dir / "transformer",
+        torch_dtype=dtype,
+        low_cpu_mem_usage=True,
+    )
+    vae = AutoencoderKLQwenImage.from_pretrained(
+        model_dir / "vae",
+        torch_dtype=dtype,
+        low_cpu_mem_usage=True,
+    )
+    return text_encoder, transformer, vae
+
+
+def export_qwen_image_edit(
+    model_id: str = "Qwen/Qwen-Image-Edit",
+    output_dir: Union[str, Path] = "./ov_model_qwen_image_edit",
+    dtype: torch.dtype = torch.bfloat16,
+    image_size: int = 512,
+    export_text_encoder: bool = True,
+    export_vae: bool = True,
+    export_transformer: bool = True,
+) -> dict:
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    results = {}
+
+    text_encoder, transformer, vae = _load_components(model_id, dtype)
+
+    if export_text_encoder:
+        text_encoder = text_encoder.eval().to(torch.float32)
+        text_encoder_wrapper = TextEncoderWrapper(text_encoder).eval()
+        text_inputs = {
+            "input_ids": torch.ones((1, 32), dtype=torch.long),
+            "attention_mask": torch.ones((1, 32), dtype=torch.long),
+        }
+        with torch.no_grad():
+            text_encoder_wrapper(**text_inputs)
+        results["text_encoder"] = _export_component(
+            text_encoder_wrapper,
+            text_inputs,
+            output_dir / "text_encoder.xml",
+            "text_encoder",
+        )
+        del text_encoder_wrapper, text_encoder
+        gc.collect()
+
+    if export_vae:
+        vae = vae.eval().to(torch.float32)
+        vae_encoder = VAEEncoderWrapper(vae).eval()
+        image = torch.randn(1, 3, 1, image_size, image_size)
+        with torch.no_grad():
+            latent = vae_encoder(image)
+        results["vae_encoder"] = _export_component(vae_encoder, image, output_dir / "vae_encoder.xml", "vae_encoder")
+
+        vae_decoder = VAEDecoderWrapper(vae).eval()
+        results["vae_decoder"] = _export_component(
+            vae_decoder,
+            torch.randn_like(latent),
+            output_dir / "vae_decoder.xml",
+            "vae_decoder",
+        )
+        del vae_decoder, vae_encoder, vae
+        gc.collect()
+
+    if export_transformer:
+        transformer = transformer.eval().to(torch.float32)
+        patch_size = getattr(transformer.config, "patch_size", 2)
+        height = image_size // 8 // patch_size
+        width = image_size // 8 // patch_size
+        seq_len = height * width
+        transformer_wrapper = TransformerWrapper(transformer, [(1, height, width)]).eval()
+        transformer_inputs = {
+            "hidden_states": torch.randn(1, seq_len, transformer.config.in_channels),
+            "encoder_hidden_states": torch.randn(1, 32, transformer.config.joint_attention_dim),
+            "encoder_hidden_states_mask": torch.ones(1, 32, dtype=torch.bool),
+            "timestep": torch.tensor([500.0]),
+        }
+        with torch.no_grad():
+            transformer_wrapper(**transformer_inputs)
+        results["transformer"] = _export_component(
+            transformer_wrapper,
+            transformer_inputs,
+            output_dir / "transformer.xml",
+            "transformer",
+        )
+        del transformer_wrapper, transformer
+        gc.collect()
+
+    return results
+
+
+if __name__ == "__main__":
+    import sys
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    destination = sys.argv[1] if len(sys.argv) > 1 else "./ov_model_qwen_image_edit"
+    summary = export_qwen_image_edit(output_dir=destination)
+    raise SystemExit(0 if any(summary.values()) else 1)

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -106,6 +106,7 @@ if is_diffusers_available():
         OVPipelineForInpainting,
         OVPipelineForText2Image,
         OVPipelineForText2Video,
+        OVQwenImageEditPipeline,
         OVSanaPipeline,
         OVSanaSprintPipeline,
         OVStableDiffusion3Img2ImgPipeline,

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -126,6 +126,11 @@ if is_diffusers_version(">=", "0.35.0"):
 else:
     CacheMixin = object
 
+if is_diffusers_version(">=", "0.38.0"):
+    from diffusers import QwenImageEditPipeline
+else:
+    QwenImageEditPipeline = object
+
 DIFFUSION_MODEL_TRANSFORMER_SUBFOLDER = "transformer"
 DIFFUSION_MODEL_TEXT_ENCODER_3_SUBFOLDER = "text_encoder_3"
 
@@ -171,6 +176,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
         tokenizer_2: Optional[CLIPTokenizer] = None,
         tokenizer_3: Optional[CLIPTokenizer] = None,
         feature_extractor: Optional[CLIPImageProcessor] = None,
+        processor: Optional[Any] = None,
         # stable diffusion xl specific arguments
         force_zeros_for_empty_prompt: bool = True,
         requires_aesthetics_score: bool = False,
@@ -250,6 +256,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
         self.tokenizer_2 = tokenizer_2
         self.tokenizer_3 = tokenizer_3
         self.feature_extractor = feature_extractor
+        self.processor = processor
 
         # we allow passing these as torch models for now
         self.image_encoder = kwargs.pop("image_encoder", None)  # TODO: maybe mplement OVModelImageEncoder
@@ -269,6 +276,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
             "tokenizer_2": self.tokenizer_2,
             "tokenizer_3": self.tokenizer_3,
             "feature_extractor": self.feature_extractor,
+            "processor": self.processor,
             "requires_aesthetics_score": requires_aesthetics_score,
             "force_zeros_for_empty_prompt": force_zeros_for_empty_prompt,
             "add_watermarker": add_watermarker,
@@ -356,6 +364,8 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
             self.tokenizer_3.save_pretrained(save_directory / "tokenizer_3")
         if self.feature_extractor is not None:
             self.feature_extractor.save_pretrained(save_directory / "feature_extractor")
+        if getattr(self, "processor", None) is not None:
+            self.processor.save_pretrained(save_directory / "processor")
         if getattr(self, "safety_checker", None) is not None:
             self.safety_checker.save_pretrained(save_directory / "safety_checker")
 
@@ -466,6 +476,7 @@ class OVDiffusionPipeline(OVBaseModel, DiffusionPipeline):
             "tokenizer_2": None,
             "tokenizer_3": None,
             "feature_extractor": None,
+            "processor": None,
             "safety_checker": None,
             "image_encoder": None,
         }
@@ -1163,12 +1174,17 @@ class OVModelTextEncoder(OVPipelinePart):
         attention_mask: Optional[Union[np.ndarray, torch.Tensor]] = None,
         output_hidden_states: Optional[bool] = None,
         return_dict: bool = False,
+        **kwargs,
     ):
         self.compile()
         model_inputs = {"input_ids": input_ids}
 
         if "attention_mask" in self.input_names:
             model_inputs["attention_mask"] = attention_mask
+
+        for name, value in kwargs.items():
+            if value is not None and name in self.input_names:
+                model_inputs[name] = value
 
         ov_outputs = self.request(model_inputs, share_inputs=True)
         main_out = ov_outputs[0]
@@ -1185,6 +1201,8 @@ class OVModelTextEncoder(OVPipelinePart):
         ):
             hidden_states = [torch.from_numpy(ov_outputs[out_name]) for out_name in self.hidden_states_output_names]
             model_outputs["hidden_states"] = hidden_states
+        elif output_hidden_states and "last_hidden_state" in model_outputs:
+            model_outputs["hidden_states"] = [model_outputs["last_hidden_state"]]
 
         if return_dict:
             return model_outputs
@@ -1258,6 +1276,8 @@ class OVModelTransformer(OVPipelinePart):
         block_controlnet_hidden_states: List = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         encoder_attention_mask: torch.LongTensor = None,
+        encoder_hidden_states_mask: torch.LongTensor = None,
+        img_shapes: Optional[Union[torch.Tensor, List[Tuple[int, int, int]]]] = None,
         num_frames: Optional[int] = None,
         height: Optional[int] = None,
         width: Optional[int] = None,
@@ -1267,6 +1287,7 @@ class OVModelTransformer(OVPipelinePart):
         return_dict: bool = True,
     ):
         self.compile()
+        input_names = {inp.get_any_name() for inp in self.model.inputs}
 
         model_inputs = {
             "hidden_states": hidden_states,
@@ -1283,8 +1304,17 @@ class OVModelTransformer(OVPipelinePart):
         if guidance is not None:
             model_inputs["guidance"] = guidance
 
-        if encoder_attention_mask is not None:
+        if encoder_attention_mask is not None and "encoder_attention_mask" in input_names:
             model_inputs["encoder_attention_mask"] = encoder_attention_mask
+        if encoder_hidden_states_mask is not None:
+            if "encoder_hidden_states_mask" in input_names:
+                model_inputs["encoder_hidden_states_mask"] = encoder_hidden_states_mask
+            elif "encoder_attention_mask" in input_names:
+                model_inputs["encoder_attention_mask"] = encoder_hidden_states_mask
+        if img_shapes is not None and "img_shapes" in input_names:
+            if not isinstance(img_shapes, torch.Tensor):
+                img_shapes = torch.tensor(img_shapes)
+            model_inputs["img_shapes"] = img_shapes
         if num_frames is not None:
             model_inputs["num_frames"] = num_frames
         if height is not None:
@@ -1663,6 +1693,12 @@ class OVLTXPipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, LTXPipel
     auto_model_class = LTXPipeline
 
 
+class OVQwenImageEditPipeline(OVDiffusionPipeline, OVTextualInversionLoaderMixin, QwenImageEditPipeline):
+    main_input_name = "image"
+    export_feature = "image-to-image"
+    auto_model_class = QwenImageEditPipeline
+
+
 SUPPORTED_OV_PIPELINES = [
     OVStableDiffusionPipeline,
     OVStableDiffusionImg2ImgPipeline,
@@ -1747,6 +1783,10 @@ if is_diffusers_version(">=", "0.32.0"):
 if is_diffusers_version(">=", "0.33.0"):
     SUPPORTED_OV_PIPELINES.append(OVSanaSprintPipeline)
     OV_TEXT2IMAGE_PIPELINES_MAPPING["sana-sprint"] = OVSanaSprintPipeline
+
+if is_diffusers_version(">=", "0.38.0"):
+    SUPPORTED_OV_PIPELINES.append(OVQwenImageEditPipeline)
+    OV_IMAGE2IMAGE_PIPELINES_MAPPING["qwen-image-edit"] = OVQwenImageEditPipeline
 
 SUPPORTED_OV_PIPELINES_MAPPINGS = [
     OV_TEXT2IMAGE_PIPELINES_MAPPING,

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -233,6 +233,7 @@ MODEL_NAMES = {
     "ltx-video": "optimum-intel-internal-testing/tiny-random-ltx-video",
     "zamba2": "optimum-intel-internal-testing/tiny-random-zamba2",
     "qwen3_eagle3": "AngelSlim/Qwen3-1.7B_eagle3",
+    "qwen-image-edit": "hf-internal-testing/tiny-qwen-image-edit",
 }
 
 EAGLE3_MODELS = {"qwen3_eagle3": ("AngelSlim/Qwen3-1.7B_eagle3", "Qwen/Qwen3-1.7B")}


### PR DESCRIPTION
## Summary

Adds a custom OpenVINO export helper for the `Qwen/Qwen-Image-Edit` pipeline components.

### Architecture
- **text_encoder**: `Qwen2_5_VLForConditionalGeneration` exported through a cache-free wrapper returning hidden states
- **transformer**: `QwenImageTransformer2DModel` exported with DiT-style latent inputs and fixed `img_shapes`
- **vae**: `AutoencoderKLQwenImage` exported as separate encoder/decoder wrappers using 5D tensors

### Key Challenges & Solutions
1. **Pipeline loading failure with current env**: avoid `Qwen2VLProcessor` loading by exporting components directly from snapshot subfolders
2. **VLM text encoder**: disable cache and export the underlying text model path returning hidden states only
3. **Custom DiT transformer**: feed latent-space inputs using config-driven `in_channels`, `joint_attention_dim`, and fixed image shape metadata
4. **3D Qwen VAE**: use image/video-shaped 5D tensors `[B, C, T, H, W]` for both encode and decode
5. **Multi-strategy export**: fall back through `ov.convert_model → torch.export → torch.jit.trace`

### Files Added
- `optimum/exporters/openvino/qwen_image_edit_export.py` — standalone export helper

### Usage
```python
from optimum.exporters.openvino.qwen_image_edit_export import export_qwen_image_edit
results = export_qwen_image_edit('Qwen/Qwen-Image-Edit', output_dir='./ov_output')
# returns {'text_encoder': bool, 'vae_encoder': bool, 'vae_decoder': bool, 'transformer': bool}
```

Related: intel-sandbox/applications.ai.openvino.meat#872