### PR TITLE
[EXPERIMENT][WIP][OpenVINO] Add support for nvidia/Nemotron-Labs-Diffusion-14B-Base

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from requests.exceptions import ConnectionError as RequestsConnectionError
-from transformers import AutoConfig, AutoTokenizer, PreTrainedTokenizerBase, ProcessorMixin
+from transformers import AutoConfig, AutoModel, AutoTokenizer, PreTrainedTokenizerBase, ProcessorMixin
 from transformers.utils import is_torch_available
 
 from openvino import Core, Type, save_model
@@ -522,26 +522,53 @@ def main_export(
             # remote code models like phi3_v internvl2, minicpmv, internvl2, nanollava, maira2 should be loaded using AutoModelForCausalLM and not AutoModelForImageTextToText
             # TODO: use config.auto_map to load remote code models instead (for other models we can directly use config.architectures)
             task_model_loading = task
+            load_with_automodel = False
             if library_name == "transformers":
-                has_remote_code = hasattr(config, "auto_map")
+                auto_map = getattr(config, "auto_map", None) or {}
+                has_remote_code = bool(auto_map)
                 if has_remote_code and trust_remote_code and task == "image-text-to-text":
                     task_model_loading = "text-generation"
+                elif (
+                    model_type == "nemotron_labs_diffusion"
+                    and task in {"feature-extraction", "feature-extraction-with-past", "text-generation", "text-generation-with-past"}
+                    and "AutoModel" in auto_map
+                    and "AutoModelForCausalLM" not in auto_map
+                ):
+                    load_with_automodel = True
 
-            model = TasksManager.get_model_from_task(
-                task_model_loading,
-                model_name_or_path,
-                subfolder=subfolder,
-                revision=revision,
-                cache_dir=cache_dir,
-                token=token,
-                local_files_only=local_files_only,
-                force_download=force_download,
-                trust_remote_code=trust_remote_code,
-                framework=framework,
-                device=device,
-                library_name=library_name,
-                **loading_kwargs,
-            )
+            if load_with_automodel:
+                if isinstance(device, str):
+                    device = torch.device(device)
+                elif device is None:
+                    device = torch.device("cpu")
+                with device:
+                    model = AutoModel.from_pretrained(
+                        model_name_or_path,
+                        subfolder=subfolder,
+                        revision=revision,
+                        cache_dir=cache_dir,
+                        token=token,
+                        local_files_only=local_files_only,
+                        force_download=force_download,
+                        trust_remote_code=trust_remote_code,
+                        torch_dtype=loading_kwargs.get("torch_dtype"),
+                    )
+            else:
+                model = TasksManager.get_model_from_task(
+                    task_model_loading,
+                    model_name_or_path,
+                    subfolder=subfolder,
+                    revision=revision,
+                    cache_dir=cache_dir,
+                    token=token,
+                    local_files_only=local_files_only,
+                    force_download=force_download,
+                    trust_remote_code=trust_remote_code,
+                    framework=framework,
+                    device=device,
+                    library_name=library_name,
+                    **loading_kwargs,
+                )
 
         if getattr(model, "dtype", None) in [torch.float16, torch.bfloat16]:
             patch_16bit = True

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -73,6 +73,7 @@ from optimum.exporters.onnx.model_configs import (
     MobileViTOnnxConfig,
     MPNetOnnxConfig,
     MPTOnnxConfig,
+    NemotronOnnxConfig,
     NystromformerOnnxConfig,
     Olmo2OnnxConfig,
     OPTOnnxConfig,
@@ -934,6 +935,20 @@ class LlamaOpenVINOConfig(LlamaOnnxConfig):
         if self.eagle3:
             common_outputs["d2t"] = {0: "vocab_size"}
         return common_outputs
+
+
+@register_in_tasks_manager(
+    "nemotron_labs_diffusion",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class NemotronLabsDiffusionOpenVINOConfig(NemotronOnnxConfig):
+    _MODEL_PATCHER = OVDecoderModelPatcher
 
 
 @register_in_tasks_manager(


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

# What does this PR do?

Adds OpenVINO export and inference support for `nvidia/Nemotron-Labs-Diffusion-14B-Base`, a bidirectional diffusion language model from NVIDIA.

The model uses a non-standard `nemotron_labs_diffusion` architecture requiring `trust_remote_code=True`. This PR registers `NemotronLabsDiffusionOpenVINOConfig` in `model_configs.py` and adds AutoModel fallback logic in `__main__.py` for architectures that advertise only `AutoModel` (not `AutoModelForCausalLM`).

## Installation instructions

```bash
cd /opt/home/mlukasze/dev/nvidia-Nemotron-Labs-Diffusion-14B-Base
source venv/bin/activate
pip install -e ./optimum-intel[openvino] --no-deps
```

## Exporting cmd-line

```bash
optimum-cli export openvino \
  --model nvidia/Nemotron-Labs-Diffusion-14B-Base \
  --task text-generation-with-past \
  --weight-format int4 \
  --trust-remote-code \
  ov_model
```

## Inference script

```python
from optimum.intel import OVModelForCausalLM
from transformers import AutoTokenizer

model = OVModelForCausalLM.from_pretrained('ov_model', trust_remote_code=True)
tokenizer = AutoTokenizer.from_pretrained('nvidia/Nemotron-Labs-Diffusion-14B-Base', trust_remote_code=True)
inputs = tokenizer('The quick brown fox', return_tensors='pt')
outputs = model.generate(**inputs, max_new_tokens=10)
print(tokenizer.decode(outputs[0], skip_special_tokens=True))
```

## Testing

- Exported INT4 OpenVINO model successfully with `text-generation-with-past`
- CPU inference smoke test passed via `OVModelForCausalLM`
- GPU compile smoke tests passed on `GPU.0` and `GPU.1`
- `pytest -q tests/openvino/test_export.py -k 'test_compare_openvino_onnx_supported_architectures'`

## Follow-ups

- [ ] tests/openvino/test_export.py — add NemotronLabsDiffusion export test
- [ ] docs/source/openvino.mdx — mention Nemotron-Labs-Diffusion support

## Known limitations

- Bidirectional diffusion architecture remains experimental in the standard text-generation path
- `trust_remote_code=True` is required
