### PR TITLE
fix calibration calibration collection

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -1203,6 +1203,8 @@ class OVCalibrationDatasetBuilder:
                     )
                     if inputs["input_ids"].shape[1] > seq_len:
                         inputs["input_ids"] = inputs["input_ids"][:, :seq_len]
+                        if "attention_mask" in inputs:
+                            inputs["attention_mask"] = inputs["attention_mask"][:, :seq_len]
 
                 self.model(**inputs)
 


### PR DESCRIPTION
fix https://github.com/huggingface/optimum-intel/actions/runs/27227432572/job/80398255793

```
FAILED tests/openvino/test_exporters_cli.py::OVCLIExportTestCase::test_exporters_cli_full_quantization_00_automatic_speech_recognition - subprocess.CalledProcessError: Command 'optimum-cli export openvino --task automatic-speech-recognition --model optimum-intel-internal-testing/tiny-random-whisper --quant-mode int8 --dataset librispeech --num-samples 1 --smooth-quant-alpha 0.9 --trust-remote-code /tmp/tmpeurgnhpo' returned non-zero exit status 134.
FAILED tests/openvino/test_exporters_cli.py::OVCLIExportTestCase::test_exporters_cli_full_quantization_01_automatic_speech_recognition_with_past - subprocess.CalledProcessError: Command 'optimum-cli export openvino --task automatic-speech-recognition-with-past --model optimum-intel-internal-testing/tiny-random-whisper --quant-mode f8e4m3 --dataset librispeech --num-samples 1 --smooth-quant-alpha 0.9 --trust-remote-code /tmp/tmpmkkwsdz9' returned non-zero exit status 134.
```