### PR TITLE
Add support for Ouro (ByteDance/Ouro-1.4B)

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -119,7 +119,6 @@ Here is the list of the supported architectures :
 - OLMo 2
 - OPT
 - Orion
-- Ouro
 - Pegasus
 - Perceiver
 - Persimmon

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -119,6 +119,7 @@ Here is the list of the supported architectures :
 - OLMo 2
 - OPT
 - Orion
+- Ouro
 - Pegasus
 - Perceiver
 - Persimmon
@@ -203,3 +204,9 @@ Here is the list of the supported architectures :
 ## [AngelSlim] (https://github.com/Tencent/AngelSlim)
 - Qwen3-VL-4B-Instruct_eagle3
 - Qwen3-1.7B_eagle3
+
+## [Ouro](https://huggingface.co/ByteDance/Ouro-1.4B)
+- Ouro-1.4B
+- Ouro-1.4B-Thinking
+- Ouro-2.6B
+- Ouro-2.6B-Thinking

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -121,6 +121,7 @@ Here is the list of the supported architectures :
 - OLMo 2
 - OPT
 - Orion
+- Ouro
 - Pegasus
 - Perceiver
 - Persimmon
@@ -218,3 +219,8 @@ Here is the list of the supported architectures :
 - Qwen3.5-*-DFlash
 - Qwen3.6-*-DFlash
 - Qwen3-Coder-30B-A3B-DFlash
+## [Ouro](https://huggingface.co/ByteDance/Ouro-1.4B)
+- Ouro-1.4B
+- Ouro-1.4B-Thinking
+- Ouro-2.6B
+- Ouro-2.6B-Thinking

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -121,7 +121,6 @@ Here is the list of the supported architectures :
 - OLMo 2
 - OPT
 - Orion
-- Ouro
 - Pegasus
 - Perceiver
 - Persimmon
@@ -219,6 +218,7 @@ Here is the list of the supported architectures :
 - Qwen3.5-*-DFlash
 - Qwen3.6-*-DFlash
 - Qwen3-Coder-30B-A3B-DFlash
+
 ## [Ouro](https://huggingface.co/ByteDance/Ouro-1.4B)
 - Ouro-1.4B
 - Ouro-1.4B-Thinking

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -476,6 +476,32 @@ class SmolLM3OpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
     _MODEL_PATCHER = OVDecoderModelPatcher
 
 
+class NormalizedOuroConfig(NormalizedTextConfig):
+    """Ouro is a Universal Transformer: the same ``num_hidden_layers`` decoder layers are looped
+    ``total_ut_steps`` times, and every iteration stores its own key/value entry. The exported model
+    therefore exposes ``num_hidden_layers * total_ut_steps`` past-key-value pairs."""
+
+    @property
+    def num_layers(self):
+        return self.config.num_hidden_layers * getattr(self.config, "total_ut_steps", 1)
+
+
+@register_in_tasks_manager(
+    "ouro",
+    *[
+        "text-generation",
+        "text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class OuroOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, MistralDummyPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = MistralDummyPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedOuroConfig
+    MIN_TRANSFORMERS_VERSION = "4.53.0"
+    _MODEL_PATCHER = OVDecoderModelPatcher
+
+
 @register_in_tasks_manager("stablelm", *["text-generation", "text-generation-with-past"], library_name="transformers")
 class StableLMOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, MistralDummyPastKeyValuesGenerator)

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -499,6 +499,7 @@ class OuroOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
     DUMMY_PKV_GENERATOR_CLASS = MistralDummyPastKeyValuesGenerator
     NORMALIZED_CONFIG_CLASS = NormalizedOuroConfig
     MIN_TRANSFORMERS_VERSION = "4.53.0"
+    MAX_TRANSFORMERS_VERSION = "4.57.99" 
     _MODEL_PATCHER = OVDecoderModelPatcher
 
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -630,6 +630,34 @@ class SmolLM3OpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
     _MODEL_PATCHER = OVDecoderModelPatcher
 
 
+class NormalizedOuroConfig(NormalizedTextConfig):
+    """Ouro is a Universal Transformer: the same ``num_hidden_layers`` decoder layers are looped
+    ``total_ut_steps`` times, and every iteration stores its own key/value entry. The exported model
+    therefore exposes ``num_hidden_layers * total_ut_steps`` past-key-value pairs."""
+
+    @property
+    def num_layers(self):
+        return self.config.num_hidden_layers * getattr(self.config, "total_ut_steps", 1)
+
+
+@register_in_tasks_manager(
+    "ouro",
+    *[
+        "text-generation",
+        "text-generation-with-past",
+    ],
+    library_name="transformers",
+)
+class OuroOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, MistralDummyPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = MistralDummyPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedOuroConfig
+    MIN_TRANSFORMERS_VERSION = "4.53.0"
+    # Ouro relies on remote modeling code that is incompatible with transformers v5
+    MAX_TRANSFORMERS_VERSION = "4.57.6"
+    _MODEL_PATCHER = OVDecoderModelPatcher
+
+
 @register_in_tasks_manager("stablelm", *["text-generation", "text-generation-with-past"], library_name="transformers")
 class StableLMOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, MistralDummyPastKeyValuesGenerator)

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -147,6 +147,10 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
     if is_transformers_version(">=", "4.54.0") and is_transformers_version("<", "5"):
         SUPPORTED_ARCHITECTURES += ("exaone4",)
 
+    # Ouro relies on remote modeling code that is incompatible with transformers v5
+    if is_transformers_version(">=", "4.53.0") and is_transformers_version("<", "5"):
+        SUPPORTED_ARCHITECTURES += ("ouro",)
+
     if is_transformers_version("<", "4.54.0"):
         SUPPORTED_ARCHITECTURES += ("minicpm", "minicpm3", "arctic")
 
@@ -259,6 +263,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "falcon_mamba": 0,
         "arcee": 2,
         "smollm3": 2,
+        "ouro": 8,
         "gpt_oss": 2,
         "gpt_oss_mxfp4": 2,
         "zamba2": 1,
@@ -502,6 +507,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
             "internlm2",
             "jais",
             "orion",
+            "ouro",
             "xverse",
         }:
             additional_inputs = {"use_cache": False}
@@ -877,6 +883,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
                 "internlm2",
                 "jais",
                 "orion",
+                "ouro",
                 "xverse",
             }:
                 additional_inputs["use_cache"] = False

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -117,6 +117,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "jais",
         "baichuan2",
         "baichuan2-13b",
+        "ouro",
         # remote modeling code failing with v5
         "aquila",
         "xverse",
@@ -223,6 +224,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "falcon_mamba": 0,
         "arcee": 2,
         "smollm3": 2,
+        "ouro": 8,
         "gpt_oss": 2,
         "gpt_oss_mxfp4": 2,
         "zamba2": 1,
@@ -459,6 +461,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
             "internlm2",
             "jais",
             "orion",
+            "ouro",
             "xverse",
         }:
             additional_inputs = {"use_cache": False}
@@ -817,6 +820,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
                 "internlm2",
                 "jais",
                 "orion",
+                "ouro",
                 "xverse",
             }:
                 additional_inputs["use_cache"] = False

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -108,6 +108,10 @@ class ExportModelTest(unittest.TestCase):
     if is_transformers_version(">=", "4.54") and is_transformers_version("<", "5"):
         SUPPORTED_ARCHITECTURES.update({"exaone4": OVModelForCausalLM, "lfm2": OVModelForCausalLM})
 
+    # Ouro relies on remote modeling code that is incompatible with transformers v5
+    if is_transformers_version(">=", "4.53.0") and is_transformers_version("<", "5"):
+        SUPPORTED_ARCHITECTURES.update({"ouro": OVModelForCausalLM})
+
     if is_transformers_version(">=", "4.55.0") and is_transformers_version("<", "4.58.0"):
         SUPPORTED_ARCHITECTURES.update({"afmoe": OVModelForCausalLM})
 

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -107,6 +107,7 @@ class ExportModelTest(unittest.TestCase):
         "qwen3": OVModelForFeatureExtraction,
         "zamba2": OVModelForCausalLM,
         "exaone4": OVModelForCausalLM,
+        "ouro": OVModelForCausalLM,
         "lfm2": OVModelForCausalLM,
         "afmoe": OVModelForCausalLM,
         "qwen3_next": OVModelForCausalLM,

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -174,6 +174,14 @@ class OVCLIExportTestCase(unittest.TestCase):
             ]
         )
 
+    # Ouro relies on remote modeling code that is incompatible with transformers v5
+    if is_transformers_version(">=", "4.53.0") and is_transformers_version("<", "5"):
+        SUPPORTED_ARCHITECTURES.extend(
+            [
+                ("text-generation-with-past", "ouro"),
+            ]
+        )
+
     if is_transformers_version(">=", "4.57") and is_transformers_version("<", "5.0.0"):
         SUPPORTED_ARCHITECTURES.extend(
             [
@@ -230,6 +238,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "bitnet": 2,
         "granitemoehybrid": 2,
         "smollm3": 2,
+        "ouro": 2,
         "qwen3_vl_eagle3": 0,
     }
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -128,6 +128,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         ("text-generation-with-past", "qwen3_dflash"),
         ("text-generation-with-past", "zamba2"),
         ("text-generation-with-past", "exaone4"),
+        ("text-generation-with-past", "ouro"),
         ("text-generation-with-past", "bitnet"),
         ("text-generation-with-past", "qwen3_next"),
         ("image-text-to-text", "qwen3_vl_eagle3"),
@@ -182,6 +183,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "bitnet": 2,
         "granitemoehybrid": 2,
         "smollm3": 2,
+        "ouro": 2,
         "qwen3_vl_eagle3": 0,
         "qwen3_vl_embedding": 2,
     }

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1077,6 +1077,10 @@ class OVWeightCompressionTest(unittest.TestCase):
     if is_transformers_version(">=", "4.53.0"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForCausalLM, "smollm3", False))
 
+    # Ouro relies on remote modeling code that is incompatible with transformers v5
+    if is_transformers_version(">=", "4.53.0") and is_transformers_version("<", "5"):
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForCausalLM, "ouro", True))
+
     if is_transformers_version(">=", "4.54.0") and is_transformers_version("<", "5"):
         SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForCausalLM, "exaone4", True))
 

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1171,6 +1171,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         (OVModelForFeatureExtraction, "qwen3_vl_embedding", False),
         (OVModelForVisualCausalLM, "qwen3_omni_moe", False),
         (OVModelForCausalLM, "exaone4", True),
+        (OVModelForCausalLM, "ouro", True),
         (OVModelForVisualCausalLM, "llava_next_video", False),
         (OVModelForVisualCausalLM, "minicpmv", True),
         (OVModelForSpeechSeq2Seq, "qwen3_asr", True),

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -274,6 +274,7 @@ MODEL_NAMES = {
     "nystromformer": "optimum-intel-internal-testing/tiny-random-NystromformerModel",
     "olmo": "optimum-intel-internal-testing/tiny-random-olmo-hf",
     "orion": "optimum-intel-internal-testing/tiny-random-orion",
+    "ouro": "optimum-intel-internal-testing/tiny-random-ouro",
     "pegasus": "optimum-intel-internal-testing/tiny-random-pegasus",
     "perceiver_text": "optimum-intel-internal-testing/tiny-random-language_perceiver",
     "perceiver_vision": "optimum-intel-internal-testing/tiny-random-vision_perceiver_conv",
@@ -546,6 +547,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "text_embeddings_per_layer_model": 0,
     },
     "smollm3": {"model": 30},
+    "ouro": {"model": 34},
     "qwen3_asr": {
         "encoder": 36,
         "decoder": 30,
@@ -583,7 +585,7 @@ REMOTE_CODE_MODELS = (
 )
 
 if is_transformers_version("<", "5"):
-    REMOTE_CODE_MODELS += ("afmoe",)
+    REMOTE_CODE_MODELS += ("afmoe", "ouro")
 
 
 SDPA_ARCHS_ONNX_EXPORT_NOT_SUPPORTED = [

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -279,6 +279,7 @@ HUB_MODEL_NAMES = {
     "nystromformer": "optimum-intel-internal-testing/tiny-random-NystromformerModel",
     "olmo": "optimum-intel-internal-testing/tiny-random-olmo-hf",
     "orion": "optimum-intel-internal-testing/tiny-random-orion",
+    "ouro": "optimum-intel-internal-testing/tiny-random-ouro",
     "pegasus": "optimum-intel-internal-testing/tiny-random-pegasus",
     "perceiver_text": "optimum-intel-internal-testing/tiny-random-language_perceiver",
     "perceiver_vision": "optimum-intel-internal-testing/tiny-random-vision_perceiver_conv",
@@ -627,6 +628,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "text_embeddings_model": 1,
         "vision_embeddings_model": 3,
     },
+    "ouro": {"model": 34},
     "qwen3_asr": {
         "encoder": 36,
         "decoder": 30,
@@ -671,7 +673,7 @@ REMOTE_CODE_MODELS = (
 )
 
 if is_transformers_version("<", "5"):
-    REMOTE_CODE_MODELS += ("afmoe",)
+    REMOTE_CODE_MODELS += ("afmoe", "ouro")
 
 
 ARCH_TO_MODEL_CLASS = {


### PR DESCRIPTION
## What does this PR do?

This PR adds OpenVINO export and inference support for the [Ouro](https://huggingface.co/ByteDance/Ouro-1.4B) model family (`OuroForCausalLM`).

Ouro is a **Universal Transformer** decoder: the same `num_hidden_layers` decoder layers are looped `total_ut_steps` times, and every iteration stores its own key/value entry. The only thing required for a correct export is a normalized config that reports `num_layers = num_hidden_layers * total_ut_steps`, so the exported model exposes the right number of past-key-value pairs. No custom model patching or new operators are needed — the stock `OVDecoderModelPatcher` is reused.

Export the model:

```bash
optimum-cli export openvino --model ByteDance/Ouro-1.4B --trust-remote-code ouro_ov
```

Run inference:

```python
from transformers import AutoTokenizer
from optimum.intel import OVModelForCausalLM

model_id = "ByteDance/Ouro-1.4B"
tokenizer = AutoTokenizer.from_pretrained(model_id)
model = OVModelForCausalLM.from_pretrained(model_id, export=True, trust_remote_code=True)

inputs = tokenizer("The quick brown fox", return_tensors="pt")
outputs = model.generate(**inputs, max_new_tokens=20)
print(tokenizer.batch_decode(outputs, skip_special_tokens=True)[0])
```

Notes:
- Ouro relies on remote modeling code that is incompatible with `transformers` v5, so tests are gated to `>=4.53.0, <5` (validated against `transformers==4.57.1`).
- Ouro's custom `UniversalTransformerCache` makes cached generation diverge from uncached under left-padding + beam search (this happens in `transformers` too), so in tests Ouro joins the other remote-code custom-cache models that compare against transformers with `use_cache=False`.
- A tiny test model is added at `optimum-intel-internal-testing/tiny-random-ouro` (full vocab + real tokenizer, `total_ut_steps=4`).

Fixes # (issue)

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?