### PR TITLE
Improve performance with acceptable accuracy for Qwen/Qwen3.6-35B-A3B

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -486,7 +486,7 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
             "lm_model": {
                 "bits": 4,
                 "sym": False,
-                "group_size": 128,
+                "group_size": 64,
             },
             "text_embeddings_model": {"bits": 8, "sym": True, "weight_only": True},
             "vision_embeddings_merger_model": {"bits": 8, "sym": True, "weight_only": True},
@@ -634,11 +634,6 @@ _DEFAULT_IGNORED_SCOPE_CONFIGS = {
         },
     },
     "Qwen/Qwen3.5-35B-A3B": {
-        "lm_model": {
-            "patterns": [".*shared_expert.*", ".*attn.*"],
-        },
-    },
-    "Qwen/Qwen3.6-35B-A3B": {
         "lm_model": {
             "patterns": [".*shared_expert.*", ".*attn.*"],
         },


### PR DESCRIPTION
# What does this PR do?

Change default compression config for Qwen/Qwen3.6-35B-A3B.

wwb --target-model Qwen3.6-35B-A3B-Int4/ --gt-data models/gt_qwen_3_6_35B.csv --model-type visual-text --ov-config 
similarity 0.876817

