### PR TITLE
Auto Transformers Version For Model Export

### DIFF
--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -41,6 +41,7 @@ usage: optimum-cli export openvino [-h] -m MODEL [--task TASK] [--framework {pt}
                                    [--quantization-statistics-path QUANTIZATION_STATISTICS_PATH]
                                    [--num-samples NUM_SAMPLES] [--disable-stateful] [--disable-convert-tokenizer]
                                    [--smooth-quant-alpha SMOOTH_QUANT_ALPHA]
+                                   [--transformers-version TRANSFORMERS_VERSION]
                                    output
 
 optional arguments:
@@ -167,6 +168,10 @@ Optional arguments:
   --smooth-quant-alpha SMOOTH_QUANT_ALPHA
                         SmoothQuant alpha parameter that improves the distribution of activations before MatMul layers
                         and reduces quantization error. Valid only when activations quantization is enabled.
+  --transformers-version TRANSFORMERS_VERSION
+                        Export the model using a different Transformers version, installed on the fly in an isolated
+                        `uv` environment. Pass "auto" to infer the required version from the model, or an explicit
+                        version such as "5.2.0". Requires `uv` to be installed.
 ```
 
 You can also apply fp16, 8-bit or 4-bit weight-only quantization on the Linear, Convolutional and Embedding layers when exporting your model by setting `--weight-format` to respectively `fp16`, `int8` or `int4`.
@@ -193,6 +198,21 @@ optimum-cli export openvino --model meta-llama/Meta-Llama-3-8B \
 ```
 
 For more information on the quantization parameters checkout the [documentation](inference#weight-only-quantization)
+
+
+### Exporting with a different Transformers version
+
+Some models require a Transformers version different from the one installed in your environment (for example, a newer architecture not yet supported by your current version). Instead of changing your environment manually, you can let the export run in an isolated `uv` environment with the required version, installed on the fly:
+
+```bash
+# Infer the required version from the model
+optimum-cli export openvino --model <model_id> --transformers-version auto ov_model/
+
+# Or pin an explicit version
+optimum-cli export openvino --model <model_id> --transformers-version 4.57.0 ov_model/
+```
+
+With `auto`, the required version is inferred from optimum-intel's export configuration, falling back to the `transformers_version` recorded in the model's `config.json`. Your environment is left untouched; only the export subprocess uses the requested version. This requires `uv`, which you can install with `pip install optimum-intel[transformers-switch]`.
 
 
 <Tip warning={true}>

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -65,6 +65,16 @@ def parse_args_openvino(parser: "ArgumentParser"):
         ),
     )
     optional_group.add_argument(
+        "--transformers-version",
+        type=str,
+        default=None,
+        help=(
+            "Export the model using a different Transformers version, installed on the fly in an isolated `uv` "
+            'environment. Pass "auto" to infer the required version from the model, or an explicit version such as '
+            '"4.57.0". Requires `uv` to be installed.'
+        ),
+    )
+    optional_group.add_argument(
         "--weight-format",
         type=str,
         choices=["fp32", "fp16", "int8", "int4", "mxfp4", "nf4", "cb4"],
@@ -341,6 +351,10 @@ class OVExportCommand(BaseOptimumCLICommand):
         return parse_args_openvino(parser)
 
     def run(self):
+        from .transformers_version import maybe_switch_transformers_version
+
+        maybe_switch_transformers_version(self.args.model, self.args.transformers_version, self.args.cache_dir)
+
         from ...exporters.openvino.__main__ import _main_quantize, _merge_move, main_export
         from ...intel.openvino.configuration import (
             _DEFAULT_4BIT_WQ_CONFIG,

--- a/optimum/commands/export/transformers_version.py
+++ b/optimum/commands/export/transformers_version.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Resolve and switch the Transformers version required to export a given model."""
+
+import logging
+import os
+import shutil
+import sys
+
+from packaging.version import Version
+
+from ...intel.utils.import_utils import _transformers_version
+
+
+logger = logging.getLogger(__name__)
+
+_REEXEC_GUARD = "_OPTIMUM_INTEL_TF_REEXEC"
+
+
+def _export_config_bounds(model_type):
+    try:
+        import optimum.exporters.openvino.model_configs  # noqa: F401
+        from optimum.exporters.tasks import TasksManager
+    except Exception:
+        return None, None
+
+    entry = TasksManager._SUPPORTED_MODEL_TYPE.get(model_type, {})
+    config_constructors = entry.get("openvino", {})
+    for constructor in config_constructors.values():
+        config_class = getattr(constructor, "func", constructor)
+        min_version = getattr(config_class, "MIN_TRANSFORMERS_VERSION", None)
+        max_version = getattr(config_class, "MAX_TRANSFORMERS_VERSION", None)
+        if min_version is not None or max_version is not None:
+            return _as_version_string(min_version), _as_version_string(max_version)
+    return None, None
+
+
+def _as_version_string(version):
+    if isinstance(version, Version):
+        return version.base_version
+    return version
+
+
+def _read_model_config(model, cache_dir):
+    from transformers import PretrainedConfig
+
+    config_dict, _ = PretrainedConfig.get_config_dict(model, cache_dir=cache_dir)
+    return config_dict.get("model_type"), config_dict.get("transformers_version")
+
+
+def resolve_transformers_specifier(model, requested, cache_dir):
+    """Return a pip requirement specifier to switch Transformers to, or None if no switch is needed.
+
+    `requested` is the raw value of `--transformers-version`: a concrete version, or "auto".
+    """
+    current = Version(Version(_transformers_version).base_version)
+
+    if requested != "auto":
+        target = Version(requested)
+        if target == current:
+            return None
+        return f"transformers=={requested}"
+
+    model_type, config_version = _read_model_config(model, cache_dir)
+    min_version, max_version = _export_config_bounds(model_type)
+
+    if min_version is not None or max_version is not None:
+        if config_version is not None and max_version is not None and Version(config_version) > Version(max_version):
+            raise ValueError(
+                f"The model was saved with transformers=={config_version}, but optimum-intel supports it only up to "
+                f"transformers=={max_version}. Export may not work. To attempt it anyway, pass an explicit version, "
+                f'e.g. --transformers-version="{config_version}".'
+            )
+
+        in_range = (min_version is None or current >= Version(min_version)) and (
+            max_version is None or current <= Version(max_version)
+        )
+        if in_range:
+            return None
+
+        bounds = []
+        if min_version is not None:
+            bounds.append(f">={min_version}")
+        if max_version is not None:
+            bounds.append(f"<={max_version}")
+        return "transformers" + ",".join(bounds)
+
+    if config_version is not None and current < Version(config_version):
+        return f"transformers=={config_version}"
+
+    return None
+
+
+def maybe_switch_transformers_version(model, requested, cache_dir):
+    """Re-exec the current command under an ephemeral `uv` environment with the required Transformers version.
+
+    Returns without re-execing when the current environment already satisfies the requirement.
+    """
+    if requested is None:
+        return
+
+    specifier = resolve_transformers_specifier(model, requested, cache_dir)
+    if specifier is None:
+        return
+
+    if os.environ.get(_REEXEC_GUARD):
+        raise RuntimeError(
+            f"Failed to switch the Transformers version: `{specifier}` is required, but the isolated environment "
+            f"still resolves to transformers=={_transformers_version}. This is likely due to a `uv` version whose "
+            f"overlay does not take precedence over the base environment; please upgrade `uv`."
+        )
+
+    uv = shutil.which("uv")
+    if uv is None:
+        raise RuntimeError(
+            "`--transformers-version` requires `uv` to switch the Transformers version in an isolated environment. "
+            "Install it with `pip install optimum-intel[transformers-switch]` or `pip install uv`."
+        )
+
+    logger.warning(
+        f"Re-running export in an isolated `uv` environment with `{specifier}` "
+        f"(current: transformers=={_transformers_version})."
+    )
+    env = {**os.environ, _REEXEC_GUARD: "1", "VIRTUAL_ENV": sys.prefix}
+    args = [uv, "run", "--active", "--no-project", "--with", specifier, "--", "optimum-cli", *sys.argv[1:]]
+    os.execve(uv, args, env)

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,7 @@ EXTRAS_REQUIRE = {
     "nncf": ["nncf>=2.19.0"],
     "openvino": ["nncf>=2.19.0", "openvino>=2026.0", "openvino-tokenizers>=2026.0"],
     "diffusers": ["diffusers"],
+    "transformers-switch": ["uv>=0.8.4"],
     "quality": QUALITY_REQUIRE,
     "tests": TESTS_REQUIRE,
 }

--- a/tests/openvino/test_transformers_version_resolver.py
+++ b/tests/openvino/test_transformers_version_resolver.py
@@ -1,0 +1,148 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+from unittest.mock import patch
+
+from optimum.commands.export import transformers_version as tv
+
+TINY_GPT2 = "optimum-intel-internal-testing/tiny-random-gpt2"
+
+
+class TransformersVersionResolverTest(unittest.TestCase):
+    def _resolve(self, *, current, requested="auto", bounds=(None, None), config_version=None, model_type="arch"):
+        with (
+            patch.object(tv, "_transformers_version", current),
+            patch.object(tv, "_export_config_bounds", return_value=bounds),
+            patch.object(tv, "_read_model_config", return_value=(model_type, config_version)),
+        ):
+            return tv.resolve_transformers_specifier("model", requested, None)
+
+    def test_explicit_version_equal_to_current_is_noop(self):
+        self.assertIsNone(self._resolve(current="4.57.6", requested="4.57.6"))
+
+    def test_explicit_version_different_pins_exactly(self):
+        self.assertEqual(self._resolve(current="4.57.6", requested="4.55.0"), "transformers==4.55.0")
+
+    def test_explicit_version_ignores_resolution(self):
+        # Bounds / config are irrelevant when an explicit version is requested.
+        self.assertEqual(
+            self._resolve(current="4.57.6", requested="5.2.0", bounds=(None, "4.53.3"), config_version="5.2.0"),
+            "transformers==5.2.0",
+        )
+
+    def test_auto_in_range_is_noop(self):
+        self.assertIsNone(self._resolve(current="4.55.0", bounds=("4.50.0", "4.57.0")))
+
+    def test_auto_below_min_returns_range(self):
+        self.assertEqual(self._resolve(current="4.49.0", bounds=("4.51.0", None)), "transformers>=4.51.0")
+
+    def test_auto_above_max_returns_range(self):
+        self.assertEqual(self._resolve(current="4.57.6", bounds=(None, "4.53.3")), "transformers<=4.53.3")
+
+    def test_auto_min_and_max_returns_full_range(self):
+        self.assertEqual(
+            self._resolve(current="4.49.0", bounds=("4.51.0", "4.55.4")),
+            "transformers>=4.51.0,<=4.55.4",
+        )
+
+    def test_auto_config_floor_newer_pins_exactly(self):
+        self.assertEqual(
+            self._resolve(current="4.57.6", bounds=(None, None), config_version="5.9.0"),
+            "transformers==5.9.0",
+        )
+
+    def test_auto_config_floor_older_is_noop(self):
+        self.assertIsNone(self._resolve(current="4.57.6", bounds=(None, None), config_version="4.40.0"))
+
+    def test_auto_no_signal_is_noop(self):
+        self.assertIsNone(self._resolve(current="4.57.6", bounds=(None, None), config_version=None))
+
+    def test_auto_conflict_raises(self):
+        with self.assertRaises(ValueError):
+            self._resolve(current="4.57.6", bounds=(None, "4.53.3"), config_version="5.2.0")
+
+    def test_export_config_bounds_normalizes_version_objects(self):
+        from packaging.version import Version
+
+        from optimum.exporters.tasks import TasksManager
+
+        class FakeConfig:
+            MIN_TRANSFORMERS_VERSION = Version("4.51.0")
+            MAX_TRANSFORMERS_VERSION = None
+
+        with patch.object(
+            TasksManager,
+            "_SUPPORTED_MODEL_TYPE",
+            {"fake": {"openvino": {"text-generation": FakeConfig}}},
+        ):
+            self.assertEqual(tv._export_config_bounds("fake"), ("4.51.0", None))
+
+    def test_real_model_config_read(self):
+        # Integration over the real config.json read for a known tiny model.
+        model_type, config_version = tv._read_model_config(TINY_GPT2, None)
+        self.assertEqual(model_type, "gpt2")
+
+
+class MaybeSwitchTransformersVersionTest(unittest.TestCase):
+    def test_no_request_is_noop(self):
+        with patch.object(tv, "resolve_transformers_specifier") as resolve:
+            tv.maybe_switch_transformers_version("model", None, None)
+            resolve.assert_not_called()
+
+    def test_reexec_guard_satisfied_is_noop(self):
+        with (
+            patch.dict("os.environ", {tv._REEXEC_GUARD: "1"}),
+            patch.object(tv, "resolve_transformers_specifier", return_value=None),
+            patch("os.execve") as execve,
+        ):
+            tv.maybe_switch_transformers_version("model", "auto", None)
+            execve.assert_not_called()
+
+    def test_reexec_guard_still_unsatisfied_raises(self):
+        with (
+            patch.dict("os.environ", {tv._REEXEC_GUARD: "1"}),
+            patch.object(tv, "resolve_transformers_specifier", return_value="transformers>=5.2.0,<=5.2.99"),
+        ):
+            with self.assertRaises(RuntimeError):
+                tv.maybe_switch_transformers_version("model", "auto", None)
+
+    def test_no_switch_needed_does_not_exec(self):
+        with (
+            patch.object(tv, "resolve_transformers_specifier", return_value=None),
+            patch("os.execve") as execve,
+        ):
+            tv.maybe_switch_transformers_version("model", "auto", None)
+            execve.assert_not_called()
+
+    def test_missing_uv_raises(self):
+        with (
+            patch.object(tv, "resolve_transformers_specifier", return_value="transformers==4.55.0"),
+            patch("shutil.which", return_value=None),
+        ):
+            with self.assertRaises(RuntimeError):
+                tv.maybe_switch_transformers_version("model", "4.55.0", None)
+
+    def test_reexec_invokes_uv_with_specifier(self):
+        with (
+            patch.object(tv, "resolve_transformers_specifier", return_value="transformers==4.55.0"),
+            patch("shutil.which", return_value="/usr/bin/uv"),
+            patch("os.execve") as execve,
+        ):
+            tv.maybe_switch_transformers_version("model", "4.55.0", None)
+            execve.assert_called_once()
+            program, args, env = execve.call_args[0]
+            self.assertEqual(program, "/usr/bin/uv")
+            self.assertIn("transformers==4.55.0", args)
+            self.assertIn("--with", args)
+            self.assertEqual(env[tv._REEXEC_GUARD], "1")


### PR DESCRIPTION
# What does this PR do?

Add `--transformers-version` to `optimum-cli export openvino`.

Different models need different transformers versions to export (some newer than optimum-intel's <5.1 pin). Today users must manually `pip install transformers==X` per model. This adds a flag that switches transformers on the fly in an ephemeral uv environment, leaving the user's env untouched:

```
optimum-cli export openvino -m <model> --transformers-version=auto <out>   # infer
optimum-cli export openvino -m <model> --transformers-version=5.2.0 <out>  # pin
```

When a switch is needed, the command re-execs under `uv run --active --with transformers==<X>`, overlaying only transformers on the existing venv (torch/openvino reused, ~3–5s). With no switch needed, uv is never invoked.

 `auto` resolution: 
1. read the model's `MIN/MAX_TRANSFORMERS_VERSION` from the OpenVINO export config;
1. fall back to the `"transformers_version"` in the model's `config.json` for unknown architectures; 
1. abort with a clear message if the model is newer than optimum-intel's MAX (use explicit --transformers-version=X to override).

**Robustness**: uv's overlay precedence is non-monotonic (0.8.0–0.8.3 silently ignore it), so the re-exec'd process re-verifies the active version actually satisfies the requirement and errors clearly otherwise. Adds a `transformers-switch` extra pinned to uv>=0.8.4.

**Changes**: 
- new `transformers_version.py` (version resolution + re-exec); 
- `--transformers-version` flag in `openvino.py`; 
- `transformers-switch` extra in `setup.py`; 
- 19 unit tests.

<details>
<summary>Usage example</summary>

```bash
(venv) ~/python/optimum-intel/temp$ pip show transformers | grep Version
Version: 4.57.6

(venv) ~/python/optimum-intel/temp$ optimum-cli export openvino -m optimum-intel-internal-testing/tiny-random-qwen3.5-moe --task="image-text-to-text" qwen3.5-moe
Traceback (most recent call last):
  File "/home/apaniuko/python/optimum-intel/venv/lib/python3.10/site-packages/transformers/models/auto/configuration_auto.py", line 1360, in from_pretrained
    config_class = CONFIG_MAPPING[config_dict["model_type"]]
  File "/home/apaniuko/python/optimum-intel/venv/lib/python3.10/site-packages/transformers/models/auto/configuration_auto.py", line 1048, in __getitem__
    raise KeyError(key)
KeyError: 'qwen3_5_moe'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/apaniuko/python/optimum-intel/venv/bin/optimum-cli", line 6, in <module>
    sys.exit(main())
  File "/home/apaniuko/python/optimum-intel/venv/lib/python3.10/site-packages/optimum/commands/optimum_cli.py", line 219, in main
    service.run()
  File "/home/apaniuko/python/optimum-intel/optimum/commands/export/openvino.py", line 482, in run
    main_export(
  File "/home/apaniuko/python/optimum-intel/optimum/exporters/openvino/__main__.py", line 321, in main_export
    task = infer_task(
  File "/home/apaniuko/python/optimum-intel/optimum/exporters/openvino/__main__.py", line 132, in infer_task
    config = AutoConfig.from_pretrained(
  File "/home/apaniuko/python/optimum-intel/venv/lib/python3.10/site-packages/transformers/models/auto/configuration_auto.py", line 1362, in from_pretrained
    raise ValueError(
ValueError: The checkpoint you are trying to load has model type `qwen3_5_moe` but Transformers does not recognize this architecture. This could be because of an issue with the checkpoint, or because your version of Transformers is out of date.

You can update Transformers with the command `pip install --upgrade transformers`. If this does not work, and the checkpoint is very new, then there may not be a release version that supports this model yet. In this case, you can get the most up-to-date code by installing Transformers from source with the command `pip install git+https://github.com/huggingface/transformers.git`

(venv) ~/python/optimum-intel/temp$ optimum-cli export openvino -m optimum-intel-internal-testing/tiny-random-qwen3.5-moe --task="image-text-to-text" --transformers-version=auto qwen3.5-moe
Re-running export in an isolated `uv` environment with `transformers>=5.2.0,<=5.2.99` (current: transformers==4.57.6).
`torch_dtype` is deprecated! Use `dtype` instead!
The fast path is not available because one of the required library is not installed. Falling back to torch implementation. To install follow https://github.com/fla-org/flash-linear-attention#installation and https://github.com/Dao-AILab/causal-conv1d
Loading weights: 100%|████████████████████████████████████████████████████████████████████████| 105/105 [00:00<00:00, 1241.13it/s, Materializing param=model.visual.pos_embed.weight]
`loss_type=None` was set in the config but it is unrecognized. Using the default loss: `ForCausalLMLoss`.
/home/apaniuko/.cache/uv/archive-v0/f3cfEd7Wg4jYL6Su/lib/python3.10/site-packages/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py:1473: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if position_ids.ndim == 3 and position_ids.shape[0] == 4:
/home/apaniuko/.cache/uv/archive-v0/f3cfEd7Wg4jYL6Su/lib/python3.10/site-packages/transformers/masking_utils.py:192: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if (padding_length := kv_length + kv_offset - attention_mask.shape[-1]) > 0:
/home/apaniuko/python/optimum-intel/optimum/exporters/openvino/patching_utils.py:247: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.
  torch.tensor(0.0, device=mask.device, dtype=dtype),
/home/apaniuko/python/optimum-intel/optimum/exporters/openvino/patching_utils.py:248: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.
  torch.tensor(torch.finfo(torch.float16).min, device=mask.device, dtype=dtype),
/home/apaniuko/.cache/uv/archive-v0/f3cfEd7Wg4jYL6Su/lib/python3.10/site-packages/transformers/models/qwen3_5_moe/modeling_qwen3_5_moe.py:1521: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  if cache_position[0] > 0 or (attention_mask is not None and torch.all(attention_mask == 1)):
/home/apaniuko/.cache/uv/archive-v0/f3cfEd7Wg4jYL6Su/lib/python3.10/site-packages/transformers/integrations/sdpa_attention.py:77: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!
  is_causal = query.shape[2] > 1 and attention_mask is None and is_causal

(venv) ~/python/optimum-intel/temp$ optimum-cli export openvino -m optimum-intel-internal-testing/tiny-random-gemma4-unified --task="image-text-to-text" --transf
ormers-version=auto gemma4-unified
config.json: 2.33kB [00:00, 4.67MB/s]
Re-running export in an isolated `uv` environment with `transformers>=5.10,<=5.10.99` (current: transformers==4.57.6).
Installed 28 packages in 62ms
[transformers] `torch_dtype` is deprecated! Use `dtype` instead!
model.safetensors: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 34.8M/34.8M [00:04<00:00, 8.55MB/s]
Loading weights: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 67/67 [00:00<00:00, 4828.83it/s]
generation_config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 216/216 [00:00<00:00, 544kB/s]
tokenizer_config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.53k/1.53k [00:00<00:00, 2.39MB/s]
tokenizer.json: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 32.2M/32.2M [00:01<00:00, 18.0MB/s]
processor_config.json: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1.41k/1.41k [00:00<00:00, 2.13MB/s]
[transformers] `loss_type=None` was set in the config but it is unrecognized. Using the default loss: `ForCausalLMLoss`.
/home/apaniuko/python/optimum-intel/optimum/exporters/openvino/model_patcher.py:9308: TracerWarning: torch.tensor results are registered as constants in the trace. You can safely ignore this warning if you use this function to create tensors out of constant variables that would be the same every time you call this function. In any other case, this might cause the trace to be incorrect.
  vision_group_ids = torch.where(is_vision, vision_group_ids, torch.tensor(-1, dtype=torch.int32, device=device))

(venv) ~/python/optimum-intel/temp$ ls gemma4-unified/
config.json               openvino_detokenizer.xml     openvino_text_embeddings_model.bin  openvino_tokenizer.xml                preprocessor_config.json  tokenizer.json
generation_config.json    openvino_language_model.bin  openvino_text_embeddings_model.xml  openvino_vision_embeddings_model.bin  processor_config.json
openvino_detokenizer.bin  openvino_language_model.xml  openvino_tokenizer.bin              openvino_vision_embeddings_model.xml  tokenizer_config.json

(venv) ~/python/optimum-intel/temp$ pip show transformers | grep Version
Version: 4.57.6
```
</details>

🤖 Generated with Claude Code

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

