### PR TITLE
Fix "nncf.errors.InvalidGroupSizeError" during int4 compression of Kokoro

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -492,6 +492,12 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
             "vision_embeddings_merger_model": {"bits": 8, "sym": True, "weight_only": True},
         },
     },
+    "hexgrad/Kokoro-82M": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 128,
+        "group_size_fallback": "adjust",
+    },
 }
 
 _DEFAULT_8BIT_WQ_CONFIGS = {


### PR DESCRIPTION
# What does this PR do?

Fixes an error with "nncf.errors.InvalidGroupSizeError" during int4 weight compression of Kokoro model. NNCF reports it because it can't apply default group size 128. 

Fixes NA

## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

