### PR TITLE
[OpenVINO] Set dq_group_size=64 for gemma-4-26B-A4B-it by default

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -454,6 +454,7 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "group_size": 64,
         "quant_method": OVQuantizationMethod.AWQ,
         "group_size_fallback": "adjust",
+        "dq_group_size": 64,
     },
     "google/gemma-4-26B-A4B": {
         "bits": 4,


### PR DESCRIPTION
# What does this PR do?
Changes:
- Added explicit setting of `dq_group_size=64` in `_DEFAULT_4BIT_WQ_CONFIGS` for `gemma-4-26B-A4B-it` model in order to pass `DYNAMIC_QUANTIZATION_GROUP_SIZE` property to OV plugins
- Without this property there are problems with accuracy

Fixes #[186656](https://jira.devtools.intel.com/browse/CVS-186656)