### PR TITLE
[WIP][Experimental] Add support for nvidia/Nemotron-Labs-Diffusion-VLM-8B (nemotron_labs_diffusion_vlm)

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from requests.exceptions import ConnectionError as RequestsConnectionError
-from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase, ProcessorMixin
+from transformers import AutoConfig, AutoModel, AutoTokenizer, PreTrainedTokenizerBase, ProcessorMixin
 from transformers.utils import is_torch_available
 
 from openvino import Core, Type, save_model
@@ -522,26 +522,53 @@ def main_export(
             # remote code models like phi3_v internvl2, minicpmv, internvl2, nanollava, maira2 should be loaded using AutoModelForCausalLM and not AutoModelForImageTextToText
             # TODO: use config.auto_map to load remote code models instead (for other models we can directly use config.architectures)
             task_model_loading = task
+            load_with_automodel = False
             if library_name == "transformers":
-                has_remote_code = hasattr(config, "auto_map")
+                auto_map = getattr(config, "auto_map", None) or {}
+                has_remote_code = bool(auto_map)
                 if has_remote_code and trust_remote_code and task == "image-text-to-text":
                     task_model_loading = "text-generation"
+                elif (
+                    model_type == "nemotron_labs_diffusion"
+                    and task in {"feature-extraction", "feature-extraction-with-past", "text-generation", "text-generation-with-past"}
+                    and "AutoModel" in auto_map
+                    and "AutoModelForCausalLM" not in auto_map
+                ):
+                    load_with_automodel = True
 
-            model = TasksManager.get_model_from_task(
-                task_model_loading,
-                model_name_or_path,
-                subfolder=subfolder,
-                revision=revision,
-                cache_dir=cache_dir,
-                token=token,
-                local_files_only=local_files_only,
-                force_download=force_download,
-                trust_remote_code=trust_remote_code,
-                framework=framework,
-                device=device,
-                library_name=library_name,
-                **loading_kwargs,
-            )
+            if load_with_automodel:
+                if isinstance(device, str):
+                    device = torch.device(device)
+                elif device is None:
+                    device = torch.device("cpu")
+                with device:
+                    model = AutoModel.from_pretrained(
+                        model_name_or_path,
+                        subfolder=subfolder,
+                        revision=revision,
+                        cache_dir=cache_dir,
+                        token=token,
+                        local_files_only=local_files_only,
+                        force_download=force_download,
+                        trust_remote_code=trust_remote_code,
+                        torch_dtype=loading_kwargs.get("torch_dtype"),
+                    )
+            else:
+                model = TasksManager.get_model_from_task(
+                    task_model_loading,
+                    model_name_or_path,
+                    subfolder=subfolder,
+                    revision=revision,
+                    cache_dir=cache_dir,
+                    token=token,
+                    local_files_only=local_files_only,
+                    force_download=force_download,
+                    trust_remote_code=trust_remote_code,
+                    framework=framework,
+                    device=device,
+                    library_name=library_name,
+                    **loading_kwargs,
+                )
 
         if getattr(model, "dtype", None) in [torch.float16, torch.bfloat16]:
             patch_16bit = True

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -196,6 +196,7 @@ from .model_patcher import (
     MiniCPMVResamplerModelPatcher,
     MistralModelPatcher,
     MixtralModelPatcher,
+    NemotronLabsDiffusionVLMLanguageModelPatcher,
     MPTModelPatcher,
     OVDecoderModelPatcher,
     OVSeq2SeqModelPatcher,
@@ -389,6 +390,24 @@ def init_model_configs():
             "NemotronLabsDiffusionModelLoader",
         )
         TasksManager._CUSTOM_CLASSES[("pt", "nemotron_labs_diffusion", "text-generation-with-past")] = (
+            "optimum.exporters.openvino.model_configs",
+            "NemotronLabsDiffusionModelLoader",
+        )
+
+        # Register nemotron_labs_diffusion_vlm for image-text-to-text task
+        # This VLM variant combines pixtral vision encoder with nemotron_labs_diffusion text model
+        TasksManager._CUSTOM_CLASSES[("pt", "nemotron_labs_diffusion_vlm", "image-text-to-text")] = (
+            "transformers",
+            "AutoModelForCausalLM",
+        )
+        
+        # Register nemotron_labs_diffusion_vlm for text generation tasks
+        # These are used when exporting the language model portion of the VLM
+        TasksManager._CUSTOM_CLASSES[("pt", "nemotron_labs_diffusion_vlm", "text-generation")] = (
+            "optimum.exporters.openvino.model_configs",
+            "NemotronLabsDiffusionModelLoader",
+        )
+        TasksManager._CUSTOM_CLASSES[("pt", "nemotron_labs_diffusion_vlm", "text-generation-with-past")] = (
             "optimum.exporters.openvino.model_configs",
             "NemotronLabsDiffusionModelLoader",
         )
@@ -2120,6 +2139,21 @@ class VLMConfigBehavior(str, enum.Enum):
     LANGUAGE = "language"
 
 
+class DummyNemotronLabsDiffusionVLMInputGenerator(DummyVisionInputGenerator):
+    SUPPORTED_INPUT_NAMES = ("pixel_values", "image_sizes")
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "image_sizes":
+            import torch
+
+            return torch.tensor(
+                [[self.height, self.width] for _ in range(self.batch_size)],
+                dtype=DTYPE_MAPPER.pt(int_dtype),
+            )
+
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
 class BaseVLMOpenVINOConfig(OnnxConfig):
     SUPPORTED_BEHAVIORS = [model_type.value for model_type in VLMConfigBehavior]
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
@@ -2251,6 +2285,91 @@ class LlavaOpenVINOConfig(BaseVLMOpenVINOConfig):
 
     def generate_dummy_inputs(self, framework: str = "pt", **kwargs) -> Dict:
         if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and self._config.model_type == "pixtral":
+            kwargs["batch_size"] = 1
+        return super().generate_dummy_inputs(framework, **kwargs)
+
+
+@register_in_tasks_manager("nemotron_labs_diffusion_vlm", *["image-text-to-text"], library_name="transformers")
+class NemotronLabsDiffusionVLMOpenVINOConfig(BaseVLMOpenVINOConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyNemotronLabsDiffusionVLMInputGenerator,)
+    _OV_2026_1_MODEL_TYPE = "nemotron_labs_diffusion_vlm"
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            behavior=behavior,
+            preprocessors=preprocessors,
+            **kwargs,
+        )
+        self._orig_config = config
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            vision_config = config.vision_config
+            if isinstance(vision_config, dict):
+                vision_config = PretrainedConfig(**vision_config)
+            self._config = vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+        _warn_potential_accuracy_issue_ov_2026_1(self._OV_2026_1_MODEL_TYPE, min_transformers_version="5.0")
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior != VLMConfigBehavior.VISION_EMBEDDINGS:
+            return super().inputs
+        return {
+            "pixel_values": {0: "batch_size", 2: "height", 3: "width"},
+            "image_sizes": {0: "batch_size"},
+        }
+
+    def with_behavior(
+        self,
+        behavior: Union[str, VLMConfigBehavior],
+    ):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config(
+                "nemotron_labs_diffusion", self._orig_config, self.int_dtype, self.float_dtype
+            )
+
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            return get_vlm_text_generation_config(
+                "nemotron_labs_diffusion",
+                self._orig_config,
+                self.int_dtype,
+                self.float_dtype,
+                model_patcher=NemotronLabsDiffusionVLMLanguageModelPatcher,
+            )
+
+        return super().with_behavior(behavior)
+
+    def get_model_for_behavior(self, model, behavior: Union[str, VLMConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            text_embedding = model.get_input_embeddings()
+            text_embedding.config = model.config
+            return text_embedding
+
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            return model
+
+        return super().get_model_for_behavior(model, behavior)
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs) -> Dict:
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and getattr(self._config, "model_type", None) == "pixtral":
             kwargs["batch_size"] = 1
         return super().generate_dummy_inputs(framework, **kwargs)
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -73,6 +73,7 @@ from optimum.exporters.onnx.model_configs import (
     MobileViTOnnxConfig,
     MPNetOnnxConfig,
     MPTOnnxConfig,
+    NemotronOnnxConfig,
     NystromformerOnnxConfig,
     Olmo2OnnxConfig,
     OPTOnnxConfig,
@@ -269,6 +270,34 @@ if TYPE_CHECKING:
     from transformers.modeling_utils import PreTrainedModel  # noqa: F811
 
 
+class NemotronLabsDiffusionModelLoader:
+    """
+    Custom model loader for NemotronLabsDiffusion models.
+    Wraps AutoModelForCausalLM and handles the custom config registration.
+    """
+    
+    @staticmethod
+    def from_pretrained(model_name_or_path, **kwargs):
+        """Load NemotronLabsDiffusion model with proper config registration."""
+        from transformers import AutoModelForCausalLM
+        from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+        from transformers import AutoConfig
+        
+        # Register the config if not already registered
+        if 'nemotron_labs_diffusion' not in CONFIG_MAPPING:
+            try:
+                config = AutoConfig.from_pretrained(model_name_or_path, trust_remote_code=True)
+                CONFIG_MAPPING._extra_content['nemotron_labs_diffusion'] = config.__class__
+            except Exception:
+                pass  # If registration fails, continue anyway
+        
+        # Ensure trust_remote_code is enabled
+        kwargs['trust_remote_code'] = True
+        
+        # Load the model
+        return AutoModelForCausalLM.from_pretrained(model_name_or_path, **kwargs)
+
+
 def init_model_configs():
     if "open_clip" not in TasksManager._LIBRARY_TO_SUPPORTED_MODEL_TYPES:
         TasksManager._LIBRARY_TO_SUPPORTED_MODEL_TYPES["open_clip"] = {}
@@ -343,6 +372,25 @@ def init_model_configs():
         TasksManager._CUSTOM_CLASSES[("pt", "qwen3_asr", "automatic-speech-recognition-with-past")] = (
             "transformers",
             "AutoModel",
+        )
+        # Register nemotron_labs_diffusion to use custom loader class
+        # The model has a custom config that isn't in transformers' registry,
+        # so we need a custom loader that registers it before loading
+        TasksManager._CUSTOM_CLASSES[("pt", "nemotron_labs_diffusion", "feature-extraction")] = (
+            "optimum.exporters.openvino.model_configs",
+            "NemotronLabsDiffusionModelLoader",
+        )
+        TasksManager._CUSTOM_CLASSES[("pt", "nemotron_labs_diffusion", "feature-extraction-with-past")] = (
+            "optimum.exporters.openvino.model_configs",
+            "NemotronLabsDiffusionModelLoader",
+        )
+        TasksManager._CUSTOM_CLASSES[("pt", "nemotron_labs_diffusion", "text-generation")] = (
+            "optimum.exporters.openvino.model_configs",
+            "NemotronLabsDiffusionModelLoader",
+        )
+        TasksManager._CUSTOM_CLASSES[("pt", "nemotron_labs_diffusion", "text-generation-with-past")] = (
+            "optimum.exporters.openvino.model_configs",
+            "NemotronLabsDiffusionModelLoader",
         )
 
     if is_diffusers_available() and "fill" not in TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS:
@@ -934,6 +982,30 @@ class LlamaOpenVINOConfig(LlamaOnnxConfig):
         if self.eagle3:
             common_outputs["d2t"] = {0: "vocab_size"}
         return common_outputs
+
+
+@register_in_tasks_manager(
+    "nemotron",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+@register_in_tasks_manager(
+    "nemotron_labs_diffusion",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class NemotronOpenVINOConfig(NemotronOnnxConfig):
+    _MODEL_PATCHER = OVDecoderModelPatcher
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -4358,6 +4358,50 @@ class Qwen2VLLanguageModelPatcher(OVDecoderModelPatcher):
         self._model.forward = self._model.__orig_forward
 
 
+class NemotronLabsDiffusionVLMLanguageModelPatcher(OVDecoderModelPatcher):
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Dict[str, Any] = None,
+    ):
+        def lm_forward(
+            self,
+            attention_mask=None,
+            position_ids=None,
+            past_key_values=None,
+            inputs_embeds=None,
+            use_cache=True,
+        ):
+            if past_key_values is None:
+                pkv = None
+            elif is_transformers_version("<", "5"):
+                pkv = DynamicCache.from_legacy_cache(past_key_values)
+            else:
+                pkv = DynamicCache(past_key_values)
+
+            outputs = self.encoder(
+                inputs_embeds=inputs_embeds,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=pkv,
+                is_training=False,
+            )
+            logits = self.diffusion_head(outputs.last_hidden_state)
+            next_pkv = outputs.past_key_values
+            if next_pkv is not None:
+                next_pkv = postprocess_past_key_values(next_pkv)
+            return logits, next_pkv
+
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(lm_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
 class Qwen3VLLanguageModelPatcher(OVDecoderModelPatcher):
     def __init__(
         self,

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -336,6 +336,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "llama4",
     "minicpmo",
     "videochat_flash_qwen",
+    "nemotron_labs_diffusion_vlm",
 ]
 
 SSM_MODELS = [

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -3879,6 +3879,66 @@ class _OVQwen3VLForCausalLM(OVModelForVisualCausalLM, Qwen3VLModel, Qwen3VLVisio
         return super().generate(*args, **kwargs)
 
 
+class _OVNemotronLabsDiffusionVLMForCausalLM(_OVLlavaForCausalLM):
+    _IMAGE_TOKEN_ID = 19
+
+    def get_vision_embeddings(self, pixel_values, input_ids=None, image_sizes=None, **kwargs):
+        if input_ids is not None and input_ids.shape[1] == 1:
+            return None
+        if image_sizes is None:
+            raise ValueError("image_sizes are required for Nemotron-Labs-Diffusion-VLM vision inputs")
+        return self.vision_embeddings(pixel_values, image_sizes=image_sizes).last_hidden_state
+
+    def merge_vision_text_embeddings(
+        self,
+        vision_embeds,
+        inputs_embeds,
+        input_ids,
+        attention_mask,
+        position_ids=None,
+        legacy_processing=False,
+        **kwargs,
+    ):
+        image_features = torch.from_numpy(vision_embeds) if isinstance(vision_embeds, np.ndarray) else vision_embeds
+        inputs_embeds = torch.from_numpy(inputs_embeds) if isinstance(inputs_embeds, np.ndarray) else inputs_embeds
+
+        image_token_id = getattr(self.config, "image_token_id", self._IMAGE_TOKEN_ID)
+        num_image_tokens = (input_ids == image_token_id).sum().item()
+        if num_image_tokens != image_features.shape[0]:
+            raise ValueError(
+                f"Image features and image tokens do not match: tokens: {num_image_tokens}, features: {image_features.shape[0]}"
+            )
+
+        special_image_mask = (input_ids == image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        image_features = image_features.to(inputs_embeds.device, inputs_embeds.dtype)
+        inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
+        return inputs_embeds, attention_mask, position_ids
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None:
+            raise ValueError("Processor is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        conversation = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+        if image is not None:
+            conversation[0]["content"].insert(0, {"type": "image"})
+
+        text_prompt = processor.apply_chat_template(conversation, add_generation_prompt=True, tokenize=False)
+        return processor(images=image, text=text_prompt, return_tensors="pt")
+
+
 class _OVMaira2ForCausalLM(_OVLlavaForCausalLM):
     @staticmethod
     def preprocess_inputs(
@@ -5818,9 +5878,16 @@ class _OVQwen3_5ForCausalLM(OVModelForVisualCausalLM, Qwen3_5Model, Qwen3_5Visio
         return super().generate(*args, **kwargs)
 
 
+
+class _OVNemotronLabsDiffusionVLMForCausalLM(_OVIdefics3ForCausalLM):
+    """Nemotron Labs Diffusion VLM model for OpenVINO."""
+    pass
+
+
 MODEL_TYPE_TO_CLS_MAPPING = {
     "llava": _OVLlavaForCausalLM,
     "llava_next": _OVLlavaNextForCausalLM,
+    "nemotron_labs_diffusion_vlm": _OVNemotronLabsDiffusionVLMForCausalLM,
     "llava_next_video": _OVLlavaNextVideoForCausalLM,
     "minicpmv": _OVMiniCPMVForCausalLM,
     "llava-qwen2": _OVNanoLlavaForCausalLM,
@@ -5846,4 +5913,5 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen3_5_moe_text": _OVQwen3_5ForCausalLM,
     "minicpmo": _OVMiniCPMOForCausalLM,
     "videochat_flash_qwen": _OVVideoChatFlashQwenForCausalLM,
+    "nemotron_labs_diffusion_vlm": _OVNemotronLabsDiffusionVLMForCausalLM
 }


### PR DESCRIPTION
## Summary

This PR adds OpenVINO export support for [nvidia/Nemotron-Labs-Diffusion-VLM-8B](https://huggingface.co/nvidia/Nemotron-Labs-Diffusion-VLM-8B).

> ⚠️ **DRAFT / EXPERIMENTAL** — Do not merge without: (1) discrete GPU accuracy verification, (2) full CI green.

### Architecture

- Model type: `nemotron_labs_diffusion_vlm`
- Vision encoder: pixtral (PixtralVisionModel)
- Text model: Nemotron Labs Diffusion (34 layers, 4096 hidden)
- Pipeline: `image-text-to-text`
- Requires `transformers >= 5.0.0` and `trust_remote_code=True`

### Changes

Multi-component VLM export with 3 sub-models:
- **`openvino_language_model`** (7.5 GB INT4) — main LLM
- **`openvino_vision_embeddings_model`** (822 MB) — pixtral vision encoder
- **`openvino_text_embeddings_model`** (1.1 GB) — text embeddings

Files changed:
- `model_configs.py`: `NemotronLabsDiffusionVLMOpenVINOConfig` + `DummyNemotronLabsDiffusionVLMInputGenerator`
- `model_patcher.py`: VLM model patcher for vision encoder
- `modeling_visual_language.py`: VLM model support
- `__main__.py`: nemotron_labs_diffusion_vlm task routing

### Testing

- Export verified: model_type=`nemotron_labs_diffusion_vlm`, 34 layers, 4096 hidden ✅
- INT4 quantization applied to language model ✅
- CPU (no GPU available in test environment)

### Related

- Companion to PR #1749 (Nemotron-Labs-Diffusion-14B-Base, text-only variant)
- Issue: https://github.com/intel-sandbox/applications.ai.openvino.meat/issues/906

### TODO before merging

- [ ] Discrete GPU accuracy verification
- [ ] Full CI pass
- [ ] Review by optimum-intel maintainers