### PR TITLE
[EXPERIMENT][WIP] fix: remap text-ranking to image-text-to-text for Qwen3-VL reranker models

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -420,6 +420,12 @@ def main_export(
         elif model_type == "qwen3_omni_moe":
             task = "image-text-to-text"
 
+        # Remap HuggingFace pipeline tags that are not valid optimum tasks.
+        # Qwen3-VL-based reranker models (pipeline_tag=text-ranking) use the VLM architecture.
+        _VLM_RERANKER_TYPES = {"qwen3_vl", "qwen2_vl", "qwen2_5_vl"}
+        if task == "text-ranking" and model_type in _VLM_RERANKER_TYPES:
+            task = "image-text-to-text"
+
         if model_type not in TasksManager._SUPPORTED_MODEL_TYPE:
             if custom_export_configs is None:
                 raise ValueError(

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -1481,6 +1481,23 @@ class OVCLIExportTestCase(unittest.TestCase):
             self.assertTrue("text_features" in model.text_model.output_names)
             self.assertTrue("image_features" in model.visual_model.output_names)
 
+    def test_export_text_ranking_remaps_to_image_text_to_text_for_qwen3_vl(self):
+        if is_transformers_version("<", "4.52"):
+            self.skipTest("qwen3_vl export requires transformers >= 4.52")
+
+        with TemporaryDirectory() as tmpdir:
+            main_export(model_name_or_path=MODEL_NAMES["qwen3_vl"], output=tmpdir, task="text-ranking")
+
+            for artifact_name in (
+                "openvino_language_model.xml",
+                "openvino_text_embeddings_model.xml",
+                "openvino_vision_embeddings_model.xml",
+            ):
+                self.assertTrue((Path(tmpdir) / artifact_name).exists())
+
+            model = OVModelForVisualCausalLM.from_pretrained(tmpdir, compile=False)
+            self.assertIsInstance(model, OVModelForVisualCausalLM)
+
     def test_export_openvino_with_missed_weight_format(self):
         # Test that exception is raised when some compression parameter is given, but weight format is not.
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary

This fix enables export of Qwen3-VL-Reranker-2B (and similar VLM-based reranker models) to OpenVINO IR.

### Problem

Qwen3-VL-Reranker-2B has `pipeline_tag=text-ranking` on HuggingFace, but uses the `qwen3_vl` VLM architecture. When optimum-cli attempts export with `--task text-ranking`, it fails because the VLM architecture requires `image-text-to-text` task.

### Fix

Added task remapping in `__main__.py`: if the task is `text-ranking` and the model type is a VLM-based reranker (`qwen3_vl`, `qwen2_vl`, `qwen2_5_vl`), automatically remap to `image-text-to-text`.

### Testing

- Exported Qwen/Qwen3-VL-Reranker-2B successfully with fp16 precision
- WWB CPU similarity: 0.9999 (32 samples)
- WWB GPU similarity: 0.9802 (32 samples)