### PR TITLE
[OpenVINO] Use performant 3GEMM MoE for Qwen3.5

### DIFF
--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9425,7 +9425,9 @@ def patched_qwen3_5_moe_sparse_moe_block(self, hidden_states: torch.Tensor) -> t
     act_fn = self.experts.act_fn
 
     # compute experts outputs in a vectorized form using torch.bmm
-    gate, up = torch.bmm(hidden_states, self.experts.gate_up_proj.transpose(1, 2)).chunk(2, dim=-1)
+    gate_proj, up_proj = self.experts.gate_up_proj.chunk(2, dim=-2)
+    gate = torch.bmm(hidden_states, gate_proj.transpose(1, 2))
+    up = torch.bmm(hidden_states, up_proj.transpose(1, 2))
     gate_up = act_fn(gate) * up
     next_states = torch.bmm(gate_up, self.experts.down_proj.transpose(1, 2))
     next_states = next_states.view(num_experts, batch_size, -1, hidden_dim)

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -348,7 +348,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "vision_embeddings_pos_model": 1,
     },
     "qwen3_5_moe": {
-        "lm_model": 102,
+        "lm_model": 110,
         "text_embeddings_model": 1,
         "vision_embeddings_model": 1,
         "vision_embeddings_merger_model": 10,


### PR DESCRIPTION
# What does this PR do?

Use performant 3GEMM MoE for Qwen3.5. This pattern is expected by MoE transformations for fusing into internal MoE op.

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [N/A] Did you make sure to update the documentation with your changes?
- [N/A] Did you write any new necessary tests?

