### PR TITLE
[OpenVINO] Support GLM-Edge-V models

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -63,6 +63,7 @@ Here is the list of the supported architectures :
 - FlauBERT
 - GLM-4
 - GLM-Edge
+- GLM-Edge-V
 - GPT-2
 - GPT-BigCode
 - GPT-J

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -439,6 +439,14 @@ def main_export(
             elif config.torch_dtype == torch.bfloat16:
                 dtype = torch.bfloat16
 
+        # GLM-Edge-V: force fp32 export. Its SigLIP vision tower is numerically
+        # fragile and the 16-bit tracing path (ModuleExtension wrapping + bf16
+        # boi/eoi parameters) corrupts the image features, producing outputs that
+        # diverge from transformers (which runs bf16 but upcasts internally). HF
+        # itself matches fp32 in bf16/fp16, so fp32 export reproduces HF exactly.
+        if getattr(config, "model_type", "") == "glm" and hasattr(config, "vision_config"):
+            dtype = torch.float32
+
         if dtype is not None:
             if dtype in [torch.float16, torch.bfloat16]:
                 patch_16bit = True

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -45,9 +45,9 @@ from optimum.intel.utils.modeling_utils import (
 
 from .utils import (
     _MAX_UNCOMPRESSED_SIZE,
-    MULTI_MODAL_TEXT_GENERATION_MODELS,
     clear_class_registry,
     deduce_diffusers_dtype,
+    is_multi_modal_text_generation_model,
     load_preprocessors,
     patch_qwenvl_configs,
 )
@@ -161,6 +161,10 @@ def infer_task(
             model_type = config.export_model_type
         else:
             model_type = config.model_type
+        # GLM-Edge-V reports model_type="glm" (same as the text-only GLM decoder); the
+        # presence of a `vision_config` marks it as an image-text-to-text model.
+        if model_type == "glm" and hasattr(config, "vision_config") and original_task == "auto":
+            return "image-text-to-text"
         custom_architecture = model_type not in TasksManager._SUPPORTED_MODEL_TYPE
         if not custom_architecture and task + "-with-past" in TasksManager.get_supported_tasks_for_model_type(
             model_type, exporter="openvino", library_name=library_name
@@ -425,10 +429,7 @@ def main_export(
         if (
             dtype is None
             and framework == "pt"
-            and (
-                task.startswith("text-generation")
-                or getattr(config, "model_type", "") in MULTI_MODAL_TEXT_GENERATION_MODELS
-            )
+            and (task.startswith("text-generation") or is_multi_modal_text_generation_model(config))
             and getattr(config, "torch_dtype", torch.float32) in [torch.float16, torch.bfloat16]
         ):
             if ov_config is not None and ov_config.dtype in {"fp16", "fp32"}:
@@ -702,6 +703,8 @@ def _main_quantize(
         )
         model_type = config.model_type
         if model_type in ["phi4mm", "phi4_multimodal"]:
+            task = "image-text-to-text"
+        elif model_type == "glm" and hasattr(config, "vision_config"):
             task = "image-text-to-text"
 
     # Step 1. Obtain the correct OpenVINO model class

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -535,6 +535,16 @@ def main_export(
                 has_remote_code = hasattr(config, "auto_map")
                 if has_remote_code and trust_remote_code and task == "image-text-to-text":
                     task_model_loading = "text-generation"
+                elif has_remote_code and not trust_remote_code and task == "image-text-to-text":
+                    # Remote-code VLMs (e.g. GLM-Edge-V, nanoLLaVA, phi3_v) define their
+                    # multimodal class via `auto_map` and cannot be loaded by the built-in
+                    # AutoModelForImageTextToText. Fail early with an actionable message
+                    # instead of the cryptic "Unrecognized configuration class" error.
+                    raise ValueError(
+                        f"The model {model_name_or_path} relies on custom code to load its "
+                        f"`{task}` architecture. Please re-run the export with `--trust-remote-code` "
+                        "(or `trust_remote_code=True`)."
+                    )
 
             model = TasksManager.get_model_from_task(
                 task_model_loading,

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -30,7 +30,6 @@ from openvino import Model, save_model
 from openvino.exceptions import OVTypeError
 from openvino.tools.ovc import convert_model
 from optimum.exporters.openvino.utils import (
-    MULTI_MODAL_TEXT_GENERATION_MODELS,
     ONNX_SUPPORTED_ARCHITECTURES,
     OV_XML_FILE_NAME,
     _get_dynamic_shapes_info,
@@ -41,6 +40,7 @@ from optimum.exporters.openvino.utils import (
     _normalize_dummy_inputs,
     allow_skip_tracing_check,
     clear_class_registry,
+    is_multi_modal_text_generation_model,
     remove_none_from_dummy_inputs,
     save_config,
     save_preprocessors,
@@ -638,7 +638,9 @@ def export_from_model(
         if model.config.decoder_start_token_id is None:
             model.config.decoder_start_token_id = 0
     stateful = stateful and (
-        ensure_export_task_support_stateful(task) or ensure_model_type_support_stateful(model_type)
+        ensure_export_task_support_stateful(task)
+        or ensure_model_type_support_stateful(model_type)
+        or is_multi_modal_text_generation_model(getattr(model, "config", None))
     )
 
     if (
@@ -1011,7 +1013,7 @@ def _get_submodels_and_export_configs(
     if (
         not custom_architecture
         and library_name == "transformers"
-        and model.config.model_type in MULTI_MODAL_TEXT_GENERATION_MODELS
+        and is_multi_modal_text_generation_model(model.config)
     ):
         return _get_multi_modal_submodels_and_export_configs(
             model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -104,6 +104,8 @@ from optimum.exporters.openvino.model_patcher import (
     Gemma3LMModelPatcher,
     Gemma4ImageEmbeddingsModelPatcher,
     Gemma4LMModelPatcher,
+    GlmEdgeVImageEmbeddingsModelPatcher,
+    GlmEdgeVLMModelPatcher,
     GptJModelPatcher,
     GptNeoModelPatcher,
     GptNeoxModelPatcher,
@@ -3332,6 +3334,132 @@ class GLMOpenVINOConfig(LlamaOpenVINOConfig):
 )
 class GLM4OpenVINOConfig(LlamaOpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "4.51.3"
+
+
+# GLM-Edge-V (e.g. zai-org/glm-edge-v-2b) is a vision-language model whose config
+# reports model_type="glm" (same as the text-only GLM decoder) but carries an extra
+# `vision_config`. It is registered here only for the image-text-to-text task so the
+# text-only GLM export path (registered above) is untouched. The multimodal export
+# routing is additionally gated on `hasattr(config, "vision_config")`.
+@register_in_tasks_manager("glm", *["image-text-to-text"], library_name="transformers")
+class GLMEdgeVOpenVINOConfig(BaseVLMOpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "4.46.0"
+    SUPPORTS_PAST = True
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self._behavior = behavior
+        self._orig_config = config
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            # GLM-Edge-V stores `vision_config` as a plain dict; wrap it in a SigLIP
+            # vision config so the dummy input generator can read `image_size`/
+            # `patch_size` and build correctly shaped pixel values (SigLIP uses a
+            # fixed-size learned position embedding).
+            vision_config = config.vision_config
+            if isinstance(vision_config, dict):
+                from transformers import SiglipVisionConfig
+
+                vision_config = SiglipVisionConfig(**vision_config)
+            self._config = vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if not self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return {}
+        return {"pixel_values": {0: "batch_size"}}
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if not self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return {}
+        return {"last_hidden_state": {0: "batch_size"}}
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs) -> Dict:
+        # The adapter concatenates the learned boi/eoi parameters with `.repeat(batch, ...)`,
+        # which would be traced as a constant. Export the vision graph with batch_size=1
+        # so the batch axis stays dynamic at inference time.
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            kwargs["batch_size"] = 1
+        return super().generate_dummy_inputs(framework, **kwargs)
+
+    def with_behavior(
+        self,
+        behavior: Union[str, VLMConfigBehavior],
+    ):
+        """
+        Creates a config for different behaviour.
+
+        Args:
+            behavior ([`ConfigBehavior`]):
+                The behavior to use for the new instance.
+        """
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+
+        # GLM-Edge-V embeds its text decoder directly under model_type="glm",
+        # so both the text-embeddings and language-model graphs reuse the plain
+        # GLM text-generation export config.
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config("glm", self._orig_config, self.int_dtype, self.float_dtype)
+
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            return get_vlm_text_generation_config(
+                "glm",
+                self._orig_config,
+                self.int_dtype,
+                self.float_dtype,
+                model_patcher=GlmEdgeVLMModelPatcher,
+            )
+
+        if behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return self.__class__(
+                self._orig_config,
+                task=self.task,
+                int_dtype=self.int_dtype,
+                float_dtype=self.float_dtype,
+                behavior=behavior,
+                preprocessors=self._preprocessors,
+            )
+
+    @staticmethod
+    def get_model_for_behavior(model, behavior: Union[str, VLMConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            # The language-model graph is built from the full GlmForCausalLM (its
+            # forward is replaced by GlmEdgeVLMModelPatcher to skip the vision merge).
+            return model
+
+        if behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return model
+
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            text_embedding = model.get_input_embeddings()
+            text_embedding.config = model.model.config
+            return text_embedding
+
+    def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
+        model_kwargs = model_kwargs or {}
+        if self._behavior != VLMConfigBehavior.VISION_EMBEDDINGS:
+            return super().patch_model_for_export(model, model_kwargs)
+        return GlmEdgeVImageEmbeddingsModelPatcher(self, model, model_kwargs)
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -3944,6 +3944,73 @@ class InputEmbeddingPatcher(ModelPatcher):
         self._model.forward = self._model.__orig_forward
 
 
+def glm_edge_v_vision_embeddings_forward(self, pixel_values: torch.FloatTensor):
+    # GLM-Edge-V keeps the whole image branch (SigLIP encoder + conv/GLU adapter
+    # with learned boi/eoi parameters) inside `GlmForCausalLM.model.vision`.
+    # Running it as a standalone graph turns the (b, 3, 672, 672) pixel values into
+    # (b, 578, hidden_size) image embeddings.
+    return self.model.vision(pixel_values)
+
+
+class GlmEdgeVImageEmbeddingsModelPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Dict[str, Any],
+    ):
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(glm_edge_v_vision_embeddings_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
+class GlmEdgeVLMModelPatcher(OVDecoderModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        # GLM-Edge-V reuses the plain `glm` decoder, but `GlmForCausalLM.forward`
+        # expects `pixel_values` and `GlmModel.forward` performs the image/text
+        # embedding merge during prefill. For the language model graph we receive
+        # already merged `inputs_embeds`, so we bypass the vision branch and run
+        # the decoder stack with a stateful KV cache directly.
+        def forward(self, attention_mask, position_ids, past_key_values, inputs_embeds, use_cache=True):
+            pkv = DynamicCache.from_legacy_cache(past_key_values)
+            past_seen_tokens = past_key_values[0][0].shape[-2]
+            cache_position = torch.arange(
+                past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+            )
+
+            result = self.model(
+                input_ids=None,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                cache_position=cache_position,
+                past_key_values=pkv,
+                inputs_embeds=inputs_embeds,
+                use_cache=use_cache,
+            )
+            hidden_states = result[0]
+            logits = self.lm_head(hidden_states)
+            upd_pkv = result["past_key_values"]
+            return {"logits": logits, "past_key_values": postprocess_past_key_values(upd_pkv)}
+
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(forward, model)
+
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
 def phi3_vision_embeddings_forward(self, pixel_values: torch.FloatTensor):
     return self.get_img_features(pixel_values)
 

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -338,6 +338,22 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "videochat_flash_qwen",
 ]
 
+
+def is_multi_modal_text_generation_model(config) -> bool:
+    """
+    Returns whether a model config corresponds to a multimodal text-generation
+    (image-text-to-text) model exported as separate vision/text submodels.
+
+    Besides the explicit `MULTI_MODAL_TEXT_GENERATION_MODELS` list, GLM-Edge-V
+    shares its `model_type` ("glm") with the text-only GLM decoder and is only
+    distinguishable by the presence of a nested `vision_config`.
+    """
+    model_type = getattr(config, "model_type", "") or ""
+    if model_type in MULTI_MODAL_TEXT_GENERATION_MODELS:
+        return True
+    return model_type == "glm" and hasattr(config, "vision_config")
+
+
 SSM_MODELS = [
     "mamba",
     "falcon_mamba",

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -4096,6 +4096,69 @@ class _OVGemma4ForCausalLM(_OVGemma3ForCausalLM):
         return model_kwargs
 
 
+class _OVGlmEdgeVForCausalLM(OVModelForVisualCausalLM):
+    def get_vision_embeddings(self, pixel_values, input_ids=None, **kwargs):
+        if input_ids is not None and input_ids.shape[1] == 1:
+            return None
+        pixel_values = torch.from_numpy(pixel_values) if isinstance(pixel_values, np.ndarray) else pixel_values
+        # GLM-Edge-V image processor produces a 6D tensor
+        # (batch, num_concurrent_media, num_tiles, channels, height, width);
+        # flatten it to (num_images, channels, height, width) like the original
+        # GlmForCausalLM.forward does before calling the vision tower.
+        if pixel_values.ndim == 6:
+            batch, media, tiles, channels, height, width = pixel_values.shape
+            pixel_values = pixel_values.reshape(batch * media * tiles, channels, height, width)
+        return self.vision_embeddings(pixel_values).last_hidden_state
+
+    def merge_vision_text_embeddings(
+        self, vision_embeds, inputs_embeds, input_ids=None, attention_mask=None, position_ids=None, **kwargs
+    ):
+        # Adopted from https://huggingface.co/zai-org/glm-edge-v-2b/blob/main/modeling_glm.py
+        # The processor inserts `boi_token_id` placeholders (one per image embedding,
+        # including the learned boi/eoi tokens). Replace them with the vision features.
+        image_features = torch.from_numpy(vision_embeds) if isinstance(vision_embeds, np.ndarray) else vision_embeds
+        inputs_embeds = torch.from_numpy(inputs_embeds) if isinstance(inputs_embeds, np.ndarray) else inputs_embeds
+        image_features = image_features.to(inputs_embeds.dtype)
+
+        special_image_mask = (input_ids == self.config.boi_token_id).unsqueeze(-1)
+        special_image_mask = special_image_mask.expand_as(inputs_embeds)
+        inputs_embeds = inputs_embeds.masked_scatter(special_image_mask, image_features)
+
+        return inputs_embeds, attention_mask, position_ids
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if tokenizer is None:
+            raise ValueError("Tokenizer is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        content = [{"type": "text", "text": text}]
+        if image is not None:
+            if processor is None:
+                raise ValueError("Processor is required for image input.")
+            content.insert(0, {"type": "image"})
+        messages = [{"role": "user", "content": content}]
+
+        inputs = tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, return_dict=True, tokenize=True, return_tensors="pt"
+        )
+        if image is not None:
+            pixel_values = torch.tensor(processor(image).pixel_values)
+            inputs["pixel_values"] = pixel_values
+        return inputs
+
+
 class _OVGotOCR2ForCausalLM(OVModelForVisualCausalLM):
     def get_vision_embeddings(self, pixel_values, input_ids, **kwargs):
         if input_ids is not None and input_ids.shape[1] == 1 and kwargs.get("past_key_values") is not None:
@@ -5832,6 +5895,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen2_5_vl": _OVQwen2_5_VLForCausalLM,
     "qwen2_5_vl_text": _OVQwen2_5_VLForCausalLM,
     "got_ocr2": _OVGotOCR2ForCausalLM,
+    "glm": _OVGlmEdgeVForCausalLM,
     "gemma3": _OVGemma3ForCausalLM,
     "gemma4": _OVGemma4ForCausalLM,
     "idefics3": _OVIdefics3ForCausalLM,

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -659,7 +659,10 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
     SUPPORT_AUDIO = []
     # "llama" is registered for image-text-to-text
     # to support VLM Eagle3 draft models (tested separately in test_genai.py).
-    UNSUPPORTED_ARCHITECTURES = {"phi4_multimodal", "llama"}
+    # "glm" is registered for image-text-to-text to support GLM-Edge-V; it is tested
+    # under the "glm_edge_v" alias since its model_type ("glm") collides with the
+    # text-only GLM decoder.
+    UNSUPPORTED_ARCHITECTURES = {"phi4_multimodal", "llama", "glm"}
     OVMODEL_CLASS = OVModelForVisualCausalLM
     TASK = "image-text-to-text"
 
@@ -707,7 +710,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
 
     if is_transformers_version("<", "4.54.0"):
         # remote code models differs after transformers v4.54
-        SUPPORTED_ARCHITECTURES += ["llava-qwen2", "phi3_v"]
+        SUPPORTED_ARCHITECTURES += ["llava-qwen2", "phi3_v", "glm_edge_v"]
 
     if is_transformers_version("<", "5"):
         # remote code models incompatible after transformers v5
@@ -733,6 +736,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         "maira2",
         "phi4mm",
         "videochat_flash_qwen",
+        "glm_edge_v",
     ]
     IMAGE = Image.open(
         requests.get(
@@ -1154,6 +1158,14 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
             preprocessors = {"processor": None, "tokenizer": tokenizer, "config": config}
+        elif model_arch == "glm_edge_v":
+            # GLM-Edge-V keeps the image processor and tokenizer separate; the
+            # tokenizer holds the chat template that expands image placeholders.
+            from transformers import AutoImageProcessor
+
+            processor = AutoImageProcessor.from_pretrained(model_id, trust_remote_code=True)
+            tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
+            preprocessors = {"processor": processor, "tokenizer": tokenizer, "config": config}
         else:
             processor = AutoProcessor.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -345,6 +345,7 @@ MODEL_NAMES = {
     "xverse": "optimum-intel-internal-testing/tiny-random-xverse",
     "glm4": "optimum-intel-internal-testing/tiny-random-glm4",
     "glm": "optimum-intel-internal-testing/tiny-random-glm-edge",
+    "glm_edge_v": "optimum-intel-internal-testing/tiny-random-glm-edge-v",
     "open-clip": "optimum-intel-internal-testing/tiny-open-clip-model",
     "open-clip-ov": "optimum-intel-internal-testing/tiny-open-clip-model",
     "st-bert": "optimum-intel-internal-testing/all-MiniLM-L6-v2",


### PR DESCRIPTION
# What does this PR do?

Set up environment:

```sh
pip install transformers==4.48.0
pip install optimum-intel@
```

Export the model:

```sh
optimum-cli export openvino -m zai-org/glm-edge-v-2b ./glm-edge-v-2b --task=image-text-to-text --trust-remote-code
```

Inference the model:

```python
from transformers import AutoProcessor
import requests
import torch
from PIL import Image
from transformers import AutoProcessor, AutoModelForCausalLM, AutoImageProcessor, AutoTokenizer
from optimum.intel.openvino import OVModelForVisualCausalLM

#model_id = "zai-org/glm-edge-v-2b"
model_id = "./glm-edge-v-2b"
url = "https://github.com/openvinotoolkit/openvino_notebooks/assets/29454499/d5fbbd1a-d484-415c-88cb-9986625b7b11"
image = Image.open(requests.get(url, stream=True).raw)

messages = [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "describe this image"}]}]

processor = AutoImageProcessor.from_pretrained(model_id, trust_remote_code=True)
tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True)
f32_config = {"INFERENCE_PRECISION_HINT": "f32",
              "KV_CACHE_PRECISION": "f32", "DYNAMIC_QUANTIZATION_GROUP_SIZE": 0
              }
model = OVModelForVisualCausalLM.from_pretrained(model_id, trust_remote_code=True, ov_config=f32_config)

inputs = tokenizer.apply_chat_template(
    messages, add_generation_prompt=True, return_dict=True, tokenize=True, return_tensors="pt"
)

generate_kwargs = {
    **inputs,
    "pixel_values": torch.tensor(processor(image).pixel_values),
}
output = model.generate(**generate_kwargs, max_new_tokens=100)
print(tokenizer.decode(output[0][len(inputs["input_ids"][0]):], skip_special_tokens=True))
```

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

