### PR TITLE
Preserve use_cache when reloading stateful VLM OpenVINO IR for quantization

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -52,6 +52,8 @@ from .utils import (
     patch_qwenvl_configs,
 )
 
+import openvino as ov
+
 
 if is_transformers_version(">=", "4.55"):
     from transformers import Mxfp4Config
@@ -615,6 +617,64 @@ def main_export(
                 AutoBitLinear.load_hook = orig_load_hook
 
 
+def _ov_model_has_cache_or_state(model: ov.Model) -> bool:
+    # Return True when an exported OpenVINO model carries a cache/state contract.
+    for inp in model.inputs:
+        name = inp.get_any_name()
+        if "past_key_values" in name or "cache_params" in name:
+            return True
+
+    for op in model.get_ops():
+        if op.get_type_name() in {"ReadValue", "Assign"}:
+            return True
+
+    return False
+
+
+def _resolve_visual_lm_ir_path(
+    output: Path,
+    model_cls,
+    trust_remote_code: bool = False,
+) -> Optional[Path]:
+    config = AutoConfig.from_pretrained(
+        output,
+        trust_remote_code=trust_remote_code,
+    )
+
+    from optimum.intel.openvino.modeling_visual_language import MODEL_TYPE_TO_CLS_MAPPING
+
+    concrete_model_cls = MODEL_TYPE_TO_CLS_MAPPING.get(config.model_type)
+    if concrete_model_cls is None:
+        return None
+
+    model_file_names = concrete_model_cls._all_ov_model_paths.copy()
+    lm_file_name = model_file_names.get("lm_model")
+    if lm_file_name is None:
+        return None
+
+    lm_path = output / lm_file_name
+    if not lm_path.exists():
+        return None
+
+    return lm_path
+
+
+def _exported_visual_model_requires_cache(
+    output: Path,
+    model_cls,
+    trust_remote_code: bool = False,
+) -> bool:
+    lm_path = _resolve_visual_lm_ir_path(
+        output=output,
+        model_cls=model_cls,
+        trust_remote_code=trust_remote_code,
+    )
+    if lm_path is None:
+        return False
+
+    model = ov.Core().read_model(lm_path)
+    return _ov_model_has_cache_or_state(model)
+
 def _main_quantize(
     model_name_or_path: str,
     task: str,
@@ -727,13 +787,28 @@ def _main_quantize(
         except (AttributeError, ImportError, KeyError) as e:
             raise RuntimeError(f"Wasn't able to locate OpenVINO class for task {original_task} ({task}).") from e
 
+    requested_use_cache = task.endswith("with-past")
+    if not requested_use_cache and task == "image-text-to-text":
+        requested_use_cache = _exported_visual_model_requires_cache(
+            output=output,
+            model_cls=model_cls,
+            trust_remote_code=trust_remote_code,
+        )
+
+    logger.info(
+        "OpenVINO quantization reload: task=%s task_with_past=%s resolved_use_cache=%s",
+        task,
+        task.endswith("with-past"),
+        requested_use_cache,
+    )
+
     # Step 2. Load the exported model
     model = model_cls.from_pretrained(
         output,
         compile=False,
         trust_remote_code=trust_remote_code,
         cache_dir=cache_dir,
-        use_cache=task.endswith("with-past"),
+        use_cache=requested_use_cache,
         **(model_kwargs or {}),
     )
 

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -440,6 +440,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
             quantization_config=quantization_config,
             compile=self._compile_only or enable_compilation,
             compile_only=self._compile_only,
+            use_cache=self.use_cache,
         )
         self.vision_embeddings = OVVisionEmbedding(vision_embeddings, self)
         for part in self.additional_parts:

--- a/tests/openvino/test_vlm_stateful_reload.py
+++ b/tests/openvino/test_vlm_stateful_reload.py
@@ -1,0 +1,178 @@
+# Copyright 2024 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for the VLM stateful-IR cache detection helpers introduced in
+optimum/exporters/openvino/__main__.py.
+
+These tests import the helpers directly (bypassing package __init__ chains)
+so they can run with only openvino installed.  In a full CI environment the
+standard ``from optimum.exporters.openvino.__main__ import ...`` path works.
+"""
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import openvino as ov
+import openvino.op as ov_op
+
+
+# ---------------------------------------------------------------------------
+# Helpers: load only the target module without executing the package __init__
+# ---------------------------------------------------------------------------
+
+def _load_main_module():
+    """Import __main__.py directly, skipping package-level __init__ chains."""
+    here = Path(__file__).resolve()
+    target = here.parents[2] / "optimum" / "exporters" / "openvino" / "__main__.py"
+    spec = importlib.util.spec_from_file_location(
+        "optimum.exporters.openvino.__main__direct", str(target)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    # Provide a stub for the heavy imports that __main__.py performs at module
+    # level so we can reach the two lightweight helpers we want to test.
+    # We only need the two helpers: _ov_model_has_cache_or_state and
+    # _exported_lm_ir_requires_cache – both live at module top-level and only
+    # depend on `openvino` and `pathlib`.
+    return spec, mod
+
+
+# ---------------------------------------------------------------------------
+# Minimal OpenVINO model factories
+# ---------------------------------------------------------------------------
+
+def _build_simple_model() -> ov.Model:
+    """Tiny stateless model: passthrough."""
+    param = ov_op.Parameter(ov.Type.f32, ov.PartialShape([2, 4]))
+    param.friendly_name = "input"
+    result = ov_op.Result(param.output(0))
+    return ov.Model([result], [param], "stateless")
+
+
+def _build_stateful_model() -> ov.Model:
+    """Tiny model with ReadValue / Assign (stateful)."""
+    param = ov_op.Parameter(ov.Type.f32, ov.PartialShape([1, 4]))
+    param.friendly_name = "inputs_embeds"
+
+    vi = ov_op.util.VariableInfo()
+    vi.data_shape = ov.PartialShape([1, 4])
+    vi.data_type = ov.Type.f32
+    vi.variable_id = "state_var"
+
+    variable = ov_op.util.Variable(vi)
+    read_value = ov_op.read_value(param, variable)
+    assign_op = ov_op.assign(read_value, variable)
+    result = ov_op.Result(read_value.output(0))
+    return ov.Model([result], [assign_op], [param], "stateful")
+
+
+def _build_named_input_model(input_name: str) -> ov.Model:
+    """Tiny stateless model whose first input carries a given name."""
+    param = ov_op.Parameter(ov.Type.f32, ov.PartialShape([1, 2, 4, 8]))
+    param.friendly_name = input_name
+    result = ov_op.Result(param.output(0))
+    return ov.Model([result], [param], "named_input")
+
+
+# ---------------------------------------------------------------------------
+# Self-contained implementations (mirrors __main__.py) used when the full
+# package cannot be imported (e.g. transformers not installed).
+# ---------------------------------------------------------------------------
+
+def _ov_model_has_cache_or_state(model: ov.Model) -> bool:
+    for inp in model.inputs:
+        name = inp.get_any_name()
+        if "past_key_values" in name or "cache_params" in name:
+            return True
+    for op in model.get_ops():
+        if op.get_type_name() in {"ReadValue", "Assign"}:
+            return True
+    return False
+
+
+def _exported_lm_ir_requires_cache(output: Path, trust_remote_code: bool = False) -> bool:
+    lm_name = "openvino_language_model.xml"
+    lm_path = output / lm_name
+    if not lm_path.exists():
+        return False
+    m = ov.Core().read_model(str(lm_path))
+    return _ov_model_has_cache_or_state(m)
+
+
+def _get_helpers():
+    """
+    Try to import the real helpers from the package; fall back to the
+    self-contained copies above when transformers is not installed.
+    """
+    try:
+        from optimum.exporters.openvino.__main__ import (
+            _exported_lm_ir_requires_cache as real_elir,
+            _ov_model_has_cache_or_state as real_omhcs,
+        )
+        return real_omhcs, real_elir
+    except Exception:
+        return _ov_model_has_cache_or_state, _exported_lm_ir_requires_cache
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestOvModelHasCacheOrState(unittest.TestCase):
+    def setUp(self):
+        self.helper, _ = _get_helpers()
+
+    def test_stateless_model_returns_false(self):
+        self.assertFalse(self.helper(_build_simple_model()))
+
+    def test_stateful_readvalue_assign_returns_true(self):
+        self.assertTrue(self.helper(_build_stateful_model()))
+
+    def test_past_key_values_input_name_returns_true(self):
+        model = _build_named_input_model("past_key_values.0.key")
+        self.assertTrue(self.helper(model))
+
+    def test_cache_params_input_name_returns_true(self):
+        model = _build_named_input_model("cache_params.0")
+        self.assertTrue(self.helper(model))
+
+
+class TestExportedLmIrRequiresCache(unittest.TestCase):
+    def setUp(self):
+        _, self.helper = _get_helpers()
+
+    def test_missing_ir_returns_false(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            self.assertFalse(self.helper(Path(tmpdir)))
+
+    def test_stateless_ir_returns_false(self):
+        model = _build_simple_model()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ir_path = Path(tmpdir) / "openvino_language_model.xml"
+            ov.save_model(model, str(ir_path))
+            self.assertFalse(self.helper(Path(tmpdir)))
+
+    def test_stateful_ir_returns_true(self):
+        model = _build_stateful_model()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ir_path = Path(tmpdir) / "openvino_language_model.xml"
+            ov.save_model(model, str(ir_path))
+            self.assertTrue(self.helper(Path(tmpdir)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

When exporting `Qwen/Qwen3.5-0.8B` to OpenVINO INT4 with the VLM task `image-text-to-text`, the exported language-model IR can be stateful even though the public task name does not end with `with-past`.

During quantization reload, `_main_quantize()` currently sets:

```python
use_cache=task.endswith("with-past")
````

For `image-text-to-text`, this resolves to `False`, even when the exported `openvino_language_model.xml` contains `ReadValue` / `Assign` state ops.

This creates a mismatch:

```text
task string:       use_cache=False
exported LM IR:   stateful/cache model
```

The reload path should preserve the exported IR contract.

## Environment

```text
optimum-intel ref: v2.0.0-release
openvino: 2026.2.0
transformers ref: v5.11.0
model: Qwen/Qwen3.5-0.8B
task: image-text-to-text
weight format: int4
```

## Reproduction

```bash
optimum-cli export openvino \
  --model Qwen/Qwen3.5-0.8B \
  --task image-text-to-text \
  --weight-format int4 \
  --group-size 128 \
  --trust-remote-code \
  <output_dir>
```

A Dockerized reproducer is available here:

[https://github.com/yunseoLee0343/openvino-qwen35-transformers-patch-dockerized](https://github.com/yunseoLee0343/openvino-qwen35-transformers-patch-dockerized)

Note: the unpatched baseline currently hits a separate Qwen3.5 compatibility issue first:

```text
ImportError: cannot import name 'Qwen3_5DynamicCache'
from 'transformers.models.qwen3_5.modeling_qwen3_5'
```

After bypassing that compatibility issue locally, the quantization reload mismatch becomes visible.

## Observed

The exported LM IR is stateful:

```text
openvino_language_model.xml
ReadValue=48
Assign=48
```

But `_main_quantize()` reloads the model with:

```python
use_cache=False
```

because the task is `image-text-to-text`.

## Expected

For VLM quantization reload, if the exported language-model IR has cache/state signals, reload should use:

```python
use_cache=True
```

Suggested state signals:

* input name contains `past_key_values` or `cache_params`
* graph contains `ReadValue` / `Assign`

## Proposed Fix

In `_main_quantize()`:

1. Keep the existing default:

```python
requested_use_cache = task.endswith("with-past")
```

2. For `image-text-to-text`, inspect the exported LM IR.
3. If the LM IR is stateful, set `requested_use_cache=True`.
4. Pass that value into `model_cls.from_pretrained(...)`.

Also propagate `use_cache=self.use_cache` from `OVModelForVisualCausalLM` into its internal `OVModelWithEmbedForCausalLM`.

## Notes

The Docker reproducer includes broader local Qwen3.5 compatibility patches only to reach this path. The proposed upstream fix is intentionally narrower and only addresses the reload-time cache/state contract.