### PR TITLE
[OpenVINO] Support Qwen3.5-35B-A3B with task image-text-to-text

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -137,6 +137,7 @@ Here is the list of the supported architectures :
 - Qwen3
 - Qwen3MoE
 - Qwen3-VL
+- Qwen3-VL-MoE
 - Qwen3.5
 - Qwen3.5-MoE
 - Qwen3.6

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -113,7 +113,7 @@ def infer_task(
                         # should use image-text-to-text task for proper inputs_embeds/3D position_ids export.
                         if "Eagle3LlamaForCausalLM" in config.architectures and (
                             getattr(config, "modal_type", "") == "VLM"
-                            or getattr(config, "target_model_type", "") in {"qwen2_vl", "qwen3_vl"}
+                            or getattr(config, "target_model_type", "") in {"qwen2_vl", "qwen3_vl", "qwen3_vl_moe"}
                         ):
                             task = "image-text-to-text"
                         else:

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -218,6 +218,8 @@ from .model_patcher import (
     Qwen3ASRModelPatcher,
     Qwen3MoeModelPatcher,
     Qwen3NextModelPatcher,
+    Qwen3VLMoeLanguageModelPatcher,
+    Qwen3VLMoeTextModelPatcher,
     Qwen3VLLanguageModelPatcher,
     Qwen3VLVisionEmbMergerPatcher,
     QwenModelPatcher,
@@ -497,6 +499,13 @@ class DummyQwen3VLLMInputGenerator(DummyTextInputGenerator):
         float_dtype: str = "fp32",
         bool_dtype: str = "bool",
     ):
+        if input_name == "position_ids":
+            return self.constant_tensor(
+                shape=[3, self.batch_size, self.sequence_length],
+                framework=framework,
+                value=0,
+                dtype=DTYPE_MAPPER.pt(int_dtype),
+            )
         if input_name == "deepstack_visual_embeds":
             return self.random_float_tensor(
                 [self.num_layers, 2 * self.sequence_length, self.embed_dim], framework=framework, dtype=float_dtype
@@ -533,6 +542,19 @@ class Qwen3VLTextOpenVINOConfig(TextDecoderWithPositionIdsOnnxConfig):
         common_inputs["visual_pos_masks"] = {0: "batch_size", 1: "sequence_length"}
         common_inputs["deepstack_visual_embeds"] = {0: "num_layers", 1: "visual_seqlen"}
         return common_inputs
+
+
+@register_in_tasks_manager(
+    "qwen3_vl_moe_text",
+    *[
+        "text-generation",
+        "text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class Qwen3VLMoeTextOpenVINOConfig(Qwen3VLTextOpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "5.0.0"
+    _MODEL_PATCHER = Qwen3VLMoeTextModelPatcher
 
 
 @register_in_tasks_manager(
@@ -4189,6 +4211,62 @@ class Qwen3VLOpenVINOConfig(Qwen2VLOpenVINOConfig):
                 "qwen3_vl_text", self._orig_config.text_config, self.int_dtype, self.float_dtype
             ).outputs
         raise Exception("Unknown Qwen3VL behavior type.")
+
+
+@register_in_tasks_manager(
+    "qwen3_vl_moe",
+    *["image-text-to-text"],
+    library_name="transformers",
+)
+class Qwen3VLMoeOpenVINOConfig(Qwen3VLOpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "5.0.0"
+
+    def with_behavior(
+        self,
+        behavior: Union[str, QwenVLConfigBehavior],
+    ):
+        if isinstance(behavior, str) and not isinstance(behavior, QwenVLConfigBehavior):
+            behavior = QwenVLConfigBehavior(behavior)
+
+        if behavior == QwenVLConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config(
+                "qwen3_vl_moe_text", self._orig_config.text_config, self.int_dtype, self.float_dtype
+            )
+
+        if behavior == QwenVLConfigBehavior.LANGUAGE:
+            config = get_vlm_text_generation_config(
+                "qwen3_vl_moe_text",
+                self._orig_config.text_config,
+                self.int_dtype,
+                self.float_dtype,
+                model_patcher=Qwen3VLMoeLanguageModelPatcher,
+                dummy_input_generator=DummyQwen3VLLMInputGenerator,
+                inputs_update={"position_ids": {1: "batch_size", 2: "sequence_length"}},
+            )
+            config._normalized_config.deepstack_visual_indexes = self._orig_config.vision_config.deepstack_visual_indexes
+            return config
+
+        if behavior in (
+            QwenVLConfigBehavior.VISION_EMBEDDINGS,
+            QwenVLConfigBehavior.VISION_EMBEDDINGS_MERGER,
+            QwenVLConfigBehavior.VISION_EMBEDDINGS_POS,
+        ):
+            return self.__class__(
+                self._orig_config,
+                task=self.task,
+                int_dtype=self.int_dtype,
+                float_dtype=self.float_dtype,
+                behavior=behavior,
+                preprocessors=self._preprocessors,
+            )
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == QwenVLConfigBehavior.LANGUAGE:
+            return get_vlm_internal_text_generation_config(
+                "qwen3_vl_moe_text", self._orig_config.text_config, self.int_dtype, self.float_dtype
+            ).outputs
+        return super().outputs
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -4406,6 +4406,41 @@ class Qwen3VLLanguageModelPatcher(OVDecoderModelPatcher):
         self._model.forward = self._model.__orig_forward
 
 
+class Qwen3VLMoeTextModelPatcher(OVDecoderModelPatcher):
+    def __enter__(self):
+        super().__enter__()
+        from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import Qwen3VLMoeTextExperts
+
+        self._orig_experts_forward = Qwen3VLMoeTextExperts.forward
+        Qwen3VLMoeTextExperts.forward = lfm2_moe_experts_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import Qwen3VLMoeTextExperts
+
+        Qwen3VLMoeTextExperts.forward = self._orig_experts_forward
+        super().__exit__(exc_type, exc_value, traceback)
+
+
+class Qwen3VLMoeLanguageModelPatcher(Qwen3VLLanguageModelPatcher):
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: Union["PreTrainedModel"],
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(config, model, model_kwargs)
+        from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import Qwen3VLMoeTextExperts
+
+        self._orig_experts_forward = Qwen3VLMoeTextExperts.forward
+        Qwen3VLMoeTextExperts.forward = lfm2_moe_experts_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        from transformers.models.qwen3_vl_moe.modeling_qwen3_vl_moe import Qwen3VLMoeTextExperts
+
+        Qwen3VLMoeTextExperts.forward = self._orig_experts_forward
+        super().__exit__(exc_type, exc_value, traceback)
+
+
 def patch_qwen2vl_vision_blocks(model, force_new_behaviour=False):
     if not force_new_behaviour and is_transformers_version("<=", "4.48.99"):
         # Modified from https://github.com/huggingface/transformers/blob/v4.45.2/src/transformers/models/qwen2_vl/modeling_qwen2_vl.py#L390
@@ -4645,7 +4680,11 @@ class Qwen3VLVisionEmbMergerPatcher(ModelPatcher):
                     )
                     deepstack_feature_lists.append(deepstack_feature)
             last_hidden_state = self.merger(hidden_states)
-            return last_hidden_state, torch.stack(deepstack_feature_lists, dim=0)
+            if len(deepstack_feature_lists) == 0:
+                deepstack_feature_tensor = hidden_states.new_empty((0,) + hidden_states.shape)
+            else:
+                deepstack_feature_tensor = torch.stack(deepstack_feature_lists, dim=0)
+            return last_hidden_state, deepstack_feature_tensor
 
         model.forward = types.MethodType(image_embed_forward, model)
         super().__init__(config, model, model_kwargs)

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -324,6 +324,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "qwen2_vl",
     "qwen2_5_vl",
     "qwen3_vl",
+    "qwen3_vl_moe",
     "qwen3_5",
     "qwen3_5_moe",
     "got_ocr2",

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -196,7 +196,7 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
 
             if self.config.model_type in ["qwen3_5", "qwen3_5_moe"] and position_ids.ndim != 3:
                 position_ids = np.repeat(np.expand_dims(position_ids, 0), 4, axis=0)
-            elif self.config.model_type in ["qwen2_vl", "qwen3_vl"] and position_ids.ndim != 3:
+            elif self.config.model_type in ["qwen2_vl", "qwen3_vl", "qwen3_vl_moe"] and position_ids.ndim != 3:
                 position_ids = np.repeat(np.expand_dims(position_ids, 0), 3, axis=0)
 
             inputs["position_ids"] = position_ids
@@ -209,7 +209,12 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
 
         if "deepstack_visual_embeds" in self.input_names:
             if deepstack_visual_embeds is not None:
-                inputs["deepstack_visual_embeds"] = torch.Tensor(deepstack_visual_embeds)
+                deepstack_tensor = torch.Tensor(deepstack_visual_embeds)
+                if deepstack_tensor.numel() == 0:
+                    num_layers = len(self.config.vision_config.deepstack_visual_indexes)
+                    emd_dim = self.config.text_config.hidden_size
+                    deepstack_tensor = torch.zeros((num_layers, 1, emd_dim), dtype=torch.float32)
+                inputs["deepstack_visual_embeds"] = deepstack_tensor
             else:
                 num_layers = len(self.config.vision_config.deepstack_visual_indexes)
                 emd_dim = self.config.text_config.hidden_size
@@ -795,7 +800,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
 
         # Prepare additional kwargs for qwen3_vl models
         additional_kwargs = {}
-        if self.config.model_type in ("qwen3_vl",) and extra_outputs:
+        if self.config.model_type in ("qwen3_vl", "qwen3_vl_moe") and extra_outputs:
             additional_kwargs["visual_pos_masks"] = extra_outputs[0]
             additional_kwargs["deepstack_visual_embeds"] = extra_outputs[1]
 
@@ -5840,6 +5845,8 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "phi4_multimodal": _OVPhi4MMForCausalLM,
     "llama4": _OVLlama4ForCausalLM,
     "qwen3_vl": _OVQwen3VLForCausalLM,
+    "qwen3_vl_moe": _OVQwen3VLForCausalLM,
+    "qwen3_vl_moe_text": _OVQwen3VLForCausalLM,
     "qwen3_5": _OVQwen3_5ForCausalLM,
     "qwen3_5_text": _OVQwen3_5ForCausalLM,
     "qwen3_5_moe": _OVQwen3_5ForCausalLM,

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -317,7 +317,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
             supported_architectures -= {"lfm2_moe"}
         # qwen3_vl_text a part of qwen3_vl architecture and is tested in seq2seq group
         if is_transformers_version(">=", str(Qwen3VLOpenVINOConfig.MIN_TRANSFORMERS_VERSION)):
-            supported_architectures -= {"qwen3_vl_text"}
+            supported_architectures -= {"qwen3_vl_text", "qwen3_vl_moe_text"}
 
         # TODO: add fix for v5 and update MAX_TRANSFORMERS_VERSION accordingly
         if is_transformers_version(">=", "5"):

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -133,6 +133,7 @@ class ExportModelTest(unittest.TestCase):
 
     if is_transformers_version(">=", "5.0"):
         SUPPORTED_ARCHITECTURES.update({"lfm2_moe": OVModelForCausalLM})
+        SUPPORTED_ARCHITECTURES.update({"qwen3_vl_moe": OVModelForVisualCausalLM})
 
     EXPECTED_DIFFUSERS_SCALE_FACTORS = {
         "stable-diffusion-xl": {"vae_encoder": "128.0", "vae_decoder": "128.0"},

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -192,6 +192,7 @@ class OVCLIExportTestCase(unittest.TestCase):
             [
                 ("text-generation", "lfm2_moe"),
                 ("text-generation-with-past", "lfm2_moe"),
+                ("image-text-to-text", "qwen3_vl_moe"),
             ]
         )
 
@@ -229,6 +230,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "bitnet": 2,
         "granitemoehybrid": 2,
         "qwen3_vl_eagle3": 0,
+        "qwen3_vl_moe": 2,
     }
 
     TOKENIZER_CHAT_TEMPLATE_TESTS_MODELS = {

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1081,6 +1081,9 @@ class OVWeightCompressionTest(unittest.TestCase):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "qwen3_vl", False))
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForCausalLM, "hunyuan_v1_dense", False))
 
+    if is_transformers_version(">=", "5.0"):
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "qwen3_vl_moe", False))
+
     if is_transformers_version("==", "4.57.6"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForSpeechSeq2Seq, "qwen3_asr", True))
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -293,6 +293,7 @@ MODEL_NAMES = {
     "qwen3": "optimum-intel-internal-testing/tiny-random-qwen3",
     "qwen3_moe": "optimum-intel-internal-testing/tiny-random-qwen3moe",
     "qwen3_vl": "optimum-intel-internal-testing/tiny-random-qwen3-vl",
+    "qwen3_vl_moe": "/home/mohamed-ashraf/Desktop/projects/GSoC26/auto-openvino-bot/workspace/tiny-qwen3_5-35b-a3b",
     "qwen3_next": "optimum-intel-internal-testing/tiny-random-qwen3-next",
     "qwen3_5": "optimum-intel-internal-testing/tiny-random-qwen3.5",
     "qwen3_5_moe": "optimum-intel-internal-testing/tiny-random-qwen3.5-moe",
@@ -469,6 +470,13 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "text_embeddings_model": 1,
         "vision_embeddings_model": 1,
         "vision_embeddings_merger_model": 32,
+        "vision_embeddings_pos_model": 1,
+    },
+    "qwen3_vl_moe": {
+        "lm_model": 66,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 1,
+        "vision_embeddings_merger_model": 18,
         "vision_embeddings_pos_model": 1,
     },
     "videochat_flash_qwen": {


### PR DESCRIPTION
## Summary

Adds Optimum Intel support for Qwen/Qwen3.5-35B-A3B with task image-text-to-text.

## Validation

- Optimum export passed locally.
- WWB similarity validation passed locally.

## Notes

Created by the auto-openvino-bot PR helper.
