### PR TITLE
Use base version of package in `is_transformers_version`

### DIFF
--- a/optimum/intel/utils/import_utils.py
+++ b/optimum/intel/utils/import_utils.py
@@ -361,7 +361,7 @@ def is_transformers_version(operation: str, version: str):
     """
     if not _transformers_available:
         return False
-    return compare_versions(parse(_transformers_version), operation, version)
+    return compare_versions(parse(parse(_transformers_version).base_version), operation, version)
 
 
 def is_tokenizers_version(operation: str, version: str):


### PR DESCRIPTION
# What does this PR do?

Compare base version of transformers. 

Incorecct comparing versions of transformers with rc sufix

For example on pipy avalible `5.0.0rc3`

```python 
import optimum.intel.utils.import_utils as iu
iu._is_transformers_available = True
iu._transformers_version = "5.0.0rc3"

print(iu.is_transformers_version("<", "5"))  # True

iu._transformers_version = "5.0.0"
print(iu.is_transformers_version("<", "5"))   # False
```

Expected that `is_transformers_version` returns same results `False` for `5.0.0rc3` and `5.0.0`.

In results if use `transformers==5.0.0rc3` optimum-intel falls:

```
  File "/home/runner/work/nncf/nncf/examples/llm_compression/openvino/tiny_llama_find_hyperparams/main.py", line 240, in main
    model = OVModelForCausalLM.from_pretrained(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_tune_params_0/venv/lib/python3.12/site-packages/optimum/intel/openvino/modeling_base.py", line 656, in from_pretrained
    return super().from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_tune_params_0/venv/lib/python3.12/site-packages/optimum/modeling_base.py", line 407, in from_pretrained
    return from_pretrained_method(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_tune_params_0/venv/lib/python3.12/site-packages/optimum/intel/openvino/modeling_decoder.py", line 374, in _export
    return cls._from_pretrained(
           ^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_tune_params_0/venv/lib/python3.12/site-packages/optimum/intel/openvino/modeling_decoder.py", line 928, in _from_pretrained
    causal_model = init_cls(
                   ^^^^^^^^^
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_tune_params_0/venv/lib/python3.12/site-packages/optimum/intel/openvino/modeling_decoder.py", line 142, in __init__
    super().__init__(
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_tune_params_0/venv/lib/python3.12/site-packages/optimum/intel/openvino/modeling.py", line 125, in __init__
    super().__init__(model, config, **kwargs)
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_tune_params_0/venv/lib/python3.12/site-packages/optimum/intel/openvino/modeling_base.py", line 304, in __init__
    misplaced_generation_parameters = self.config._get_non_default_generation_parameters()
                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/pytest-of-runner/pytest-0/test_examples_llm_tune_params_0/venv/lib/python3.12/site-packages/transformers/configuration_utils.py", line 199, in __getattribute__
    return super().__getattribute__(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'LlamaConfig' object has no attribute '_get_non_default_generation_parameters'
```

Changes is same as for `torch`
https://github.com/huggingface/optimum-intel/blob/afc4d9709dea2ace2e7b74faa9b434b917ce189b/optimum/intel/utils/import_utils.py#L435

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

