### PR TITLE
[EXPERIMENT][WIP] feat: add google/gemma-4-12B and gemma-4-12B-it OpenVINO support

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -42,6 +42,7 @@ from optimum.exporters.openvino.utils import (
     allow_skip_tracing_check,
     clear_class_registry,
     remove_none_from_dummy_inputs,
+    patch_gemma4_export_configs,
     save_config,
     save_preprocessors,
     set_simplified_chat_template,
@@ -758,6 +759,7 @@ def export_from_model(
                 )
 
         save_preprocessors(preprocessors, model.config, output, trust_remote_code)
+        patch_gemma4_export_configs(output, getattr(model.config, "model_type", None))
 
         files_subpaths = ["openvino_" + model_name + ".xml" for model_name in models_and_export_configs.keys()]
 

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -1200,15 +1200,19 @@ class DummyGemma4VisionInputGenerator(DummyVisionInputGenerator):
 
     def __init__(self, task, normalized_config, batch_size=DEFAULT_DUMMY_SHAPES["batch_size"], **kwargs):
         super().__init__(task, normalized_config, batch_size, **kwargs)
-        self.patch_size = getattr(normalized_config, "patch_size", 16)
+        self.is_unified = hasattr(normalized_config, "model_patch_size")
+        self.patch_size = getattr(normalized_config, "model_patch_size", getattr(normalized_config, "patch_size", 16))
         self.pooling_kernel_size = getattr(normalized_config, "pooling_kernel_size", 3)
-        # Gemma4 processor always pads pixel_values to max_soft_tokens * pooling_kernel_size^2 patches.
-        # The vision model's pooling uses shape-dependent Python operations that get baked in during tracing,
-        # so the dummy input must match the actual inference shapes.
         max_soft_tokens = getattr(normalized_config, "image_seq_length", None)
         if max_soft_tokens is None:
             max_soft_tokens = getattr(normalized_config, "max_soft_tokens", 280)
-        self.num_patches = max_soft_tokens * self.pooling_kernel_size**2
+        if self.is_unified:
+            self.num_patches = max_soft_tokens
+        else:
+            # Gemma4 processor pads pixel_values to max_soft_tokens * pooling_kernel_size^2 patches.
+            # The vision model's pooling uses shape-dependent Python operations that get baked in during tracing,
+            # so the dummy input must match the actual inference shapes.
+            self.num_patches = max_soft_tokens * self.pooling_kernel_size**2
 
     def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
         if input_name == "pixel_values":
@@ -1219,24 +1223,33 @@ class DummyGemma4VisionInputGenerator(DummyVisionInputGenerator):
                 dtype=float_dtype,
             )
         if input_name == "image_position_ids":
-            # Create position ids as a grid. The patch count = h_patches * w_patches
-            # where both are divisible by pooling_kernel_size for correct pooling.
             import math
 
-            k = self.pooling_kernel_size
-            total_pooled = self.num_patches // (k * k)
-            # Find roughly square grid for pooled side
-            pooled_side = int(math.sqrt(total_pooled))
-            if pooled_side * pooled_side < total_pooled:
-                pooled_h = pooled_side
-                pooled_w = total_pooled // pooled_h
+            if self.is_unified:
+                side = max(int(math.sqrt(self.num_patches)), 1)
+                width = math.ceil(self.num_patches / side)
+                pos_ids = torch.stack(
+                    torch.meshgrid(torch.arange(side), torch.arange(width), indexing="ij"), dim=-1
+                ).reshape(1, -1, 2)
+                pos_ids = pos_ids[:, : self.num_patches, :]
             else:
-                pooled_h = pooled_w = pooled_side
-            h_patches = pooled_h * k
-            w_patches = pooled_w * k
-            pos_ids = torch.stack(
-                torch.meshgrid(torch.arange(h_patches), torch.arange(w_patches), indexing="ij"), dim=-1
-            ).reshape(1, -1, 2)
+                # Create position ids as a grid. The patch count = h_patches * w_patches
+                # where both are divisible by pooling_kernel_size for correct pooling.
+                k = self.pooling_kernel_size
+                total_pooled = self.num_patches // (k * k)
+                # Find roughly square grid for pooled side
+                pooled_side = int(math.sqrt(total_pooled))
+                if pooled_side * pooled_side < total_pooled:
+                    pooled_h = pooled_side
+                    pooled_w = total_pooled // pooled_h
+                else:
+                    pooled_h = pooled_w = pooled_side
+                h_patches = pooled_h * k
+                w_patches = pooled_w * k
+                pos_ids = torch.stack(
+                    torch.meshgrid(torch.arange(h_patches), torch.arange(w_patches), indexing="ij"), dim=-1
+                ).reshape(1, -1, 2)
+
             # Pad to num_patches with -1 (padding position)
             if pos_ids.shape[1] < self.num_patches:
                 pad = torch.full((1, self.num_patches - pos_ids.shape[1], 2), -1, dtype=pos_ids.dtype)

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1253,6 +1253,17 @@ class Gemma3TextOpenVINOConfig(Gemma2OpenVINOConfig):
 
 
 @register_in_tasks_manager(
+    "gemma4_unified_text",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text-classification",
+    ],
+    library_name="transformers",
+)
+@register_in_tasks_manager(
     "gemma4_text",
     *[
         "feature-extraction",
@@ -3806,6 +3817,7 @@ class Gemma4ConfigBehavior(str, enum.Enum):
     TEXT_EMBEDDINGS_PER_LAYER = "text_embeddings_per_layer"
 
 
+@register_in_tasks_manager("gemma4_unified", *["image-text-to-text"], library_name="transformers")
 @register_in_tasks_manager("gemma4", *["image-text-to-text"], library_name="transformers")
 class Gemma4OpenVINOConfig(Gemma3OpenVINOConfig):
     SUPPORTED_BEHAVIORS = [model_type.value for model_type in Gemma4ConfigBehavior]

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9156,7 +9156,16 @@ def patched_gemma4_clippable_linear_forward(self, hidden_states: torch.Tensor) -
 class Gemma4ImageEmbeddingsModelPatcher(CommonImageEmbeddingsModelPatcher):
     def __init__(self, config, model, model_kwargs):
         super().__init__(config, model, model_kwargs)
+        self._vision_encoder = None
+        self._orig_encoder_forward = None
+        self._gemma4_clippable_linear_cls = None
+
+        if not hasattr(model.model, "vision_tower"):
+            return
+
         from transformers.models.gemma4.modeling_gemma4 import Gemma4ClippableLinear
+
+        self._gemma4_clippable_linear_cls = Gemma4ClippableLinear
 
         # Get the vision encoder - it's at model.model.vision_tower.encoder
         vision_model = model.model.vision_tower if is_transformers_version(">=", "5") else model.vision_tower
@@ -9211,14 +9220,17 @@ class Gemma4ImageEmbeddingsModelPatcher(CommonImageEmbeddingsModelPatcher):
                         module.forward = types.MethodType(patched_gemma4_clippable_linear_forward, module)
 
     def __exit__(self, exc_type, exc_value, traceback):
-        from transformers.models.gemma4.modeling_gemma4 import Gemma4ClippableLinear
+        if self._vision_encoder is not None:
+            self._vision_encoder.forward = self._orig_encoder_forward
 
-        self._vision_encoder.forward = self._orig_encoder_forward
         super().__exit__(exc_type, exc_value, traceback)
+
+        if self._vision_encoder is None:
+            return
 
         for layer in self._vision_encoder.layers:
             for module in layer.modules():
-                if isinstance(module, Gemma4ClippableLinear) and module.use_clipped_linears:
+                if isinstance(module, self._gemma4_clippable_linear_cls) and module.use_clipped_linears:
                     if (
                         module.input_min == -float("inf")
                         and module.input_max == float("inf")

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import inspect
+import json
 import logging
 import re
 from collections import namedtuple
@@ -329,6 +330,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "got_ocr2",
     "gemma3",
     "gemma4",
+    "gemma4_unified",
     "idefics3",
     "smolvlm",
     "phi4mm",
@@ -519,6 +521,18 @@ COMPLEX_CHAT_TEMPLATES = {
 }
 
 
+GEMMA4_SIMPLIFIED_CHAT_TEMPLATE = (
+    "{{ bos_token }}"
+    "{% for message in messages %}"
+    "{% if message['role'] == 'system' and message['content'] %}{{ message['content'] + '\\n' }}"
+    "{% elif message['role'] == 'user' %}{{ '<start_of_turn>user\\n' + message['content'] + '<end_of_turn>\\n' }}"
+    "{% elif message['role'] == 'assistant' %}{{ '<start_of_turn>model\\n' + message['content'] + '<end_of_turn>\\n' }}"
+    "{% endif %}"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}{{ '<start_of_turn>model\\n' }}{% endif %}"
+)
+
+
 def set_simplified_chat_template(ov_tokenizer_model, processor_chat_template=None):
     tokenizer_chat_template = None
     if processor_chat_template is not None:
@@ -535,6 +549,27 @@ def set_simplified_chat_template(ov_tokenizer_model, processor_chat_template=Non
                 ov_tokenizer_model.set_rt_info(simplified_chat_template, "simplified_chat_template")
                 break
     return ov_tokenizer_model
+
+
+def patch_gemma4_export_configs(output: Path, model_type: Optional[str]):
+    if model_type not in {"gemma4", "gemma4_unified"}:
+        return
+
+    tokenizer_config_path = output / "tokenizer_config.json"
+    if tokenizer_config_path.exists():
+        tokenizer_config = json.loads(tokenizer_config_path.read_text())
+        tokenizer_config["chat_template"] = GEMMA4_SIMPLIFIED_CHAT_TEMPLATE
+        tokenizer_config_path.write_text(json.dumps(tokenizer_config, indent=2) + "\n")
+
+    generation_config_path = output / "generation_config.json"
+    if generation_config_path.exists():
+        generation_config = json.loads(generation_config_path.read_text())
+        stop_strings = list(generation_config.get("stop_strings") or [])
+        if "<end_of_turn>" not in stop_strings:
+            stop_strings.append("<end_of_turn>")
+        generation_config["stop_strings"] = stop_strings
+        generation_config["include_stop_str_in_output"] = False
+        generation_config_path.write_text(json.dumps(generation_config, indent=2) + "\n")
 
 
 SKIP_CHECK_TRACE_MODELS = (

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -463,6 +463,23 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "quant_method": OVQuantizationMethod.AWQ,
         "group_size_fallback": "adjust",
     },
+    "google/gemma-4-12B-it": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "ratio": 1.0,
+        "quant_method": OVQuantizationMethod.AWQ,
+        "group_size_fallback": "adjust",
+        "dq_group_size": 64,
+    },
+    "google/gemma-4-12B": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "ratio": 1.0,
+        "quant_method": OVQuantizationMethod.AWQ,
+        "group_size_fallback": "adjust",
+    },
     "google/gemma-4-E4B-it": {
         "bits": 4,
         "sym": False,

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -799,7 +799,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
             additional_kwargs["visual_pos_masks"] = extra_outputs[0]
             additional_kwargs["deepstack_visual_embeds"] = extra_outputs[1]
 
-        if self.config.model_type in ("gemma4",) and extra_outputs:
+        if self.config.model_type in ("gemma4", "gemma4_unified") and extra_outputs:
             additional_kwargs["per_layer_inputs"] = extra_outputs[0]
 
         return self.language_model.forward(
@@ -5834,6 +5834,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "got_ocr2": _OVGotOCR2ForCausalLM,
     "gemma3": _OVGemma3ForCausalLM,
     "gemma4": _OVGemma4ForCausalLM,
+    "gemma4_unified": _OVGemma4ForCausalLM,
     "idefics3": _OVIdefics3ForCausalLM,
     "smolvlm": _OVSmolVLForCasualLM,
     "phi4mm": _OVPhi4MMForCausalLM,

--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -872,7 +872,7 @@ class OVCalibrationDatasetBuilder:
                     "position_ids": position_ids,
                     "inputs_embeds": inputs_embeds,
                 }
-                if self.model.language_model.config.model_type == "gemma4":
+                if self.model.language_model.config.model_type in ("gemma4", "gemma4_unified_text"):
                     prepare_inputs_kwargs["per_layer_inputs"] = extra_outputs[0]
 
                 language_model_inputs = self.model.language_model.prepare_inputs(**prepare_inputs_kwargs)
@@ -1780,7 +1780,7 @@ def _weight_only_quantization(
     if config.dq_group_size is not None:
         compressed_model.set_rt_info(str(config.dq_group_size), ["runtime_options", "DYNAMIC_QUANTIZATION_GROUP_SIZE"])
 
-    _remove_f16_kv_cache_precision_flag(compressed_model)
+    _set_f16_kv_cache_precision(compressed_model)
     _add_nncf_version_flag(compressed_model)
 
     return compressed_model
@@ -1961,6 +1961,18 @@ def _verify_not_optimized(ov_model):
             raise RuntimeError(message_template.format(model_weight_compression_config))
         elif model_quantization_config is not None:
             raise RuntimeError(message_template.format(model_quantization_config))
+
+
+def _set_f16_kv_cache_precision(model: openvino.Model) -> openvino.Model:
+    """Preserve f16 KV cache precision for weight-compressed decoder models.
+
+    Stateful text-generation models already carry the KV cache hint before weight
+    compression. Keep it as f16 so CPU does not fall back to u8 and introduce
+    double-quantization, while leaving models without KV cache metadata untouched.
+    """
+    if model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]):
+        model.set_rt_info("f16", ["runtime_options", "KV_CACHE_PRECISION"])
+    return model
 
 
 def _remove_f16_kv_cache_precision_flag(model: openvino.Model) -> openvino.Model:

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1282,7 +1282,11 @@ class OVWeightCompressionTest(unittest.TestCase):
             # Verify that the configuration is correctly saved and loaded
             loaded_config = OVConfig.from_pretrained(tmp_dir, device=OPENVINO_DEVICE)
             self.assertEqual(OVWeightQuantizationConfig().to_dict(), loaded_config.quantization_config.to_dict())
-            self.assertFalse(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+            if task == "text-generation":
+                self.assertTrue(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+                self.assertEqual(model.model.get_rt_info(["runtime_options", "KV_CACHE_PRECISION"]).value, "f16")
+            else:
+                self.assertFalse(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_EXPECTED_4BIT_COMPRESSED_MATMULS)
     def test_ovmodel_4bit_weight_compression(self, model_cls, model_name, expected_int8_nodes, expected_int4_nodes):
@@ -1310,7 +1314,11 @@ class OVWeightCompressionTest(unittest.TestCase):
             # Verify that the configuration is correctly saved and loaded
             loaded_config = OVConfig.from_pretrained(tmp_dir, device=OPENVINO_DEVICE)
             self.assertEqual(ov_config.quantization_config.to_dict(), loaded_config.quantization_config.to_dict())
-            self.assertFalse(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+            if task == "text-generation":
+                self.assertTrue(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+                self.assertEqual(model.model.get_rt_info(["runtime_options", "KV_CACHE_PRECISION"]).value, "f16")
+            else:
+                self.assertFalse(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_STATEFUL_WITH_EXPECTED_8BIT_COMPRESSED_MATMULS)
     def test_ovmodel_8bit_weight_compression_stateful(self, model_cls, model_name, expected_pt_int8, expected_ov_int8):
@@ -1336,7 +1344,11 @@ class OVWeightCompressionTest(unittest.TestCase):
             # Verify that the configuration is correctly saved and loaded
             loaded_config = OVConfig.from_pretrained(tmp_dir, device=OPENVINO_DEVICE)
             self.assertEqual(OVWeightQuantizationConfig().to_dict(), loaded_config.quantization_config.to_dict())
-            self.assertFalse(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+            if task == "text-generation":
+                self.assertTrue(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+                self.assertEqual(model.model.get_rt_info(["runtime_options", "KV_CACHE_PRECISION"]).value, "f16")
+            else:
+                self.assertFalse(model.model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
 
     @parameterized.expand(
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION,
@@ -1369,7 +1381,13 @@ class OVWeightCompressionTest(unittest.TestCase):
 
         expected_ov_int8 = _ARCHITECTURES_TO_EXPECTED_INT8[model_type]
         expected_ov_int8 = {k: {"int8": v} for k, v in expected_ov_int8.items()}
-        check_compression_state_per_model(self, model.ov_models, expected_ov_int8)
+        expected_kv_cache_precision = {"lm_model": "f16"} if model_type in {"gemma4", "gemma4_moe"} else None
+        check_compression_state_per_model(
+            self,
+            model.ov_models,
+            expected_ov_int8,
+            expected_kv_cache_precision_per_model=expected_kv_cache_precision,
+        )
 
     @parameterized.expand(SUPPORTED_ARCHITECTURES_WITH_HYBRID_QUANTIZATION)
     def test_ovmodel_hybrid_quantization(self, model_cls, model_type, expected_fake_nodes, expected_int8_nodes):

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -677,10 +677,12 @@ def check_compression_state_per_model(
     models: Dict[str, ov.Model],
     expected_num_weight_nodes_per_model: Dict[str, Dict[str, int]],
     expected_num_fake_nodes_per_model: Optional[Dict[str, int]] = None,
+    expected_kv_cache_precision_per_model: Optional[Dict[str, str]] = None,
 ):
     test_case.assertEqual(len(models), len(expected_num_weight_nodes_per_model))
     actual_num_weights_per_model = {}
     actual_num_fake_nodes_per_model = {}
+    expected_kv_cache_precision_per_model = expected_kv_cache_precision_per_model or {}
     for ov_model_name, ov_model in models.items():
         expected_num_weight_nodes = expected_num_weight_nodes_per_model[ov_model_name]
         num_fake_nodes, num_weight_nodes = get_num_quantized_nodes(ov_model)
@@ -689,7 +691,15 @@ def check_compression_state_per_model(
         actual_num_weights_per_model[ov_model_name] = num_weight_nodes
         actual_num_fake_nodes_per_model[ov_model_name] = num_fake_nodes
 
-        test_case.assertFalse(ov_model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+        expected_kv_cache_precision = expected_kv_cache_precision_per_model.get(ov_model_name)
+        if expected_kv_cache_precision is None:
+            test_case.assertFalse(ov_model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+        else:
+            test_case.assertTrue(ov_model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+            test_case.assertEqual(
+                ov_model.get_rt_info(["runtime_options", "KV_CACHE_PRECISION"]).value,
+                expected_kv_cache_precision,
+            )
 
     # Check weight nodes
     test_case.assertEqual(expected_num_weight_nodes_per_model, actual_num_weights_per_model)


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary

Adds OpenVINO support for google/gemma-4-12B and google/gemma-4-12B-it (Gemma 4 unified multimodal model).

## Changes

1. Register `gemma4_unified` for image-text-to-text and text-generation tasks.
2. Add `DummyGemma4VisionInputGenerator` for Gemma4 export config keys.
3. Guard `Gemma4ImageEmbeddingsModelPatcher` for models without `vision_tower`.
4. Add `GEMMA4_SIMPLIFIED_CHAT_TEMPLATE` and `patch_gemma4_export_configs()`.
5. Add `gemma4_unified` to multimodal text-generation mappings.
6. Add `google/gemma-4-12B` and `google/gemma-4-12B-it` to default 4-bit weight configs.
7. Preserve `KV_CACHE_PRECISION=f16` through INT4 compression.
8. Patch post-export configs in `convert.py`.
9. Update quantization tests/helpers for Gemma4 KV-cache expectations.

## Validation

- Export / inference smoke validation:
  - FP16 CPU ✅
  - FP16 GPU.0 (iGPU) ✅
  - FP16 GPU.1 (dGPU) ✅
  - INT4 (KV-cache-fixed) CPU ✅
  - INT4 (KV-cache-fixed) GPU.0 (iGPU) ✅
  - INT4 (KV-cache-fixed) GPU.1 (dGPU) ✅
- Targeted existing tests:
  - `python -m pytest -q tests/openvino/test_quantization.py::OVWeightCompressionTest::test_build_dataset_gemma4 tests/openvino/test_quantization.py::OVWeightCompressionTest::test_build_dataset_gemma4_moe tests/openvino/test_quantization.py::OVWeightCompressionTest::test_ovmodel_load_with_compressed_weights_gemma4 tests/openvino/test_quantization.py::OVWeightCompressionTest::test_ovmodel_load_with_compressed_weights_gemma4_moe tests/openvino/test_quantization.py::OVWeightCompressionTest::test_ovmodel_load_with_uncompressed_weights_gemma4 tests/openvino/test_quantization.py::OVWeightCompressionTest::test_ovmodel_load_with_uncompressed_weights_gemma4_moe` ✅

## Known Issues

- INT4 default CPU still degrades generation quality because CPU falls back to quantized KV cache when the f16 hint is lost. This PR fixes the hint-preservation path; use the `kvcache-fixed` export for validation.
- Full WWB CLI text-mode evaluation required a manual workaround because the Gemma4 baseline/exported pair is not yet supported by stock WWB text loading.

## Related Issues

- openvinotoolkit/omega#5
