### PR TITLE
[OpenVINO] Add export support for gemma4_unified architecture

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -74,6 +74,7 @@ Here is the list of the supported architectures :
 - Gemma 2
 - Gemma 3
 - Gemma 4
+- Gemma 4 Unified
 - GOT-OCR 2.0
 - Granite
 - Granite 4.0

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -30,6 +30,7 @@ from transformers.utils import is_torch_available
 from openvino import Core, Type, save_model
 from optimum.exporters.openvino.base import OpenVINOConfig
 from optimum.exporters.tasks import TasksManager
+import optimum.exporters.openvino.model_configs  # ensure model registrations are loaded
 from optimum.intel.utils.import_utils import (
     DIFFUSERS_IMPORT_ERROR,
     is_diffusers_available,
@@ -701,7 +702,7 @@ def _main_quantize(
             trust_remote_code=trust_remote_code,
         )
         model_type = config.model_type
-        if model_type in ["phi4mm", "phi4_multimodal"]:
+        if model_type in ["phi4mm", "phi4_multimodal", "gemma4", "gemma4_unified"]:
             task = "image-text-to-text"
 
     # Step 1. Obtain the correct OpenVINO model class

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -1245,6 +1245,46 @@ class DummyGemma4VisionInputGenerator(DummyVisionInputGenerator):
         return super().generate(input_name, framework, int_dtype, float_dtype)
 
 
+class DummyGemma4UnifiedVisionInputGenerator(DummyVisionInputGenerator):
+    """Dummy input generator for gemma4_unified encoder-free vision embedder.
+    embed_vision expects [batch, num_soft_tokens, pooling_kernel_size^2 * 3 * patch_size^2]
+    """
+    SUPPORTED_INPUT_NAMES = ("pixel_values", "image_position_ids")
+
+    def __init__(self, task, normalized_config, batch_size=DEFAULT_DUMMY_SHAPES["batch_size"], **kwargs):
+        super().__init__(task, normalized_config, batch_size, **kwargs)
+        vision_cfg = getattr(normalized_config.config, "vision_config", None)
+        self.patch_size = getattr(vision_cfg, "patch_size", 16) if vision_cfg else 16
+        self.pooling_kernel_size = getattr(vision_cfg, "pooling_kernel_size", 3) if vision_cfg else 3
+        self.num_soft_tokens = getattr(vision_cfg, "num_soft_tokens", 280) if vision_cfg else 280
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "pixel_values":
+            # embed_vision expects [batch, num_soft_tokens, pooling_kernel_size^2 * 3 * patch_size^2]
+            flat_dim = self.pooling_kernel_size ** 2 * 3 * self.patch_size ** 2
+            return self.random_float_tensor(
+                shape=[self.batch_size, self.num_soft_tokens * self.pooling_kernel_size ** 2, flat_dim],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "image_position_ids":
+            import torch
+            import math
+            k = self.pooling_kernel_size
+            total = self.num_soft_tokens
+            side = int(math.sqrt(total))
+            h, w = side, total // side
+            pos_ids = torch.stack(
+                torch.meshgrid(torch.arange(h * k), torch.arange(w * k), indexing="ij"), dim=-1
+            ).reshape(1, -1, 2)
+            num_patches = self.num_soft_tokens * k * k
+            if pos_ids.shape[1] < num_patches:
+                pad = torch.full((1, num_patches - pos_ids.shape[1], 2), -1, dtype=pos_ids.dtype)
+                pos_ids = torch.cat([pos_ids, pad], dim=1)
+            return pos_ids[:, :num_patches].expand(self.batch_size, -1, -1).clone()
+        return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
 class DummyVisionPositionIdsInputGenerator(DummyVisionInputGenerator):
     SUPPORTED_INPUT_NAMES = ("patch_attention_mask", "patch_position_ids")
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -43,6 +43,7 @@ from optimum.exporters.openvino.input_generators import (
     DummyFluxTextInputGenerator,
     DummyFluxTransformerInputGenerator,
     DummyGemma4VisionInputGenerator,
+    DummyGemma4UnifiedVisionInputGenerator,
     DummyKokoroInputGenerator,
     DummyLLavaMultiModalProjectorInputGenerator,
     DummyMiniCPMVImageInputGenerator,
@@ -1290,6 +1291,21 @@ class Gemma4TextOpenVINOConfig(Gemma3TextOpenVINOConfig):
             inputs_or_outputs[f"{name}.{i}.key"] = {0: "batch_size", 2: decoder_sequence_name}
             inputs_or_outputs[f"{name}.{i}.value"] = {0: "batch_size", 2: decoder_sequence_name}
 
+
+
+@register_in_tasks_manager(
+    "gemma4_unified_text",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text-classification",
+    ],
+    library_name="transformers",
+)
+class Gemma4UnifiedTextOpenVINOConfig(Gemma4TextOpenVINOConfig):
+    pass
 
 @register_in_tasks_manager("deci", *["text-generation", "text-generation-with-past"], library_name="transformers")
 class DeciOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
@@ -3807,6 +3823,7 @@ class Gemma4ConfigBehavior(str, enum.Enum):
 
 
 @register_in_tasks_manager("gemma4", *["image-text-to-text"], library_name="transformers")
+@register_in_tasks_manager("gemma4_unified", *["image-text-to-text", "text-generation-with-past", "text-generation"], library_name="transformers")
 class Gemma4OpenVINOConfig(Gemma3OpenVINOConfig):
     SUPPORTED_BEHAVIORS = [model_type.value for model_type in Gemma4ConfigBehavior]
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator, DummyTextInputGenerator)
@@ -3819,6 +3836,8 @@ class Gemma4OpenVINOConfig(Gemma3OpenVINOConfig):
         float_dtype: str = "fp32",
         behavior: Gemma4ConfigBehavior = Gemma4ConfigBehavior.VISION_EMBEDDINGS,
         preprocessors: Optional[List[Any]] = None,
+        use_past: bool = False,
+        **kwargs,
     ):
         super().__init__(
             config=config,
@@ -3828,9 +3847,13 @@ class Gemma4OpenVINOConfig(Gemma3OpenVINOConfig):
             preprocessors=preprocessors,
             behavior=behavior,
         )
+        self.use_past = use_past
         self._behavior = behavior
         if self._behavior == Gemma4ConfigBehavior.VISION_EMBEDDINGS:
-            self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyGemma4VisionInputGenerator,)
+            if getattr(config, 'model_type', '') == 'gemma4_unified':
+                self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyGemma4UnifiedVisionInputGenerator,)
+            else:
+                self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyGemma4VisionInputGenerator,)
             # Attach image_seq_length from preprocessor to normalized config so
             # the dummy input generator can compute the correct number of patches.
             # The vision model's pooling uses shape-dependent Python operations baked in
@@ -3867,7 +3890,7 @@ class Gemma4OpenVINOConfig(Gemma3OpenVINOConfig):
             behavior = Gemma4ConfigBehavior(behavior)
 
         if behavior == Gemma4ConfigBehavior.LANGUAGE:
-            model_type = "gemma4_text"
+            model_type = "gemma4_unified_text" if getattr(self._orig_config, "model_type", "") == "gemma4_unified" else "gemma4_text"
             inputs_update = {
                 "per_layer_inputs": {0: "batch_size", 1: "sequence_length", 2: "num_hidden_layers"},
             }

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9179,6 +9179,13 @@ class Gemma4ImageEmbeddingsModelPatcher(CommonImageEmbeddingsModelPatcher):
         from transformers.models.gemma4.modeling_gemma4 import Gemma4ClippableLinear
 
         # Get the vision encoder - it's at model.model.vision_tower.encoder
+        # gemma4_unified uses embed_vision instead of vision_tower (encoder-free architecture)
+        if hasattr(model.model, "embed_vision"):
+            self._is_unified = True
+            self._vision_encoder = model.model.embed_vision
+            self._orig_encoder_forward = self._vision_encoder.forward
+            return
+        self._is_unified = False
         vision_model = model.model.vision_tower if is_transformers_version(">=", "5") else model.vision_tower
         self._vision_encoder = vision_model.encoder
 
@@ -9235,6 +9242,8 @@ class Gemma4ImageEmbeddingsModelPatcher(CommonImageEmbeddingsModelPatcher):
 
         self._vision_encoder.forward = self._orig_encoder_forward
         super().__exit__(exc_type, exc_value, traceback)
+        if getattr(self, "_is_unified", False):
+            return
 
         for layer in self._vision_encoder.layers:
             for module in layer.modules():

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -329,6 +329,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "got_ocr2",
     "gemma3",
     "gemma4",
+    "gemma4_unified",
     "idefics3",
     "smolvlm",
     "phi4mm",

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -799,7 +799,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
             additional_kwargs["visual_pos_masks"] = extra_outputs[0]
             additional_kwargs["deepstack_visual_embeds"] = extra_outputs[1]
 
-        if self.config.model_type in ("gemma4",) and extra_outputs:
+        if self.config.model_type in ("gemma4", "gemma4_unified") and extra_outputs:
             additional_kwargs["per_layer_inputs"] = extra_outputs[0]
 
         return self.language_model.forward(
@@ -5834,6 +5834,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "got_ocr2": _OVGotOCR2ForCausalLM,
     "gemma3": _OVGemma3ForCausalLM,
     "gemma4": _OVGemma4ForCausalLM,
+    "gemma4_unified": _OVGemma4ForCausalLM,
     "idefics3": _OVIdefics3ForCausalLM,
     "smolvlm": _OVSmolVLForCasualLM,
     "phi4mm": _OVPhi4MMForCausalLM,

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -117,6 +117,7 @@ class ExportModelTest(unittest.TestCase):
     if is_transformers_version(">=", "5.5.0"):
         SUPPORTED_ARCHITECTURES.update({"gemma4": OVModelForVisualCausalLM})
         SUPPORTED_ARCHITECTURES.update({"gemma4_moe": OVModelForVisualCausalLM})
+        SUPPORTED_ARCHITECTURES.update({"gemma4_unified": OVModelForVisualCausalLM})
 
     if is_transformers_version(">=", "5.2.0") and is_transformers_version("<", "5.3.0"):
         SUPPORTED_ARCHITECTURES.update({"qwen3_5": OVModelForVisualCausalLM})

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1102,6 +1102,7 @@ class OVWeightCompressionTest(unittest.TestCase):
     if is_transformers_version(">=", "5.5.0"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "gemma4", False))
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "gemma4_moe", False))
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "gemma4_unified", False))
 
     SUPPORTED_ARCHITECTURES_WITH_HYBRID_QUANTIZATION = [
         (OVStableDiffusionPipeline, "stable-diffusion", 72, 195),
@@ -1694,6 +1695,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         [
             ("gemma4",),
             ("gemma4_moe",),
+            ("gemma4_unified",),
         ]
         if is_transformers_version(">=", "5.5.0")
         else [],

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -714,7 +714,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         SUPPORTED_ARCHITECTURES += ["internvl_chat", "minicpmv"]
 
     if is_transformers_version(">=", "5.5"):
-        SUPPORTED_ARCHITECTURES += ["gemma4", "gemma4_moe"]
+        SUPPORTED_ARCHITECTURES += ["gemma4", "gemma4_moe", "gemma4_unified"]
 
     if is_transformers_version(">=", "5.2.0") and is_transformers_version("<", "5.3.0"):
         SUPPORTED_ARCHITECTURES += ["qwen3_5", "qwen3_5_moe"]

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -206,6 +206,7 @@ MODEL_NAMES = {
     "gemma3": "optimum-intel-internal-testing/tiny-random-gemma3",
     "gemma4": "optimum-intel-internal-testing/tiny-random-gemma4",
     "gemma4_moe": "optimum-intel-internal-testing/tiny-random-gemma4-moe",
+    "gemma4_unified": "optimum-intel-internal-testing/tiny-random-gemma4-unified",
     "falcon": "optimum-intel-internal-testing/really-tiny-falcon-testing",
     "falcon-40b": "optimum-intel-internal-testing/tiny-random-falcon-40b",
     "falcon_mamba": "optimum-intel-internal-testing/tiny-falcon-mamba",


### PR DESCRIPTION
Gemma 4 Unified (`gemma4_unified`) is an encoder-free multimodal architecture. Unlike `gemma4`, it uses `embed_vision` instead of `vision_tower` and expects vision inputs shaped `[batch, num_patches, pooling_kernel_size² × 3 × patch_size²]`.

- `model_configs.py`: Register `gemma4_unified` and `gemma4_unified_text` model types; add `use_past`/`**kwargs` to `Gemma4OpenVINOConfig.__init__`; select the correct dummy input generator based on `model_type` at runtime
- `model_patcher.py`: Handle `embed_vision` in `Gemma4ImageEmbeddingsModelPatcher` for unified architecture (skip `vision_tower` layer patching on exit)
- `input_generators.py`: Add `DummyGemma4UnifiedVisionInputGenerator` with correct `pixel_values` and `image_position_ids` shapes for the encoder-free embedder
- `utils.py`: Add `gemma4_unified` to `MULTI_MODAL_TEXT_GENERATION_MODELS`
- `__main__.py`: Import `model_configs` to ensure registrations are loaded; add `gemma4`/`gemma4_unified` to `image-text-to-text` auto-detection
- `modeling_visual_language.py`: Add `gemma4_unified` to `per_layer_inputs` handling and `MODEL_TYPE_TO_CLS_MAPPING`

## What does this PR do?

Adds OpenVINO export support for the `gemma4_unified` model type (Gemma 4 Unified), released June 4, 2026. This architecture is encoder-free — it replaces the `vision_tower` used in `gemma4` with a lightweight `embed_vision` module that processes patches directly via linear projections.

Without these changes, attempting to export `google/gemma-4-12B-it` raises:
ValueError: Trying to export a gemma4_unified model, that is a custom or
unsupported architecture, but no custom export configuration was passed.


Tested end-to-end on `google/gemma-4-12B-it` (Intel Core Ultra 7 155U, 32GB RAM):

```bash
optimum-cli export openvino \
  --model google/gemma-4-12B-it \
  --weight-format fp16 \
  --task image-text-to-text \
  ./gemma4-openvino
```

Successfully exports all submodels:

| File | Size |
|------|------|
| `openvino_language_model.bin` | 23GB |
| `openvino_text_embeddings_model.bin` | 1.9GB |
| `openvino_vision_embeddings_model.bin` | 96MB |
| `openvino_text_embeddings_per_layer_model.bin` | — |

Inference verified working with `OVModelForVisualCausalLM`.

## Before submitting checklist
- [x] Add Gemma 4 Unified to supported models list in docs
- [x] Add test fixtures for gemma4_unified architecture
