### PR TITLE
[EXPERIMENT][WIP][OpenVINO] Add support for Cohere2 MoE (cohere2_moe)

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -38,6 +38,7 @@ Here is the list of the supported architectures :
 - CodeGen2
 - Cohere
 - Cohere2
+- Cohere2 MoE
 - ConvBERT
 - ConvNeXt
 - DBRX

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -219,7 +219,6 @@ from optimum.utils.normalized_config import (
     NormalizedVisionConfig,
 )
 
-
 COMMON_TEXT_TASKS = [
     "feature-extraction",
     "fill-mask",

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -98,6 +98,7 @@ from optimum.exporters.openvino.model_patcher import (
     BloomModelPatcher,
     ChatGLMModelPatcher,
     CodeGenModelPatcher,
+    Cohere2MoePatcher,
     CommonImageEmbeddingsModelPatcher,
     DBRXModelPatcher,
     DeciLMModelPatcher,
@@ -812,6 +813,16 @@ class ArceeOpenVINOConfig(LlamaOpenVINOConfig):
 )
 class Cohere2OpenVINOConfig(LlamaOpenVINOConfig):
     pass
+
+
+@register_in_tasks_manager(
+    "cohere2_moe",
+    *["text-generation", "text-generation-with-past"],
+    library_name="transformers",
+)
+class Cohere2MoeOpenVINOConfig(Cohere2OpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "5.8.0"
+    _MODEL_PATCHER = Cohere2MoePatcher
 
 
 @register_in_tasks_manager("qwen", *["text-generation", "text-generation-with-past"])

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9469,6 +9469,35 @@ class Qwen3_5MoeModelPatcher(Qwen3_5ModelPatcher):
                 sparse_moe_block.forward = sparse_moe_block._orig_forward
 
 
+class Cohere2MoePatcher(OVDecoderModelPatcher):
+    """
+    Model patcher for cohere2_moe (Cohere2MoeForCausalLM).
+
+    Patches Cohere2MoeExperts.forward with the vectorized lfm2_moe_experts_forward
+    that uses torch.bmm over the fused gate_up_proj [E, 2*I, H] weight,
+    split via chunk(2, dim=-2), to make the MoE expert dispatch traceable
+    for OpenVINO export.
+
+    Requires transformers >= 5.8.0 (PR #46115: cohere2_moe model).
+    """
+
+    def __enter__(self):
+        super().__enter__()
+        if is_transformers_version(">=", "5.8.0"):
+            from transformers.models.cohere2_moe.modeling_cohere2_moe import Cohere2MoeExperts
+
+            self._orig_cohere2moe_experts_forward = Cohere2MoeExperts.forward
+            Cohere2MoeExperts.forward = lfm2_moe_experts_forward
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if is_transformers_version(">=", "5.8.0"):
+            from transformers.models.cohere2_moe.modeling_cohere2_moe import Cohere2MoeExperts
+
+            Cohere2MoeExperts.forward = self._orig_cohere2moe_experts_forward
+        super().__exit__(exc_type, exc_value, traceback)
+
+
 class Qwen3ASRModelPatcher(OVSeq2SeqModelPatcher):
     """
     Model patcher for Qwen3-ASR encoder-decoder export.

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -55,6 +55,20 @@ class OVQuantizationMethod(str, Enum):
 
 # Default configs for 4-bit weight quantization
 _DEFAULT_4BIT_WQ_CONFIGS = {
+    # cohere2_moe sparse MoE (128 experts, top-8 sigmoid router, tied embeddings).
+    # The tied embed_tokens/lm_head and the per-layer MoE routers are numerically
+    # sensitive; quantizing them collapses greedy generation quality, so they are
+    # kept in higher precision via ignored_scope. Note: 4-bit weight compression of
+    # the experts still perturbs the top-8 routing enough to noticeably degrade
+    # greedy similarity for this model; int8 is recommended when accuracy is critical.
+    "CohereLabs/North-Mini-Code-1.0": {
+        "bits": 4,
+        "sym": False,
+        "group_size": 64,
+        "ratio": 1.0,
+        "backup_precision": "int8_asym",
+        "ignored_scope": {"patterns": [".*embed_tokens.*", ".*mlp\\.gate/aten::linear.*"]},
+    },
     "databricks/dolly-v2-3b": {
         "bits": 4,
         "sym": False,
@@ -505,6 +519,14 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
 
 _DEFAULT_8BIT_WQ_CONFIGS = {
     "Qwen/Qwen2.5-Coder-3B-Instruct": {"bits": 8, "sym": False, "dq_group_size": 128},
+    # cohere2_moe: keep the tied embed_tokens/lm_head and MoE routers out of weight
+    # compression (ignored_scope). With this protection int8 weight compression
+    # recovers near-baseline greedy similarity for this sparse-MoE model.
+    "CohereLabs/North-Mini-Code-1.0": {
+        "bits": 8,
+        "sym": False,
+        "ignored_scope": {"patterns": [".*embed_tokens.*", ".*mlp\\.gate/aten::linear.*"]},
+    },
 }
 
 # Add configs for model id aliases

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -40,7 +40,6 @@ from .utils import (
     PREDEFINED_VISUAL_LM_DATASETS,
 )
 
-
 if is_nncf_available():
     import nncf
 

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -100,6 +100,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "minicpm3",
         "arctic",
         "deepseek",
+        "cohere2_moe",
         ## not supporter after v5
         "llama4",
         "bitnet",
@@ -197,6 +198,7 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         "dbrx": 2,
         "cohere": 2,
         "cohere2": 2,
+        "cohere2_moe": 2,
         "qwen2": 2,
         "qwen2_moe": 4,
         "arctic": 4,

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -37,7 +37,6 @@ from optimum.intel.openvino.utils import _print_compiled_model_properties
 from optimum.intel.pipelines import pipeline as optimum_pipeline
 from optimum.intel.utils.import_utils import is_openvino_version, is_transformers_version
 
-
 if is_transformers_version(">=", "4.55"):
     from transformers import Mxfp4Config
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -177,6 +177,7 @@ HUB_MODEL_NAMES = {
     "convbert": "optimum-intel-internal-testing/tiny-random-ConvBertForSequenceClassification",
     "cohere": "optimum-intel-internal-testing/tiny-random-CohereForCausalLM",
     "cohere2": "optimum-intel-internal-testing/tiny-random-aya-base",
+    "cohere2_moe": "optimum-internal-testing/tiny-random-Cohere2MoeForCausalLM",
     "chatglm": "optimum-intel-internal-testing/tiny-random-chatglm",
     "chatglm4": "optimum-intel-internal-testing/tiny-random-chatglm4",
     "codegen": "optimum-intel-internal-testing/tiny-random-CodeGenForCausalLM",


### PR DESCRIPTION
⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
This PR was created by an AI agent as part of automated model enablement.
A human maintainer must review and approve it before it can be considered for merge.
Do **NOT** merge without human review and sign-off.

# What does this PR do?

Add OpenVINO export support for the Cohere2 MoE architecture (model_type `cohere2_moe`, `Cohere2MoeForCausalLM`; e.g. CohereLabs/North-Mini-Code-1.0 — 30B total / 3B active, 128 experts / 8 active, sigmoid router, hybrid sliding-window+RoPE / global-NoPE attention, Cohere2 parallel block).

Changes (minimal, scoped to cohere2_moe):
- `Cohere2MoeOpenVINOConfig(Cohere2OpenVINOConfig)` registered for `cohere2_moe` (text-generation[-with-past]).
- `Cohere2MoePatcher`: replaces the untraceable `Cohere2MoeExperts.forward` (fused `gate_up_proj`, per-hit-expert loop) with the existing vectorized `lfm2_moe_experts_forward` (torch.bmm, `chunk(2, dim=-2)`), mirroring the Qwen3.5-MoE approach (PR #1689/#1728). Patcher numerically verified vs the original forward (max-abs diff ~3e-7 in fp32).
- Default weight-compression config keeping `embed_tokens`/`lm_head` (tied) and per-layer MoE routers out of compression via `ignored_scope` — required for accuracy on this sparse-MoE model.
- Tiny random cohere2_moe added to the OpenVINO test suite.

Validation: tiny-model greedy export matches PyTorch 25/25 tokens. Full model WWB text-similarity vs PyTorch baseline (CPU, greedy, 8 samples): INT8 = 0.925 (PASS, ≥0.9). 

Known limitations (flagged for human review, NOT addressed here):
- INT4 weight-only PTQ has a proven accuracy ceiling (~0.78) on this model (swept group_size/ratio/AWQ/scale-estimation) — INT8 is the recommended precision.
- OpenVINO GPU: the compressed-MoE op `MOECompressed` is not fused on the GPU plugin for cohere2_moe routing (`FuseMOE3GemmCompressed` only matches activation-before-topk + normalized routers; cohere2_moe applies sigmoid after top-k with no normalization). GPU inference therefore fails (`MOECompressed reached the GPU backend without being fused`). Additionally INT8 (29GB) exceeds available dGPU VRAM (22.7GB). Recommended owner: OpenVINO GPU plugin / MoE team. CPU INT8 is the supported path.

## Installation instructions

```bash
pip install "git+https://github.com/huggingface/optimum-intel.git@main#egg=optimum-intel[openvino]"
# transformers from main is required for cohere2_moe (PR #46115):
pip install "git+https://github.com/huggingface/transformers.git"
```

## Exporting cmd-line

```bash
# INT8 is the recommended/validated precision (CPU). The per-model default config
# automatically keeps embeddings/lm_head + MoE routers uncompressed for accuracy.
optimum-cli export openvino -m CohereLabs/North-Mini-Code-1.0 --weight-format int8 --task text-generation-with-past ./North-Mini-Code-1.0-ov-int8
```

## Inference script

```python
import openvino_genai as ov_genai

pipe = ov_genai.LLMPipeline("./North-Mini-Code-1.0-ov-int8", "CPU")
config = ov_genai.GenerationConfig()
config.max_new_tokens = 128
config.apply_chat_template = False  # Cohere Jinja template uses constructs unsupported by GenAI Minja
print(pipe.generate("def fibonacci(n):\n    ", config))
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
