### PR TITLE
Fix Phi-3.5-vision eos token temporary fix

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -761,6 +761,13 @@ def export_from_model(
         generation_config = getattr(model, "generation_config", None)
         if generation_config is not None:
             try:
+                # Todo: delete this check once phi-3 eos token get fixed in generation_configs.json
+                # Phi-3.5-vision ships stale eos_token_id=2 but its tokenizer eos is 32000, so add it as a stop token.
+                if model_type == "phi3_v":
+                    t = next((e for p in (preprocessors or []) if (e := getattr(p, "eos_token_id", None)) is not None), None)
+                    g = generation_config.eos_token_id
+                    if t is not None and t not in (g if isinstance(g, list) else [g]):
+                        generation_config.eos_token_id = (g if isinstance(g, list) else [g]) + [t]
                 generation_config.save_pretrained(output)
             except Exception as exception:
                 logger.warning(

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -928,6 +928,26 @@ class OVCLIExportTestCase(unittest.TestCase):
 
         self._openvino_export(MODEL_NAMES[model_type], task, model_kwargs=model_kwargs, loading_kwargs=loading_kwargs)
 
+    @unittest.skipUnless(
+        is_transformers_version(">=", "4.40.0") and is_transformers_version("<=", "4.53.3"),
+        reason="Phi-3.5-vision export is only supported for transformers 4.40.0 - 4.53.3",
+    )
+    def test_export_phi3_v_eos_token_id(self):
+        # Phi-3.5-vision ships a stale eos_token_id=2 while its tokenizer eos is 32000, so export
+        # must add the tokenizer eos as a stop token to avoid infinite generation (issue #1630).
+        model_id = MODEL_NAMES["phi3_v"]
+        with TemporaryDirectory() as tmpdir:
+            subprocess.run(
+                f"optimum-cli export openvino --model {model_id} --task image-text-to-text --trust-remote-code {tmpdir}",
+                shell=True,
+                check=True,
+            )
+            tokenizer_eos_token_id = AutoTokenizer.from_pretrained(model_id, trust_remote_code=True).eos_token_id
+            with open(Path(tmpdir) / "generation_config.json") as fp:
+                eos_token_id = json.load(fp)["eos_token_id"]
+            eos_token_ids = eos_token_id if isinstance(eos_token_id, list) else [eos_token_id]
+            self.assertIn(tokenizer_eos_token_id, eos_token_ids)
+
     @parameterized.expand(SUPPORTED_ARCHITECTURES)
     def test_exporters_cli(self, task: str, model_type: str):
         with TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
# What does this PR do?

As pointed our correctly in issue #1630 with default config provided by `microsoft/Phi-3.5-vision-instruct` results into infinite generation loop. The issue is mismatch in stale `eos_token_id=2` in `generation_config.json` while tokenizer's actual eos token is `32000`. This fix modifies `eos_token_id` to be `[2, 32000]`. I have added `#TODO` to remove it in future when upstream config gets fixed.

Fixes # (issue)
#1630 


## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [NA] Did you write any new necessary tests?

