### PR TITLE
Fix Gemma4 shared KV export compatibility for transformer 5.12.0 with older support as well

### DIFF
--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1293,6 +1293,7 @@ class Gemma4TextOpenVINOConfig(Gemma3TextOpenVINOConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, Gemma4DummyPastKeyValuesGenerator)
     DUMMY_PKV_GENERATOR_CLASS = Gemma4DummyPastKeyValuesGenerator
     MIN_TRANSFORMERS_VERSION = "5.5"
+    MAX_TRANSFORMERS_VERSION = "5.12.99"
 
     def add_past_key_values(self, inputs_or_outputs: dict[str, dict[int, str]], direction: str):
         if direction not in ["inputs", "outputs"]:
@@ -3923,6 +3924,8 @@ class Gemma4ConfigBehavior(str, enum.Enum):
 class Gemma4OpenVINOConfig(Gemma3OpenVINOConfig):
     SUPPORTED_BEHAVIORS = [model_type.value for model_type in Gemma4ConfigBehavior]
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator, DummyTextInputGenerator)
+    MIN_TRANSFORMERS_VERSION = "5.5"
+    MAX_TRANSFORMERS_VERSION = "5.12.99"
 
     def __init__(
         self,

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -5474,6 +5474,7 @@ def gemma4_text_attention_forward(
     hidden_states: torch.Tensor,
     position_embeddings: torch.Tensor,
     attention_mask: Optional[torch.Tensor],
+    shared_kv_states: Optional[dict] = None,
     past_key_values: Optional[Cache] = None,
     cache_position: Optional[torch.LongTensor] = None,
     **kwargs,
@@ -5490,7 +5491,11 @@ def gemma4_text_attention_forward(
     query_states = apply_rotary_pos_emb_gemma4(query_states, cos, sin, unsqueeze_dim=2)
     query_states = query_states.transpose(1, 2)
 
-    if self.is_kv_shared_layer and past_key_values is not None:
+    if self.is_kv_shared_layer and shared_kv_states is not None:
+        key_states, value_states = shared_kv_states[self.layer_type]
+        key_states = key_states.to(query_states.device)
+        value_states = value_states.to(query_states.device)
+    elif self.is_kv_shared_layer and past_key_values is not None:
         key_states, value_states = past_key_values.shared_layers[self.kv_shared_layer_index]
         key_states = key_states.to(query_states.device)
         value_states = value_states.to(query_states.device)
@@ -5514,7 +5519,10 @@ def gemma4_text_attention_forward(
         }
         if not self.is_kv_shared_layer:
             key_states, value_states = past_key_values.update(key_states, value_states, self.layer_idx, cache_kwargs)
-        if self.store_full_length_kv:
+    if self.store_full_length_kv:
+        if shared_kv_states is not None:
+            shared_kv_states[self.layer_type] = key_states, value_states
+        elif past_key_values is not None:
             if not hasattr(past_key_values, "shared_layers"):
                 past_key_values.shared_layers = {}
             past_key_values.shared_layers[self.layer_idx] = key_states, value_states


### PR DESCRIPTION
# What does this PR do?

ov export for gemma4 models failed with recent transformers version 5.12.0 because it has changed internal model implementation of Gemma4. They started using `shared_kv_states` along with `past_key_values`. Older 5.5.0 implementation of gemma4 had only `past_key_values` with `shared_kv_states` inside it.

This patch adds support for latest transformers as well as old transformers.

Fixes # (issue)
#1785 


## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

### Reference links
https://github.com/huggingface/transformers/blob/v5.12.1/src/transformers/models/gemma4/modeling_gemma4.py#L1234
