### PR TITLE
Update of Gemma-4 int4 compression configs

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -440,13 +440,23 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "bits": 4,
         "sym": False,
         "group_size": 64,
+        "quant_method": OVQuantizationMethod.AWQ,
         "group_size_fallback": "adjust",
     },
     "google/gemma-4-26B-A4B": {
         "bits": 4,
         "sym": False,
         "group_size": 64,
+        "quant_method": OVQuantizationMethod.AWQ,
         "group_size_fallback": "adjust",
+    },
+    "google/gemma-4-E4B-it": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "dataset": "contextual",
+        "quant_method": OVQuantizationMethod.AWQ,
+        "scale_estimation": True,
     },
     "Qwen/Qwen3.5-35B-A3B": {
         "quantization_configs": {


### PR DESCRIPTION
# What does this PR do?

- Added int4 compression config for gemma-4-E4B-it improving WWB Similarity from 0.794922 to 0.873958 (CPU).
- Updated int4 gemma-4-26B-A4B compression configs improving WWB Similarity from 0.851884 to 0.870474 (CPU).

<!-- Remove if not applicable -->

Fixes # (issue) 182354


## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

