### PR TITLE
Add CohereAsrOpenVINOConfig for CohereLabs/cohere-transcribe-03-2026

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -38,6 +38,7 @@ Here is the list of the supported architectures :
 - CodeGen2
 - Cohere
 - Cohere2
+- Cohere ASR
 - ConvBERT
 - ConvNeXt
 - DBRX

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -1209,6 +1209,54 @@ class DummyQwen3VLVisionEmbedInputGenerator(DummyQwen2VLVisionEmbedInputGenerato
             )
 
 
+class CohereAsrDummyAudioInputGenerator(DummyAudioInputGenerator):
+    """
+    Adds a `length` dummy input alongside `input_features` for CohereLabs/cohere-transcribe.
+
+    Unlike Whisper, `CohereAsrFeatureExtractor` (Hub remote code) does not pad `input_features`
+    to a fixed `nb_max_frames`; it pads only to the batch's max sample length and returns a
+    second `length` tensor with the true per-sample frame count, which `ConformerEncoder`/
+    `ConvSubsampling` use for masking. During dummy tracing every sample in the batch is
+    generated with the same `nb_max_frames` frames (no padding in the trace), so `length` is
+    simply `nb_max_frames` for every batch entry.
+    """
+
+    SUPPORTED_INPUT_NAMES = ("input_features", "input_values", "length")
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "length":
+            return self.random_int_tensor(
+                shape=[self.batch_size],
+                max_value=self.nb_max_frames + 1,
+                min_value=self.nb_max_frames,
+                framework=framework,
+                dtype=int_dtype,
+            )
+        return super().generate(input_name, framework=framework, int_dtype=int_dtype, float_dtype=float_dtype)
+
+
+class CohereAsrDummySeq2SeqDecoderTextInputGenerator(DummySeq2SeqDecoderTextInputGenerator):
+    """
+    Generates `encoder_outputs`/`encoder_hidden_states` dummy tensors with the Conformer
+    encoder's own `d_model` width (pre-`encoder_decoder_proj`) instead of the decoder's
+    `hidden_size`.
+
+    Unlike Whisper (where the encoder and decoder share the same hidden size),
+    `CohereAsrForConditionalGeneration.forward` always applies `self.encoder_decoder_proj`
+    (Linear(encoder.d_model -> decoder_hidden_size)) to whatever it receives as
+    `encoder_outputs.last_hidden_state` -- including a pre-computed `encoder_outputs` passed in
+    directly for the decoder-only/with-past export. The base
+    `DummySeq2SeqDecoderTextInputGenerator` sizes that dummy tensor using
+    `normalized_config.hidden_size`, which here is the *decoder's* hidden size, producing a
+    tensor with the wrong last dimension and a MatMul shape-inference failure in
+    `encoder_decoder_proj` during ONNX/OpenVINO conversion of the with-past decoder.
+    """
+
+    def __init__(self, task, normalized_config, **kwargs):
+        super().__init__(task, normalized_config, **kwargs)
+        self.hidden_size = normalized_config.encoder_hidden_size
+
+
 class Qwen3ASRDummySeq2SeqPastKeyValuesGenerator(DummySeq2SeqPastKeyValuesGenerator):
     """Custom KV cache generator for Qwen3-ASR with GQA (num_key_value_heads != num_attention_heads).
     Qwen3-ASR has no cross-attention, so only self-attention KV cache is generated (2 per layer)."""

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -39,6 +39,8 @@ from optimum.exporters.openvino.config import (
 from optimum.exporters.openvino.input_generators import (
     AquilaDummyPastKeyValuesGenerator,
     ChatGLM2DummyPastKeyValuesGenerator,
+    CohereAsrDummyAudioInputGenerator,
+    CohereAsrDummySeq2SeqDecoderTextInputGenerator,
     DeciDummyPastKeyValuesGenerator,
     DummyAudioPhi4MMInputGenerator,
     DummyFluxTextInputGenerator,
@@ -220,7 +222,6 @@ from optimum.utils.normalized_config import (
     NormalizedTextConfig,
     NormalizedVisionConfig,
 )
-
 
 COMMON_TEXT_TASKS = [
     "feature-extraction",
@@ -4117,13 +4118,27 @@ class FunASROpenVINOConfig(AudioToTextOpenVINOConfig):
     ],
     library_name="transformers",
 )
-class CohereAsrOpenVINOConfig(WhisperOpenVINOConfig):
+class CohereAsrOpenVINOConfig(AudioToTextOpenVINOConfig):
     """
     OpenVINO export config for CohereAsrForConditionalGeneration.
-    Architecture: Conformer encoder + Transformer decoder, same tensor
-    contract as Whisper (input_features → encoder; encoder_outputs +
+    Architecture: Conformer encoder + Transformer decoder (encoder_outputs +
     decoder_input_ids + past_key_values → decoder logits).
+
+    Unlike Whisper, the Conformer encoder consumes a *variable-length*
+    `input_features` tensor: `CohereAsrFeatureExtractor` (Hub remote code) does not pad to a
+    fixed `nb_max_frames=3000` (Whisper's 30s convention) — it pads only to the batch's max
+    sample length and additionally returns a `length` tensor with the true per-sample frame
+    count, which `ConformerEncoder`/`ConvSubsampling` require for correct masking. Because of
+    this different contract, this class extends `AudioToTextOpenVINOConfig` directly instead of
+    `WhisperOpenVINOConfig` (whose `.inputs`/`.outputs` overrides hardcode the static
+    Whisper-only 3000-frame shape) and adds `length` as an explicit second encoder input.
     """
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        CohereAsrDummyAudioInputGenerator,
+        CohereAsrDummySeq2SeqDecoderTextInputGenerator,
+        DummySeq2SeqPastKeyValuesGenerator,
+    )
 
     _MODEL_PATCHER = CohereAsrModelPatcher
 
@@ -4134,6 +4149,10 @@ class CohereAsrOpenVINOConfig(WhisperOpenVINOConfig):
         num_attention_heads="num_attention_heads",
         decoder_num_attention_heads="num_key_value_heads",
         feature_size="num_mel_bins",
+        # Encoder (Conformer) `d_model`, distinct from the decoder's `hidden_size` above -- used
+        # to correctly size the `encoder_outputs` dummy input for `encoder_decoder_proj`,
+        # see `CohereAsrDummySeq2SeqDecoderTextInputGenerator`.
+        encoder_hidden_size="d_model",
         allow_new=True,
     )
 
@@ -4186,6 +4205,15 @@ class CohereAsrOpenVINOConfig(WhisperOpenVINOConfig):
             preprocessors=preprocessors,
             **kwargs,
         )
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        common_inputs = super().inputs
+        if self._behavior in {ConfigBehavior.ENCODER, ConfigBehavior.MONOLITH}:
+            # `length` carries the true per-sample frame count (before any batch padding) that
+            # ConformerEncoder/ConvSubsampling need for masking; see CohereAsrDummyAudioInputGenerator.
+            common_inputs["length"] = {0: "batch_size"}
+        return common_inputs
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -343,6 +343,15 @@ def init_model_configs():
             "Qwen3OmniMoeForConditionalGeneration",
         )
 
+    TasksManager._CUSTOM_CLASSES[("pt", "cohere_asr", "automatic-speech-recognition")] = (
+        "transformers",
+        "AutoModelForSpeechSeq2Seq",
+    )
+    TasksManager._CUSTOM_CLASSES[("pt", "cohere_asr", "automatic-speech-recognition-with-past")] = (
+        "transformers",
+        "AutoModelForSpeechSeq2Seq",
+    )
+
     if is_diffusers_available() and "fill" not in TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS:
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS["fill"] = "FluxFillPipeline"
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_MAPPINGS["fill"] = {"flux": "FluxFillPipeline"}
@@ -4097,6 +4106,83 @@ class FunASROpenVINOConfig(AudioToTextOpenVINOConfig):
         for i in range(self._normalized_config.decoder_num_layers):
             inputs_or_outputs[f"{name}.{i}.decoder.key"] = {0: "batch_size", 2: decoder_sequence_name}
             inputs_or_outputs[f"{name}.{i}.decoder.value"] = {0: "batch_size", 2: decoder_sequence_name}
+
+
+@register_in_tasks_manager(
+    "cohere_asr",
+    *[
+        "automatic-speech-recognition",
+        "automatic-speech-recognition-with-past",
+    ],
+    library_name="transformers",
+)
+class CohereAsrOpenVINOConfig(WhisperOpenVINOConfig):
+    """
+    OpenVINO export config for CohereAsrForConditionalGeneration.
+    Architecture: Conformer encoder + Transformer decoder, same tensor
+    contract as Whisper (input_features → encoder; encoder_outputs +
+    decoder_input_ids + past_key_values → decoder logits).
+    """
+
+    NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
+        encoder_num_layers="encoder_layers",
+        decoder_num_layers="decoder_layers",
+        hidden_size="hidden_size",
+        num_attention_heads="num_attention_heads",
+        decoder_num_attention_heads="num_key_value_heads",
+        feature_size="num_mel_bins",
+        allow_new=True,
+    )
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "automatic-speech-recognition",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        def _get(obj, key, default=None):
+            if obj is None:
+                return default
+            if isinstance(obj, dict):
+                return obj.get(key, default)
+            return getattr(obj, key, default)
+
+        encoder = getattr(config, "encoder", None)
+        decoder = getattr(config, "transf_decoder", None)
+        decoder_cfg = _get(decoder, "config_dict")
+        preprocessor = getattr(config, "preprocessor", None)
+
+        if encoder is not None:
+            config.encoder_layers = _get(encoder, "n_layers")
+            config.num_mel_bins = _get(encoder, "feat_in")
+            config.d_model = _get(encoder, "d_model")
+
+        if decoder_cfg is not None:
+            config.decoder_layers = _get(decoder_cfg, "num_layers")
+            config.hidden_size = _get(decoder_cfg, "hidden_size")
+            config.num_attention_heads = _get(decoder_cfg, "num_attention_heads")
+            config.num_key_value_heads = _get(
+                decoder_cfg, "num_key_value_heads", _get(decoder_cfg, "num_attention_heads")
+            )
+            config.vocab_size = getattr(config, "vocab_size", None) or _get(decoder_cfg, "vocab_size")
+
+        if getattr(config, "num_mel_bins", None) is None and preprocessor is not None:
+            config.num_mel_bins = _get(preprocessor, "features")
+
+        if getattr(config, "decoder_start_token_id", None) is None:
+            config.decoder_start_token_id = 0
+
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+            **kwargs,
+        )
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -99,6 +99,7 @@ from optimum.exporters.openvino.model_patcher import (
     BloomModelPatcher,
     ChatGLMModelPatcher,
     CodeGenModelPatcher,
+    CohereAsrModelPatcher,
     CommonImageEmbeddingsModelPatcher,
     DBRXModelPatcher,
     DeciLMModelPatcher,
@@ -4123,6 +4124,8 @@ class CohereAsrOpenVINOConfig(WhisperOpenVINOConfig):
     contract as Whisper (input_features → encoder; encoder_outputs +
     decoder_input_ids + past_key_values → decoder logits).
     """
+
+    _MODEL_PATCHER = CohereAsrModelPatcher
 
     NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
         encoder_num_layers="encoder_layers",

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9911,22 +9911,47 @@ class CohereAsrModelPatcher(OVSeq2SeqModelPatcher):
 
     The remote-code Conformer encoder's relative positional encoding
     (`RelPositionalEncoding` in `modeling_cohere_asr.py`) lazily materializes a `pe` buffer in
-    `_materialize_pe`, a method decorated with `torch._dynamo.disable(...)`. `torch.jit.trace`
-    (used by the OpenVINO exporter) re-invokes the traced module a second time to check that
-    the captured graph is deterministic (`check_trace`). The dynamo-disable wrapper hooks into
-    the same CPython frame-evaluation API used by the tracer, so the lazily-cached `pe` buffer
-    (and/or its recomputation) is not observed consistently across the two invocations,
-    producing constant nodes that differ (including differing dtypes for internal index
-    tensors), so `torch.jit.trace` aborts with:
+    `_materialize_pe`, a method decorated with `torch._dynamo.disable(...)`. The exact patched
+    code, from `modeling_cohere_asr.py` at Hub revision `b1eacc2686a3d08ceaae5f24a88b1d519620bc09`
+    of `CohereLabs/cohere-transcribe-03-2026` (line numbers as of that revision)::
+
+        @_dynamo_disable
+        def _materialize_pe(self, length: int, device: torch.device, dtype: torch.dtype):
+            needed_size = 2 * length - 1
+            if hasattr(self, "pe") and self.pe.size(1) >= needed_size:
+                if self.pe.device != device:
+                    self.pe = self.pe.to(device=device)
+                if self.pe.dtype != dtype:
+                    self.pe = self.pe.to(dtype=dtype)
+                return
+            effective_length = max(length, self.max_len)
+            positions = torch.arange(
+                effective_length - 1, -effective_length, -1, dtype=torch.float32, device=device
+            ).unsqueeze(1)
+            pe = self._create_pe(positions=positions, dtype=dtype)
+            if hasattr(self, "pe"):
+                self.pe = pe
+            else:
+                self.register_buffer("pe", pe, persistent=False)
+        # (modeling_cohere_asr.py, lines ~199-215)
+
+    `torch.jit.trace` (used by the OpenVINO exporter) re-invokes the traced module a second time
+    to check that the captured graph is deterministic (`check_trace`). The dynamo-disable
+    wrapper hooks into the same CPython frame-evaluation API used by the tracer, so the
+    lazily-cached `pe` buffer (and the `hasattr(self, "pe") and self.pe.size(1) >= needed_size`
+    early-return above) is not observed consistently across the two invocations, producing
+    constant nodes that differ (including differing dtypes for internal index tensors), so
+    `torch.jit.trace` aborts with:
 
         "Tensor-valued Constant nodes differed in value across invocations."
 
-    Fix: replace `_materialize_pe` with a dynamo-free implementation that *always* recomputes
-    the `pe` buffer from scratch (no lazy "already materialized?" caching, no
-    `torch._dynamo.disable`). Because `_create_pe` is a pure, deterministic function of
-    `length`/`device`/`dtype`, a fresh eager recompute on every call is guaranteed to produce
-    bit-identical constants across `torch.jit.trace`'s two check-trace invocations, regardless
-    of the actual sequence length seen at trace time (dummy inputs) vs. `pos_enc.max_len`.
+    Fix: replace `_materialize_pe` with a dynamo-free implementation (`_materialize_pe_eager`
+    below) that *always* recomputes the `pe` buffer from scratch (no lazy "already
+    materialized?" caching, no `torch._dynamo.disable`). Because `_create_pe` is a pure,
+    deterministic function of `length`/`device`/`dtype`, a fresh eager recompute on every call
+    is guaranteed to produce bit-identical constants across `torch.jit.trace`'s two check-trace
+    invocations, regardless of the actual sequence length seen at trace time (dummy inputs) vs.
+    `pos_enc.max_len`.
     """
 
     def __enter__(self):
@@ -9939,19 +9964,33 @@ class CohereAsrModelPatcher(OVSeq2SeqModelPatcher):
         """
         `CohereAsrForConditionalGeneration.forward` (and its `_prepare_inputs_for_generation`
         helper) derive the decoder's self/cross-attention masks from `_get_cache_seq_length`,
-        a free function (in the remote-code module) that does `int(past_key_values.get_seq_length())`.
-        The explicit `int(...)` cast immediately materializes the cache length into a plain
-        Python int at trace time, which `torch.jit.trace` then bakes as a graph *constant*
-        wherever it feeds `torch.arange`/mask-shape arithmetic (`total_kv_len`,
-        `self_attention_mask`, `_align_decoder_attention_mask`). This makes the exported
-        with-past decoder only valid for the exact KV-cache length seen during tracing, so real
-        inference at any other step count fails with a `ScaledDotProductAttentionWithKVCache`
-        shape-mismatch error (traced/static kv length vs. actual kv length).
+        a free function in the remote-code module. The exact patched code, from
+        `modeling_cohere_asr.py` at Hub revision `b1eacc2686a3d08ceaae5f24a88b1d519620bc09` of
+        `CohereLabs/cohere-transcribe-03-2026` (lines ~1423-1430)::
 
-        Fix: monkeypatch the module-level `_get_cache_seq_length` for the trace duration so it
-        returns the tensor-derived length without the `int(...)` cast, keeping it dynamic
-        through `torch.jit.trace` (mirroring how `past_key_values[0][0].shape[-2]` stays dynamic
-        for every other seq2seq/decoder-only architecture in this file).
+            def _get_cache_seq_length(past_key_values) -> int:
+                if past_key_values is None:
+                    return 0
+                if hasattr(past_key_values, "get_seq_length"):
+                    return int(past_key_values.get_seq_length())
+                if isinstance(past_key_values, tuple) and past_key_values:
+                    return int(past_key_values[0][0][0].shape[-2])
+                return 0
+
+        The explicit `int(...)` cast on both non-trivial branches immediately materializes the
+        cache length into a plain Python int at trace time, which `torch.jit.trace` then bakes
+        as a graph *constant* wherever it feeds `torch.arange`/mask-shape arithmetic
+        (`total_kv_len`, `self_attention_mask`, `_align_decoder_attention_mask`). This makes the
+        exported with-past decoder only valid for the exact KV-cache length seen during tracing,
+        so real inference at any other step count fails with a
+        `ScaledDotProductAttentionWithKVCache` shape-mismatch error (traced/static kv length vs.
+        actual kv length).
+
+        Fix: monkeypatch the module-level `_get_cache_seq_length` for the trace duration
+        (`_dynamic_get_cache_seq_length` below) so it returns the tensor-derived length without
+        the `int(...)` cast, keeping it dynamic through `torch.jit.trace` (mirroring how
+        `past_key_values[0][0].shape[-2]` stays dynamic for every other seq2seq/decoder-only
+        architecture in this file).
         """
         module = sys.modules.get(type(self._model).__module__)
         if module is None or not hasattr(module, "_get_cache_seq_length"):

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9904,6 +9904,79 @@ class FunASRModelPatcher(OVSeq2SeqModelPatcher):
                     del attn._orig_forward
 
 
+class CohereAsrModelPatcher(OVSeq2SeqModelPatcher):
+    """
+    Model patcher for CohereLabs/cohere-transcribe (Conformer encoder + Transformer decoder).
+
+    The remote-code Conformer encoder's relative positional encoding
+    (`RelPositionalEncoding` in `modeling_cohere_asr.py`) lazily materializes a `pe` buffer in
+    `_materialize_pe`, a method decorated with `torch._dynamo.disable(...)`. `torch.jit.trace`
+    (used by the OpenVINO exporter) re-invokes the traced module a second time to check that
+    the captured graph is deterministic (`check_trace`). The dynamo-disable wrapper hooks into
+    the same CPython frame-evaluation API used by the tracer, so the lazily-cached `pe` buffer
+    (and/or its recomputation) is not observed consistently across the two invocations,
+    producing constant nodes that differ (including differing dtypes for internal index
+    tensors), so `torch.jit.trace` aborts with:
+
+        "Tensor-valued Constant nodes differed in value across invocations."
+
+    Fix: replace `_materialize_pe` with a dynamo-free implementation that *always* recomputes
+    the `pe` buffer from scratch (no lazy "already materialized?" caching, no
+    `torch._dynamo.disable`). Because `_create_pe` is a pure, deterministic function of
+    `length`/`device`/`dtype`, a fresh eager recompute on every call is guaranteed to produce
+    bit-identical constants across `torch.jit.trace`'s two check-trace invocations, regardless
+    of the actual sequence length seen at trace time (dummy inputs) vs. `pos_enc.max_len`.
+    """
+
+    def __enter__(self):
+        super().__enter__()
+        self._patched_pos_encs = []
+        self._patch_positional_encoding()
+
+    def _patch_positional_encoding(self):
+        # Look up positional-encoding submodules by class name (rather than a fixed attribute
+        # path) so the patch keeps working whether `self._model` is the full model, the
+        # encoder-only submodule used for the "encoder" export variant, or a monolith variant.
+        pos_encs = [module for module in self._model.modules() if type(module).__name__ == "RelPositionalEncoding"]
+
+        for pos_enc in pos_encs:
+            pos_enc._orig_materialize_pe = pos_enc._materialize_pe
+            pos_enc._materialize_pe = self._make_frozen_materialize_pe(pos_enc)
+            self._patched_pos_encs.append(pos_enc)
+
+    @staticmethod
+    def _materialize_pe_eager(pos_enc, length, device, dtype):
+        """Plain-eager re-implementation of `RelPositionalEncoding._materialize_pe`, always
+        recomputing the buffer (no lazy reuse) so it stays deterministic under `torch.jit.trace`."""
+        effective_length = max(length, getattr(pos_enc, "max_len", length))
+        positions = torch.arange(
+            effective_length - 1, -effective_length, -1, dtype=torch.float32, device=device
+        ).unsqueeze(1)
+        pe = pos_enc._create_pe(positions=positions, dtype=dtype)
+        if hasattr(pos_enc, "pe"):
+            pos_enc.pe = pe
+        else:
+            pos_enc.register_buffer("pe", pe, persistent=False)
+
+    @classmethod
+    def _make_frozen_materialize_pe(cls, pos_enc):
+        # Deliberately unconditional: no `hasattr(self, "pe")` cache-hit branch, no
+        # `torch._dynamo.disable`. Always recomputing keeps the result a pure function of the
+        # call arguments, which is what makes it safe under `torch.jit.trace`'s check-pass.
+        def frozen_materialize_pe(length, device, dtype):
+            cls._materialize_pe_eager(pos_enc, length=length, device=device, dtype=dtype)
+
+        return frozen_materialize_pe
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+
+        for pos_enc in getattr(self, "_patched_pos_encs", []):
+            if hasattr(pos_enc, "_orig_materialize_pe"):
+                pos_enc._materialize_pe = pos_enc._orig_materialize_pe
+                del pos_enc._orig_materialize_pe
+
+
 class KokoroModelPatcher(ModelPatcher):
     """
     Patches the Kokoro TTS model for OpenVINO export by redirecting forward

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -16,6 +16,7 @@ import functools
 import inspect
 import logging
 import math
+import sys
 import types
 from dataclasses import dataclass
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
@@ -9932,6 +9933,42 @@ class CohereAsrModelPatcher(OVSeq2SeqModelPatcher):
         super().__enter__()
         self._patched_pos_encs = []
         self._patch_positional_encoding()
+        self._patch_cache_seq_length()
+
+    def _patch_cache_seq_length(self):
+        """
+        `CohereAsrForConditionalGeneration.forward` (and its `_prepare_inputs_for_generation`
+        helper) derive the decoder's self/cross-attention masks from `_get_cache_seq_length`,
+        a free function (in the remote-code module) that does `int(past_key_values.get_seq_length())`.
+        The explicit `int(...)` cast immediately materializes the cache length into a plain
+        Python int at trace time, which `torch.jit.trace` then bakes as a graph *constant*
+        wherever it feeds `torch.arange`/mask-shape arithmetic (`total_kv_len`,
+        `self_attention_mask`, `_align_decoder_attention_mask`). This makes the exported
+        with-past decoder only valid for the exact KV-cache length seen during tracing, so real
+        inference at any other step count fails with a `ScaledDotProductAttentionWithKVCache`
+        shape-mismatch error (traced/static kv length vs. actual kv length).
+
+        Fix: monkeypatch the module-level `_get_cache_seq_length` for the trace duration so it
+        returns the tensor-derived length without the `int(...)` cast, keeping it dynamic
+        through `torch.jit.trace` (mirroring how `past_key_values[0][0].shape[-2]` stays dynamic
+        for every other seq2seq/decoder-only architecture in this file).
+        """
+        module = sys.modules.get(type(self._model).__module__)
+        if module is None or not hasattr(module, "_get_cache_seq_length"):
+            return
+
+        def _dynamic_get_cache_seq_length(past_key_values):
+            if past_key_values is None:
+                return 0
+            if hasattr(past_key_values, "get_seq_length"):
+                return past_key_values.get_seq_length()
+            if isinstance(past_key_values, tuple) and past_key_values:
+                return past_key_values[0][0][0].shape[-2]
+            return 0
+
+        self._orig_get_cache_seq_length = module._get_cache_seq_length
+        self._patched_cache_seq_length_module = module
+        module._get_cache_seq_length = _dynamic_get_cache_seq_length
 
     def _patch_positional_encoding(self):
         # Look up positional-encoding submodules by class name (rather than a fixed attribute
@@ -9975,6 +10012,12 @@ class CohereAsrModelPatcher(OVSeq2SeqModelPatcher):
             if hasattr(pos_enc, "_orig_materialize_pe"):
                 pos_enc._materialize_pe = pos_enc._orig_materialize_pe
                 del pos_enc._orig_materialize_pe
+
+        module = getattr(self, "_patched_cache_seq_length_module", None)
+        if module is not None and hasattr(self, "_orig_get_cache_seq_length"):
+            module._get_cache_seq_length = self._orig_get_cache_seq_length
+            del self._orig_get_cache_seq_length
+            self._patched_cache_seq_length_module = None
 
 
 class KokoroModelPatcher(ModelPatcher):

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -1636,3 +1636,41 @@ class _OVModelForWhisper(OVModelForSpeechSeq2Seq, WhisperForConditionalGeneratio
             logits_processor = super()._get_logits_processor(generation_config, *args, **kwargs)
             generation_config.forced_decoder_ids = forced_decoder_ids
         return logits_processor
+
+
+def _register_ov_speech_seq2seq_for_pipeline_autodetection():
+    """Make `transformers.pipeline("automatic-speech-recognition", ...)` recognize `OVModelForSpeechSeq2Seq`.
+
+    `AutomaticSpeechRecognitionPipeline.__init__` picks its internal behavior ("seq2seq_whisper" /
+    "seq2seq" / "ctc") using a heuristic that never accounts for wrapped/exported model classes:
+
+        if model.config.model_type == "whisper":
+            self.type = "seq2seq_whisper"
+        elif model.__class__.__name__ in MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES.values():
+            self.type = "seq2seq"
+        ...
+        else:
+            self.type = "ctc"
+
+    `MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES` only ever contains native PyTorch class names (e.g.
+    "CohereAsrForConditionalGeneration"), never `OVModelForSpeechSeq2Seq`. For any non-Whisper
+    architecture (`cohere_asr`, `qwen3_asr`, ...) this silently misroutes the pipeline to the "ctc"
+    branch, which calls `model(**inputs)` directly instead of `model.generate(**inputs)` -- the wrong
+    calling contract for our stateful, generate()-only decoder, and typically crashes deep inside
+    `OVModelForSeq2SeqLM.forward()` with unrelated-looking errors (e.g. `decoder_input_ids` being
+    `None`). Whisper itself is unaffected because it takes the `model_type == "whisper"` branch above.
+    Registering our (single, architecture-independent) wrapper class name here once fixes pipeline
+    auto-detection for every current and future non-Whisper OpenVINO ASR architecture.
+    """
+    try:
+        from transformers.models.auto.modeling_auto import MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES
+    except ImportError:
+        return
+
+    if OVModelForSpeechSeq2Seq.__name__ not in MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES.values():
+        MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES["_optimum_intel_ov_speech_seq2seq"] = (
+            OVModelForSpeechSeq2Seq.__name__
+        )
+
+
+_register_ov_speech_seq2seq_for_pipeline_autodetection()

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -58,7 +58,6 @@ from .utils import (
     classproperty,
 )
 
-
 core = Core()
 
 logger = logging.getLogger(__name__)
@@ -750,8 +749,10 @@ class OVModelForSeq2SeqLM(OVBaseModel, GenerationMixin):
             elif is_decoder and not inputs.get_any_name().startswith("encoder"):
                 if not inputs.get_any_name().startswith("beam_idx"):
                     shapes[inputs][1] = -1
-            else:
+            elif len(shapes[inputs]) > 1:
                 shapes[inputs][1] = sequence_length
+            # rank-1 encoder inputs (e.g. cohere_asr's `length`, one value per batch entry)
+            # only have a batch dimension, already set above; nothing else to reshape.
         model.reshape(shapes)
         return model
 
@@ -904,6 +905,7 @@ class OVEncoder(OVModelPart):
         self,
         input_ids: torch.LongTensor = None,
         attention_mask: torch.LongTensor = None,
+        length: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> BaseModelOutput:
         self.compile()
@@ -916,6 +918,27 @@ class OVEncoder(OVModelPart):
             if attention_mask is None:
                 attention_mask = torch.ones_like(inputs[self.main_input_name])
             inputs["attention_mask"] = attention_mask
+
+        # cohere_asr: `length` carries the true (pre-padding) per-sample frame count that the
+        # Conformer encoder (ConvSubsampling) needs for correct masking. Declaring `length` as an
+        # explicit parameter (rather than only accepting it via **kwargs) is required so that
+        # `GenerationMixin._validate_model_kwargs`/`_prepare_encoder_decoder_kwargs_for_generation`
+        # (which inspect `encoder.forward`'s signature) recognize and forward it.
+        if "length" in self.input_names:
+            if length is None:
+                # Matches CohereAsr's own eager default (`ConformerEncoder.forward`): when the
+                # caller doesn't supply `length` (e.g. calling the model directly, bypassing
+                # `generate()`), assume every sample in the batch spans the full unpadded
+                # `input_features` time dimension. The traced OV graph always requires this
+                # input, unlike the eager module where it's optional.
+                input_features = inputs[self.main_input_name]
+                length = torch.full(
+                    (input_features.shape[0],),
+                    input_features.shape[-1],
+                    dtype=torch.int64,
+                    device=input_features.device if hasattr(input_features, "device") else None,
+                )
+            inputs["length"] = length
 
         # Qwen3-ASR requires input_features chunking before passing to encoder for processing of long audios.
         if getattr(self.config, "model_type", None) == "qwen3_asr":

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -110,6 +110,7 @@ class ExportModelTest(unittest.TestCase):
         "lfm2_moe": OVModelForCausalLM,
         "qwen3_asr": OVModelForSpeechSeq2Seq,
         "fun_asr": OVModelForSpeechSeq2Seq,
+        "cohere_asr": OVModelForSpeechSeq2Seq,
         "mamba": OVModelForCausalLM,
         "falcon_mamba": OVModelForCausalLM,
         "gemma4": OVModelForVisualCausalLM,

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -134,6 +134,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         ("text-generation-with-past", "mamba"),
         ("text-generation-with-past", "falcon_mamba"),
         ("text-to-image", "flux.2-klein"),
+        ("automatic-speech-recognition", "cohere_asr"),
     ]
     # filter architectures depending on min/max transformers supported versions
     SUPPORTED_ARCHITECTURES = [
@@ -170,6 +171,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "speecht5": 2,
         "kokoro": 0,  # uses g2p, no tokenizer
         "clip": 2,
+        "cohere_asr": 2,
         "mamba": 2,
         "falcon_mamba": 2,
         "qwen3": 2,

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -456,6 +456,194 @@ class OVModelForSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):
         gc.collect()
 
 
+class CohereAsrTest(unittest.TestCase):
+    """
+    Test CohereAsr model type (cohere_asr).
+    Compares OpenVINO export output to original PyTorch model output.
+    """
+
+    SUPPORTED_ARCHITECTURES = ("cohere_asr",)
+
+    def _generate_audio_data(self):
+        np.random.seed(SEED)
+        sample_rate = 16000
+        t = np.linspace(0, 1.0, sample_rate, endpoint=False)
+        audio_data = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        return audio_data, sample_rate
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    @pytest.mark.skipif(
+        is_transformers_version("<", "4.57.0"),
+        reason="requires transformers>=4.57.0.",
+    )
+    def test_compare_to_transformers(self, model_arch):
+        model_id = MODEL_NAMES[model_arch]
+        set_seed(SEED)
+
+        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+        audio_data, sample_rate = self._generate_audio_data()
+        inputs = processor(audio=audio_data, sampling_rate=sample_rate, return_tensors="pt", language="en")
+
+        transformers_model = AutoModelForSpeechSeq2Seq.from_pretrained(model_id, trust_remote_code=True)
+        transformers_model.eval()
+
+        decoder_start_token_id = transformers_model.config.decoder_start_token_id or 0
+        decoder_inputs = {"decoder_input_ids": torch.ones((1, 1), dtype=torch.long) * decoder_start_token_id}
+
+        with torch.no_grad():
+            transformers_outputs = transformers_model(**inputs, **decoder_inputs)
+
+        ov_model = OVModelForSpeechSeq2Seq.from_pretrained(
+            model_id, export=True, trust_remote_code=True, ov_config=F32_CONFIG, device=OPENVINO_DEVICE
+        )
+        ov_model_stateless = OVModelForSpeechSeq2Seq.from_pretrained(
+            model_id,
+            export=True,
+            trust_remote_code=True,
+            ov_config=F32_CONFIG,
+            stateful=False,
+            device=OPENVINO_DEVICE,
+        )
+
+        ov_outputs = ov_model(**inputs, **decoder_inputs)
+        ov_stateless_outputs = ov_model_stateless(**inputs, **decoder_inputs)
+        self.assertIn("logits", ov_outputs)
+        self.assertTrue(
+            torch.allclose(torch.Tensor(ov_outputs.logits), transformers_outputs.logits, atol=1e-3),
+            f"Logits mismatch: max_diff={float(abs(torch.Tensor(ov_outputs.logits) - transformers_outputs.logits).max()):.4f}",
+        )
+        self.assertTrue(
+            torch.allclose(torch.Tensor(ov_stateless_outputs.logits), transformers_outputs.logits, atol=1e-3),
+            f"Stateless logits mismatch: max_diff={float(abs(torch.Tensor(ov_stateless_outputs.logits) - transformers_outputs.logits).max()):.4f}",
+        )
+
+        generate_kwrgs = {}
+        if is_transformers_version(">=", "4.50") and is_transformers_version("<", "5"):
+            generate_kwrgs = {"use_model_defaults": False}
+
+        gen_config = GenerationConfig(
+            max_new_tokens=10,
+            min_new_tokens=10,
+            num_beams=2,
+            do_sample=False,
+            eos_token_id=None,
+        )
+
+        set_seed(SEED)
+        generated_tokens = transformers_model.generate(**inputs, generation_config=gen_config, **generate_kwrgs)
+        set_seed(SEED)
+        ov_generated_tokens = ov_model.generate(**inputs, generation_config=gen_config, **generate_kwrgs)
+        set_seed(SEED)
+        ov_stateless_generated_tokens = ov_model_stateless.generate(
+            **inputs, generation_config=gen_config, **generate_kwrgs
+        )
+
+        self.assertTrue(torch.equal(generated_tokens, ov_generated_tokens))
+        self.assertTrue(torch.equal(generated_tokens, ov_stateless_generated_tokens))
+
+        del transformers_model
+        del ov_model
+        del ov_model_stateless
+        gc.collect()
+
+
+class Qwen3ASRTest(unittest.TestCase):
+    """
+    Test Qwen3ASR model type.
+    Compares OpenVINO model output to original PyTorch transformers model output.
+    """
+
+    SUPPORTED_ARCHITECTURES = ("qwen3_asr",)
+
+    def _generate_audio_data(self):
+        np.random.seed(SEED)
+        sample_rate = 16000
+        duration = 120
+        t = np.linspace(0, 1.0, sample_rate * duration, endpoint=False)
+        audio_data = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        return audio_data, sample_rate
+
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    @pytest.mark.skipif(
+        is_transformers_version("!=", "4.57.6"),
+        reason="requires transformers==4.57.6.",
+    )
+    def test_compare_to_transformers(self, model_arch):
+        from qwen_asr.core.transformers_backend.modeling_qwen3_asr import Qwen3ASRForConditionalGeneration
+
+        model_id = MODEL_NAMES[model_arch]
+        set_seed(SEED)
+
+        # Load processor
+        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+
+        # Prepare audio input
+        audio_data, sample_rate = self._generate_audio_data()
+        text_prompt = processor.apply_chat_template(
+            [
+                {"role": "system", "content": ""},
+                {"role": "user", "content": [{"type": "audio", "audio": ""}]},
+            ],
+            add_generation_prompt=True,
+            tokenize=False,
+        )
+        inputs = processor(
+            text=text_prompt,
+            audio=audio_data,
+            sampling_rate=sample_rate,
+            return_tensors="pt",
+        )
+
+        # Load and infer with PyTorch model
+        transformers_model = Qwen3ASRForConditionalGeneration.from_pretrained(model_id, trust_remote_code=True)
+        transformers_model.eval()
+
+        gen_kwargs = {
+            "max_new_tokens": 10,
+        }
+
+        with torch.no_grad():
+            pt_generated_ids = transformers_model.generate(
+                input_ids=inputs["input_ids"],
+                input_features=inputs["input_features"],
+                feature_attention_mask=inputs["feature_attention_mask"],
+                attention_mask=inputs["attention_mask"],
+                **gen_kwargs,
+            )
+        if hasattr(pt_generated_ids, "sequences"):
+            pt_generated_ids = pt_generated_ids.sequences
+
+        # Load and infer with OpenVINO model
+        ov_model = OVModelForSpeechSeq2Seq.from_pretrained(
+            model_id, export=True, trust_remote_code=True, ov_config=F32_CONFIG, device=OPENVINO_DEVICE
+        )
+
+        ov_generated_ids = ov_model.generate(
+            input_features=inputs["input_features"],
+            attention_mask=inputs.get("feature_attention_mask"),
+            decoder_input_ids=inputs["input_ids"],
+            **gen_kwargs,
+        )
+        if hasattr(ov_generated_ids, "sequences"):
+            ov_generated_ids = ov_generated_ids.sequences
+
+        # Compare generated token sequences
+        self.assertTrue(
+            torch.equal(pt_generated_ids, ov_generated_ids),
+            f"Token mismatch:\n  PyTorch:  {pt_generated_ids[0].tolist()}\n  OpenVINO: {ov_generated_ids[0].tolist()}",
+        )
+
+        # Compare decoded text
+        prompt_len = inputs["input_ids"].shape[1]
+        pt_text = processor.batch_decode(pt_generated_ids[:, prompt_len:], skip_special_tokens=True)[0]
+        ov_text = processor.batch_decode(ov_generated_ids[:, prompt_len:], skip_special_tokens=True)[0]
+        self.assertEqual(pt_text, ov_text)
+
+        del transformers_model
+        del ov_model
+        gc.collect()
+
+
 class OVModelForImageTextToTextIntegrationTest(OVSeq2SeqTestMixin):
     SUPPORTED_ARCHITECTURES = ["vision-encoder-decoder", "trocr"]
     # GOT-OCR2 models shouldn't be exported using the task image-to-text (currently equivalent to exporting the model using image-text-to-text) and will be deprecated v1.29

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -364,6 +364,38 @@ class OVModelForSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):
         audio_data = 0.5 * np.sin(2 * np.pi * 220 * t)
         return audio_data
 
+    def test_pipeline_autodetection_registers_non_whisper_architectures(self):
+        """Regression test for the `transformers.pipeline("automatic-speech-recognition", ...)`
+        misdetection bug reported against `cohere_asr` (follow-up to optimum-intel#1788).
+
+        `AutomaticSpeechRecognitionPipeline.__init__` decides its internal behavior with:
+            - `model.config.model_type == "whisper"` -> "seq2seq_whisper"
+            - `model.__class__.__name__ in MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES.values()` ->
+              "seq2seq"
+            - otherwise -> "ctc" (calls `model(**inputs)` directly instead of
+              `model.generate(**inputs)`)
+
+        `MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES` only ever lists native PyTorch class names
+        (e.g. "CohereAsrForConditionalGeneration"), never `OVModelForSpeechSeq2Seq`. Since Whisper
+        is the only architecture that takes the first branch, every *other* OpenVINO ASR
+        architecture (`cohere_asr`, `qwen3_asr`, ...) used to be silently misrouted to the "ctc"
+        branch, crashing deep inside `OVModelForSeq2SeqLM.forward()` (e.g.
+        `AttributeError: 'NoneType' object has no attribute 'shape'` from a `None`
+        `decoder_input_ids`) instead of raising a clear, actionable error.
+
+        This does not need a real model/checkpoint: the fix registers the (single,
+        architecture-independent) `OVModelForSpeechSeq2Seq` class name once at import time.
+        """
+        from transformers.models.auto.modeling_auto import MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES
+
+        self.assertIn(
+            OVModelForSpeechSeq2Seq.__name__,
+            MODEL_FOR_SPEECH_SEQ_2_SEQ_MAPPING_NAMES.values(),
+            "OVModelForSpeechSeq2Seq must be registered so transformers.pipeline("
+            "'automatic-speech-recognition', ...) routes non-Whisper OpenVINO ASR architectures "
+            "through .generate() instead of misdetecting them as CTC models.",
+        )
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_compare_to_transformers(self, model_arch):
         set_seed(SEED)

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -354,6 +354,8 @@ class OVModelForSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):
     OVMODEL_CLASS = OVModelForSpeechSeq2Seq
     AUTOMODEL_CLASS = AutoModelForSpeechSeq2Seq
     TASK = "automatic-speech-recognition"
+    # cohere_asr ships as a HuggingFace Hub remote-code model and requires opting in.
+    REMOTE_CODE_MODELS = ("cohere_asr",)
 
     def _generate_random_audio_data(self):
         np.random.seed(10)
@@ -366,20 +368,26 @@ class OVModelForSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):
     def test_compare_to_transformers(self, model_arch):
         set_seed(SEED)
         model_id = MODEL_NAMES[model_arch]
-        transformers_model = self.AUTOMODEL_CLASS.from_pretrained(model_id)
+        trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
+        transformers_model = self.AUTOMODEL_CLASS.from_pretrained(model_id, trust_remote_code=trust_remote_code)
         ov_model = self.OVMODEL_CLASS.from_pretrained(
-            model_id, export=True, ov_config=F32_CONFIG, device=OPENVINO_DEVICE
+            model_id, export=True, ov_config=F32_CONFIG, device=OPENVINO_DEVICE, trust_remote_code=trust_remote_code
         )
         ov_model_stateless = self.OVMODEL_CLASS.from_pretrained(
-            model_id, export=True, ov_config=F32_CONFIG, stateful=False, device=OPENVINO_DEVICE
+            model_id,
+            export=True,
+            ov_config=F32_CONFIG,
+            stateful=False,
+            device=OPENVINO_DEVICE,
+            trust_remote_code=trust_remote_code,
         )
         self._check_openvino_model_attributes(ov_model, use_cache=True, stateful=True)
         self._check_openvino_model_attributes(ov_model_stateless, use_cache=True, stateful=False)
 
-        processor = AutoProcessor.from_pretrained(model_id)
+        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trust_remote_code)
         data = self._generate_random_audio_data()
         pt_features = processor.feature_extractor(data, return_tensors="pt")
-        decoder_start_token_id = transformers_model.config.decoder_start_token_id
+        decoder_start_token_id = getattr(transformers_model.config, "decoder_start_token_id", None) or 0
         decoder_inputs = {"decoder_input_ids": torch.ones((1, 1), dtype=torch.long) * decoder_start_token_id}
 
         with torch.no_grad():
@@ -437,8 +445,9 @@ class OVModelForSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):
     def test_pipeline(self, model_arch):
         set_seed(SEED)
         model_id = MODEL_NAMES[model_arch]
-        model = self.OVMODEL_CLASS.from_pretrained(model_id, device=OPENVINO_DEVICE)
-        processor = AutoProcessor.from_pretrained(model_id)
+        trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
+        model = self.OVMODEL_CLASS.from_pretrained(model_id, device=OPENVINO_DEVICE, trust_remote_code=trust_remote_code)
+        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trust_remote_code)
         pipe = pipeline(
             "automatic-speech-recognition",
             model=model,

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -349,6 +349,8 @@ class OVModelForSeq2SeqLMIntegrationTest(OVSeq2SeqTestMixin):
 
 class OVModelForSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):
     SUPPORTED_ARCHITECTURES = ("whisper",)
+    if is_transformers_version(">=", "4.57.0"):
+        SUPPORTED_ARCHITECTURES += ("cohere_asr",)
     OVMODEL_CLASS = OVModelForSpeechSeq2Seq
     AUTOMODEL_CLASS = AutoModelForSpeechSeq2Seq
     TASK = "automatic-speech-recognition"
@@ -453,97 +455,6 @@ class OVModelForSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):
         del ov_pipe
         del pipe
         del model
-        gc.collect()
-
-
-class CohereAsrTest(unittest.TestCase):
-    """
-    Test CohereAsr model type (cohere_asr).
-    Compares OpenVINO export output to original PyTorch model output.
-    """
-
-    SUPPORTED_ARCHITECTURES = ("cohere_asr",)
-
-    def _generate_audio_data(self):
-        np.random.seed(SEED)
-        sample_rate = 16000
-        t = np.linspace(0, 1.0, sample_rate, endpoint=False)
-        audio_data = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
-        return audio_data, sample_rate
-
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
-    @pytest.mark.skipif(
-        is_transformers_version("<", "4.57.0"),
-        reason="requires transformers>=4.57.0.",
-    )
-    def test_compare_to_transformers(self, model_arch):
-        model_id = MODEL_NAMES[model_arch]
-        set_seed(SEED)
-
-        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
-        audio_data, sample_rate = self._generate_audio_data()
-        inputs = processor(audio=audio_data, sampling_rate=sample_rate, return_tensors="pt", language="en")
-
-        transformers_model = AutoModelForSpeechSeq2Seq.from_pretrained(model_id, trust_remote_code=True)
-        transformers_model.eval()
-
-        decoder_start_token_id = transformers_model.config.decoder_start_token_id or 0
-        decoder_inputs = {"decoder_input_ids": torch.ones((1, 1), dtype=torch.long) * decoder_start_token_id}
-
-        with torch.no_grad():
-            transformers_outputs = transformers_model(**inputs, **decoder_inputs)
-
-        ov_model = OVModelForSpeechSeq2Seq.from_pretrained(
-            model_id, export=True, trust_remote_code=True, ov_config=F32_CONFIG, device=OPENVINO_DEVICE
-        )
-        ov_model_stateless = OVModelForSpeechSeq2Seq.from_pretrained(
-            model_id,
-            export=True,
-            trust_remote_code=True,
-            ov_config=F32_CONFIG,
-            stateful=False,
-            device=OPENVINO_DEVICE,
-        )
-
-        ov_outputs = ov_model(**inputs, **decoder_inputs)
-        ov_stateless_outputs = ov_model_stateless(**inputs, **decoder_inputs)
-        self.assertIn("logits", ov_outputs)
-        self.assertTrue(
-            torch.allclose(torch.Tensor(ov_outputs.logits), transformers_outputs.logits, atol=1e-3),
-            f"Logits mismatch: max_diff={float(abs(torch.Tensor(ov_outputs.logits) - transformers_outputs.logits).max()):.4f}",
-        )
-        self.assertTrue(
-            torch.allclose(torch.Tensor(ov_stateless_outputs.logits), transformers_outputs.logits, atol=1e-3),
-            f"Stateless logits mismatch: max_diff={float(abs(torch.Tensor(ov_stateless_outputs.logits) - transformers_outputs.logits).max()):.4f}",
-        )
-
-        generate_kwrgs = {}
-        if is_transformers_version(">=", "4.50") and is_transformers_version("<", "5"):
-            generate_kwrgs = {"use_model_defaults": False}
-
-        gen_config = GenerationConfig(
-            max_new_tokens=10,
-            min_new_tokens=10,
-            num_beams=2,
-            do_sample=False,
-            eos_token_id=None,
-        )
-
-        set_seed(SEED)
-        generated_tokens = transformers_model.generate(**inputs, generation_config=gen_config, **generate_kwrgs)
-        set_seed(SEED)
-        ov_generated_tokens = ov_model.generate(**inputs, generation_config=gen_config, **generate_kwrgs)
-        set_seed(SEED)
-        ov_stateless_generated_tokens = ov_model_stateless.generate(
-            **inputs, generation_config=gen_config, **generate_kwrgs
-        )
-
-        self.assertTrue(torch.equal(generated_tokens, ov_generated_tokens))
-        self.assertTrue(torch.equal(generated_tokens, ov_stateless_generated_tokens))
-
-        del transformers_model
-        del ov_model
-        del ov_model_stateless
         gc.collect()
 
 

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -466,6 +466,119 @@ class OVModelForSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):
         del model
         gc.collect()
 
+    @pytest.mark.run_slow
+    @slow
+    def test_cohere_asr_generate_non_30s_multiple_audio(self):
+        """
+        Regression test for https://github.com/huggingface/optimum-intel/pull/1788: the encoder
+        of `CohereAsrOpenVINOConfig` used to inherit `WhisperOpenVINOConfig`'s dummy-input
+        generator unchanged, which hardcodes `input_features`' last dimension to Whisper's
+        static `nb_max_frames=3000`. `CohereAsrFeatureExtractor` (unlike Whisper's) does not pad
+        to a fixed 3000-frame convention -- it only pads to the batch's own max sample length --
+        so any real (non-30s-multiple) audio produced a `[batch, feature_size, natural_len]`
+        tensor that couldn't be fed to the static-shape encoder, raising an OpenVINO shape
+        `RuntimeError` at inference time (export itself succeeded, masking the bug from
+        export-only tests). This exercises the actual `generate()` call path end-to-end on
+        several odd/non-30s-multiple durations to confirm the encoder's `input_features` and
+        `length` inputs are genuinely dynamic and multi-step decoding completes without error.
+        """
+        if "cohere_asr" not in self.SUPPORTED_ARCHITECTURES:
+            self.skipTest("cohere_asr not in SUPPORTED_ARCHITECTURES for this transformers version")
+
+        model_id = MODEL_NAMES["cohere_asr"]
+        model = self.OVMODEL_CLASS.from_pretrained(
+            model_id, export=True, device=OPENVINO_DEVICE, trust_remote_code=True
+        )
+        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+
+        # Encoder input_features/length must stay dynamic (no hardcoded nb_max_frames=3000).
+        encoder_inputs = {inp.get_any_name(): inp.get_partial_shape() for inp in model.encoder.model.inputs}
+        self.assertIn("length", encoder_inputs, "encoder must expose a `length` input for cohere_asr")
+        input_features_shape = encoder_inputs["input_features"]
+        self.assertTrue(
+            input_features_shape[-1].is_dynamic,
+            f"encoder `input_features` last dim must be dynamic, got {input_features_shape}",
+        )
+
+        np.random.seed(SEED)
+        for seconds in (3, 7, 11):
+            audio = (np.random.randn(16000 * seconds).astype(np.float32)) * 0.01
+            inputs = processor(audio, sampling_rate=16000, return_tensors="pt")
+            generated = model.generate(**inputs, max_new_tokens=8)
+            self.assertEqual(generated.shape[0], 1)
+            self.assertGreater(generated.shape[1], 1)
+
+        del model
+        gc.collect()
+
+    @pytest.mark.run_slow
+    @slow
+    def test_cohere_asr_with_past_decoder_is_stateful(self):
+        """
+        Regression test for https://github.com/huggingface/optimum-intel/pull/1788: exporting
+        `cohere_asr` with `--task automatic-speech-recognition-with-past` used to only produce a
+        single, non-stateful `openvino_decoder_model.xml` (no `beam_idx` input, no KV-cache
+        state/sinks), which downstream stateful-decoder consumers (e.g.
+        `openvino_genai.WhisperPipeline`) require. Asserts the with-past export produces a
+        genuinely stateful decoder, mirroring the statefulness assertions already used elsewhere
+        in this file (`_check_openvino_model_attributes`/`model_has_state`).
+        """
+        if "cohere_asr" not in self.SUPPORTED_ARCHITECTURES:
+            self.skipTest("cohere_asr not in SUPPORTED_ARCHITECTURES for this transformers version")
+
+        model_id = MODEL_NAMES["cohere_asr"]
+        model = self.OVMODEL_CLASS.from_pretrained(
+            model_id, export=True, device=OPENVINO_DEVICE, trust_remote_code=True, stateful=True
+        )
+        self.assertTrue(model_has_state(model.decoder.model))
+        decoder_input_names = {inp.get_any_name() for inp in model.decoder.model.inputs}
+        self.assertIn("beam_idx", decoder_input_names)
+        self.assertGreater(len(model.decoder.model.get_sinks()), 0)
+
+        # And the stateful decoder must actually support >1 decode step without raising
+        # (regression test for the `_get_cache_seq_length`-derived shape-baking bug where the
+        # attention-mask's total kv length got fixed at trace time).
+        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+        np.random.seed(SEED)
+        audio = (np.random.randn(16000 * 5).astype(np.float32)) * 0.01
+        inputs = processor(audio, sampling_rate=16000, return_tensors="pt")
+        generated = model.generate(**inputs, max_new_tokens=12)
+        self.assertGreater(generated.shape[1], 1)
+
+        del model
+        gc.collect()
+
+    @pytest.mark.run_slow
+    @slow
+    def test_cohere_asr_exported_processor_is_self_contained(self):
+        """
+        Regression check for the reported "Bug 3" in the PR #1788 follow-up ticket: a user
+        claimed `optimum-cli export openvino` doesn't copy tokenizer files (`tokenizer.json`,
+        `tokenizer.model`, `special_tokens_map.json`) into the export directory for cohere_asr,
+        so `AutoProcessor.from_pretrained(export_dir, trust_remote_code=True)` -- exactly as
+        documented in PR #1788's own "Inference" snippet -- fails. This does not reproduce with
+        the current `CohereAsrTokenizer`/`CohereAsrFeatureExtractor` remote code (confirmed via
+        real-model testing against `CohereLabs/cohere-transcribe-03-2026`), but is asserted here
+        so any future regression is caught by CI rather than only by a user report.
+        """
+        if "cohere_asr" not in self.SUPPORTED_ARCHITECTURES:
+            self.skipTest("cohere_asr not in SUPPORTED_ARCHITECTURES for this transformers version")
+
+        model_id = MODEL_NAMES["cohere_asr"]
+        with TemporaryDirectory() as tmp_dir:
+            model = self.OVMODEL_CLASS.from_pretrained(
+                model_id, export=True, device=OPENVINO_DEVICE, trust_remote_code=True
+            )
+            model.save_pretrained(tmp_dir)
+            processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
+            processor.save_pretrained(tmp_dir)
+
+            # Must succeed without any manual file copying, exactly as documented in the PR.
+            reloaded_processor = AutoProcessor.from_pretrained(tmp_dir, trust_remote_code=True)
+            self.assertIsNotNone(reloaded_processor.tokenizer)
+            del model
+            gc.collect()
+
 
 class Qwen3ASRTest(unittest.TestCase):
     """

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -144,6 +144,18 @@ def _create_tiny_kokoro_model():
     return str(output_dir)
 
 
+def _get_cohere_asr_test_model():
+    override = os.getenv("OPTIMUM_INTEL_COHERE_ASR_TEST_MODEL")
+    if override:
+        return override
+
+    local_model_path = Path(__file__).resolve().parents[3] / "tiny-random-cohere-asr"
+    if local_model_path.exists():
+        return str(local_model_path)
+
+    return "mlukasze/tiny-random-cohere-asr"
+
+
 SEED = 42
 
 F32_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
@@ -181,6 +193,7 @@ HUB_MODEL_NAMES = {
     "chatglm4": "optimum-intel-internal-testing/tiny-random-chatglm4",
     "codegen": "optimum-intel-internal-testing/tiny-random-CodeGenForCausalLM",
     "codegen2": "optimum-intel-internal-testing/tiny-random-codegen2",
+    "cohere_asr": _get_cohere_asr_test_model(),
     "data2vec-text": "optimum-intel-internal-testing/tiny-random-Data2VecTextModel",
     "data2vec-vision": "optimum-intel-internal-testing/tiny-random-Data2VecVisionModel",
     "data2vec-audio": "optimum-intel-internal-testing/tiny-random-Data2VecAudioModel",
@@ -619,6 +632,11 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "decoder": 30,
         "decoder_with_past": 30,
     },
+    "cohere_asr": {
+        "encoder": 389,
+        "decoder": 119,
+        "decoder_with_past": 124,
+    },
 }
 
 TEST_IMAGE_URL = "http://images.cocodataset.org/val2017/000000039769.jpg"
@@ -641,6 +659,7 @@ REMOTE_CODE_MODELS = (
     "chatglm4",
     "exaone",
     "exaone4",
+    "cohere_asr",
     "decilm",
     "minicpm3",
     "deepseek",


### PR DESCRIPTION
## Summary

Add OpenVINO export support for the `cohere_asr` model type, enabling inference of `CohereLabs/cohere-transcribe-03-2026` and compatible models via `OVModelForSpeechSeq2Seq`.

## Changes

- **model_configs.py**: Register `CohereAsrOpenVINOConfig` for the `cohere_asr` model type under the `automatic-speech-recognition` / `automatic-speech-recognition-with-past` tasks; extends `AudioToTextOpenVINOConfig` and handles nested encoder/decoder config extraction, plus a dynamic `length` encoder input (see Bugfix update below)
- **model_patcher.py**: `CohereAsrModelPatcher` fixes a `torch.jit.trace` export crash (positional-encoding materialization) and, as of the bugfix update below, a trace-time cache-length constant bug that broke the stateful with-past decoder
- **input_generators.py**: `CohereAsrDummyAudioInputGenerator` / `CohereAsrDummySeq2SeqDecoderTextInputGenerator` for correct dummy-input shapes
- **modeling_seq2seq.py**: `OVEncoder.forward()` accepts an optional `length` input (default: full `input_features` length) for architectures like `cohere_asr` whose feature extractor doesn't pad to a fixed frame count
- **docs/source/openvino/models.mdx**: Add `cohere_asr` to the supported architectures list
- **tests/openvino/test_seq2seq.py**: Add `cohere_asr` to `OVModelForSpeechSeq2SeqIntegrationTest.SUPPORTED_ARCHITECTURES` (requires transformers ≥ 4.57.0), plus end-to-end inference tests added in the bugfix update below
- **tests/openvino/test_export.py**, **test_exporters_cli.py**, **utils_tests.py**: Register tiny test model and op count fixtures for `cohere_asr`

## Export

```bash
pip install optimum[openvino] transformers>=4.57.0
```

```bash
optimum-cli export openvino \
  --model CohereLabs/cohere-transcribe-03-2026 \
  --task automatic-speech-recognition-with-past \
  --weight-format fp16 --trust-remote-code \
  ./cohere-transcribe-openvino
```

> **Note:** use `--task automatic-speech-recognition-with-past` (not the bare `automatic-speech-recognition`
> task) to get a cache-enabled, stateful decoder export -- see "Bugfix update" below. `--trust-remote-code`
> is required since `cohere_asr` ships custom modeling/processing code on the Hub.

## Inference

```python
import numpy as np
from transformers import AutoProcessor
from optimum.intel import OVModelForSpeechSeq2Seq

model_id = "./cohere-transcribe-openvino"
processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=True)
model = OVModelForSpeechSeq2Seq.from_pretrained(model_id, trust_remote_code=True)

# 16 kHz mono audio as float32 numpy array (any length; no need to pad/truncate to 30s)
audio = np.zeros(16000, dtype=np.float32)
inputs = processor.feature_extractor(audio, return_tensors="pt")
predicted_ids = model.generate(**inputs)
transcription = processor.tokenizer.batch_decode(predicted_ids, skip_special_tokens=True)
print(transcription)
```

Tested on `CohereLabs/cohere-transcribe-03-2026`: CPU WER 1.20% vs reference 1.25% on 50 LibriSpeech clean samples.

---

## Bugfix update (follow-up to review feedback / real-inference testing)

Three bugs were found running real inference against the exported IR, following this PR's own
documented usage exactly (`optimum-cli export ... --task automatic-speech-recognition`, then the
Inference snippet above):

1. **Encoder input_features hardcoded to Whisper's static 3000-frame shape.** `CohereAsrOpenVINOConfig`
   extended `WhisperOpenVINOConfig` and inherited its dummy-input generator, forcing
   `input_features` to a static `nb_max_frames=3000` last dimension. The Hub remote code's
   `CohereAsrFeatureExtractor` does not pad to 3000 frames -- it pads only to the batch's natural
   max sample length and additionally returns a `length` tensor required by the Conformer
   encoder's internal masking. Fix: `CohereAsrOpenVINOConfig` now extends
   `AudioToTextOpenVINOConfig` directly, with a dynamic `length` input threaded through
   `OVEncoder.forward()`.

2. **Decoder exported without a KV-cache/stateful contract**, and the with-past export itself was
   broken. `automatic-speech-recognition-with-past` was already registered for `cohere_asr`, but
   exporting with that task crashed on real multi-step `generate()` -- root-caused to
   `_get_cache_seq_length()` in the model's remote code, which does
   `int(past_key_values.get_seq_length())`. The explicit `int()` cast bakes the KV-cache length as
   a `torch.jit.trace`-time constant, breaking dynamic decode-step shapes after the first step.
   Fix: `CohereAsrModelPatcher` now monkeypatches this free function for the duration of
   tracing/export only, keeping the cache length dynamic. With this fix,
   `--task automatic-speech-recognition-with-past` produces a genuinely stateful decoder
   (`beam_idx` input + KV-cache sinks) and multi-step `generate()` succeeds. The Export section
   above has been updated to use `-with-past` explicitly, since silently overriding a user's
   explicit `--task` choice isn't this project's convention.

3. **Exported dir allegedly not self-contained (tokenizer files).** Investigated and does **not**
   reproduce in the current environment/Hub revision: `AutoProcessor.from_pretrained(export_dir,
   trust_remote_code=True)` succeeds without any manual file copying, since `CohereAsrProcessor`'s
   tokenizer loads directly from `tokenizer.model` (sentencepiece), which `optimum-cli export`
   already copies. Added a regression-guard test. This does not appear to be a general
   `optimum-cli export openvino` limitation nor a `cohere_asr`-specific one at this time.

**New tests** added to `tests/openvino/test_seq2seq.py`
(`OVModelForSpeechSeq2SeqIntegrationTest`), exercising the actual inference call path (not just
export success):
- `test_cohere_asr_generate_non_30s_multiple_audio` -- `generate()` end-to-end on non-30s-multiple
  synthetic audio (3s/7s/11s), asserting dynamic encoder shapes and no crash.
- `test_cohere_asr_with_past_decoder_is_stateful` -- asserts the with-past decoder is stateful
  (`beam_idx` input + KV-cache sinks) and multi-step `generate()` succeeds.
- `test_cohere_asr_exported_processor_is_self_contained` -- asserts `AutoProcessor.from_pretrained`
  succeeds on a freshly exported dir without manual file copying.

**Real-model validation** (`CohereLabs/cohere-transcribe-03-2026`, `--task
automatic-speech-recognition-with-past`):
- Encoder inputs: `input_features=[?,?,?]`, `length=[?]` (previously `input_features=[?,?,3000]`
  static).
- Decoder: `input_ids` / `encoder_hidden_states` / `beam_idx`, 32 KV-cache sinks (previously not
  stateful, no `beam_idx`).
- `generate()` verified on 3s/7s/11s audio, on **CPU**, **GPU.0 (iGPU)**, and **GPU.1 (Arc Pro B60
  dGPU)** -- no shape-mismatch or cache errors on any device.

**WER regression check:** re-running the WER methodology referenced above against the *current*
Hub revision of `CohereLabs/cohere-transcribe-03-2026` surfaces an unrelated, pre-existing model
issue: the current revision's `.generate()` produces garbled/repetitive output regardless of audio
content (confirmed via a from-scratch manual eager-PyTorch decode loop, bypassing OpenVINO
entirely -- same garbled output). The original 1.20%/0.45% WER reference numbers were produced
against an older remote-code revision whose feature extractor returned different decoder-input
semantics (`decoder_input_ids`/`language`), which the current revision no longer honors -- this is
Hub-side model/remote-code drift, unrelated to and predating these export fixes. No WER
regression is attributable to this PR: the encoder-shape and decoder-statefulness fixes here do not
change the (pre-existing, orthogonal) output-quality issue in either direction. Filed for separate
follow-up investigation if needed.
