### PR TITLE
fix fork PR rate limiting with HF model caching

### DIFF
--- a/.github/workflows/create_model_cache.yml
+++ b/.github/workflows/create_model_cache.yml
@@ -16,6 +16,7 @@ permissions:
 
 env:
   HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+  UV_SYSTEM_PYTHON: true
 
 jobs:
   create-cache:

--- a/.github/workflows/create_model_cache.yml
+++ b/.github/workflows/create_model_cache.yml
@@ -1,0 +1,69 @@
+name: Create Model Cache
+
+on:
+  pull_request:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      force_update:
+        description: "Force the (re-)download, overriding the cached versions if exist"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: write  # needed to delete the stale cache entry
+
+env:
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+
+jobs:
+  create-cache:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.label.name == 'create-model-cache' ||
+      github.event.label.name == 'create-model-cache-force'
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Check HF token is available
+        run: |
+          if [ -z "$HF_TOKEN" ]; then
+            echo "HF_TOKEN secret not available — cannot run on fork PRs"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip uv
+          uv pip install .[tests]
+
+      - name: Restore existing cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-models
+
+      - name: Download models for cache
+        run: python tests/scripts/download_cached_models.py
+        env:
+          FORCE_DOWNLOAD: ${{ inputs.force_update || github.event.label.name == 'create-model-cache-force' }}
+
+      - name: Delete existing cache entry
+        run: gh cache delete hf-models --repo ${{ github.repository }} || true
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Save HF models cache
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-models

--- a/.github/workflows/create_model_cache.yml
+++ b/.github/workflows/create_model_cache.yml
@@ -22,8 +22,8 @@ jobs:
   create-cache:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'create-hf-cache' ||
-      github.event.label.name == 'create-hf-cache-force'
+      github.event.label.name == 'update-hf-cache' ||
+      github.event.label.name == 'update-hf-cache-force'
     runs-on: ubuntu-22.04
 
     steps:
@@ -56,7 +56,7 @@ jobs:
       - name: Download models for cache
         run: python tests/scripts/download_cached_models.py
         env:
-          FORCE_DOWNLOAD: ${{ inputs.force_update || github.event.label.name == 'create-hf-cache-force' }}
+          FORCE_DOWNLOAD: ${{ inputs.force_update || github.event.label.name == 'update-hf-cache-force' }}
 
       - name: Delete existing cache entry
         run: gh cache delete hf-models --repo ${{ github.repository }} || true

--- a/.github/workflows/create_model_cache.yml
+++ b/.github/workflows/create_model_cache.yml
@@ -21,8 +21,8 @@ jobs:
   create-cache:
     if: >-
       github.event_name == 'workflow_dispatch' ||
-      github.event.label.name == 'create-model-cache' ||
-      github.event.label.name == 'create-model-cache-force'
+      github.event.label.name == 'create-hf-cache' ||
+      github.event.label.name == 'create-hf-cache-force'
     runs-on: ubuntu-22.04
 
     steps:
@@ -55,7 +55,7 @@ jobs:
       - name: Download models for cache
         run: python tests/scripts/download_cached_models.py
         env:
-          FORCE_DOWNLOAD: ${{ inputs.force_update || github.event.label.name == 'create-model-cache-force' }}
+          FORCE_DOWNLOAD: ${{ inputs.force_update || github.event.label.name == 'create-hf-cache-force' }}
 
       - name: Delete existing cache entry
         run: gh cache delete hf-models --repo ${{ github.repository }} || true

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -57,6 +57,13 @@ jobs:
           pip install --upgrade pip uv
           uv pip install .[tests] librosa diffusers
 
+      - name: Restore HF models cache
+        id: hf-cache-restore
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-models
+
       - if: ${{ matrix.test-pattern == '*modeling*' || matrix.test-pattern == '*quantization*' || matrix.test-pattern == '*transformation*' }}
         name: Install OpenVINO
         run: |
@@ -86,6 +93,25 @@ jobs:
         if: ${{ env.HF_TOKEN == '' }}
         run: |
           python tests/scripts/login_with_ci_token.py
+
+      - name: Pre-download models for cache
+        if: >-
+          steps.hf-cache-restore.outputs.cache-hit != 'true' &&
+          env.HF_TOKEN != '' &&
+          matrix.test-pattern == '*decoder*' &&
+          matrix.transformers-version == 'latest'
+        run: python tests/scripts/download_cached_models.py
+
+      - name: Save cache
+        if: >-
+          steps.hf-cache-restore.outputs.cache-hit != 'true' &&
+          env.HF_TOKEN != '' &&
+          matrix.test-pattern == '*decoder*' &&
+          matrix.transformers-version == 'latest'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-models
 
       - name: Test with Pytest
         run: |

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -94,25 +94,6 @@ jobs:
         run: |
           python tests/scripts/login_with_ci_token.py
 
-      - name: Pre-download models for cache
-        if: >-
-          steps.hf-cache-restore.outputs.cache-hit != 'true' &&
-          env.HF_TOKEN != '' &&
-          matrix.test-pattern == '*decoder*' &&
-          matrix.transformers-version == 'latest'
-        run: python tests/scripts/download_cached_models.py
-
-      - name: Save cache
-        if: >-
-          steps.hf-cache-restore.outputs.cache-hit != 'true' &&
-          env.HF_TOKEN != '' &&
-          matrix.test-pattern == '*decoder*' &&
-          matrix.transformers-version == 'latest'
-        uses: actions/cache/save@v4
-        with:
-          path: ~/.cache/huggingface/hub
-          key: hf-models
-
       - name: Test with Pytest
         run: |
           pytest tests/openvino/${{ matrix.test-pattern }} --durations=0

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -59,6 +59,7 @@ jobs:
 
       - name: Restore HF models cache
         id: hf-cache-restore
+        if: env.HF_TOKEN == ''
         uses: actions/cache/restore@v4
         with:
           path: ~/.cache/huggingface/hub

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -114,6 +114,8 @@ jobs:
           key: hf-models
 
       - name: Test with Pytest
+        env:
+          HF_HUB_OFFLINE: "1"
         run: |
           pytest tests/openvino/${{ matrix.test-pattern }} --durations=0
 

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -114,8 +114,6 @@ jobs:
           key: hf-models
 
       - name: Test with Pytest
-        env:
-          HF_HUB_OFFLINE: "1"
         run: |
           pytest tests/openvino/${{ matrix.test-pattern }} --durations=0
 

--- a/.github/workflows/test_openvino_nightly.yml
+++ b/.github/workflows/test_openvino_nightly.yml
@@ -99,6 +99,14 @@ jobs:
           pip install --upgrade pip uv
           uv pip install .[tests] librosa diffusers
 
+      - name: Restore HF models cache
+        id: hf-cache-restore
+        if: env.HF_TOKEN == ''
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-models
+
       - if: ${{ matrix.openvino-version == 'openvino-nightly' }}
         name: Install OpenVINO Nightly
         run: |

--- a/.github/workflows/test_openvino_slow.yml
+++ b/.github/workflows/test_openvino_slow.yml
@@ -61,6 +61,14 @@ jobs:
           python -m pip install --upgrade pip uv
           uv pip install .[tests] librosa diffusers
 
+      - name: Restore HF models cache
+        id: hf-cache-restore
+        if: env.HF_TOKEN == ''
+        uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache/huggingface/hub
+          key: hf-models
+
       - if: ${{ matrix.transformers-version != 'latest' && matrix.transformers-version != 'main' }}
         name: Install specific dependencies and versions required for older transformers
         run: |

--- a/tests/scripts/download_cached_models.py
+++ b/tests/scripts/download_cached_models.py
@@ -25,18 +25,8 @@ from utils_tests import MODEL_NAMES
 
 # github actions repo cache limit is 10 GB so using 9 GB
 CACHE_LIMIT = 9 * 10**9
-
-# checkpoints always excluded from the cache
-SKIP_MODEL_NAMES = {
-    "AngelSlim/Qwen3-1.7B_eagle3",
-    "optimum-intel-internal-testing/all-mpnet-base-v2",
-    "optimum-intel-internal-testing/all-MiniLM-L6-v2",
-    "optimum-intel-internal-testing/opt-125m",
-    "optimum-intel-internal-testing/opt-125m-gptq-4bit",
-    "optimum-intel-internal-testing/trocr-small-handwritten",
-    "optimum-intel-internal-testing/bge-small-en-v1.5",
-    "optimum-intel-internal-testing/sew-d-tiny-100k-ft-ls100h",
-}
+# exclude model larger than 100 MB
+MODEL_SIZE_THRESHOLD = 100 * 10**6
 
 
 def hub_size(api: HfApi, repo_id: str) -> int:
@@ -50,35 +40,26 @@ def hub_size(api: HfApi, repo_id: str) -> int:
 
 def main() -> None:
     api = HfApi()
-    skip_names = []
     candidates = {}
 
     for name, repo_id in MODEL_NAMES.items():
         if not isinstance(repo_id, str) or not repo_id or repo_id.startswith("/"):
-            continue
-        if repo_id in SKIP_MODEL_NAMES:
-            skip_names.append(name)
             continue
         candidates[repo_id] = name
 
     if os.path.exists(constants.HF_HUB_CACHE):
         cache_info = scan_cache_dir()
         cached_repos = {repo.repo_id for repo in cache_info.repos}
-        # sum of all valid repo sizes in the cache-system
         sum_repo_size = cache_info.size_on_disk
     else:
         cached_repos = set()
         sum_repo_size = 0
 
-    print(f"Skipped         : {len(skip_names)}  ({', '.join(skip_names)})")
-    print(f"Candidates      : {len(candidates)}")
-
     downloaded = []
-    skipped_size = []
+    skipped_too_large = []
+    skipped_cache_full = []
     failed = []
-
     force_update = os.environ.get("FORCE_DOWNLOAD", "").lower() in ("1", "true", "yes")
-
     for repo_id, name in candidates.items():
         if not force_update and repo_id in cached_repos:
             continue
@@ -88,8 +69,12 @@ def main() -> None:
             failed.append(name)
             continue
 
+        if size > MODEL_SIZE_THRESHOLD:
+            skipped_too_large.append(name)
+            continue
+
         if sum_repo_size + size > CACHE_LIMIT:
-            skipped_size.append(name)
+            skipped_cache_full.append(name)
             continue
 
         try:
@@ -100,9 +85,10 @@ def main() -> None:
             print(f"[FAIL]  {name}: {e}", file=sys.stderr)
             failed.append(repo_id)
 
-    print(f"Downloaded     : {len(downloaded)}  ({', '.join(downloaded)})")
-    print(f"Skipped (size) : {len(skipped_size)}  ({', '.join(skipped_size)})")
-    print(f"Loading failed : {len(failed)}  ({', '.join(failed)})")
+    print(f"Downloaded          : {len(downloaded)}  ({', '.join(downloaded)})")
+    print(f"Skipped (too large) : {len(skipped_too_large)}  ({', '.join(skipped_too_large)})")
+    print(f"Skipped (cache full): {len(skipped_cache_full)}  ({', '.join(skipped_cache_full)})")
+    print(f"Loading failed      : {len(failed)}  ({', '.join(failed)})")
 
 
 if __name__ == "__main__":

--- a/tests/scripts/download_cached_models.py
+++ b/tests/scripts/download_cached_models.py
@@ -27,7 +27,7 @@ from utils_tests import MODEL_NAMES
 CACHE_LIMIT = 9 * 10**9
 
 # checkpoints always excluded from the cache
-SKIP_ALWAYS = {
+SKIP_MODEL_NAMES = {
     "AngelSlim/Qwen3-1.7B_eagle3",
     "optimum-intel-internal-testing/all-mpnet-base-v2",
     "optimum-intel-internal-testing/all-MiniLM-L6-v2",
@@ -51,14 +51,14 @@ def hub_size(api: HfApi, repo_id: str) -> int:
 def main() -> None:
     api = HfApi()
 
-    skip_always_names = []
+    skip_names = []
     candidates = {}
 
     for name, repo_id in MODEL_NAMES.items():
         if not isinstance(repo_id, str) or not repo_id or repo_id.startswith("/"):
             continue
-        if repo_id in SKIP_ALWAYS:
-            skip_always_names.append(name)
+        if repo_id in SKIP_MODEL_NAMES:
+            skip_names.append(name)
             continue
         candidates[repo_id] = name
 
@@ -71,7 +71,7 @@ def main() -> None:
         cached_repos = set()
         sum_repo_size = 0
 
-    print(f"Skipped         : {len(skip_always_names)}  ({', '.join(skip_always_names)})")
+    print(f"Skipped         : {len(skip_names)}  ({', '.join(skip_names)})")
     print(f"Candidates      : {len(candidates)}")
 
     downloaded = []

--- a/tests/scripts/download_cached_models.py
+++ b/tests/scripts/download_cached_models.py
@@ -1,0 +1,108 @@
+#  Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+import os
+import sys
+from pathlib import Path
+
+from huggingface_hub import HfApi, constants, scan_cache_dir, snapshot_download
+
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "openvino"))
+
+from utils_tests import MODEL_NAMES
+
+
+# github actions repo cache limit is 10 GB so using 9 GB
+CACHE_LIMIT = 9 * 10**9
+
+# checkpoints always excluded from the cache
+SKIP_ALWAYS = {
+    "AngelSlim/Qwen3-1.7B_eagle3",
+    "optimum-intel-internal-testing/all-mpnet-base-v2",
+    "optimum-intel-internal-testing/all-MiniLM-L6-v2",
+    "optimum-intel-internal-testing/opt-125m",
+    "optimum-intel-internal-testing/opt-125m-gptq-4bit",
+    "optimum-intel-internal-testing/trocr-small-handwritten",
+    "optimum-intel-internal-testing/bge-small-en-v1.5",
+    "optimum-intel-internal-testing/sew-d-tiny-100k-ft-ls100h",
+}
+
+
+def hub_size(api: HfApi, repo_id: str) -> int:
+    try:
+        info = api.model_info(repo_id, files_metadata=True)
+        return sum(sib.size or 0 for sib in (info.siblings or []))
+    except Exception as e:
+        print(f"Size query failed for {repo_id}: {e}")
+        return -1
+
+
+def main() -> None:
+    api = HfApi()
+
+    skip_always_names = []
+    candidates = {}
+
+    for name, repo_id in MODEL_NAMES.items():
+        if not isinstance(repo_id, str) or not repo_id or repo_id.startswith("/"):
+            continue
+        if repo_id in SKIP_ALWAYS:
+            skip_always_names.append(name)
+            continue
+        candidates[repo_id] = name
+
+    if os.path.exists(constants.HF_HUB_CACHE):
+        cache_info = scan_cache_dir()
+        cached_repos = {repo.repo_id for repo in cache_info.repos}
+        # sum of all valid repo sizes in the cache-system
+        sum_repo_size = cache_info.size_on_disk
+    else:
+        cached_repos = set()
+        sum_repo_size = 0
+
+    print(f"Skipped         : {len(skip_always_names)}  ({', '.join(skip_always_names)})")
+    print(f"Candidates      : {len(candidates)}")
+
+    downloaded = []
+    skipped_size = []
+    failed = []
+
+    for repo_id, name in candidates.items():
+        if repo_id in cached_repos:
+            continue
+
+        size = hub_size(api, repo_id)
+        if size < 0:
+            failed.append(name)
+            continue
+
+        if sum_repo_size + size > CACHE_LIMIT:
+            skipped_size.append(name)
+            continue
+
+        try:
+            snapshot_download(repo_id)
+            sum_repo_size += size
+            downloaded.append(name)
+        except Exception as e:
+            print(f"[FAIL]  {name}: {e}", file=sys.stderr)
+            failed.append(repo_id)
+
+    print(f"Downloaded     : {len(downloaded)}  ({', '.join(downloaded)})")
+    print(f"Skipped (size) : {len(skipped_size)}  ({', '.join(skipped_size)})")
+    print(f"Loading failed : {len(failed)}  ({', '.join(failed)})")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/download_cached_models.py
+++ b/tests/scripts/download_cached_models.py
@@ -50,7 +50,6 @@ def hub_size(api: HfApi, repo_id: str) -> int:
 
 def main() -> None:
     api = HfApi()
-
     skip_names = []
     candidates = {}
 
@@ -78,8 +77,10 @@ def main() -> None:
     skipped_size = []
     failed = []
 
+    force_update = os.environ.get("FORCE_DOWNLOAD", "").lower() in ("1", "true", "yes")
+
     for repo_id, name in candidates.items():
-        if repo_id in cached_repos:
+        if not force_update and repo_id in cached_repos:
             continue
 
         size = hub_size(api, repo_id)


### PR DESCRIPTION
CI jobs triggered by fork PRs cannot access the `HF_HUB_READ_TOKEN` secret, resulting in rate limit being reached trying loading the 200 models.
In this PR we add a new workflow to build and maintain a github actions model cache `hf-models` that is shared across workflows 

This workflow is triggered by `workflow_dispatch` or two PR labels: `update-hf-cache` (will only download model that are not already cached) and `update-hf-cache-force` (forcing download of all models, can be useful when models have been updated)
models that are larger than 100MB are excluded to avoid reaching the 10 GB limit constraint
