### PR TITLE
[EXPERIMENT][WIP][OpenVINO] Add support for nvidia/LocateAnything-3B (MoonViT + Qwen2.5-3B VLM)

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -97,6 +97,7 @@ Here is the list of the supported architectures :
 - LLaVa-NeXT
 - LLaVa-NeXT-Video
 - LLaVa-Qwen2 (NanoLLaVa)
+- LocateAnything
 - LongT5
 - M2M-100
 - MAIRA-2

--- a/locateanything_enablement/README.md
+++ b/locateanything_enablement/README.md
@@ -1,0 +1,31 @@
+# LocateAnything-3B OpenVINO enablement — eval & parity scripts
+
+Reusable scripts used to validate the LocateAnything-3B OpenVINO export
+(FP16/INT8/INT4) on CPU + GPU. Run them from the workspace root
+`dev/nvidia-LocateAnything-3B/` (paths to `ov_ir_*`, `parity_artifacts/`,
+`eval_images/`, `eval_artifacts/` are relative to that dir).
+
+| script | purpose |
+| :--- | :--- |
+| `ref_pytorch.py` | PyTorch reference: prefill logits + greedy slow-AR artifacts (Milestone B). |
+| `parity.py` | Milestone-B FP16 OV-vs-PyTorch parity (vision/prefill cossim + token match). |
+| `parity_multi.py` | Same parity generalized over `--ir-dir {fp16,int8,int4}` × `--device {CPU,GPU.0,...}`. |
+| `eval_box_parity.py` | Box IoU / F1 accuracy parity (OV vs PyTorch GT): F1@0.5, F1@mean, corner-L1, box-count. |
+| `perf.py` | Informational slow-AR LLM TTFT / ITL across precision × device. |
+
+Reproduce (in the dedicated venv, with HF_TOKEN sourced):
+
+```bash
+./venv/bin/python ref_pytorch.py
+./venv/bin/python parity_multi.py --ir-dir ov_ir_int4 --device CPU
+./venv/bin/python eval_box_parity.py --precisions fp16,int8,int4 --devices CPU,GPU.0
+./venv/bin/python perf.py --precisions fp16,int4 --devices CPU,GPU.0 --runs 3
+```
+
+Quantized IRs are produced via:
+```bash
+optimum-cli export openvino --model nvidia/LocateAnything-3B --task image-text-to-text \
+    --trust-remote-code --weight-format int8 ov_ir_int8
+optimum-cli export openvino --model nvidia/LocateAnything-3B --task image-text-to-text \
+    --trust-remote-code --weight-format int4 --group-size 128 --ratio 1.0 ov_ir_int4
+```

--- a/locateanything_enablement/eval_box_parity.py
+++ b/locateanything_enablement/eval_box_parity.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Box IoU / F1 accuracy-parity eval: OpenVINO vs PyTorch reference for LocateAnything-3B.
+
+Treats the PyTorch (HF, trust_remote_code, bf16) slow-AR output as ground truth and
+measures how closely each OpenVINO precision (FP16/INT8/INT4) on each device (CPU/GPU)
+reproduces it: F1@0.5, F1@mean(IoU 0.5:0.05:0.95), mean box-corner L1, box-count match.
+
+Methodology / fairness:
+  * The exported vision IR bakes pos-emb + 2x2 patch-merge at the fixed 448x448 export
+    resolution (256 image tokens). To compare apples-to-apples in one coordinate frame,
+    BOTH the PyTorch reference and the OV pipeline preprocess every image at 448x448.
+  * PyTorch reference: pure slow-AR greedy (use_cache=False), which keeps the vendored
+    Qwen2 on its standard-causal branch (no magi / no PBD fast path) -- the in-scope path.
+  * OV pipeline: vision IR -> scatter image features at <IMG_CONTEXT> -> text-embed IR ->
+    stateful language IR with KV cache, greedy AR. (KV-cache greedy == slow-AR recompute
+    for a causal model; validated by the Milestone-B 8/8 token match.)
+
+Boxes parsed via regex <box><x1><y1><x2><y2></box>; coords are 0..1000 normalized.
+
+Usage:
+  python eval_box_parity.py --precisions fp16,int8,int4 --devices CPU,GPU.0
+  python eval_box_parity.py --refresh-reference   # recompute the PyTorch GT cache
+"""
+import argparse
+import json
+import os
+import re
+import time
+
+import numpy as np
+from PIL import Image
+
+RES = 448
+EOS = 151645
+IMG_TOKEN = 151665
+MAX_NEW = 128
+ART = "eval_artifacts"
+BOX_RE = re.compile(r"<box><(\d+)><(\d+)><(\d+)><(\d+)></box>")
+
+# (image filename, query) pairs -- diverse detection + phrase-grounding queries.
+SAMPLES = [
+    ("000000039769.jpg", "cat"),
+    ("000000039769.jpg", "remote control"),
+    ("000000000139.jpg", "person"),
+    ("000000000139.jpg", "tv"),
+    ("000000000285.jpg", "bear"),
+    ("000000000632.jpg", "bed"),
+    ("000000000724.jpg", "stop sign"),
+    ("000000001000.jpg", "person"),
+    ("000000001268.jpg", "person"),
+    ("000000001296.jpg", "car"),
+    ("000000001503.jpg", "train"),
+    ("000000002006.jpg", "the largest object in the image"),
+    ("000000002149.jpg", "person"),
+    ("000000002261.jpg", "bird"),
+    ("000000002431.jpg", "person"),
+]
+
+IMG_DIR = "eval_images"
+
+
+def build_prompt(query):
+    return f"Locate all the instances that matches the following description: {query}."
+
+
+def parse_boxes(text):
+    """Return list of [x1,y1,x2,y2] in 0..1 normalized coords (from 0..1000 tokens)."""
+    out = []
+    for m in BOX_RE.finditer(text):
+        x1, y1, x2, y2 = (int(v) / 1000.0 for v in m.groups())
+        if x2 < x1:
+            x1, x2 = x2, x1
+        if y2 < y1:
+            y1, y2 = y2, y1
+        out.append([x1, y1, x2, y2])
+    return out
+
+
+def iou(a, b):
+    ix1, iy1 = max(a[0], b[0]), max(a[1], b[1])
+    ix2, iy2 = min(a[2], b[2]), min(a[3], b[3])
+    iw, ih = max(0.0, ix2 - ix1), max(0.0, iy2 - iy1)
+    inter = iw * ih
+    ua = (a[2] - a[0]) * (a[3] - a[1]) + (b[2] - b[0]) * (b[3] - b[1]) - inter
+    return inter / ua if ua > 0 else 0.0
+
+
+def greedy_match(ov_boxes, gt_boxes):
+    """Greedy IoU matching. Returns list of (ov_idx, gt_idx, iou) sorted desc."""
+    pairs = []
+    for i, ob in enumerate(ov_boxes):
+        for j, gb in enumerate(gt_boxes):
+            pairs.append((iou(ob, gb), i, j))
+    pairs.sort(reverse=True)
+    used_o, used_g, matches = set(), set(), []
+    for v, i, j in pairs:
+        if i in used_o or j in used_g:
+            continue
+        used_o.add(i)
+        used_g.add(j)
+        matches.append((i, j, v))
+    return matches
+
+
+def f1_at(matches, n_ov, n_gt, thr):
+    tp = sum(1 for _, _, v in matches if v >= thr)
+    fp = n_ov - tp
+    fn = n_gt - tp
+    denom = 2 * tp + fp + fn
+    return (2 * tp / denom) if denom > 0 else 1.0  # both empty -> perfect agreement
+
+
+def per_image_metrics(ov_boxes, gt_boxes):
+    matches = greedy_match(ov_boxes, gt_boxes)
+    n_ov, n_gt = len(ov_boxes), len(gt_boxes)
+    f1_50 = f1_at(matches, n_ov, n_gt, 0.5)
+    thrs = np.arange(0.5, 0.951, 0.05)
+    f1_mean = float(np.mean([f1_at(matches, n_ov, n_gt, t) for t in thrs]))
+    # corner L1 over matched pairs (in 0..1000 frame), only for IoU-matched pairs >0
+    l1s = []
+    for i, j, v in matches:
+        if v > 0:
+            a = np.array(ov_boxes[i]) * 1000.0
+            b = np.array(gt_boxes[j]) * 1000.0
+            l1s.append(float(np.abs(a - b).mean()))
+    l1 = float(np.mean(l1s)) if l1s else None
+    count_match = int(n_ov == n_gt)
+    return {"f1_50": f1_50, "f1_mean": f1_mean, "corner_l1": l1,
+            "count_match": count_match, "n_ov": n_ov, "n_gt": n_gt}
+
+
+# --------------------------- PyTorch reference ---------------------------
+
+def compute_reference(refresh=False):
+    path = os.path.join(ART, "reference_boxes.json")
+    if os.path.exists(path) and not refresh:
+        return json.load(open(path))
+    import torch
+    from transformers import AutoModel, AutoProcessor, AutoTokenizer
+
+    MODEL = "nvidia/LocateAnything-3B"
+    tok = AutoTokenizer.from_pretrained(MODEL, trust_remote_code=True)
+    proc = AutoProcessor.from_pretrained(MODEL, trust_remote_code=True)
+    model = AutoModel.from_pretrained(MODEL, dtype=torch.bfloat16, trust_remote_code=True).eval()
+    model.tie_weights()
+    idx = model.config.image_token_index
+    ref = {}
+    for fn, query in SAMPLES:
+        key = f"{fn}::{query}"
+        img = Image.open(os.path.join(IMG_DIR, fn)).convert("RGB").resize((RES, RES), Image.BICUBIC)
+        messages = [{"role": "user", "content": [{"type": "image", "image": img},
+                                                  {"type": "text", "text": build_prompt(query)}]}]
+        text = proc.py_apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        images, videos = proc.process_vision_info(messages)
+        inputs = proc(text=[text], images=images, videos=videos, return_tensors="pt")
+        pv = inputs["pixel_values"].to(torch.bfloat16)
+        ids = inputs["input_ids"]
+        am = inputs["attention_mask"]
+        gh = inputs["image_grid_hws"]
+        if isinstance(gh, np.ndarray):
+            gh = torch.from_numpy(gh)
+        gh = gh.to(torch.int32)
+        with torch.no_grad():
+            vit = model.extract_feature(pv, gh)
+            if isinstance(vit, (list, tuple)):
+                vit = torch.cat(vit, dim=0)
+            feats = model.mlp1(vit)
+        gen = ids.clone()
+        amask = am.clone()
+        out = []
+        t0 = time.time()
+        for _ in range(MAX_NEW):
+            with torch.no_grad():
+                o = model.language_model(input_ids=gen,
+                                         visual_features=feats.to(model.language_model.dtype),
+                                         image_token_index=idx, attention_mask=amask, use_cache=False)
+            nxt = int(o.logits[0, -1].argmax())
+            out.append(nxt)
+            if nxt == EOS:
+                break
+            gen = torch.cat([gen, torch.tensor([[nxt]], dtype=gen.dtype)], dim=1)
+            amask = torch.cat([amask, torch.ones((1, 1), dtype=amask.dtype)], dim=1)
+        decoded = tok.decode(out, skip_special_tokens=False)
+        ref[key] = {"text": decoded, "boxes": parse_boxes(decoded),
+                    "n_tokens": len(out), "seconds": round(time.time() - t0, 2),
+                    "prompt_len": int(ids.shape[1])}
+        print(f"[REF] {key}: {len(parse_boxes(decoded))} boxes, {len(out)} tok, {ref[key]['seconds']}s :: {decoded[:90]}")
+    os.makedirs(ART, exist_ok=True)
+    json.dump(ref, open(path, "w"), indent=2)
+    return ref
+
+
+# --------------------------- OV pipeline ---------------------------
+
+class OVPipeline:
+    def __init__(self, ir_dir, device):
+        from optimum.intel.openvino import OVModelForVisualCausalLM
+        from transformers import AutoProcessor, AutoTokenizer
+        self.tok = AutoTokenizer.from_pretrained(ir_dir, trust_remote_code=True)
+        self.proc = AutoProcessor.from_pretrained(ir_dir, trust_remote_code=True)
+        self.model = OVModelForVisualCausalLM.from_pretrained(ir_dir, trust_remote_code=True, device=device)
+        self.vreq = self.model.vision_embeddings.request
+        self.lreq = self.model.language_model.request
+
+    def _inputs(self, fn, query):
+        img = Image.open(os.path.join(IMG_DIR, fn)).convert("RGB").resize((RES, RES), Image.BICUBIC)
+        messages = [{"role": "user", "content": [{"type": "image", "image": img},
+                                                 {"type": "text", "text": build_prompt(query)}]}]
+        text = self.proc.py_apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        images, videos = self.proc.process_vision_info(messages)
+        inputs = self.proc(text=[text], images=images, videos=videos, return_tensors="pt")
+        return (inputs["input_ids"].numpy(), inputs["attention_mask"].numpy(),
+                inputs["pixel_values"].numpy().astype(np.float32),
+                np.asarray(inputs["image_grid_hws"]).astype(np.int32))
+
+    def generate(self, fn, query, max_new=MAX_NEW):
+        ids, am, pv, gh = self._inputs(fn, query)
+        vout = self.vreq({"pixel_values": pv, "image_grid_hws": gh})
+        feats = list(vout.values())[0]
+        # prefill embeddings with scattered vision features
+        te = self.model.language_model.embed_tokens(ids.astype(np.int64))
+        emb = np.array(te)[0].copy()
+        sel = ids[0] == IMG_TOKEN
+        emb[sel] = feats.astype(emb.dtype)
+        S = ids.shape[1]
+        mask = am.copy()
+        self.lreq.reset_state()
+        # prefill
+        r = self.lreq.infer({"inputs_embeds": emb[None].astype(np.float32),
+                             "attention_mask": mask.astype(np.int64),
+                             "position_ids": np.arange(S, dtype=np.int64)[None],
+                             "beam_idx": np.zeros(1, dtype=np.int32)})
+        logits = list(r.values())[0][0]
+        nxt = int(logits[-1].argmax())
+        out = [nxt]
+        pos = S
+        t0 = time.time()
+        ttft = None
+        while nxt != EOS and len(out) < max_new:
+            te1 = self.model.language_model.embed_tokens(np.array([[nxt]], dtype=np.int64))
+            e1 = np.array(te1).astype(np.float32)
+            mask = np.concatenate([mask, [[1]]], axis=1)
+            r = self.lreq.infer({"inputs_embeds": e1,
+                                 "attention_mask": mask.astype(np.int64),
+                                 "position_ids": np.array([[pos]], dtype=np.int64),
+                                 "beam_idx": np.zeros(1, dtype=np.int32)})
+            if ttft is None:
+                ttft = time.time() - t0
+            logits = list(r.values())[0][0]
+            nxt = int(logits[-1].argmax())
+            out.append(nxt)
+            pos += 1
+        decoded = self.tok.decode(out, skip_special_tokens=False)
+        return decoded, parse_boxes(decoded)
+
+
+def run_matrix(precisions, devices, ref):
+    rows = []
+    for prec in precisions:
+        ir_dir = f"ov_ir_{prec}"
+        for dev in devices:
+            print(f"\n=== OV {prec} on {dev} ===")
+            pipe = OVPipeline(ir_dir, dev)
+            per = []
+            for fn, query in SAMPLES:
+                key = f"{fn}::{query}"
+                decoded, ov_boxes = pipe.generate(fn, query)
+                m = per_image_metrics(ov_boxes, ref[key]["boxes"])
+                per.append(m)
+                print(f"  {key}: ov={m['n_ov']} gt={m['n_gt']} f1@.5={m['f1_50']:.3f} "
+                      f"f1mean={m['f1_mean']:.3f} L1={m['corner_l1']}")
+            f1_50 = float(np.mean([p["f1_50"] for p in per]))
+            f1_mean = float(np.mean([p["f1_mean"] for p in per]))
+            l1vals = [p["corner_l1"] for p in per if p["corner_l1"] is not None]
+            corner_l1 = float(np.mean(l1vals)) if l1vals else None
+            count_match = int(sum(p["count_match"] for p in per))
+            row = {"precision": prec, "device": dev, "n_images": len(SAMPLES),
+                   "f1_at_0.5": round(f1_50, 4), "f1_mean": round(f1_mean, 4),
+                   "mean_corner_l1_px448": round(corner_l1, 2) if corner_l1 is not None else None,
+                   "count_matched_images": count_match,
+                   "per_image": per}
+            rows.append(row)
+            print(f"  -> {prec}/{dev}: F1@.5={f1_50:.4f} F1mean={f1_mean:.4f} "
+                  f"L1={corner_l1} countmatch={count_match}/{len(SAMPLES)}")
+            del pipe
+    return rows
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--precisions", default="fp16,int8,int4")
+    ap.add_argument("--devices", default="CPU")
+    ap.add_argument("--refresh-reference", action="store_true")
+    ap.add_argument("--out", default=os.path.join(ART, "box_parity_results.json"))
+    args = ap.parse_args()
+    os.makedirs(ART, exist_ok=True)
+
+    ref = compute_reference(refresh=args.refresh_reference)
+    precisions = [p.strip() for p in args.precisions.split(",") if p.strip()]
+    devices = [d.strip() for d in args.devices.split(",") if d.strip()]
+    rows = run_matrix(precisions, devices, ref)
+
+    summary = {"reference": "PyTorch nvidia/LocateAnything-3B bf16 slow-AR (GT)",
+               "resolution": RES, "n_samples": len(SAMPLES),
+               "table": [{k: v for k, v in r.items() if k != "per_image"} for r in rows],
+               "rows": rows}
+    json.dump(summary, open(args.out, "w"), indent=2)
+    print("\n==== SUMMARY TABLE ====")
+    print(f"{'prec':6} {'device':8} {'F1@0.5':8} {'F1@mean':8} {'L1(px448)':10} {'count':8}")
+    for r in summary["table"]:
+        print(f"{r['precision']:6} {r['device']:8} {r['f1_at_0.5']:<8} {r['f1_mean']:<8} "
+              f"{str(r['mean_corner_l1_px448']):10} {r['count_matched_images']}/{r['n_images']}")
+    print("saved", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/locateanything_enablement/eval_box_parity.py
+++ b/locateanything_enablement/eval_box_parity.py
@@ -125,11 +125,18 @@ def per_image_metrics(ov_boxes, gt_boxes):
             l1s.append(float(np.abs(a - b).mean()))
     l1 = float(np.mean(l1s)) if l1s else None
     count_match = int(n_ov == n_gt)
-    return {"f1_50": f1_50, "f1_mean": f1_mean, "corner_l1": l1,
-            "count_match": count_match, "n_ov": n_ov, "n_gt": n_gt}
+    return {
+        "f1_50": f1_50,
+        "f1_mean": f1_mean,
+        "corner_l1": l1,
+        "count_match": count_match,
+        "n_ov": n_ov,
+        "n_gt": n_gt,
+    }
 
 
 # --------------------------- PyTorch reference ---------------------------
+
 
 def compute_reference(refresh=False):
     path = os.path.join(ART, "reference_boxes.json")
@@ -148,8 +155,12 @@ def compute_reference(refresh=False):
     for fn, query in SAMPLES:
         key = f"{fn}::{query}"
         img = Image.open(os.path.join(IMG_DIR, fn)).convert("RGB").resize((RES, RES), Image.BICUBIC)
-        messages = [{"role": "user", "content": [{"type": "image", "image": img},
-                                                  {"type": "text", "text": build_prompt(query)}]}]
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "image", "image": img}, {"type": "text", "text": build_prompt(query)}],
+            }
+        ]
         text = proc.py_apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
         images, videos = proc.process_vision_info(messages)
         inputs = proc(text=[text], images=images, videos=videos, return_tensors="pt")
@@ -171,9 +182,13 @@ def compute_reference(refresh=False):
         t0 = time.time()
         for _ in range(MAX_NEW):
             with torch.no_grad():
-                o = model.language_model(input_ids=gen,
-                                         visual_features=feats.to(model.language_model.dtype),
-                                         image_token_index=idx, attention_mask=amask, use_cache=False)
+                o = model.language_model(
+                    input_ids=gen,
+                    visual_features=feats.to(model.language_model.dtype),
+                    image_token_index=idx,
+                    attention_mask=amask,
+                    use_cache=False,
+                )
             nxt = int(o.logits[0, -1].argmax())
             out.append(nxt)
             if nxt == EOS:
@@ -181,10 +196,16 @@ def compute_reference(refresh=False):
             gen = torch.cat([gen, torch.tensor([[nxt]], dtype=gen.dtype)], dim=1)
             amask = torch.cat([amask, torch.ones((1, 1), dtype=amask.dtype)], dim=1)
         decoded = tok.decode(out, skip_special_tokens=False)
-        ref[key] = {"text": decoded, "boxes": parse_boxes(decoded),
-                    "n_tokens": len(out), "seconds": round(time.time() - t0, 2),
-                    "prompt_len": int(ids.shape[1])}
-        print(f"[REF] {key}: {len(parse_boxes(decoded))} boxes, {len(out)} tok, {ref[key]['seconds']}s :: {decoded[:90]}")
+        ref[key] = {
+            "text": decoded,
+            "boxes": parse_boxes(decoded),
+            "n_tokens": len(out),
+            "seconds": round(time.time() - t0, 2),
+            "prompt_len": int(ids.shape[1]),
+        }
+        print(
+            f"[REF] {key}: {len(parse_boxes(decoded))} boxes, {len(out)} tok, {ref[key]['seconds']}s :: {decoded[:90]}"
+        )
     os.makedirs(ART, exist_ok=True)
     json.dump(ref, open(path, "w"), indent=2)
     return ref
@@ -192,10 +213,12 @@ def compute_reference(refresh=False):
 
 # --------------------------- OV pipeline ---------------------------
 
+
 class OVPipeline:
     def __init__(self, ir_dir, device):
         from optimum.intel.openvino import OVModelForVisualCausalLM
         from transformers import AutoProcessor, AutoTokenizer
+
         self.tok = AutoTokenizer.from_pretrained(ir_dir, trust_remote_code=True)
         self.proc = AutoProcessor.from_pretrained(ir_dir, trust_remote_code=True)
         self.model = OVModelForVisualCausalLM.from_pretrained(ir_dir, trust_remote_code=True, device=device)
@@ -204,14 +227,21 @@ class OVPipeline:
 
     def _inputs(self, fn, query):
         img = Image.open(os.path.join(IMG_DIR, fn)).convert("RGB").resize((RES, RES), Image.BICUBIC)
-        messages = [{"role": "user", "content": [{"type": "image", "image": img},
-                                                 {"type": "text", "text": build_prompt(query)}]}]
+        messages = [
+            {
+                "role": "user",
+                "content": [{"type": "image", "image": img}, {"type": "text", "text": build_prompt(query)}],
+            }
+        ]
         text = self.proc.py_apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
         images, videos = self.proc.process_vision_info(messages)
         inputs = self.proc(text=[text], images=images, videos=videos, return_tensors="pt")
-        return (inputs["input_ids"].numpy(), inputs["attention_mask"].numpy(),
-                inputs["pixel_values"].numpy().astype(np.float32),
-                np.asarray(inputs["image_grid_hws"]).astype(np.int32))
+        return (
+            inputs["input_ids"].numpy(),
+            inputs["attention_mask"].numpy(),
+            inputs["pixel_values"].numpy().astype(np.float32),
+            np.asarray(inputs["image_grid_hws"]).astype(np.int32),
+        )
 
     def generate(self, fn, query, max_new=MAX_NEW):
         ids, am, pv, gh = self._inputs(fn, query)
@@ -226,10 +256,14 @@ class OVPipeline:
         mask = am.copy()
         self.lreq.reset_state()
         # prefill
-        r = self.lreq.infer({"inputs_embeds": emb[None].astype(np.float32),
-                             "attention_mask": mask.astype(np.int64),
-                             "position_ids": np.arange(S, dtype=np.int64)[None],
-                             "beam_idx": np.zeros(1, dtype=np.int32)})
+        r = self.lreq.infer(
+            {
+                "inputs_embeds": emb[None].astype(np.float32),
+                "attention_mask": mask.astype(np.int64),
+                "position_ids": np.arange(S, dtype=np.int64)[None],
+                "beam_idx": np.zeros(1, dtype=np.int32),
+            }
+        )
         logits = list(r.values())[0][0]
         nxt = int(logits[-1].argmax())
         out = [nxt]
@@ -240,10 +274,14 @@ class OVPipeline:
             te1 = self.model.language_model.embed_tokens(np.array([[nxt]], dtype=np.int64))
             e1 = np.array(te1).astype(np.float32)
             mask = np.concatenate([mask, [[1]]], axis=1)
-            r = self.lreq.infer({"inputs_embeds": e1,
-                                 "attention_mask": mask.astype(np.int64),
-                                 "position_ids": np.array([[pos]], dtype=np.int64),
-                                 "beam_idx": np.zeros(1, dtype=np.int32)})
+            r = self.lreq.infer(
+                {
+                    "inputs_embeds": e1,
+                    "attention_mask": mask.astype(np.int64),
+                    "position_ids": np.array([[pos]], dtype=np.int64),
+                    "beam_idx": np.zeros(1, dtype=np.int32),
+                }
+            )
             if ttft is None:
                 ttft = time.time() - t0
             logits = list(r.values())[0][0]
@@ -267,21 +305,30 @@ def run_matrix(precisions, devices, ref):
                 decoded, ov_boxes = pipe.generate(fn, query)
                 m = per_image_metrics(ov_boxes, ref[key]["boxes"])
                 per.append(m)
-                print(f"  {key}: ov={m['n_ov']} gt={m['n_gt']} f1@.5={m['f1_50']:.3f} "
-                      f"f1mean={m['f1_mean']:.3f} L1={m['corner_l1']}")
+                print(
+                    f"  {key}: ov={m['n_ov']} gt={m['n_gt']} f1@.5={m['f1_50']:.3f} "
+                    f"f1mean={m['f1_mean']:.3f} L1={m['corner_l1']}"
+                )
             f1_50 = float(np.mean([p["f1_50"] for p in per]))
             f1_mean = float(np.mean([p["f1_mean"] for p in per]))
             l1vals = [p["corner_l1"] for p in per if p["corner_l1"] is not None]
             corner_l1 = float(np.mean(l1vals)) if l1vals else None
             count_match = int(sum(p["count_match"] for p in per))
-            row = {"precision": prec, "device": dev, "n_images": len(SAMPLES),
-                   "f1_at_0.5": round(f1_50, 4), "f1_mean": round(f1_mean, 4),
-                   "mean_corner_l1_px448": round(corner_l1, 2) if corner_l1 is not None else None,
-                   "count_matched_images": count_match,
-                   "per_image": per}
+            row = {
+                "precision": prec,
+                "device": dev,
+                "n_images": len(SAMPLES),
+                "f1_at_0.5": round(f1_50, 4),
+                "f1_mean": round(f1_mean, 4),
+                "mean_corner_l1_px448": round(corner_l1, 2) if corner_l1 is not None else None,
+                "count_matched_images": count_match,
+                "per_image": per,
+            }
             rows.append(row)
-            print(f"  -> {prec}/{dev}: F1@.5={f1_50:.4f} F1mean={f1_mean:.4f} "
-                  f"L1={corner_l1} countmatch={count_match}/{len(SAMPLES)}")
+            print(
+                f"  -> {prec}/{dev}: F1@.5={f1_50:.4f} F1mean={f1_mean:.4f} "
+                f"L1={corner_l1} countmatch={count_match}/{len(SAMPLES)}"
+            )
             del pipe
     return rows
 
@@ -300,16 +347,21 @@ def main():
     devices = [d.strip() for d in args.devices.split(",") if d.strip()]
     rows = run_matrix(precisions, devices, ref)
 
-    summary = {"reference": "PyTorch nvidia/LocateAnything-3B bf16 slow-AR (GT)",
-               "resolution": RES, "n_samples": len(SAMPLES),
-               "table": [{k: v for k, v in r.items() if k != "per_image"} for r in rows],
-               "rows": rows}
+    summary = {
+        "reference": "PyTorch nvidia/LocateAnything-3B bf16 slow-AR (GT)",
+        "resolution": RES,
+        "n_samples": len(SAMPLES),
+        "table": [{k: v for k, v in r.items() if k != "per_image"} for r in rows],
+        "rows": rows,
+    }
     json.dump(summary, open(args.out, "w"), indent=2)
     print("\n==== SUMMARY TABLE ====")
     print(f"{'prec':6} {'device':8} {'F1@0.5':8} {'F1@mean':8} {'L1(px448)':10} {'count':8}")
     for r in summary["table"]:
-        print(f"{r['precision']:6} {r['device']:8} {r['f1_at_0.5']:<8} {r['f1_mean']:<8} "
-              f"{str(r['mean_corner_l1_px448']):10} {r['count_matched_images']}/{r['n_images']}")
+        print(
+            f"{r['precision']:6} {r['device']:8} {r['f1_at_0.5']:<8} {r['f1_mean']:<8} "
+            f"{str(r['mean_corner_l1_px448']):10} {r['count_matched_images']}/{r['n_images']}"
+        )
     print("saved", args.out)
 
 

--- a/locateanything_enablement/parity.py
+++ b/locateanything_enablement/parity.py
@@ -31,7 +31,7 @@ def main():
     input_ids = np.load(os.path.join(ART, "input_ids.npy"))
     attention_mask = np.load(os.path.join(ART, "attention_mask.npy"))
     ref_logits = np.load(os.path.join(ART, "ref_prefill_logits.npy"))  # (S, V)
-    ref_feats = np.load(os.path.join(ART, "ref_vision_feats.npy"))      # (256, 2048)
+    ref_feats = np.load(os.path.join(ART, "ref_vision_feats.npy"))  # (256, 2048)
     meta = json.load(open(os.path.join(ART, "ref_meta.json")))
     img_tok = meta["image_token_index"]
 
@@ -40,10 +40,7 @@ def main():
 
     # ---- vision IR parity (MoonViT + mlp1) ----
     vreq = model.vision_embeddings.request
-    vout = vreq(
-        {"pixel_values": pixel_values.astype(np.float32),
-         "image_grid_hws": image_grid_hws.astype(np.int32)}
-    )
+    vout = vreq({"pixel_values": pixel_values.astype(np.float32), "image_grid_hws": image_grid_hws.astype(np.int32)})
     ov_feats = list(vout.values())[0]
     vcos = cossim(ov_feats.reshape(-1), ref_feats.reshape(-1))
     vper = cossim(ov_feats, ref_feats, axis=-1)
@@ -93,12 +90,14 @@ def main():
         s2 = cur_ids[0] == img_tok
         e[s2] = ov_feats.astype(e.dtype)
         lreq.reset_state()
-        r = lreq.infer({
-            "inputs_embeds": e[None].astype(np.float32),
-            "attention_mask": cur_mask.astype(np.int64),
-            "position_ids": pos,
-            "beam_idx": np.zeros(1, dtype=np.int32),
-        })
+        r = lreq.infer(
+            {
+                "inputs_embeds": e[None].astype(np.float32),
+                "attention_mask": cur_mask.astype(np.int64),
+                "position_ids": pos,
+                "beam_idx": np.zeros(1, dtype=np.int32),
+            }
+        )
         lg = list(r.values())[0][0]
         nxt = int(lg[-1].argmax())
         ov_greedy.append(nxt)

--- a/locateanything_enablement/parity.py
+++ b/locateanything_enablement/parity.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Milestone B parity: OpenVINO IR vs PyTorch reference for LocateAnything-3B.
+
+Loads the exported IRs via optimum-intel's OVModelForVisualCausalLM and compares
+prefill logits + greedy slow-AR tokens against the PyTorch reference artifacts.
+"""
+import json
+import os
+
+import numpy as np
+import torch
+
+OV_DIR = "ov_ir_fp16"
+ART = "parity_artifacts"
+N_GREEDY = 8
+
+
+def cossim(a, b, axis=-1, eps=1e-8):
+    a = a.astype(np.float64)
+    b = b.astype(np.float64)
+    num = (a * b).sum(axis)
+    den = np.linalg.norm(a, axis=axis) * np.linalg.norm(b, axis=axis) + eps
+    return num / den
+
+
+def main():
+    from optimum.intel.openvino import OVModelForVisualCausalLM
+
+    pixel_values = np.load(os.path.join(ART, "pixel_values.npy"))
+    image_grid_hws = np.load(os.path.join(ART, "image_grid_hws.npy"))
+    input_ids = np.load(os.path.join(ART, "input_ids.npy"))
+    attention_mask = np.load(os.path.join(ART, "attention_mask.npy"))
+    ref_logits = np.load(os.path.join(ART, "ref_prefill_logits.npy"))  # (S, V)
+    ref_feats = np.load(os.path.join(ART, "ref_vision_feats.npy"))      # (256, 2048)
+    meta = json.load(open(os.path.join(ART, "ref_meta.json")))
+    img_tok = meta["image_token_index"]
+
+    model = OVModelForVisualCausalLM.from_pretrained(OV_DIR, trust_remote_code=True)
+    print("loaded OV model:", type(model).__name__)
+
+    # ---- vision IR parity (MoonViT + mlp1) ----
+    vreq = model.vision_embeddings.request
+    vout = vreq(
+        {"pixel_values": pixel_values.astype(np.float32),
+         "image_grid_hws": image_grid_hws.astype(np.int32)}
+    )
+    ov_feats = list(vout.values())[0]
+    vcos = cossim(ov_feats.reshape(-1), ref_feats.reshape(-1))
+    vper = cossim(ov_feats, ref_feats, axis=-1)
+    print(f"vision feats shape {ov_feats.shape} ref {ref_feats.shape}")
+    print(f"vision cossim flat={float(vcos):.6f} per-token mean={float(vper.mean()):.6f} min={float(vper.min()):.6f}")
+
+    # ---- build inputs_embeds: text embeds with image features scattered ----
+    inputs_embeds = model.language_model.embed_tokens(input_ids.astype(np.int64))  # (1, S, 2048)
+    emb = np.array(inputs_embeds)[0].copy()
+    flat_ids = input_ids[0]
+    sel = flat_ids == img_tok
+    assert sel.sum() == ov_feats.shape[0], (int(sel.sum()), ov_feats.shape)
+    emb[sel] = ov_feats.astype(emb.dtype)
+    inputs_embeds = emb[None]
+
+    # ---- language IR prefill ----
+    S = input_ids.shape[1]
+    position_ids = np.arange(S, dtype=np.int64)[None]
+    lreq = model.language_model.request
+    lreq.reset_state()
+    res = lreq.infer(
+        {
+            "inputs_embeds": inputs_embeds.astype(np.float32),
+            "attention_mask": attention_mask.astype(np.int64),
+            "position_ids": position_ids,
+            "beam_idx": np.zeros(1, dtype=np.int32),
+        }
+    )
+    ov_logits = list(res.values())[0][0]  # (S, V)
+    print(f"OV prefill logits {ov_logits.shape} ref {ref_logits.shape}")
+
+    pc = cossim(ov_logits, ref_logits, axis=-1)
+    print(f"PREFILL cossim mean={float(pc.mean()):.6f} min={float(pc.min()):.6f}")
+    last_cos = float(cossim(ov_logits[-1], ref_logits[-1]))
+    print(f"last-position cossim={last_cos:.6f}")
+    print("OV argmax last:", int(ov_logits[-1].argmax()), "ref argmax last:", int(ref_logits[-1].argmax()))
+
+    # ---- greedy slow-AR (recompute, no cache reuse: rerun prefill each step) ----
+    ov_greedy = []
+    cur_ids = input_ids.copy()
+    cur_mask = attention_mask.copy()
+    for _ in range(N_GREEDY):
+        Sc = cur_ids.shape[1]
+        pos = np.arange(Sc, dtype=np.int64)[None]
+        te = model.language_model.embed_tokens(cur_ids.astype(np.int64))
+        e = np.array(te)[0].copy()
+        s2 = cur_ids[0] == img_tok
+        e[s2] = ov_feats.astype(e.dtype)
+        lreq.reset_state()
+        r = lreq.infer({
+            "inputs_embeds": e[None].astype(np.float32),
+            "attention_mask": cur_mask.astype(np.int64),
+            "position_ids": pos,
+            "beam_idx": np.zeros(1, dtype=np.int32),
+        })
+        lg = list(r.values())[0][0]
+        nxt = int(lg[-1].argmax())
+        ov_greedy.append(nxt)
+        cur_ids = np.concatenate([cur_ids, [[nxt]]], axis=1)
+        cur_mask = np.concatenate([cur_mask, [[1]]], axis=1)
+
+    ref_greedy = meta["greedy_tokens"]
+    match = sum(int(a == b) for a, b in zip(ov_greedy, ref_greedy))
+    print("OV greedy :", ov_greedy)
+    print("ref greedy:", ref_greedy)
+    print(f"token match {match}/{len(ref_greedy)}")
+
+    out = {
+        "vision_cossim_flat": float(vcos),
+        "vision_cossim_pertoken_mean": float(vper.mean()),
+        "vision_cossim_pertoken_min": float(vper.min()),
+        "prefill_cossim_mean": float(pc.mean()),
+        "prefill_cossim_min": float(pc.min()),
+        "last_pos_cossim": last_cos,
+        "ov_greedy": ov_greedy,
+        "ref_greedy": ref_greedy,
+        "token_match": f"{match}/{len(ref_greedy)}",
+        "resolution": meta["resolution"],
+    }
+    with open(os.path.join(ART, "parity_result.json"), "w") as f:
+        json.dump(out, f, indent=2)
+    print("saved", os.path.join(ART, "parity_result.json"))
+
+
+if __name__ == "__main__":
+    main()

--- a/locateanything_enablement/parity_multi.py
+++ b/locateanything_enablement/parity_multi.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Generalized OV-vs-PyTorch parity for LocateAnything-3B across precision + device.
+
+Reuses the Milestone-B methodology (parity.py): vision IR cossim, prefill-logits
+cossim vs the PyTorch reference, and greedy slow-AR token match. Parameterized by
+--ir-dir (fp16/int8/int4) and --device (CPU/GPU/GPU.0...).
+
+Usage:
+    python parity_multi.py --ir-dir ov_ir_int8 --device CPU
+"""
+import argparse
+import json
+import os
+
+import numpy as np
+
+ART = "parity_artifacts"
+N_GREEDY = 8
+
+
+def cossim(a, b, axis=-1, eps=1e-8):
+    a = a.astype(np.float64)
+    b = b.astype(np.float64)
+    num = (a * b).sum(axis)
+    den = np.linalg.norm(a, axis=axis) * np.linalg.norm(b, axis=axis) + eps
+    return num / den
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ir-dir", required=True)
+    ap.add_argument("--device", default="CPU")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    from optimum.intel.openvino import OVModelForVisualCausalLM
+
+    pixel_values = np.load(os.path.join(ART, "pixel_values.npy"))
+    image_grid_hws = np.load(os.path.join(ART, "image_grid_hws.npy"))
+    input_ids = np.load(os.path.join(ART, "input_ids.npy"))
+    attention_mask = np.load(os.path.join(ART, "attention_mask.npy"))
+    ref_logits = np.load(os.path.join(ART, "ref_prefill_logits.npy"))  # (S, V)
+    ref_feats = np.load(os.path.join(ART, "ref_vision_feats.npy"))      # (256, 2048)
+    meta = json.load(open(os.path.join(ART, "ref_meta.json")))
+    img_tok = meta["image_token_index"]
+
+    model = OVModelForVisualCausalLM.from_pretrained(
+        args.ir_dir, trust_remote_code=True, device=args.device
+    )
+    print(f"loaded OV model: {type(model).__name__} ir={args.ir_dir} device={args.device}")
+
+    # ---- vision IR parity (MoonViT + mlp1) ----
+    vreq = model.vision_embeddings.request
+    vout = vreq(
+        {"pixel_values": pixel_values.astype(np.float32),
+         "image_grid_hws": image_grid_hws.astype(np.int32)}
+    )
+    ov_feats = list(vout.values())[0]
+    vcos = cossim(ov_feats.reshape(-1), ref_feats.reshape(-1))
+    vper = cossim(ov_feats, ref_feats, axis=-1)
+    print(f"vision cossim flat={float(vcos):.6f} per-token mean={float(vper.mean()):.6f} min={float(vper.min()):.6f}")
+
+    # ---- build inputs_embeds: text embeds with image features scattered ----
+    inputs_embeds = model.language_model.embed_tokens(input_ids.astype(np.int64))
+    emb = np.array(inputs_embeds)[0].copy()
+    flat_ids = input_ids[0]
+    sel = flat_ids == img_tok
+    assert sel.sum() == ov_feats.shape[0], (int(sel.sum()), ov_feats.shape)
+    emb[sel] = ov_feats.astype(emb.dtype)
+    inputs_embeds = emb[None]
+
+    # ---- language IR prefill ----
+    S = input_ids.shape[1]
+    position_ids = np.arange(S, dtype=np.int64)[None]
+    lreq = model.language_model.request
+    lreq.reset_state()
+    res = lreq.infer(
+        {
+            "inputs_embeds": inputs_embeds.astype(np.float32),
+            "attention_mask": attention_mask.astype(np.int64),
+            "position_ids": position_ids,
+            "beam_idx": np.zeros(1, dtype=np.int32),
+        }
+    )
+    ov_logits = list(res.values())[0][0]  # (S, V)
+    pc = cossim(ov_logits, ref_logits, axis=-1)
+    last_cos = float(cossim(ov_logits[-1], ref_logits[-1]))
+    print(f"PREFILL cossim mean={float(pc.mean()):.6f} min={float(pc.min()):.6f} last={last_cos:.6f}")
+    print("OV argmax last:", int(ov_logits[-1].argmax()), "ref argmax last:", int(ref_logits[-1].argmax()))
+
+    # ---- greedy slow-AR (recompute, no cache reuse: rerun prefill each step) ----
+    ov_greedy = []
+    cur_ids = input_ids.copy()
+    cur_mask = attention_mask.copy()
+    for _ in range(N_GREEDY):
+        Sc = cur_ids.shape[1]
+        pos = np.arange(Sc, dtype=np.int64)[None]
+        te = model.language_model.embed_tokens(cur_ids.astype(np.int64))
+        e = np.array(te)[0].copy()
+        s2 = cur_ids[0] == img_tok
+        e[s2] = ov_feats.astype(e.dtype)
+        lreq.reset_state()
+        r = lreq.infer({
+            "inputs_embeds": e[None].astype(np.float32),
+            "attention_mask": cur_mask.astype(np.int64),
+            "position_ids": pos,
+            "beam_idx": np.zeros(1, dtype=np.int32),
+        })
+        lg = list(r.values())[0][0]
+        nxt = int(lg[-1].argmax())
+        ov_greedy.append(nxt)
+        cur_ids = np.concatenate([cur_ids, [[nxt]]], axis=1)
+        cur_mask = np.concatenate([cur_mask, [[1]]], axis=1)
+
+    ref_greedy = meta["greedy_tokens"]
+    match = sum(int(a == b) for a, b in zip(ov_greedy, ref_greedy))
+    print("OV greedy :", ov_greedy)
+    print("ref greedy:", ref_greedy)
+    print(f"token match {match}/{len(ref_greedy)}")
+
+    out = {
+        "ir_dir": args.ir_dir,
+        "device": args.device,
+        "vision_cossim_flat": float(vcos),
+        "vision_cossim_pertoken_mean": float(vper.mean()),
+        "vision_cossim_pertoken_min": float(vper.min()),
+        "prefill_cossim_mean": float(pc.mean()),
+        "prefill_cossim_min": float(pc.min()),
+        "last_pos_cossim": last_cos,
+        "ov_greedy": ov_greedy,
+        "ref_greedy": ref_greedy,
+        "token_match": f"{match}/{len(ref_greedy)}",
+        "token_match_n": match,
+        "resolution": meta["resolution"],
+    }
+    outpath = args.out or os.path.join(
+        ART, f"parity_{os.path.basename(args.ir_dir)}_{args.device.replace('.', '')}.json"
+    )
+    with open(outpath, "w") as f:
+        json.dump(out, f, indent=2)
+    print("saved", outpath)
+
+
+if __name__ == "__main__":
+    main()

--- a/locateanything_enablement/parity_multi.py
+++ b/locateanything_enablement/parity_multi.py
@@ -40,21 +40,16 @@ def main():
     input_ids = np.load(os.path.join(ART, "input_ids.npy"))
     attention_mask = np.load(os.path.join(ART, "attention_mask.npy"))
     ref_logits = np.load(os.path.join(ART, "ref_prefill_logits.npy"))  # (S, V)
-    ref_feats = np.load(os.path.join(ART, "ref_vision_feats.npy"))      # (256, 2048)
+    ref_feats = np.load(os.path.join(ART, "ref_vision_feats.npy"))  # (256, 2048)
     meta = json.load(open(os.path.join(ART, "ref_meta.json")))
     img_tok = meta["image_token_index"]
 
-    model = OVModelForVisualCausalLM.from_pretrained(
-        args.ir_dir, trust_remote_code=True, device=args.device
-    )
+    model = OVModelForVisualCausalLM.from_pretrained(args.ir_dir, trust_remote_code=True, device=args.device)
     print(f"loaded OV model: {type(model).__name__} ir={args.ir_dir} device={args.device}")
 
     # ---- vision IR parity (MoonViT + mlp1) ----
     vreq = model.vision_embeddings.request
-    vout = vreq(
-        {"pixel_values": pixel_values.astype(np.float32),
-         "image_grid_hws": image_grid_hws.astype(np.int32)}
-    )
+    vout = vreq({"pixel_values": pixel_values.astype(np.float32), "image_grid_hws": image_grid_hws.astype(np.int32)})
     ov_feats = list(vout.values())[0]
     vcos = cossim(ov_feats.reshape(-1), ref_feats.reshape(-1))
     vper = cossim(ov_feats, ref_feats, axis=-1)
@@ -100,12 +95,14 @@ def main():
         s2 = cur_ids[0] == img_tok
         e[s2] = ov_feats.astype(e.dtype)
         lreq.reset_state()
-        r = lreq.infer({
-            "inputs_embeds": e[None].astype(np.float32),
-            "attention_mask": cur_mask.astype(np.int64),
-            "position_ids": pos,
-            "beam_idx": np.zeros(1, dtype=np.int32),
-        })
+        r = lreq.infer(
+            {
+                "inputs_embeds": e[None].astype(np.float32),
+                "attention_mask": cur_mask.astype(np.int64),
+                "position_ids": pos,
+                "beam_idx": np.zeros(1, dtype=np.int32),
+            }
+        )
         lg = list(r.values())[0][0]
         nxt = int(lg[-1].argmax())
         ov_greedy.append(nxt)

--- a/locateanything_enablement/perf.py
+++ b/locateanything_enablement/perf.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Quick informational perf for the LocateAnything-3B slow-AR LLM (OV).
+
+Measures mean TTFT (prefill -> first generated token) and per-token ITL
+(inter-token latency, KV-cache decode steps) for the language IR, on a fixed
+image+query sample, across precision x device. Vision/embeds excluded from the
+LLM timing (reported separately as prep time).
+
+Usage: python perf.py --precisions fp16,int4 --devices CPU,GPU.0 --runs 3
+"""
+import argparse
+import json
+import os
+import time
+
+import numpy as np
+from PIL import Image
+
+RES = 448
+EOS = 151645
+IMG_TOKEN = 151665
+IMG_DIR = "eval_images"
+SAMPLE = ("000000001268.jpg", "person")  # multi-box -> a few dozen decode steps
+ART = "eval_artifacts"
+
+
+def build_prompt(q):
+    return f"Locate all the instances that matches the following description: {q}."
+
+
+class Pipe:
+    def __init__(self, ir_dir, device):
+        from optimum.intel.openvino import OVModelForVisualCausalLM
+        from transformers import AutoProcessor, AutoTokenizer
+        self.tok = AutoTokenizer.from_pretrained(ir_dir, trust_remote_code=True)
+        self.proc = AutoProcessor.from_pretrained(ir_dir, trust_remote_code=True)
+        self.model = OVModelForVisualCausalLM.from_pretrained(ir_dir, trust_remote_code=True, device=device)
+        self.vreq = self.model.vision_embeddings.request
+        self.lreq = self.model.language_model.request
+
+    def prep(self, fn, q):
+        img = Image.open(os.path.join(IMG_DIR, fn)).convert("RGB").resize((RES, RES), Image.BICUBIC)
+        messages = [{"role": "user", "content": [{"type": "image", "image": img},
+                                                 {"type": "text", "text": build_prompt(q)}]}]
+        text = self.proc.py_apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        images, videos = self.proc.process_vision_info(messages)
+        inputs = self.proc(text=[text], images=images, videos=videos, return_tensors="pt")
+        ids = inputs["input_ids"].numpy()
+        am = inputs["attention_mask"].numpy()
+        pv = inputs["pixel_values"].numpy().astype(np.float32)
+        gh = np.asarray(inputs["image_grid_hws"]).astype(np.int32)
+        vout = self.vreq({"pixel_values": pv, "image_grid_hws": gh})
+        feats = list(vout.values())[0]
+        te = self.model.language_model.embed_tokens(ids.astype(np.int64))
+        emb = np.array(te)[0].copy()
+        emb[ids[0] == IMG_TOKEN] = feats.astype(emb.dtype)
+        return ids, am, emb
+
+    def run_once(self, ids, am, emb, max_new=128):
+        S = ids.shape[1]
+        mask = am.copy()
+        self.lreq.reset_state()
+        t0 = time.time()
+        r = self.lreq.infer({"inputs_embeds": emb[None].astype(np.float32),
+                             "attention_mask": mask.astype(np.int64),
+                             "position_ids": np.arange(S, dtype=np.int64)[None],
+                             "beam_idx": np.zeros(1, dtype=np.int32)})
+        logits = list(r.values())[0][0]
+        ttft = time.time() - t0
+        nxt = int(logits[-1].argmax())
+        out = [nxt]
+        pos = S
+        itls = []
+        while nxt != EOS and len(out) < max_new:
+            te1 = self.model.language_model.embed_tokens(np.array([[nxt]], dtype=np.int64))
+            mask = np.concatenate([mask, [[1]]], axis=1)
+            ts = time.time()
+            r = self.lreq.infer({"inputs_embeds": np.array(te1).astype(np.float32),
+                                 "attention_mask": mask.astype(np.int64),
+                                 "position_ids": np.array([[pos]], dtype=np.int64),
+                                 "beam_idx": np.zeros(1, dtype=np.int32)})
+            itls.append(time.time() - ts)
+            logits = list(r.values())[0][0]
+            nxt = int(logits[-1].argmax())
+            out.append(nxt)
+            pos += 1
+        return ttft, itls, len(out), S
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--precisions", default="fp16,int4")
+    ap.add_argument("--devices", default="CPU,GPU.0")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--out", default=os.path.join(ART, "perf_results.json"))
+    args = ap.parse_args()
+    os.makedirs(ART, exist_ok=True)
+    fn, q = SAMPLE
+    rows = []
+    for prec in [p.strip() for p in args.precisions.split(",") if p.strip()]:
+        ir_dir = f"ov_ir_{prec}"
+        for dev in [d.strip() for d in args.devices.split(",") if d.strip()]:
+            print(f"\n=== perf {prec} on {dev} ===")
+            pipe = Pipe(ir_dir, dev)
+            ids, am, emb = pipe.prep(fn, q)
+            # warmup
+            pipe.run_once(ids, am, emb)
+            ttfts, itl_means, ntoks = [], [], []
+            prefill_len = None
+            for _ in range(args.runs):
+                ttft, itls, n, S = pipe.run_once(ids, am, emb)
+                ttfts.append(ttft)
+                if itls:
+                    itl_means.append(float(np.mean(itls)))
+                ntoks.append(n)
+                prefill_len = S
+            row = {"precision": prec, "device": dev, "prefill_len": prefill_len,
+                   "gen_tokens": int(np.median(ntoks)),
+                   "ttft_s_mean": round(float(np.mean(ttfts)), 4),
+                   "itl_ms_mean": round(float(np.mean(itl_means)) * 1000, 2) if itl_means else None,
+                   "tok_per_s": round(1.0 / float(np.mean(itl_means)), 2) if itl_means else None,
+                   "runs": args.runs}
+            rows.append(row)
+            print(f"  -> TTFT={row['ttft_s_mean']}s ITL={row['itl_ms_mean']}ms "
+                  f"({row['tok_per_s']} tok/s) gen={row['gen_tokens']} prefill={prefill_len}")
+            del pipe
+    json.dump({"sample": f"{fn}::{q}", "rows": rows}, open(args.out, "w"), indent=2)
+    print("\n==== PERF TABLE ====")
+    print(f"{'prec':6} {'device':8} {'TTFT(s)':9} {'ITL(ms)':9} {'tok/s':8}")
+    for r in rows:
+        print(f"{r['precision']:6} {r['device']:8} {r['ttft_s_mean']:<9} {r['itl_ms_mean']:<9} {r['tok_per_s']}")
+    print("saved", args.out)
+
+
+if __name__ == "__main__":
+    main()

--- a/locateanything_enablement/perf.py
+++ b/locateanything_enablement/perf.py
@@ -32,6 +32,7 @@ class Pipe:
     def __init__(self, ir_dir, device):
         from optimum.intel.openvino import OVModelForVisualCausalLM
         from transformers import AutoProcessor, AutoTokenizer
+
         self.tok = AutoTokenizer.from_pretrained(ir_dir, trust_remote_code=True)
         self.proc = AutoProcessor.from_pretrained(ir_dir, trust_remote_code=True)
         self.model = OVModelForVisualCausalLM.from_pretrained(ir_dir, trust_remote_code=True, device=device)
@@ -40,8 +41,9 @@ class Pipe:
 
     def prep(self, fn, q):
         img = Image.open(os.path.join(IMG_DIR, fn)).convert("RGB").resize((RES, RES), Image.BICUBIC)
-        messages = [{"role": "user", "content": [{"type": "image", "image": img},
-                                                 {"type": "text", "text": build_prompt(q)}]}]
+        messages = [
+            {"role": "user", "content": [{"type": "image", "image": img}, {"type": "text", "text": build_prompt(q)}]}
+        ]
         text = self.proc.py_apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
         images, videos = self.proc.process_vision_info(messages)
         inputs = self.proc(text=[text], images=images, videos=videos, return_tensors="pt")
@@ -61,10 +63,14 @@ class Pipe:
         mask = am.copy()
         self.lreq.reset_state()
         t0 = time.time()
-        r = self.lreq.infer({"inputs_embeds": emb[None].astype(np.float32),
-                             "attention_mask": mask.astype(np.int64),
-                             "position_ids": np.arange(S, dtype=np.int64)[None],
-                             "beam_idx": np.zeros(1, dtype=np.int32)})
+        r = self.lreq.infer(
+            {
+                "inputs_embeds": emb[None].astype(np.float32),
+                "attention_mask": mask.astype(np.int64),
+                "position_ids": np.arange(S, dtype=np.int64)[None],
+                "beam_idx": np.zeros(1, dtype=np.int32),
+            }
+        )
         logits = list(r.values())[0][0]
         ttft = time.time() - t0
         nxt = int(logits[-1].argmax())
@@ -75,10 +81,14 @@ class Pipe:
             te1 = self.model.language_model.embed_tokens(np.array([[nxt]], dtype=np.int64))
             mask = np.concatenate([mask, [[1]]], axis=1)
             ts = time.time()
-            r = self.lreq.infer({"inputs_embeds": np.array(te1).astype(np.float32),
-                                 "attention_mask": mask.astype(np.int64),
-                                 "position_ids": np.array([[pos]], dtype=np.int64),
-                                 "beam_idx": np.zeros(1, dtype=np.int32)})
+            r = self.lreq.infer(
+                {
+                    "inputs_embeds": np.array(te1).astype(np.float32),
+                    "attention_mask": mask.astype(np.int64),
+                    "position_ids": np.array([[pos]], dtype=np.int64),
+                    "beam_idx": np.zeros(1, dtype=np.int32),
+                }
+            )
             itls.append(time.time() - ts)
             logits = list(r.values())[0][0]
             nxt = int(logits[-1].argmax())
@@ -114,15 +124,21 @@ def main():
                     itl_means.append(float(np.mean(itls)))
                 ntoks.append(n)
                 prefill_len = S
-            row = {"precision": prec, "device": dev, "prefill_len": prefill_len,
-                   "gen_tokens": int(np.median(ntoks)),
-                   "ttft_s_mean": round(float(np.mean(ttfts)), 4),
-                   "itl_ms_mean": round(float(np.mean(itl_means)) * 1000, 2) if itl_means else None,
-                   "tok_per_s": round(1.0 / float(np.mean(itl_means)), 2) if itl_means else None,
-                   "runs": args.runs}
+            row = {
+                "precision": prec,
+                "device": dev,
+                "prefill_len": prefill_len,
+                "gen_tokens": int(np.median(ntoks)),
+                "ttft_s_mean": round(float(np.mean(ttfts)), 4),
+                "itl_ms_mean": round(float(np.mean(itl_means)) * 1000, 2) if itl_means else None,
+                "tok_per_s": round(1.0 / float(np.mean(itl_means)), 2) if itl_means else None,
+                "runs": args.runs,
+            }
             rows.append(row)
-            print(f"  -> TTFT={row['ttft_s_mean']}s ITL={row['itl_ms_mean']}ms "
-                  f"({row['tok_per_s']} tok/s) gen={row['gen_tokens']} prefill={prefill_len}")
+            print(
+                f"  -> TTFT={row['ttft_s_mean']}s ITL={row['itl_ms_mean']}ms "
+                f"({row['tok_per_s']} tok/s) gen={row['gen_tokens']} prefill={prefill_len}"
+            )
             del pipe
     json.dump({"sample": f"{fn}::{q}", "rows": rows}, open(args.out, "w"), indent=2)
     print("\n==== PERF TABLE ====")

--- a/locateanything_enablement/ref_pytorch.py
+++ b/locateanything_enablement/ref_pytorch.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""PyTorch reference for nvidia/LocateAnything-3B prefill + slow-AR greedy.
+
+Captures prefill logits and a short greedy AR token sequence on one sample, and
+saves the exact processed inputs so the OpenVINO export can be compared 1:1.
+"""
+import json
+import os
+
+import numpy as np
+import torch
+from PIL import Image
+from transformers import AutoModel, AutoProcessor, AutoTokenizer
+
+MODEL_ID = "nvidia/LocateAnything-3B"
+OUT = "parity_artifacts"
+QUERY = "Locate all the instances that matches the following description: person."
+RES = 448
+N_GREEDY = 8
+
+os.makedirs(OUT, exist_ok=True)
+torch.manual_seed(0)
+
+
+def make_image():
+    # Deterministic synthetic RGB image at fixed resolution (content irrelevant for parity).
+    rng = np.random.RandomState(0)
+    base = np.linspace(0, 255, RES, dtype=np.float32)
+    img = np.stack([
+        np.tile(base, (RES, 1)),
+        np.tile(base[:, None], (1, RES)),
+        (rng.rand(RES, RES) * 255).astype(np.float32),
+    ], axis=-1)
+    # add a couple of solid rectangles
+    img[80:200, 100:260, 0] = 30
+    img[250:360, 300:420, 1] = 220
+    return Image.fromarray(img.clip(0, 255).astype(np.uint8), "RGB")
+
+
+def main():
+    dtype = torch.bfloat16
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_ID, trust_remote_code=True)
+    processor = AutoProcessor.from_pretrained(MODEL_ID, trust_remote_code=True)
+    model = AutoModel.from_pretrained(MODEL_ID, torch_dtype=dtype, trust_remote_code=True).eval()
+
+    # Force tie_weights (model __init__ skips post_init()).
+    model.tie_weights()
+    print("text attn impl:", model.config.text_config._attn_implementation)
+    print("vision attn impl:", model.config.vision_config._attn_implementation)
+
+    image = make_image()
+    messages = [{"role": "user", "content": [{"type": "image", "image": image}, {"type": "text", "text": QUERY}]}]
+    text = processor.py_apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    images, videos = processor.process_vision_info(messages)
+    inputs = processor(text=[text], images=images, videos=videos, return_tensors="pt")
+
+    pixel_values = inputs["pixel_values"].to(dtype)
+    input_ids = inputs["input_ids"]
+    attention_mask = inputs["attention_mask"]
+    image_grid_hws = inputs.get("image_grid_hws")
+    if isinstance(image_grid_hws, np.ndarray):
+        image_grid_hws = torch.from_numpy(image_grid_hws)
+    image_grid_hws = image_grid_hws.to(torch.int32)
+
+    print("pixel_values", tuple(pixel_values.shape), "grid", image_grid_hws.tolist(),
+          "input_ids", tuple(input_ids.shape),
+          "num_image_tokens", int((input_ids == model.config.image_token_index).sum()))
+
+    @torch.no_grad()
+    def vision_feats():
+        vit = model.extract_feature(pixel_values, image_grid_hws)
+        if isinstance(vit, (list, tuple)):
+            vit = torch.cat(vit, dim=0)
+        return model.mlp1(vit)  # (L_post, 2048)
+
+    # Cache the projected vision features once (resolution is fixed).
+    _feats = vision_feats()
+
+    @torch.no_grad()
+    def prefill_logits(ids, amask):
+        # Pass input_ids + visual_features so the vendored Qwen2 takes its
+        # standard-causal (slow-AR) mask branch; image_processing scatters the
+        # projected features into image_token positions internally.
+        out = model.language_model(
+            input_ids=ids,
+            visual_features=_feats.to(model.language_model.dtype),
+            image_token_index=model.config.image_token_index,
+            attention_mask=amask,
+            use_cache=False,
+        )
+        return out.logits
+
+    # ---- prefill logits ----
+    logits = prefill_logits(input_ids, attention_mask).float()
+    print("prefill logits", tuple(logits.shape))
+    np.save(os.path.join(OUT, "ref_prefill_logits.npy"), logits[0].numpy())
+
+    # ---- slow-AR greedy (recompute, no cache) ----
+    gen = input_ids.clone()
+    amask = attention_mask.clone()
+    greedy = []
+    for _ in range(N_GREEDY):
+        lg = prefill_logits(gen, amask)
+        nxt = int(lg[0, -1].argmax())
+        greedy.append(nxt)
+        gen = torch.cat([gen, torch.tensor([[nxt]], dtype=gen.dtype)], dim=1)
+        amask = torch.cat([amask, torch.ones((1, 1), dtype=amask.dtype)], dim=1)
+    print("greedy tokens:", greedy)
+    print("greedy decoded:", tokenizer.decode(greedy))
+
+    # ---- persist inputs for OV ----
+    np.save(os.path.join(OUT, "pixel_values.npy"), pixel_values.float().numpy())
+    np.save(os.path.join(OUT, "image_grid_hws.npy"), image_grid_hws.numpy())
+    np.save(os.path.join(OUT, "input_ids.npy"), input_ids.numpy())
+    np.save(os.path.join(OUT, "attention_mask.npy"), attention_mask.numpy())
+    np.save(os.path.join(OUT, "ref_vision_feats.npy"), vision_feats().float().numpy())
+    with open(os.path.join(OUT, "ref_meta.json"), "w") as f:
+        json.dump({
+            "query": QUERY, "resolution": RES,
+            "grid": image_grid_hws.tolist(),
+            "input_ids_len": int(input_ids.shape[1]),
+            "num_image_tokens": int((input_ids == model.config.image_token_index).sum()),
+            "greedy_tokens": greedy,
+            "greedy_text": tokenizer.decode(greedy),
+            "image_token_index": int(model.config.image_token_index),
+        }, f, indent=2)
+    print("saved reference artifacts to", OUT)
+
+
+if __name__ == "__main__":
+    main()

--- a/locateanything_enablement/ref_pytorch.py
+++ b/locateanything_enablement/ref_pytorch.py
@@ -26,11 +26,14 @@ def make_image():
     # Deterministic synthetic RGB image at fixed resolution (content irrelevant for parity).
     rng = np.random.RandomState(0)
     base = np.linspace(0, 255, RES, dtype=np.float32)
-    img = np.stack([
-        np.tile(base, (RES, 1)),
-        np.tile(base[:, None], (1, RES)),
-        (rng.rand(RES, RES) * 255).astype(np.float32),
-    ], axis=-1)
+    img = np.stack(
+        [
+            np.tile(base, (RES, 1)),
+            np.tile(base[:, None], (1, RES)),
+            (rng.rand(RES, RES) * 255).astype(np.float32),
+        ],
+        axis=-1,
+    )
     # add a couple of solid rectangles
     img[80:200, 100:260, 0] = 30
     img[250:360, 300:420, 1] = 220
@@ -62,9 +65,16 @@ def main():
         image_grid_hws = torch.from_numpy(image_grid_hws)
     image_grid_hws = image_grid_hws.to(torch.int32)
 
-    print("pixel_values", tuple(pixel_values.shape), "grid", image_grid_hws.tolist(),
-          "input_ids", tuple(input_ids.shape),
-          "num_image_tokens", int((input_ids == model.config.image_token_index).sum()))
+    print(
+        "pixel_values",
+        tuple(pixel_values.shape),
+        "grid",
+        image_grid_hws.tolist(),
+        "input_ids",
+        tuple(input_ids.shape),
+        "num_image_tokens",
+        int((input_ids == model.config.image_token_index).sum()),
+    )
 
     @torch.no_grad()
     def vision_feats():
@@ -115,15 +125,20 @@ def main():
     np.save(os.path.join(OUT, "attention_mask.npy"), attention_mask.numpy())
     np.save(os.path.join(OUT, "ref_vision_feats.npy"), vision_feats().float().numpy())
     with open(os.path.join(OUT, "ref_meta.json"), "w") as f:
-        json.dump({
-            "query": QUERY, "resolution": RES,
-            "grid": image_grid_hws.tolist(),
-            "input_ids_len": int(input_ids.shape[1]),
-            "num_image_tokens": int((input_ids == model.config.image_token_index).sum()),
-            "greedy_tokens": greedy,
-            "greedy_text": tokenizer.decode(greedy),
-            "image_token_index": int(model.config.image_token_index),
-        }, f, indent=2)
+        json.dump(
+            {
+                "query": QUERY,
+                "resolution": RES,
+                "grid": image_grid_hws.tolist(),
+                "input_ids_len": int(input_ids.shape[1]),
+                "num_image_tokens": int((input_ids == model.config.image_token_index).sum()),
+                "greedy_tokens": greedy,
+                "greedy_text": tokenizer.decode(greedy),
+                "image_token_index": int(model.config.image_token_index),
+            },
+            f,
+            indent=2,
+        )
     print("saved reference artifacts to", OUT)
 
 

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -573,6 +573,20 @@ def main_export(
                 has_remote_code = hasattr(config, "auto_map")
                 if has_remote_code and trust_remote_code and task == "image-text-to-text":
                     task_model_loading = "text-generation"
+                    # Some remote-code VLMs (e.g. locateanything) only register the
+                    # generic "AutoModel" entry in their auto_map. Loading them as a
+                    # causal LM then fails because no "AutoModelForCausalLM" entry
+                    # exists. Mirror the "AutoModel" mapping so the causal-LM loader
+                    # can resolve the remote class, and pass the patched config along.
+                    auto_map = getattr(config, "auto_map", None)
+                    if (
+                        isinstance(auto_map, dict)
+                        and "AutoModelForCausalLM" not in auto_map
+                        and "AutoModel" in auto_map
+                    ):
+                        auto_map["AutoModelForCausalLM"] = auto_map["AutoModel"]
+                        config.auto_map = auto_map
+                        loading_kwargs["config"] = config
 
             model = TasksManager.get_model_from_task(
                 task_model_loading,

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -1915,3 +1915,44 @@ class DummyQwen3OmniMoeVisionInputGenerator(DummyQwen3VLVisionEmbedInputGenerato
             return self.random_float_tensor([seq_len, self.embed_dim], framework=framework, dtype=float_dtype)
 
         return super().generate(input_name, framework, int_dtype, float_dtype)
+
+
+class DummyLocateAnythingVisionInputGenerator(DummyInputGenerator):
+    """
+    Dummy input generator for the nvidia/LocateAnything-3B MoonViT vision encoder.
+
+    Produces packed patch pixels ``pixel_values`` of shape ``(L_pre, 3, patch, patch)``
+    and ``image_grid_hws`` of shape ``(num_images, 2)`` for a fixed export resolution.
+    For a ``height`` x ``width`` image with ``patch_size`` p, ``L_pre = (height/p) * (width/p)``.
+    """
+
+    SUPPORTED_INPUT_NAMES = ("pixel_values", "image_grid_hws")
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = 1,
+        height: int = 448,
+        width: int = 448,
+        **kwargs,
+    ):
+        self.task = task
+        self.batch_size = batch_size
+        self.normalized_config = normalized_config
+        self.patch_size = getattr(normalized_config.config, "patch_size", 14)
+        self.grid_h = height // self.patch_size
+        self.grid_w = width // self.patch_size
+        self.num_patches = self.grid_h * self.grid_w
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "pixel_values":
+            return self.random_float_tensor(
+                shape=[self.num_patches, 3, self.patch_size, self.patch_size],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "image_grid_hws":
+            return torch.tensor([[self.grid_h, self.grid_w]], dtype=torch.int32)
+        raise ValueError(f"Unsupported input {input_name} for DummyLocateAnythingVisionInputGenerator")
+

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -47,6 +47,7 @@ from optimum.exporters.openvino.input_generators import (
     DummyGemma4VisionInputGenerator,
     DummyKokoroInputGenerator,
     DummyLLavaMultiModalProjectorInputGenerator,
+    DummyLocateAnythingVisionInputGenerator,
     DummyMiniCPMVImageInputGenerator,
     DummyMiniCPMVResampleInputGenerator,
     DummyPhi3VisionProjectionInputGenerator,
@@ -124,6 +125,7 @@ from optimum.exporters.openvino.model_patcher import (
     InternLMModelPatcher,
     InternVL2ChatLangModelPatcher,
     InternVLChatImageEmbeddingModelPatcher,
+    LocateAnythingImageEmbeddingModelPatcher,
     JaisModelPatcher,
     KokoroModelPatcher,
     Lfm2ModelPatcher,
@@ -2094,6 +2096,150 @@ class InternVLChatOpenVINOConfig(BaseVLMOpenVINOConfig):
         if self._behavior != VLMConfigBehavior.VISION_EMBEDDINGS:
             return super().patch_model_for_export(model, model_kwargs)
         return InternVLChatImageEmbeddingModelPatcher(self, model, model_kwargs)
+
+
+@register_in_tasks_manager("locateanything", *["image-text-to-text"], library_name="transformers")
+class LocateAnythingOpenVINOConfig(BaseVLMOpenVINOConfig):
+    """OpenVINO export config for nvidia/LocateAnything-3B.
+
+    Architecture: MoonViT-SO-400M vision encoder + ``mlp1`` projector
+    (4608 -> 2048) + Qwen2.5-3B language model with InternVL-style image-token
+    scatter. Three sub-models are exported following the InternVL layout:
+      - ``vision_embeddings``: MoonViT + ``mlp1`` -> (L_post, llm_hidden) features
+      - ``text_embeddings``: token embedding lookup
+      - ``language``: Qwen2.5 decoder (stateful)
+
+    The language sub-graph is exported from a standard ``transformers`` Qwen2
+    rebuilt from the vendored weights, since the vendored decoder uses the custom
+    "magi" block-diffusion path (data-dependent control flow) that is only needed
+    for Parallel Box Decoding; the "slow" pure auto-regressive path is plain
+    causal Qwen2 and therefore numerically identical.
+
+    Requires ``trust_remote_code=True`` and ``transformers>=4.55,<5.0``.
+    """
+
+    MIN_TRANSFORMERS_VERSION = "4.55.0"
+    MAX_TRANSFORMERS_VERSION = "4.57.6"
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyLocateAnythingVisionInputGenerator,)
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self._behavior = behavior
+        self._orig_config = config
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            self._config = config.vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return {
+                "pixel_values": {0: "num_patches"},
+                "image_grid_hws": {0: "num_images"},
+            }
+        return {}
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return {"last_hidden_state": {0: "num_merged_tokens"}}
+        return {}
+
+    def with_behavior(self, behavior: Union[str, VLMConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config(
+                "qwen2", self._orig_config.text_config, self.int_dtype, self.float_dtype
+            )
+
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            return get_vlm_text_generation_config(
+                "qwen2",
+                self._orig_config.text_config,
+                self.int_dtype,
+                self.float_dtype,
+                InternVL2ChatLangModelPatcher,
+            )
+
+        if behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return self.__class__(
+                self._orig_config,
+                task=self.task,
+                int_dtype=self.int_dtype,
+                float_dtype=self.float_dtype,
+                behavior=behavior,
+                preprocessors=self._preprocessors,
+            )
+
+    @staticmethod
+    def get_model_for_behavior(model, behavior: Union[str, VLMConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            return _build_locateanything_stock_qwen2(model)
+
+        if behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return model
+
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            text_embedding = _get_model_attribute(model, "language_model").get_input_embeddings()
+            text_embedding.config = _get_model_attribute(model, "language_model").config
+            return text_embedding
+
+    def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
+        model_kwargs = model_kwargs or {}
+        if self._behavior != VLMConfigBehavior.VISION_EMBEDDINGS:
+            return super().patch_model_for_export(model, model_kwargs)
+        return LocateAnythingImageEmbeddingModelPatcher(self, model, model_kwargs)
+
+
+def _build_locateanything_stock_qwen2(model):
+    """Rebuild a standard ``transformers`` Qwen2ForCausalLM from the vendored LLM.
+
+    The vendored LocateAnything decoder is a custom Qwen2 with block-diffusion
+    ("magi") attention and data-dependent control flow that does not trace. The
+    pure auto-regressive (causal) path is mathematically identical to a stock
+    Qwen2, so we copy the weights into a standard implementation for export.
+    """
+    from transformers import Qwen2Config as _HFQwen2Config
+    from transformers import Qwen2ForCausalLM as _HFQwen2ForCausalLM
+
+    vendored = _get_model_attribute(model, "language_model")
+    cfg_dict = vendored.config.to_dict()
+    cfg_dict["_attn_implementation"] = "sdpa"
+    hf_config = _HFQwen2Config(**{k: v for k, v in cfg_dict.items() if k != "_attn_implementation"})
+    hf_config._attn_implementation = "sdpa"
+
+    stock = _HFQwen2ForCausalLM(hf_config)
+    state = vendored.state_dict()
+    missing, unexpected = stock.load_state_dict(state, strict=False)
+    # ``lm_head.weight`` is tied to the embeddings and may be absent from the
+    # source state dict; everything else must match.
+    missing = [m for m in missing if m != "lm_head.weight"]
+    if missing or unexpected:
+        logger.warning(
+            "LocateAnything LLM weight transfer: missing=%s unexpected=%s", missing, unexpected
+        )
+    stock.tie_weights()
+    stock = stock.to(dtype=next(vendored.parameters()).dtype).eval()
+    return stock
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -125,7 +125,6 @@ from optimum.exporters.openvino.model_patcher import (
     InternLMModelPatcher,
     InternVL2ChatLangModelPatcher,
     InternVLChatImageEmbeddingModelPatcher,
-    LocateAnythingImageEmbeddingModelPatcher,
     JaisModelPatcher,
     KokoroModelPatcher,
     Lfm2ModelPatcher,
@@ -135,6 +134,7 @@ from optimum.exporters.openvino.model_patcher import (
     LlavaImageEmbeddingModelPatcher,
     LlavaNextVideoImageEmbeddingModelPatcher,
     LlavaQwen2ImageEmbeddingsModelPatcher,
+    LocateAnythingImageEmbeddingModelPatcher,
     MairaImageEmbeddingModelPatcher,
     MambaPatcher,
     MiniCPM3Patcher,
@@ -2234,9 +2234,7 @@ def _build_locateanything_stock_qwen2(model):
     # source state dict; everything else must match.
     missing = [m for m in missing if m != "lm_head.weight"]
     if missing or unexpected:
-        logger.warning(
-            "LocateAnything LLM weight transfer: missing=%s unexpected=%s", missing, unexpected
-        )
+        logger.warning("LocateAnything LLM weight transfer: missing=%s unexpected=%s", missing, unexpected)
     stock.tie_weights()
     stock = stock.to(dtype=next(vendored.parameters()).dtype).eval()
     return stock

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9787,3 +9787,148 @@ def qwen3_omni_moe_talker_sparse_forward_patched(self, hidden_states: torch.Tens
     final_hidden_states = final_hidden_states + shared_expert_output
 
     return final_hidden_states.reshape(batch_size, sequence_length, hidden_dim)
+
+
+# ======================================================================
+# LocateAnything (nvidia/LocateAnything-3B) vision patcher
+# ======================================================================
+# The MoonViT-SO-400M vision tower of LocateAnything is not torch.jit.trace
+# friendly out of the box. Two constructs must be neutralised for a fixed
+# resolution export:
+#   1. ``apply_rope`` uses ``torch.view_as_complex`` / complex multiply for the
+#      learnable 2D RoPE. Complex ops do not lower to OpenVINO, so the rotation
+#      is rewritten with real-valued cos/sin math, and ``Rope2DPosEmb`` is made
+#      to emit real (cos, sin) frequencies (avoiding ``torch.polar``).
+#   2. ``sdpa_attention`` builds a per-image block mask from ``cu_seqlens`` with
+#      a python loop over tensor values. For single-image fixed resolution export
+#      all patches attend to each other, so a clean full-attention SDPA is used.
+# In addition the projector ``mlp1`` is folded into the vision sub-graph (as in
+# InternVL) so the exported vision model already returns LLM-dimension features,
+# and ``tie_weights`` is forced (the model __init__ skips post_init and would
+# otherwise leave ``lm_head`` untied).
+
+
+def _locateanything_real_apply_rope(xq, xk, freqs):
+    """Real-valued 2D RoPE replacing torch.view_as_complex in MoonViT.
+
+    ``freqs`` is a real tensor of shape ``(seq, head_dim // 2, 2)`` holding
+    ``[cos, sin]`` for each frequency. Implements complex multiply
+    ``(a + i b)(cos + i sin)`` on the interleaved even/odd lanes of the input.
+    """
+    cos = freqs[..., 0].unsqueeze(-2)  # (seq, 1, head_dim//2)
+    sin = freqs[..., 1].unsqueeze(-2)
+
+    def _rotate(x):
+        xf = x.float()
+        x_pair = xf.view(*xf.shape[:-1], -1, 2)
+        a = x_pair[..., 0]
+        b = x_pair[..., 1]
+        out_a = a * cos - b * sin
+        out_b = a * sin + b * cos
+        return torch.stack([out_a, out_b], dim=-1).flatten(start_dim=-2).type_as(x)
+
+    return _rotate(xq), _rotate(xk)
+
+
+def _locateanything_clean_sdpa(q, k, v, q_cu_seqlens=None, k_cu_seqlens=None):
+    """Full-attention SDPA for MoonViT single-image fixed-resolution export.
+
+    Inputs are packed ``(seq, num_heads, head_dim)``; returns ``(seq, hidden)``.
+    """
+    seq_length = q.shape[0]
+    q = q.transpose(0, 1)
+    k = k.transpose(0, 1)
+    v = v.transpose(0, 1)
+    attn_output = F.scaled_dot_product_attention(q, k, v)
+    attn_output = attn_output.transpose(0, 1).reshape(seq_length, -1)
+    return attn_output
+
+
+def _locateanything_real_get_freqs_cis(self, grid_hws):
+    """Real-valued replacement for ``Rope2DPosEmb.get_freqs_cis``.
+
+    Returns a real tensor ``(sum(h*w), dim // 2, 2)`` with interleaved
+    ``[x_freq, y_freq]`` lanes (matching the original complex layout), so that
+    no ``torch.polar`` / complex tensors enter the traced graph.
+    """
+    dim = self.dim
+    theta_base = self.theta_base
+    dim_range = torch.arange(0, dim, 4, device=grid_hws.device)[: dim // 4].float()
+    inv_freq = 1.0 / (theta_base ** (dim_range / dim))  # (dim//4,)
+
+    outs = []
+    for h, w in grid_hws.tolist():
+        flat_pos = torch.arange(0, h * w, device=grid_hws.device).float()
+        x_pos = flat_pos % w
+        y_pos = torch.div(flat_pos, w, rounding_mode="floor")
+        x_ang = torch.outer(x_pos, inv_freq)  # (h*w, dim//4)
+        y_ang = torch.outer(y_pos, inv_freq)
+        cos = torch.stack([x_ang.cos(), y_ang.cos()], dim=-1).reshape(h * w, dim // 2)
+        sin = torch.stack([x_ang.sin(), y_ang.sin()], dim=-1).reshape(h * w, dim // 2)
+        outs.append(torch.stack([cos, sin], dim=-1))  # (h*w, dim//2, 2)
+    return torch.cat(outs, dim=0)
+
+
+class LocateAnythingImageEmbeddingModelPatcher(ModelPatcher):
+    """Patcher exporting MoonViT + ``mlp1`` projector as a single vision sub-graph."""
+
+    def __init__(self, config: "OpenVINOConfig", model: "PreTrainedModel", model_kwargs: Dict[str, Any]):
+        model_kwargs = model_kwargs or {}
+
+        # Neutralise the custom "magi" attention on every relevant config.
+        for cfg in (getattr(model, "config", None), getattr(model.config, "vision_config", None),
+                    getattr(model.config, "text_config", None)):
+            if cfg is not None and getattr(cfg, "_attn_implementation", None) != "sdpa":
+                cfg._attn_implementation = "sdpa"
+
+        # The model __init__ skips post_init(); force weight tying so lm_head is
+        # consistent (does not affect the vision graph but keeps the model valid).
+        if hasattr(model, "tie_weights"):
+            model.tie_weights()
+
+        model.__orig_forward = model.forward
+
+        def vision_embed_forward(self, pixel_values, image_grid_hws):
+            vit_embeds = self.vision_model(pixel_values=pixel_values, grid_hws=image_grid_hws)
+            if isinstance(vit_embeds, (list, tuple)):
+                vit_embeds = torch.cat(vit_embeds, dim=0)
+            return self.mlp1(vit_embeds)
+
+        model.forward = types.MethodType(vision_embed_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __enter__(self):
+        import sys
+
+        vision_model = self._model.vision_model
+        encoder = vision_model.encoder
+        self._moonvit_module = sys.modules[type(encoder.blocks[0]).__module__]
+
+        # 1. real-valued RoPE (replace module-level apply_rope + per-instance freqs)
+        self._orig_apply_rope = getattr(self._moonvit_module, "apply_rope", None)
+        self._moonvit_module.apply_rope = _locateanything_real_apply_rope
+        self._orig_get_freqs_cis = encoder.rope_2d.get_freqs_cis
+        encoder.rope_2d.get_freqs_cis = types.MethodType(_locateanything_real_get_freqs_cis, encoder.rope_2d)
+
+        # 2. clean full-attention SDPA for every encoder block
+        self._orig_attn_funcs = dict(self._moonvit_module.VL_VISION_ATTENTION_FUNCTIONS)
+        self._moonvit_module.VL_VISION_ATTENTION_FUNCTIONS["sdpa"] = _locateanything_clean_sdpa
+        self._orig_block_impl = []
+        for block in encoder.blocks:
+            self._orig_block_impl.append(block.attn_implementation)
+            block.attn_implementation = "sdpa"
+
+        super().__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+        encoder = self._model.vision_model.encoder
+        if self._orig_apply_rope is not None:
+            self._moonvit_module.apply_rope = self._orig_apply_rope
+        encoder.rope_2d.get_freqs_cis = self._orig_get_freqs_cis
+        self._moonvit_module.VL_VISION_ATTENTION_FUNCTIONS.clear()
+        self._moonvit_module.VL_VISION_ATTENTION_FUNCTIONS.update(self._orig_attn_funcs)
+        for block, impl in zip(encoder.blocks, self._orig_block_impl):
+            block.attn_implementation = impl

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9876,8 +9876,11 @@ class LocateAnythingImageEmbeddingModelPatcher(ModelPatcher):
         model_kwargs = model_kwargs or {}
 
         # Neutralise the custom "magi" attention on every relevant config.
-        for cfg in (getattr(model, "config", None), getattr(model.config, "vision_config", None),
-                    getattr(model.config, "text_config", None)):
+        for cfg in (
+            getattr(model, "config", None),
+            getattr(model.config, "vision_config", None),
+            getattr(model.config, "text_config", None),
+        ):
             if cfg is not None and getattr(cfg, "_attn_implementation", None) != "sdpa":
                 cfg._attn_implementation = "sdpa"
 

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -318,6 +318,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "llava_next_video",
     "llava-qwen2",
     "internvl_chat",
+    "locateanything",
     "maira2",
     "minicpmv",
     "phi3_v",

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -2371,6 +2371,32 @@ class _OVLocateAnythingForCausalLM(_OVInternVLForCausalLM):
                 )
         return inputs_embeds, attention_mask, position_ids
 
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        pixel_values=None,
+        image_sizes=None,
+        attention_mask=None,
+        image_grid_hws=None,
+        **kwargs,
+    ):
+        # MoonViT is native-resolution: image_grid_hws must reach the vision sub-graph.
+        # Declaring it here (and threading it into the model inputs) lets generate()
+        # accept it as a model kwarg and forwards it through every step.
+        model_inputs = super().prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            image_sizes=image_sizes,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+        model_inputs["image_grid_hws"] = image_grid_hws
+        return model_inputs
+
     @staticmethod
     def preprocess_inputs(
         text: str,

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -2313,6 +2313,84 @@ class _OVInternVLForCausalLM(OVModelForVisualCausalLM):
         return generation_config, model_kwargs
 
 
+class _OVLocateAnythingForCausalLM(_OVInternVLForCausalLM):
+    """OVModelForVisualCausalLM for nvidia/LocateAnything-3B.
+
+    The vision sub-graph already folds the ``mlp1`` projector (InternVL style), so
+    ``get_vision_embeddings`` returns LLM-dimension features that are scattered
+    into the token embeddings at ``config.image_token_index`` (151665). MoonViT is
+    native resolution, so ``image_grid_hws`` must be forwarded to the vision model
+    and kept out of the language model kwargs.
+    """
+
+    def get_vision_embeddings(self, pixel_values, input_ids=None, image_grid_hws=None, **kwargs):
+        if input_ids is not None and input_ids.shape[1] == 1:
+            return None
+        image_features = self.vision_embeddings(
+            pixel_values=pixel_values, image_grid_hws=image_grid_hws
+        ).last_hidden_state
+        return image_features
+
+    def merge_vision_text_embeddings(
+        self, vision_embeds, input_embeds, input_ids, attention_mask, position_ids=None, **kwargs
+    ):
+        input_embeds = torch.from_numpy(input_embeds) if isinstance(input_embeds, np.ndarray) else input_embeds
+        vision_embeds = torch.from_numpy(vision_embeds) if isinstance(vision_embeds, np.ndarray) else vision_embeds
+        image_token_id = getattr(self.config, "image_token_index", 151665)
+
+        B, N, C = input_embeds.shape
+        input_embeds = input_embeds.reshape(B * N, C)
+        input_ids = input_ids.reshape(B * N)
+        selected = input_ids == image_token_id
+        assert selected.sum() != 0
+        input_embeds[selected] = vision_embeds.reshape(-1, C).to(input_embeds.dtype)
+        input_embeds = input_embeds.reshape(B, N, C)
+        return input_embeds, attention_mask, position_ids
+
+    def get_multimodal_embeddings(
+        self, input_ids, pixel_values=None, attention_mask=None, position_ids=None, **kwargs
+    ):
+        # image_grid_hws is needed by the vision model only; keep it out of the LLM kwargs.
+        image_grid_hws = kwargs.pop("image_grid_hws", None)
+        embeds_from_args = kwargs.pop("inputs_embeds", None)
+        inputs_embeds = (
+            embeds_from_args if embeds_from_args is not None else self.get_text_embeddings(input_ids, **kwargs)
+        )
+        if pixel_values is not None:
+            vision_embeds = self.get_vision_embeddings(
+                pixel_values, input_ids=input_ids, image_grid_hws=image_grid_hws, **kwargs
+            )
+            if vision_embeds is not None:
+                inputs_embeds, attention_mask, position_ids = self.merge_vision_text_embeddings(
+                    vision_embeds,
+                    inputs_embeds,
+                    input_ids=input_ids,
+                    attention_mask=attention_mask,
+                    position_ids=position_ids,
+                    **kwargs,
+                )
+        return inputs_embeds, attention_mask, position_ids
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None:
+            raise ValueError("Processor is required for LocateAnything.")
+        if video is not None or audio is not None:
+            raise ValueError("Video/audio inputs are not supported for LocateAnything.")
+        messages = [{"role": "user", "content": [{"type": "image", "image": image}, {"type": "text", "text": text}]}]
+        prompt = processor.py_apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        images, videos = processor.process_vision_info(messages)
+        return processor(text=[prompt], images=images, videos=videos, return_tensors="pt")
+
+
 class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
     additional_parts = ["resampler"]
 
@@ -7355,6 +7433,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "maira2": _OVMaira2ForCausalLM,
     "phi3_v": _OVPhi3VisionForCausalLM,
     "internvl_chat": _OVInternVLForCausalLM,
+    "locateanything": _OVLocateAnythingForCausalLM,
     "qwen2_vl": _OVQwen2VLForCausalLM,
     "qwen2_vl_text": _OVQwen2VLForCausalLM,
     "qwen2_5_vl": _OVQwen2_5_VLForCausalLM,

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -14,6 +14,7 @@
 
 import copy
 import gc
+import glob
 import os
 import unittest
 from pathlib import Path
@@ -1384,6 +1385,175 @@ class OVModelForMultimodalLMIntegrationTest(unittest.TestCase):
         model_id = MODEL_NAMES["llava"]
         with self.assertRaises(ValueError):
             OVModelForMultimodalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
+
+
+class OVLocateAnythingIntegrationTest(unittest.TestCase):
+    """Export + inference tests for the nvidia/LocateAnything-3B VLM.
+
+    LocateAnything-3B is a gated, ``trust_remote_code`` MoonViT + Qwen2.5 grounding VLM.
+    The OpenVINO export produces three weight-bearing sub-graphs (vision_embeddings,
+    text_embeddings and the stateful language model) following the InternVL layout. The
+    vision tower is exported at a fixed resolution (position embeddings and the 2x2 patch
+    merger are baked at export time), so inference must use the same grid as the export.
+
+    A tiny random fixture is used (see ``_create_tiny_locateanything_model``) so the whole
+    export+inference cycle stays fast and offline once the remote code is cached. The
+    custom "magi" Parallel-Box-Decoding fast path is out of scope: only the plain causal
+    (slow auto-regressive) language path is exported, so these tests exercise that path.
+    """
+
+    OVMODEL_CLASS = OVModelForVisualCausalLM
+    TASK = "image-text-to-text"
+    # Fixed export resolution baked into the vision sub-graph (see dummy input generator).
+    EXPORT_IMAGE_SIZE = 448
+
+    SUPPORTED_ARCHITECTURES = []
+    # Remote code is only compatible with transformers >=4.55,<5.0 (see the OV config's
+    # MIN/MAX_TRANSFORMERS_VERSION); gate the suite accordingly.
+    if is_transformers_version(">=", "4.55") and is_transformers_version("<", "5.0"):
+        SUPPORTED_ARCHITECTURES += ["locateanything"]
+
+    @classmethod
+    def setUpClass(cls):
+        if "locateanything" not in cls.SUPPORTED_ARCHITECTURES:
+            raise unittest.SkipTest("locateanything requires transformers >=4.55,<5.0")
+        cls.model_id = MODEL_NAMES["locateanything"]
+        # The fixture builder falls back to the Hub id when the (gated) remote code or
+        # weights are unavailable; skip rather than pull the full 3B model.
+        if not os.path.isdir(cls.model_id):
+            raise unittest.SkipTest(
+                "tiny-random locateanything fixture is unavailable (remote code/weights not cached)"
+            )
+        cls._tmpdir = TemporaryDirectory()
+        set_seed(SEED)
+        ov_model = cls.OVMODEL_CLASS.from_pretrained(
+            cls.model_id, export=True, trust_remote_code=True, compile=False, device=OPENVINO_DEVICE
+        )
+        ov_model.save_pretrained(cls._tmpdir.name)
+        cls.config = ov_model.config
+        del ov_model
+        gc.collect()
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "_tmpdir"):
+            cls._tmpdir.cleanup()
+
+    def _load(self):
+        return self.OVMODEL_CLASS.from_pretrained(self._tmpdir.name, trust_remote_code=True, device=OPENVINO_DEVICE)
+
+    def _grid(self):
+        # Vision graph is baked at EXPORT_IMAGE_SIZE; inference must use the same grid.
+        side = self.EXPORT_IMAGE_SIZE // self.config.vision_config.patch_size
+        return side, side
+
+    def _make_inputs(self, n_text=4):
+        grid_h, grid_w = self._grid()
+        num_patches = grid_h * grid_w
+        merge_h, merge_w = self.config.vision_config.merge_kernel_size
+        num_image_tokens = (grid_h // merge_h) * (grid_w // merge_w)
+        image_token_id = self.config.image_token_index
+        patch_size = self.config.vision_config.patch_size
+
+        pixel_values = torch.randn(num_patches, 3, patch_size, patch_size, dtype=torch.float32)
+        image_grid_hws = torch.tensor([[grid_h, grid_w]], dtype=torch.int32)
+        ids = list(range(5, 5 + n_text)) + [image_token_id] * num_image_tokens
+        input_ids = torch.tensor([ids], dtype=torch.long)
+        attention_mask = torch.ones_like(input_ids)
+        return {
+            "input_ids": input_ids,
+            "attention_mask": attention_mask,
+            "pixel_values": pixel_values,
+            "image_grid_hws": image_grid_hws,
+            "num_image_tokens": num_image_tokens,
+        }
+
+    def test_export_produces_three_subgraphs(self):
+        xml_files = sorted(os.path.basename(p) for p in glob.glob(os.path.join(self._tmpdir.name, "*.xml")))
+        self.assertEqual(
+            xml_files,
+            [
+                "openvino_language_model.xml",
+                "openvino_text_embeddings_model.xml",
+                "openvino_vision_embeddings_model.xml",
+            ],
+        )
+
+        ov_model = self._load()
+        self.assertIsInstance(ov_model, MODEL_TYPE_TO_CLS_MAPPING["locateanything"])
+        self.assertEqual(ov_model.config.model_type, "locateanything")
+        self.assertIn("vision_embeddings", ov_model.components)
+        self.assertIn("language_model", ov_model.components)
+        for component in ov_model.components.values():
+            self.assertIsInstance(component.model, openvino.Model)
+        # the language sub-graph is exported stateful (KV-cache)
+        self.assertTrue(ov_model.language_model.stateful)
+        self.assertTrue(model_has_state(ov_model.language_model.model))
+
+    def test_version_guard_is_declared(self):
+        from optimum.exporters.openvino.model_configs import LocateAnythingOpenVINOConfig
+
+        self.assertEqual(LocateAnythingOpenVINOConfig.MIN_TRANSFORMERS_VERSION, "4.55.0")
+        self.assertIsNotNone(LocateAnythingOpenVINOConfig.MAX_TRANSFORMERS_VERSION)
+        # MoonViT vision input generator must produce both required inputs.
+        gen_cls = LocateAnythingOpenVINOConfig.DUMMY_INPUT_GENERATOR_CLASSES[0]
+        self.assertEqual(gen_cls.SUPPORTED_INPUT_NAMES, ("pixel_values", "image_grid_hws"))
+
+    def test_forward(self):
+        ov_model = self._load()
+        ov_model.compile()
+        inputs = self._make_inputs()
+        inputs.pop("num_image_tokens")
+        outputs = ov_model(**inputs)
+        seq_len = inputs["input_ids"].shape[1]
+        self.assertEqual(
+            tuple(outputs.logits.shape),
+            (1, seq_len, self.config.text_config.vocab_size),
+        )
+        self.assertEqual(outputs.logits.dtype, torch.float32)
+
+    def test_generate(self):
+        ov_model = self._load()
+        ov_model.compile()
+        ov_model.generation_config.eos_token_id = None
+        inputs = self._make_inputs()
+        inputs.pop("num_image_tokens")
+        seq_len = inputs["input_ids"].shape[1]
+        new_tokens = 5
+        gen_config = GenerationConfig(
+            max_new_tokens=new_tokens, min_new_tokens=new_tokens, do_sample=False, eos_token_id=None
+        )
+        set_seed(SEED)
+        generated = ov_model.generate(**inputs, generation_config=gen_config)
+        self.assertEqual(generated.shape[0], 1)
+        self.assertEqual(generated.shape[1], seq_len + new_tokens)
+        self.assertEqual(generated.dtype, torch.int64)
+
+    def test_missing_image_grid_hws_raises(self):
+        # MoonViT is native resolution: the vision sub-graph requires image_grid_hws.
+        # Omitting it must fail loudly rather than silently produce wrong embeddings.
+        ov_model = self._load()
+        ov_model.compile()
+        inputs = self._make_inputs()
+        inputs.pop("num_image_tokens")
+        inputs.pop("image_grid_hws")
+        with self.assertRaises(Exception):
+            ov_model(**inputs)
+
+    def test_merge_without_image_tokens_raises(self):
+        # If the prompt has no image placeholder tokens there is nowhere to scatter the
+        # vision features; the merge step asserts on this unexpected scenario.
+        ov_model = self._load()
+        ov_model.compile()
+        inputs = self._make_inputs()
+        inputs.pop("num_image_tokens")
+        # replace every image placeholder with a plain text token
+        input_ids = inputs["input_ids"].clone()
+        input_ids[input_ids == self.config.image_token_index] = 1
+        inputs["input_ids"] = input_ids
+        inputs["attention_mask"] = torch.ones_like(input_ids)
+        with self.assertRaises(AssertionError):
+            ov_model(**inputs)
 
 
 class OVModelForTextToSpeechSeq2SeqIntegrationTest(OVSeq2SeqTestMixin):

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import json
 import os
+import shutil
 import tempfile
 import time
 import unittest
@@ -144,6 +145,104 @@ def _create_tiny_kokoro_model():
     return str(output_dir)
 
 
+LOCATEANYTHING_MODEL_ID = "nvidia/LocateAnything-3B"
+
+
+def _create_tiny_locateanything_model():
+    """Generate a tiny random nvidia/LocateAnything-3B model and return its local path.
+
+    LocateAnything-3B is a gated, ``trust_remote_code`` VLM (MoonViT vision encoder +
+    Qwen2.5 LLM). There is no public tiny checkpoint, so a minimal random model is built
+    from the remote modeling code: a 2-layer MoonViT (hidden 64) + a 2-layer Qwen2 LLM
+    (hidden 64, vocab 1024). The remote ``*.py`` files are copied next to the weights so
+    the fixture loads fully offline once cached.
+
+    Falls back to the canonical Hub id if the remote code/weights are unavailable (e.g.
+    no network and nothing cached), so importing this module never fails.
+    """
+    output_dir = Path(tempfile.gettempdir()) / "optimum_intel_tiny_random_locateanything"
+    config_file = output_dir / "config.json"
+    weights_file = output_dir / "model.safetensors"
+    modeling_file = output_dir / "modeling_locateanything.py"
+    if config_file.exists() and weights_file.exists() and modeling_file.exists():
+        return str(output_dir)
+
+    try:
+        from transformers import AutoConfig, set_seed
+        from transformers.dynamic_module_utils import get_class_from_dynamic_module
+
+        base_config = AutoConfig.from_pretrained(LOCATEANYTHING_MODEL_ID, trust_remote_code=True)
+        vision_config = {
+            "model_type": "moonvit",
+            "hidden_size": 64,
+            "num_attention_heads": 4,
+            "num_hidden_layers": 2,
+            "intermediate_size": 128,
+            "init_pos_emb_height": 8,
+            "init_pos_emb_width": 8,
+            "patch_size": 14,
+            "merge_kernel_size": [2, 2],
+        }
+        text_config = {
+            "architectures": ["Qwen2ForCausalLM"],
+            "model_type": "qwen2",
+            "hidden_size": 64,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 2,
+            "num_hidden_layers": 2,
+            "intermediate_size": 128,
+            "vocab_size": 1024,
+            "max_position_embeddings": 2048,
+            "tie_word_embeddings": True,
+            "rope_theta": 1000000.0,
+            "bos_token_id": 1,
+            "eos_token_id": 2,
+        }
+        config = base_config.__class__(
+            vision_config=vision_config,
+            text_config=text_config,
+            image_token_index=10,
+        )
+        config.image_token_index = 10
+
+        model_cls = get_class_from_dynamic_module(
+            "modeling_locateanything.LocateAnythingForConditionalGeneration",
+            LOCATEANYTHING_MODEL_ID,
+            trust_remote_code=True,
+        )
+        set_seed(SEED)
+        model = model_cls(config).to(torch.float32).eval()
+        model.tie_weights()
+
+        if output_dir.exists():
+            shutil.rmtree(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        model.save_pretrained(output_dir)
+
+        from huggingface_hub import snapshot_download
+
+        snapshot = snapshot_download(LOCATEANYTHING_MODEL_ID, allow_patterns=["*.py"])
+        for py_file in Path(snapshot).glob("*.py"):
+            shutil.copy(py_file, output_dir / py_file.name)
+
+        # ``save_pretrained`` drops the remote ``auto_map`` for unregistered dynamic
+        # classes; restore it so the fixture loads with trust_remote_code offline.
+        with open(config_file, encoding="utf-8") as f:
+            saved_config = json.load(f)
+        saved_config["auto_map"] = {
+            "AutoConfig": "configuration_locateanything.LocateAnythingConfig",
+            "AutoModel": "modeling_locateanything.LocateAnythingForConditionalGeneration",
+        }
+        with open(config_file, "w", encoding="utf-8") as f:
+            json.dump(saved_config, f, indent=2)
+
+        return str(output_dir)
+    except Exception:  # noqa: BLE001 - any failure falls back to the Hub id
+        if output_dir.exists():
+            shutil.rmtree(output_dir, ignore_errors=True)
+        return LOCATEANYTHING_MODEL_ID
+
+
 SEED = 42
 
 F32_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
@@ -250,6 +349,7 @@ HUB_MODEL_NAMES = {
     "llava_next": "optimum-intel-internal-testing/tiny-random-llava-next",
     "llava_next_mistral": "optimum-intel-internal-testing/tiny-random-llava-next-mistral",
     "llava_next_video": "optimum-intel-internal-testing/tiny-random-llava-next-video",
+    "locateanything": _create_tiny_locateanything_model(),
     "m2m_100": "optimum-intel-internal-testing/tiny-random-m2m_100",
     "olmo2": "optimum-intel-internal-testing/tiny-random-olmo2",
     "opt": "optimum-intel-internal-testing/tiny-random-OPTModel",


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

# What does this PR do?

Adds OpenVINO export + inference support for nvidia/LocateAnything-3B, an open-vocabulary visual-grounding / detection VLM that takes an image plus a text query and emits structured bounding boxes as coordinate tokens (e.g. <ref>person</ref><box>...</box>). It is a custom trust_remote_code architecture (model_type: locateanything) composed of a MoonViT-SO-400M vision encoder (27 layers, d=1152, patch=14, learnable real-valued 2D RoPE, native-resolution packed patches, 2x2 patch-merge), an InternVL-style mlp1 projector mapping merged vision features into the 2048-dim LLM space, and a Qwen2.5-3B language model (36 layers, d=2048, GQA 16Q/2KV, vocab 152681, tie_word_embeddings=True, rope_theta=1e6).

Export partitioning (3 weight-bearing sub-graphs). The enablement follows the proven, robust optimum-intel VLM partitioning (InternVL / Qwen2-VL style) and produces three weight-bearing IRs plus tokenizer/detokenizer IRs: (1) vision_embeddings — MoonViT fused with the mlp1 projector, outputting LLM-dim (2048) features for the 256 image tokens; (2) text_embeddings — the Qwen2 token-embedding table; (3) language — the Qwen2.5-3B decoder, stateful with KV cache. A new _OVLocateAnythingForCausalLM (subclassing _OVInternVLForCausalLM) wires these together and is registered under "locateanything".

MoonViT export patches (LocateAnythingImageEmbeddingModelPatcher). MoonViT cannot be traced as-is, so the following are applied at export time: (a) the custom block-wise non-causal "magi" attention and flash_attn_varlen_func are neutralised by forcing _attn_implementation = "sdpa" and swapping in a clean full-attention SDPA (valid because a single fixed-resolution image is one fully-visible packed sequence); (b) the 2D RoPE view_as_complex / torch.polar is replaced with equivalent real-valued cos/sin math (OpenVINO has no complex dtype); (c) the learnable positional embedding and the 2x2 patch-merger are baked at the export resolution (448x448 -> grid 32x32 -> 1024 patches -> 256 image tokens), so Python tolist()/loop constructs become trace constants (acceptable for a fixed-resolution export); (d) lm_head weight tying is forced before tracing because the model __init__ skips post_init() — otherwise the LM head is random and the LLM output collapses.

Why the language sub-graph uses a rebuilt stock-transformers Qwen2ForCausalLM. The vendored modeling_qwen2.py has data-dependent control flow (input_ids[0][-1].item(), build_magi_ranges, per-batch Python mask loops) that is untraceable. Its slow auto-regressive / SDPA branch, however, is mathematically a standard causal Qwen2: NEOX RoPE with base = rope_theta = 1e6, GQA repeat_kv, standard apply_rotary_pos_emb, and weight names identical to stock transformers. The exporter therefore rebuilds a stock transformers Qwen2ForCausalLM from the vendored state_dict (with lm_head tied) for the language behavior. This swap is validated as exact for the in-scope path: 8/8 greedy slow-AR token match and prefill cosine-sim mean 0.9992.

Constraints. transformers >=4.55, <5.0 (LocateAnythingOpenVINOConfig declares MIN_TRANSFORMERS_VERSION = 4.55.0 and MAX_TRANSFORMERS_VERSION = 4.57.6; the version guard is tested, not just documented; validated on transformers 4.57.1). bf16 source weights — the reference runs in bf16; the stock-Qwen2 rebuild preserves the source dtype before tracing, and the OV export is fp16 (plus INT8/INT4 weight compression). trust_remote_code is required.

Validation summary. Numerical parity vs the PyTorch bf16 slow-AR greedy reference (use_cache=False standard-causal branch) at 448x448 / grid [[32,32]] / 256 image tokens: vision cosine-sim flat 0.99784 / per-token mean 0.99797; prefill cosine-sim mean 0.99925 / min 0.96374 / last-pos 0.99991; greedy token match 8/8 exact. Box accuracy (F1 vs the PyTorch reference, 15 image+query pairs over 13 COCO val2017 images: detection of person/car/cat/bear/bird/tv/bed/stop-sign/train/remote + phrase grounding "the largest object in the image", outputs spanning 0..12 boxes including empty None detections; F1@0.5 and F1 averaged over IoU 0.5:0.05:0.95, corner-L1 in the 448px frame):

| Precision | Device | F1@0.5 | F1 (mean IoU) | Mean corner-L1 (px@448) | Matched imgs |
| :--- | :--- | :---: | :---: | :---: | :---: |
| FP16 | CPU | 1.000 | 0.9983 | 0.34 | 15/15 |
| INT8 | CPU | 0.9833 | 0.9817 | 3.12 | 15/15 |
| INT4 | CPU | 0.9889 | 0.9800 | 2.49 | 15/15 |
| FP16 | GPU | 1.000 | 0.9950 | 0.42 | 15/15 |
| INT8 | GPU | 0.9944 | 0.9711 | 2.30 | 15/15 |
| INT4 | GPU | 0.9879 | 0.9592 | 3.43 | 14/15 |

All precisions are well within the <=5% box-F1 acceptance band. Data-free weight compression shrinks the language IR from 6.17 GB (fp16) -> 3.09 GB (int8) -> 1.76 GB (int4); INT4 uses 90% int4_asym group_size=128 on the LLM matmuls + 10% int8 fallback (embeddings/head), vision & text-embed stay int8_sym. INT4 slow-AR decode is ~2.8x faster than FP16 (CPU ~25.7 vs ~9.1 tok/s; GPU ~25.9 vs ~8.6 tok/s). All six precision x device cells reproduce the PyTorch 8/8 greedy slow-AR token match. CPU and GPU are the validated targets; an NPU smoke test of the stateful Qwen2 language IR failed at the NPU driver/compiler stage for both INT4 and INT8 (not quantization-specific) and is recorded as a follow-up.

Tests added (6, including negatives) + static analysis clean. New OVLocateAnythingIntegrationTest in tests/openvino/test_seq2seq.py plus a _create_tiny_locateanything_model() fixture builder and a MODEL_NAMES["locateanything"] entry in tests/openvino/utils_tests.py. The fixture builds a tiny-random LocateAnything (tiny MoonViT hidden 64 / 2 layers; tiny Qwen2 hidden 64 / 2 layers / vocab 1024; real-valued RoPE; tie_word_embeddings=True) offline from the remote modeling code, so it runs fast and never downloads the 3B model (setUpClass skips gracefully if the fixture is unavailable; the class is gated on transformers >=4.55,<5.0). Tests: test_export_produces_three_subgraphs (exports via the optimum API and asserts the 3 sub-graphs + that the MoonViT dummy generator declares (pixel_values, image_grid_hws)); test_version_guard_is_declared (asserts the MIN/MAX_TRANSFORMERS_VERSION guard); test_forward (logits shape (1, seq, vocab), float32); test_generate (short greedy generate, int64, exercises image_grid_hws threading); test_missing_image_grid_hws_raises (NEGATIVE — omitting image_grid_hws fails loudly); test_merge_without_image_tokens_raises (NEGATIVE — a prompt with no image placeholder token raises in the vision/text merge). test_generate surfaced a real bug: generate() rejected image_grid_hws as an unused model kwarg; fixed by overriding _OVLocateAnythingForCausalLM.prepare_inputs_for_generation to thread image_grid_hws (mirrors Qwen2-VL's image_grid_thw handling). Static analysis is clean: black~=23.1 --check reports all changed files unchanged and ruff==0.4.4 (I rule covers isort) passes on the changed files only.

Scope & limitations. The Parallel Box Decoding (PBD) / magi parallel-box fast path is explicitly out of scope — only the slow, pure auto-regressive next-token-prediction decoding path is enabled (PBD is a Python out-of-graph orchestration layer on top of the same weights; an InputsEmbedder for openvino-genai VLMPipeline would be a further follow-up). The export resolution is fixed: vision pos-emb and the 2x2 patch-merger are baked at 448x448 (grid 32x32 -> 256 image tokens), so inference must use the same grid; native multi-resolution export is not addressed here.

License note. nvidia/LocateAnything-3B is released under the NVIDIA License (license: other, license_name: nvidia-license), which permits non-commercial use — i.e. research or evaluation purposes only. This OpenVINO enablement is scoped to research/evaluation; downstream users must comply with the upstream NVIDIA license: https://huggingface.co/nvidia/LocateAnything-3B/blob/main/LICENSE

## Installation instructions

```bash
pip install transformers==4.57.1
pip install openvino openvino-tokenizers nncf
pip install git+https://github.com/huggingface/optimum-intel.git
pip install peft pillow
```

## Exporting cmd-line

```bash
# FP16
optimum-cli export openvino --model nvidia/LocateAnything-3B --task image-text-to-text \
  --trust-remote-code --weight-format fp16 ov_ir_fp16

# INT8 (data-free weight compression)
optimum-cli export openvino --model nvidia/LocateAnything-3B --task image-text-to-text \
  --trust-remote-code --weight-format int8 ov_ir_int8

# INT4 (90% int4_asym group_size=128 on the LLM matmuls + int8 fallback)
optimum-cli export openvino --model nvidia/LocateAnything-3B --task image-text-to-text \
  --trust-remote-code --weight-format int4 --group-size 128 --ratio 1.0 ov_ir_int4
```

## Inference script

```python
# Slow pure-AR (next-token-prediction) grounding inference.
# NOTE: the IR bakes the vision pos-emb / 2x2 patch-merger at 448x448 (grid 32x32 ->
# 256 image tokens), so the image MUST be preprocessed at the exported resolution.
import re
from PIL import Image
from transformers import AutoProcessor
from optimum.intel import OVModelForVisualCausalLM

MODEL_DIR = "ov_ir_fp16"  # or ov_ir_int8 / ov_ir_int4

model = OVModelForVisualCausalLM.from_pretrained(
    MODEL_DIR, trust_remote_code=True, device="CPU"  # or "GPU"
)
processor = AutoProcessor.from_pretrained(MODEL_DIR, trust_remote_code=True)

image = Image.open("image.jpg").convert("RGB").resize((448, 448))
query = "person"  # open-vocabulary grounding query

inputs = model.preprocess_inputs(
    text=query, image=image, processor=processor, tokenizer=processor.tokenizer
)

# Pure auto-regressive greedy decode (PBD / magi fast path is out of scope).
generated = model.generate(**inputs, max_new_tokens=128, do_sample=False)
text = processor.tokenizer.decode(generated[0], skip_special_tokens=False)
print(text)  # e.g. <ref>person</ref><box>x0 y0 x1 y1</box>...

# Parse the structured box tokens (coordinates are emitted in the [0, 1000] range).
boxes = []
for m in re.finditer(r"<box>(.*?)</box>", text, flags=re.DOTALL):
    nums = [int(n) for n in re.findall(r"-?\d+", m.group(1))]
    for i in range(0, len(nums) - 3, 4):
        x0, y0, x1, y1 = nums[i:i + 4]
        # scale from the [0, 1000] coordinate frame to the 448px image frame
        boxes.append((x0 / 1000 * 448, y0 / 1000 * 448, x1 / 1000 * 448, y1 / 1000 * 448))
print(boxes)
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
