### PR TITLE
Fix sst states for mamba / falcon mamba

### DIFF
--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -1208,26 +1208,25 @@ class OVCacheWithMambaStates(MambaCache):
         self.ssm_states = ssm_states
         if self.ssm_states is None:
             self.ssm_states: List[torch.Tensor] = []
-            if config.model_type in ["lfm2_moe", "lfm2"]:
-                for _ in range(self.num_mamba_layers):
-                    if self.n_mamba_heads and self.mamba_headdim:
-                        # Mamba2 block
-                        ssm_state_shape = (
-                            self.max_batch_size,
-                            self.n_mamba_heads,
-                            self.mamba_headdim,
-                            self.ssm_state_size,
-                        )
-                    else:
-                        # Mamba block
-                        ssm_state_shape = (self.max_batch_size, self.intermediate_size, self.ssm_state_size)
-
-                    ssm_state: torch.Tensor = torch.zeros(
-                        ssm_state_shape,
-                        device=self.device,
-                        dtype=dtype,
+            for _ in range(self.num_mamba_layers):
+                if self.n_mamba_heads and self.mamba_headdim:
+                    # Mamba2 block
+                    ssm_state_shape = (
+                        self.max_batch_size,
+                        self.n_mamba_heads,
+                        self.mamba_headdim,
+                        self.ssm_state_size,
                     )
-                    self.ssm_states.append(ssm_state)
+                else:
+                    # Mamba block
+                    ssm_state_shape = (self.max_batch_size, self.intermediate_size, self.ssm_state_size)
+
+                ssm_state: torch.Tensor = torch.zeros(
+                    ssm_state_shape,
+                    device=self.device,
+                    dtype=dtype,
+                )
+                self.ssm_states.append(ssm_state)
 
         self.key_cache = key_cache
         if self.key_cache is None:


### PR DESCRIPTION
Fix https://github.com/huggingface/optimum-intel/actions/runs/27262349757/job/80551291454


```
FAILED tests/openvino/test_decoder.py::OVModelForCausalLMIntegrationTest::test_beam_search_36_mamba - RuntimeError: Exception from src/inference/src/cpp/infer_request.cpp:246:
Exception from src/bindings/python/src/pyopenvino/core/infer_request.hpp:55:
Caught exception: Exception from src/plugins/intel_cpu/src/node.cpp:788:
[CPU] Exp node with name '__module.backbone.layers.31.mixer.selective_scan/aten::exp/Exp_1' Check 'input_shape[j] == 1' failed at src/plugins/intel_cpu/src/shape_inference/custom/eltwise.cpp:52:
Eltwise shape infer input shapes dim index: 0 mismatch
FAILED tests/openvino/test_decoder.py::OVModelForCausalLMIntegrationTest::test_beam_search_37_falcon_mamba - RuntimeError: Exception from src/inference/src/cpp/infer_request.cpp:246:
Exception from src/bindings/python/src/pyopenvino/core/infer_request.hpp:55:
Caught exception: Exception from src/plugins/intel_cpu/src/node.cpp:788:
[CPU] Exp node with name '__module.backbone.layers.15.mixer.selective_scan/aten::exp/Exp_1' Check 'input_shape[j] == 1' failed at src/plugins/intel_cpu/src/shape_inference/custom/eltwise.cpp:52:
Eltwise shape infer input shapes dim index: 0 mismatch
```