### PR TITLE
[EXPERIMENT][WIP] Add OpenVINO support for MolmoWeb-4B (molmo2) VLM

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -115,6 +115,7 @@ Here is the list of the supported architectures :
 - MobileNet v1
 - MobileNet v2
 - MobileViT
+- Molmo2
 - Nystromformer
 - OLMo
 - OLMo 2

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -525,7 +525,13 @@ def main_export(
             if library_name == "transformers":
                 has_remote_code = hasattr(config, "auto_map")
                 if has_remote_code and trust_remote_code and task == "image-text-to-text":
-                    task_model_loading = "text-generation"
+                    auto_map = getattr(config, "auto_map", {}) or {}
+                    # Some remote-code VLMs (e.g. molmo2) only expose an
+                    # AutoModelForImageTextToText entry and must be loaded with that class.
+                    # Older remote-code VLMs (internvl2, minicpmv, phi3_v, ...) expose
+                    # AutoModelForCausalLM and are loaded as text-generation.
+                    if "AutoModelForImageTextToText" not in auto_map or "AutoModelForCausalLM" in auto_map:
+                        task_model_loading = "text-generation"
 
             model = TasksManager.get_model_from_task(
                 task_model_loading,

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -1784,3 +1784,71 @@ class DummyKokoroInputGenerator(DummyInputGenerator):
             return self.random_int_tensor(shape=[1], min_value=1, max_value=10, framework=framework, dtype=float_dtype)
         else:
             raise ValueError(f"Unsupported input {input_name} for DummyKokoroInputGenerator")
+
+
+class DummyMolmo2TextPastKeyValuesGenerator(MistralDummyPastKeyValuesGenerator):
+    """Molmo2 text head_dim (128) differs from hidden_size/num_heads; read head_dim from config."""
+
+    def __init__(
+        self,
+        task,
+        normalized_config,
+        batch_size=DEFAULT_DUMMY_SHAPES["batch_size"],
+        sequence_length=DEFAULT_DUMMY_SHAPES["sequence_length"],
+        **kwargs,
+    ):
+        super().__init__(task, normalized_config, batch_size, sequence_length, **kwargs)
+        self.head_dim = getattr(normalized_config, "head_dim", self.head_dim)
+
+
+class DummyMolmo2VisionInputGenerator(DummyInputGenerator):
+    """Generates dummy inputs for Molmo2VisionBackbone.
+
+    images: f32 [batch, n_crops, n_patches, pixels_per_patch]
+    pooled_patches_idx: int64 [batch, n_pooled, pool_dim]
+    """
+
+    SUPPORTED_INPUT_NAMES = ("images", "pooled_patches_idx")
+
+    def __init__(
+        self,
+        task,
+        normalized_config,
+        batch_size=DEFAULT_DUMMY_SHAPES["batch_size"],
+        **kwargs,
+    ):
+        self.batch_size = batch_size
+        config = getattr(normalized_config, "_config", None) or getattr(normalized_config, "config", normalized_config)
+        vit_cfg = getattr(config, "vit_config", None)
+        patch_size = getattr(vit_cfg, "image_patch_size", 14) if vit_cfg else 14
+        h, w = getattr(vit_cfg, "image_default_input_size", (378, 378)) if vit_cfg else (378, 378)
+        h_patches = h // patch_size
+        w_patches = w // patch_size
+        self.n_patches = h_patches * w_patches
+        self.pixels_per_patch = 3 * patch_size * patch_size
+        self.n_crops = 1
+        pool_size = 2
+        pooled_h = (h_patches + pool_size - 1) // pool_size
+        pooled_w = (w_patches + pool_size - 1) // pool_size
+        self.n_pooled = max(1, pooled_h * pooled_w)
+        self.pool_dim = pool_size * pool_size
+
+    def generate(self, input_name, framework="pt", int_dtype="int64", float_dtype="fp32"):
+        if input_name == "images":
+            return self.random_float_tensor(
+                [self.batch_size, self.n_crops, self.n_patches, self.pixels_per_patch],
+                min_value=-1,
+                max_value=1,
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "pooled_patches_idx":
+            max_idx = max(0, self.n_crops * self.n_patches - 1)
+            return self.random_int_tensor(
+                [self.batch_size, self.n_pooled, self.pool_dim],
+                min_value=0,
+                max_value=max_idx,
+                framework=framework,
+                dtype=int_dtype,
+            )
+        raise ValueError(f"Unsupported input {input_name!r} for DummyMolmo2VisionInputGenerator")

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -49,6 +49,8 @@ from optimum.exporters.openvino.input_generators import (
     DummyLLavaMultiModalProjectorInputGenerator,
     DummyMiniCPMVImageInputGenerator,
     DummyMiniCPMVResampleInputGenerator,
+    DummyMolmo2TextPastKeyValuesGenerator,
+    DummyMolmo2VisionInputGenerator,
     DummyPhi3VisionProjectionInputGenerator,
     DummyQwen2VLLMInputGenerator,
     DummyQwen2VLVisionEmbedInputGenerator,
@@ -140,6 +142,8 @@ from optimum.exporters.openvino.model_patcher import (
     MistralModelPatcher,
     MixtralModelPatcher,
     ModelPatcher,
+    Molmo2LMModelPatcher,
+    Molmo2VisionBackbonePatcher,
     MPTModelPatcher,
     OVDecoderModelPatcher,
     OVSeq2SeqModelPatcher,
@@ -268,6 +272,10 @@ def init_model_configs():
         except ImportError:
             pass
 
+    TasksManager._CUSTOM_CLASSES[("pt", "molmo2", "image-text-to-text")] = (
+        "transformers",
+        "AutoModelForImageTextToText",
+    )
     TasksManager._CUSTOM_CLASSES[("pt", "phi4mm", "image-text-to-text")] = ("transformers", "AutoModelForCausalLM")
     TasksManager._CUSTOM_CLASSES[("pt", "phi4mm", "automatic-speech-recognition")] = (
         "transformers",
@@ -6061,3 +6069,128 @@ class TrOCROpenVINOConfig(TextSeq2SeqOpenVINOConfig):
         decoder_num_attention_heads="decoder_attention_heads",
         hidden_size="hidden_size",
     )
+
+
+@register_in_tasks_manager(
+    "molmo2_text",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text-classification",
+    ],
+    library_name="transformers",
+)
+class Molmo2TextOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
+    """Export config for the Molmo2 text-only sub-model (decoder)."""
+
+    MIN_TRANSFORMERS_VERSION = "4.55"
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, DummyMolmo2TextPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = DummyMolmo2TextPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+    _MODEL_PATCHER = OVDecoderModelPatcher
+
+
+@register_in_tasks_manager("molmo2", *["image-text-to-text"], library_name="transformers")
+class Molmo2OpenVINOConfig(BaseVLMOpenVINOConfig):
+    """Export config for the full Molmo2 VLM (molmo2).
+
+    Three subgraphs are exported:
+    * VISION_EMBEDDINGS  - Molmo2VisionBackbone -> (last_hidden_state, valid_token_mask)
+    * TEXT_EMBEDDINGS    - Molmo2Embedding (wte)
+    * LANGUAGE           - Molmo2ForConditionalGeneration with LM head
+    """
+
+    MIN_TRANSFORMERS_VERSION = "4.55"
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyMolmo2VisionInputGenerator,)
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+            behavior=behavior,
+        )
+        self._orig_config = config
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            # Keep full molmo2 config so vit_config + adapter_config are accessible.
+            self._config = config
+            self._normalized_config = NormalizedVisionConfig(config)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return {
+                "images": {0: "batch_size", 1: "num_crops", 2: "num_patches"},
+                "pooled_patches_idx": {0: "batch_size", 1: "num_pooled"},
+            }
+        return {}
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return {
+                "last_hidden_state": {0: "num_image_tokens"},
+                "valid_token_mask": {0: "num_pooled_total"},
+            }
+        return {}
+
+    def with_behavior(self, behavior: Union[str, VLMConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+        if behavior == VLMConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config(
+                "molmo2_text", self._orig_config.text_config, self.int_dtype, self.float_dtype
+            )
+        if behavior == VLMConfigBehavior.LANGUAGE:
+            return get_vlm_text_generation_config(
+                "molmo2_text",
+                self._orig_config.text_config,
+                self.int_dtype,
+                self.float_dtype,
+                model_patcher=Molmo2LMModelPatcher,
+                inputs_update={"token_type_ids": {0: "batch_size", 1: "sequence_length"}},
+            )
+        if behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return self.__class__(
+                self._orig_config,
+                task=self.task,
+                int_dtype=self.int_dtype,
+                float_dtype=self.float_dtype,
+                behavior=behavior,
+                preprocessors=self._preprocessors,
+            )
+
+    def get_model_for_behavior(self, model: "PreTrainedModel", behavior: Union[str, VLMConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, VLMConfigBehavior):
+            behavior = VLMConfigBehavior(behavior)
+        if behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            vision_backbone = model.model.vision_backbone
+            if not hasattr(vision_backbone, "config"):
+                vision_backbone.config = model.config
+            return vision_backbone
+        # TEXT_EMBEDDINGS: base returns model.get_input_embeddings() = Molmo2Embedding (wte)
+        # LANGUAGE: base returns model (has lm_head)
+        return super().get_model_for_behavior(model, behavior)
+
+    def patch_model_for_export(
+        self,
+        model: "PreTrainedModel",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        model_kwargs = model_kwargs or {}
+        if self._behavior != VLMConfigBehavior.VISION_EMBEDDINGS:
+            return super().patch_model_for_export(model, model_kwargs)
+        return Molmo2VisionBackbonePatcher(self, model, model_kwargs)

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -10317,3 +10317,176 @@ class KokoroModelPatcher(ModelPatcher):
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
         self._model.forward = self._model._orig_forward
+
+
+class Molmo2VisionBackbonePatcher(ModelPatcher):
+    """Patcher for Molmo2VisionBackbone.
+
+    Removes the data-dependent boolean index ``[valid_token.flatten()]`` that
+    produces a variable-shape output, which is not traceable.  Instead the
+    patched forward returns ALL pooled features + the valid_token mask so that
+    the OV runtime class can filter in Python.
+
+    OVVisionEmbedding maps the tuple outputs to:
+        last_hidden_state  = pooled_features.view(-1, dim)
+        pooler_output      = valid_token.flatten()
+    """
+
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        model.__orig_forward = model.forward
+
+        def patched_forward(
+            self_bb,
+            images: torch.Tensor,
+            pooled_patches_idx: torch.Tensor,
+        ):
+            batch_size, _num_image = images.shape[:2]
+            images = images.to(device=self_bb.device, dtype=self_bb.dtype)
+            image_features = self_bb.encode_image(images)
+
+            image_features = self_bb.image_feature_dropout(image_features)
+            dim = image_features.shape[-1]
+            valid = pooled_patches_idx >= 0
+            valid_token = torch.any(valid, -1)  # [batch, n_pooled]
+
+            batch_idx = torch.arange(pooled_patches_idx.shape[0], dtype=torch.long, device=pooled_patches_idx.device)
+            batch_idx = torch.tile(
+                batch_idx.view(batch_size, 1, 1),
+                [1, pooled_patches_idx.shape[1], pooled_patches_idx.shape[2]],
+            )
+
+            to_pool = image_features.reshape(batch_size, -1, dim)[batch_idx, torch.clip(pooled_patches_idx, 0)]
+            to_pool = to_pool * valid.to(self_bb.dtype)[:, :, :, None]
+            to_pool = to_pool.reshape([-1, pooled_patches_idx.shape[-1], dim])
+
+            if self_bb.adapter_config.pooling_attention_mask:
+                attn_mask = valid.reshape([-1, 1, 1, valid.shape[-1]])
+                denom = valid.view(-1, to_pool.shape[-2]).float().sum(-1)
+                denom = torch.where(denom == 0, 1, denom)
+                query = to_pool.sum(-2, keepdim=True) / denom[:, None, None].to(to_pool.dtype)
+            else:
+                attn_mask = None
+                query = to_pool.mean(-2, keepdim=True)
+
+            pooled_features = self_bb.image_pooling_2d(query, to_pool, attn_mask=attn_mask)
+            pooled_features = pooled_features.reshape([batch_size, -1, pooled_features.shape[-1]])
+            pooled_features = self_bb.image_projector(pooled_features)
+
+            # Return ALL features (no boolean index) + valid mask — data-dependent
+            # indexing removed for traceability.
+            return pooled_features.view(-1, pooled_features.shape[-1]), valid_token.flatten()
+
+        model.forward = types.MethodType(patched_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
+class Molmo2LMModelPatcher(OVDecoderModelPatcher):
+    """Patcher for Molmo2ForConditionalGeneration (language model subgraph).
+
+    Unconditionally wraps forward to:
+    1. Convert legacy past_key_values tuple → DynamicCache.
+    2. Pre-compute 4D bidirectional attention mask via _gemma3_mm_update_causal_mask.
+    3. Patch ``create_causal_mask`` in the molmo2 module to pass a 4D mask unchanged.
+    4. Call original forward with inputs_embeds + 4D mask.
+    5. Convert DynamicCache back to legacy tuple via postprocess_past_key_values.
+    """
+
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        def forward(
+            self_model,
+            attention_mask,
+            position_ids,
+            past_key_values,
+            token_type_ids,
+            inputs_embeds,
+            use_cache=True,
+        ):
+            pkv = DynamicCache(past_key_values)
+
+            past_seen_tokens = past_key_values[0][0].shape[-2]
+            cache_position = torch.arange(
+                past_seen_tokens,
+                past_seen_tokens + inputs_embeds.shape[1],
+                device=inputs_embeds.device,
+            )
+
+            # The bidirectional image mask only matters during prefill, where
+            # ``token_type_ids`` and ``inputs_embeds`` share the same sequence length.
+            # When tracing the decode-with-past subgraph the dummy ``token_type_ids``
+            # spans the full target length; align it with the current tokens so the
+            # 4D mask construction stays shape-consistent.
+            if token_type_ids is not None and token_type_ids.shape[1] != inputs_embeds.shape[1]:
+                token_type_ids = token_type_ids[:, : inputs_embeds.shape[1]]
+
+            # Build 4D bidirectional attention mask (reuse Gemma3 helper)
+            mask4d = _gemma3_mm_update_causal_mask(
+                self_model,
+                attention_mask,
+                token_type_ids,
+                None,
+                cache_position,
+                inputs_embeds,
+            )
+
+            result = self_model.__orig_forward(
+                input_ids=None,
+                inputs_embeds=inputs_embeds,
+                attention_mask=mask4d,
+                position_ids=position_ids,
+                past_key_values=pkv,
+                cache_position=cache_position,
+                use_cache=use_cache,
+                logits_to_keep=0,
+            )
+            upd_pkv = result["past_key_values"]
+            result["past_key_values"] = postprocess_past_key_values(upd_pkv)
+            return result
+
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __enter__(self):
+        import inspect as _inspect
+
+        super().__enter__()
+        # Patch create_causal_mask in the molmo2 module so a 4D mask is returned unchanged.
+        # Both Molmo2Model and Molmo2TextModel call it independently from the same module.
+        module = _inspect.getmodule(type(self._model))
+        if module is not None and hasattr(module, "create_causal_mask"):
+            self._orig_molmo2_create_causal_mask = module.create_causal_mask
+            orig_cc = self._orig_molmo2_create_causal_mask
+
+            def _passthrough_create_causal_mask(**kwargs):
+                attn_mask = kwargs.get("attention_mask")
+                if isinstance(attn_mask, torch.Tensor) and attn_mask.dim() == 4:
+                    return attn_mask
+                return orig_cc(**kwargs)
+
+            module.create_causal_mask = _passthrough_create_causal_mask
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        import inspect as _inspect
+
+        super().__exit__(exc_type, exc_value, traceback)
+        # Restore create_causal_mask
+        module = _inspect.getmodule(type(self._model))
+        if module is not None and hasattr(self, "_orig_molmo2_create_causal_mask"):
+            module.create_causal_mask = self._orig_molmo2_create_causal_mask
+            del self._orig_molmo2_create_causal_mask
+        # Restore original forward
+        self._model.forward = self._model.__orig_forward

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -337,6 +337,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "llama4",
     "minicpmo",
     "videochat_flash_qwen",
+    "molmo2",
 ]
 
 SSM_MODELS = [

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -5933,6 +5933,286 @@ class _OVQwen3_5ForCausalLM(OVModelForVisualCausalLM, Qwen3_5Model, Qwen3_5Visio
         return super().generate(*args, **kwargs)
 
 
+class _OVMolmo2ForCausalLM(OVModelForVisualCausalLM):
+    """OpenVINO runtime class for allenai/MolmoWeb-4B and the Molmo2 model family.
+
+    Three OV subgraphs:
+    * vision_embeddings : (images, pooled_patches_idx) -> (last_hidden_state, valid_token_mask)
+    * text_embeddings   : (input_ids,) -> (inputs_embeds,)
+    * language_model    : (inputs_embeds, attention_mask, position_ids,
+                           token_type_ids, past_key_values) -> (logits, past_key_values)
+    """
+
+    # ------------------------------------------------------------------ #
+    # Vision helpers                                                       #
+    # ------------------------------------------------------------------ #
+
+    def get_vision_embeddings(
+        self,
+        pixel_values,
+        input_ids=None,
+        image_token_pooling=None,
+        image_grids=None,
+        image_num_crops=None,
+        **kwargs,
+    ):
+        """Run Molmo2VisionBackbone OV subgraph and return filtered feature vectors.
+
+        Returns None during decode steps (input_ids.shape[1] == 1).
+        """
+        if input_ids is not None and input_ids.shape[1] == 1:
+            return None
+        if pixel_values is None:
+            return None
+
+        images, pooled_patches_idx = self._build_batched_images(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            image_token_pooling=image_token_pooling,
+            image_grids=image_grids,
+            image_num_crops=image_num_crops,
+        )
+
+        out = self.vision_embeddings(images, pooled_patches_idx=pooled_patches_idx)
+        feats = out.last_hidden_state  # [total_pooled, dim]
+        valid_mask = out.pooler_output  # [total_pooled]
+
+        if isinstance(valid_mask, np.ndarray):
+            feats = feats[valid_mask.astype(bool)]
+        else:
+            feats = feats[valid_mask.bool()]
+
+        return feats
+
+    def _build_batched_images(
+        self,
+        input_ids,
+        pixel_values,
+        image_token_pooling,
+        image_grids,
+        image_num_crops,
+    ):
+        """Python port of Molmo2Model.build_batched_images.
+
+        Converts flat pixel_values tensor + per-image metadata into padded
+        (images, pooled_patches_idx) tensors consumed by the vision backbone.
+        """
+
+        # -------------------------------------------------------------- #
+        # Helper: cast numpy arrays to tensors
+        # -------------------------------------------------------------- #
+        def _to_tensor(x):
+            return torch.from_numpy(x) if isinstance(x, np.ndarray) else x
+
+        input_ids = _to_tensor(input_ids)
+        pixel_values = _to_tensor(pixel_values)
+        image_token_pooling = _to_tensor(image_token_pooling)
+        image_grids = _to_tensor(image_grids)
+        image_num_crops = _to_tensor(image_num_crops)
+
+        image_end_token_id = self.config.image_end_token_id
+        # Each image contributes 2 image_end tokens (start + end sentinel)
+        raw_counts = (input_ids == image_end_token_id).sum(1)
+        counts = raw_counts // 2  # number of images per batch item [N]
+        N = counts.size(0)
+        device = input_ids.device
+
+        first_prod = image_grids[:, :2].prod(dim=1)
+        second_prod = image_grids[:, 2:].prod(dim=1)
+        num_pooled_patches_per_image = (first_prod + second_prod).to(image_num_crops.dtype)
+
+        n_crops, n_patches, pixels_per_patch = pixel_values.shape
+
+        example_ids_for_image = torch.arange(N, device=device).repeat_interleave(counts)
+
+        crops_per_example = torch.zeros(N, dtype=image_num_crops.dtype, device=image_num_crops.device)
+        crops_per_example.index_add_(0, example_ids_for_image, image_num_crops)
+        patches_per_image = image_num_crops * n_patches
+
+        counts_list = [int(x) for x in counts.tolist()]
+        index_offset_per_example_list = []
+        offset_img = 0
+        for c in counts_list:
+            per_img_patches = patches_per_image[offset_img : offset_img + c]
+            index_offset = [0] + per_img_patches.cumsum(0).tolist()[:-1]
+            index_offset_per_example_list.append(index_offset)
+            offset_img += c
+
+        num_pooled_patches_per_example = torch.zeros(
+            N,
+            dtype=num_pooled_patches_per_image.dtype,
+            device=num_pooled_patches_per_image.device,
+        )
+        num_pooled_patches_per_example.index_add_(0, example_ids_for_image, num_pooled_patches_per_image)
+
+        M = int(crops_per_example.max().item())
+        images = torch.full(
+            (N, M, n_patches, pixels_per_patch),
+            fill_value=-1,
+            dtype=pixel_values.dtype,
+            device=pixel_values.device,
+        )
+        offset_crop = 0
+        for i in range(N):
+            num = int(crops_per_example[i].item())
+            images[i, :num] = pixel_values[offset_crop : offset_crop + num]
+            offset_crop += num
+
+        P = int(num_pooled_patches_per_example.max().item())
+        _, pool_dim = image_token_pooling.shape
+        new_token_pooling = torch.full(
+            (N, P, pool_dim),
+            fill_value=-1,
+            dtype=image_token_pooling.dtype,
+            device=image_token_pooling.device,
+        )
+
+        patch_offset = 0
+        img_offset = 0
+        for i, c in enumerate(counts_list):
+            num_patches = int(num_pooled_patches_per_example[i].item())
+            cur = image_token_pooling[patch_offset : patch_offset + num_patches].clone()
+
+            index_offset_per_example = index_offset_per_example_list[i]
+            per_img_pooled = num_pooled_patches_per_image[img_offset : img_offset + c]
+
+            offset = 0
+            for j in range(c):
+                idx_off = int(index_offset_per_example[j])
+                n = int(per_img_pooled[j].item())
+                cur_slice = cur[offset : offset + n]
+                cur[offset : offset + n] = torch.where(cur_slice >= 0, cur_slice + idx_off, cur_slice)
+                offset += n
+
+            new_token_pooling[i, :num_patches] = cur
+            patch_offset += num_patches
+            img_offset += c
+
+        return images, new_token_pooling
+
+    # ------------------------------------------------------------------ #
+    # Text / merge helpers                                                 #
+    # ------------------------------------------------------------------ #
+
+    def get_text_embeddings(self, input_ids, **kwargs):
+        """Embed input_ids, clamping -1 padding indices before the lookup."""
+        if isinstance(input_ids, np.ndarray):
+            input_ids_t = torch.from_numpy(input_ids)
+        else:
+            input_ids_t = input_ids
+        input_ids_clamped = input_ids_t * (input_ids_t != -1).to(input_ids_t.dtype)
+        return self.language_model.embed_tokens(input_ids_clamped)
+
+    def merge_vision_text_embeddings(
+        self,
+        vision_embeds,
+        inputs_embeds,
+        input_ids=None,
+        attention_mask=None,
+        position_ids=None,
+        **kwargs,
+    ):
+        """Scatter-ADD vision features into inputs_embeds at image_patch_id positions.
+
+        Molmo2 uses ``+=`` (not replace) for the image placeholder tokens.
+        """
+        image_features = torch.from_numpy(vision_embeds) if isinstance(vision_embeds, np.ndarray) else vision_embeds
+        inputs_embeds_t = torch.from_numpy(inputs_embeds) if isinstance(inputs_embeds, np.ndarray) else inputs_embeds
+
+        if input_ids is not None:
+            input_ids_t = torch.from_numpy(input_ids) if isinstance(input_ids, np.ndarray) else input_ids
+            is_image_patch = input_ids_t.view(-1) == self.config.image_patch_id
+            if is_image_patch.sum() > 0:
+                image_features = image_features.to(dtype=inputs_embeds_t.dtype)
+                flat_embeds = inputs_embeds_t.view(-1, inputs_embeds_t.shape[-1])
+                flat_embeds[is_image_patch] = flat_embeds[is_image_patch] + image_features
+                inputs_embeds_t = flat_embeds.view(inputs_embeds_t.shape)
+
+        return inputs_embeds_t, attention_mask, position_ids
+
+    # ------------------------------------------------------------------ #
+    # Generation helpers                                                   #
+    # ------------------------------------------------------------------ #
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        pixel_values=None,
+        attention_mask=None,
+        token_type_ids=None,
+        image_token_pooling=None,
+        image_grids=None,
+        image_num_crops=None,
+        **kwargs,
+    ):
+        model_inputs = super().prepare_inputs_for_generation(
+            input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            **kwargs,
+        )
+        # Pass Molmo2-specific image metadata on the prefill step
+        if past_key_values is None:
+            model_inputs["image_token_pooling"] = image_token_pooling
+            model_inputs["image_grids"] = image_grids
+            model_inputs["image_num_crops"] = image_num_crops
+        return model_inputs
+
+    def _update_model_kwargs_for_generation(
+        self,
+        outputs,
+        model_kwargs: Dict[str, Any],
+        is_encoder_decoder: bool = False,
+        num_new_tokens: int = 1,
+    ) -> Dict[str, Any]:
+        model_kwargs = super()._update_model_kwargs_for_generation(
+            outputs=outputs,
+            model_kwargs=model_kwargs,
+            is_encoder_decoder=is_encoder_decoder,
+            num_new_tokens=num_new_tokens,
+        )
+        # Drop prefill-only inputs after the first generation step
+        model_kwargs.pop("token_type_ids", None)
+        model_kwargs.pop("image_token_pooling", None)
+        model_kwargs.pop("image_grids", None)
+        model_kwargs.pop("image_num_crops", None)
+        return model_kwargs
+
+    # ------------------------------------------------------------------ #
+    # Preprocessing                                                        #
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image=None,
+        processor=None,
+        tokenizer=None,
+        config=None,
+        video=None,
+        audio=None,
+    ):
+        if processor is None:
+            raise ValueError("A processor is required for Molmo2.")
+        if video is not None:
+            raise ValueError("Video input is not supported for Molmo2.")
+        if audio is not None:
+            raise ValueError("Audio input is not supported for Molmo2.")
+
+        conversation = [{"role": "user", "content": [{"type": "text", "text": text}]}]
+        if image is not None:
+            conversation[0]["content"].insert(0, {"type": "image"})
+
+        text_prompt = processor.apply_chat_template(conversation, add_generation_prompt=True, tokenize=False)
+        inputs = processor(images=image, text=text_prompt, return_tensors="pt")
+        return inputs
+
+
 MODEL_TYPE_TO_CLS_MAPPING = {
     "llava": _OVLlavaForCausalLM,
     "llava_next": _OVLlavaNextForCausalLM,
@@ -5962,4 +6242,6 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen3_5_moe_text": _OVQwen3_5ForCausalLM,
     "minicpmo": _OVMiniCPMOForCausalLM,
     "videochat_flash_qwen": _OVVideoChatFlashQwenForCausalLM,
+    "molmo2": _OVMolmo2ForCausalLM,
+    "molmo2_text": _OVMolmo2ForCausalLM,
 }

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -134,6 +134,9 @@ class ExportModelTest(unittest.TestCase):
     if is_transformers_version(">=", "4.49") and is_transformers_version("<=", "4.57.6"):
         SUPPORTED_ARCHITECTURES.update({"videochat_flash_qwen": OVModelForVisualCausalLM})
 
+    if is_transformers_version(">=", "4.55") and is_transformers_version("<", "5"):
+        SUPPORTED_ARCHITECTURES.update({"molmo2": OVModelForVisualCausalLM})
+
     if is_transformers_version(">=", "5.0"):
         SUPPORTED_ARCHITECTURES.update({"lfm2_moe": OVModelForCausalLM})
 
@@ -170,7 +173,7 @@ class ExportModelTest(unittest.TestCase):
             model_class = TasksManager.get_model_class_for_task(task, library=library_name)
             model = model_class(f"hf_hub:{model_name}", pretrained=True, exportable=True)
             TasksManager.standardize_model_attributes(model_name, model, library_name=library_name)
-        elif model_type in ["llava", "videochat_flash_qwen"]:
+        elif model_type in ["llava", "videochat_flash_qwen", "molmo2"]:
             model = MODEL_TYPE_TO_CLS_MAPPING[model_type].auto_model_class.from_pretrained(
                 model_name, **loading_kwargs
             )

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -41,9 +41,12 @@ def _create_tiny_kokoro_model():
     if config_file.exists() and weights_file.exists() and voice_file.exists():
         return str(output_dir)
 
-    from kokoro.istftnet import Decoder
-    from kokoro.modules import CustomAlbert, ProsodyPredictor, TextEncoder
-    from transformers import AlbertConfig
+    try:
+        from kokoro.istftnet import Decoder
+        from kokoro.modules import CustomAlbert, ProsodyPredictor, TextEncoder
+        from transformers import AlbertConfig
+    except ImportError:
+        return "hexgrad/Kokoro-82M"
 
     output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -140,6 +143,81 @@ def _create_tiny_kokoro_model():
     torch.save(torch.randn(256, dtype=torch.float32), voice_file)
 
     return str(output_dir)
+
+
+def _create_tiny_molmo2_model():
+    """Generate a tiny random Molmo2 model for testing and return its local path.
+
+    Falls back to the original Hub id if tiny model creation fails.
+    Result is cached on disk under the system temp dir, so subsequent calls are cheap.
+    """
+    output_dir = Path(tempfile.gettempdir()) / "optimum_intel_tiny_random_molmo2"
+    config_file = output_dir / "config.json"
+    weights_files = ("model.safetensors", "pytorch_model.bin", "model.bin")
+    if config_file.exists() and any((output_dir / weight_name).exists() for weight_name in weights_files):
+        with open(config_file, "r", encoding="utf-8") as f:
+            cached_config = json.load(f)
+
+        cached_vit_config = cached_config.get("vit_config", {})
+        cached_text_config = cached_config.get("text_config", {})
+        if (
+            cached_vit_config.get("hidden_size") == 64
+            and cached_vit_config.get("image_default_input_size") == [28, 28]
+            and cached_vit_config.get("image_num_pos") == 4
+            and cached_config.get("adapter_config", {}).get("text_hidden_size") == 64
+            and cached_config.get("adapter_config", {}).get("vit_layers") == [-1, -2]
+            and cached_text_config.get("hidden_size") == 64
+        ):
+            return str(output_dir)
+
+    try:
+        from transformers import AutoConfig, AutoModelForImageTextToText
+
+        config = AutoConfig.from_pretrained("allenai/MolmoWeb-4B", trust_remote_code=True)
+
+        config.vit_config.num_hidden_layers = 2
+        config.vit_config.hidden_size = 64
+        config.vit_config.intermediate_size = 128
+        config.vit_config.num_attention_heads = 4
+        config.vit_config.num_key_value_heads = 4
+        config.vit_config.head_dim = 16
+        config.vit_config.image_default_input_size = (28, 28)
+        config.vit_config.image_patch_size = 14
+        config.vit_config.image_num_pos = 4
+
+        if hasattr(config.adapter_config, "num_layers"):
+            config.adapter_config.num_layers = 2
+        if hasattr(config.adapter_config, "dim"):
+            config.adapter_config.dim = 64
+        if hasattr(config.adapter_config, "hidden_size"):
+            config.adapter_config.hidden_size = 64
+        if hasattr(config.adapter_config, "text_hidden_size"):
+            config.adapter_config.text_hidden_size = 64
+        if hasattr(config.adapter_config, "intermediate_size"):
+            config.adapter_config.intermediate_size = 128
+        if hasattr(config.adapter_config, "num_attention_heads"):
+            config.adapter_config.num_attention_heads = 4
+        if hasattr(config.adapter_config, "num_key_value_heads"):
+            config.adapter_config.num_key_value_heads = 4
+        if hasattr(config.adapter_config, "head_dim"):
+            config.adapter_config.head_dim = 16
+        if hasattr(config.adapter_config, "vit_layers"):
+            config.adapter_config.vit_layers = [-1, -2]
+
+        config.text_config.num_hidden_layers = 2
+        config.text_config.hidden_size = 64
+        config.text_config.intermediate_size = 128
+        config.text_config.num_attention_heads = 2
+        config.text_config.num_key_value_heads = 2
+        config.text_config.head_dim = 32
+        config.text_config.vocab_size = 152064
+
+        model = AutoModelForImageTextToText.from_config(config, trust_remote_code=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        model.save_pretrained(output_dir)
+        return str(output_dir)
+    except Exception:
+        return "allenai/MolmoWeb-4B"
 
 
 SEED = 42
@@ -259,6 +337,7 @@ MODEL_NAMES = {
     "minicpm3": "optimum-intel-internal-testing/tiny-random-minicpm3",
     "minicpmv": "optimum-intel-internal-testing/tiny-random-minicpmv-2_6",
     "minicpmo": "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
+    "molmo2": _create_tiny_molmo2_model(),
     "mistral": "optimum-intel-internal-testing/tiny-random-mistral",
     "mistral-nemo": "optimum-intel-internal-testing/tiny-random-mistral-nemo",
     "mixtral": "optimum-intel-internal-testing/tiny-mixtral",
@@ -594,6 +673,7 @@ REMOTE_CODE_MODELS = (
     "qwen3_vl_eagle3",
     "qwen3_asr",
     "videochat_flash_qwen",
+    "molmo2",
 )
 
 if is_transformers_version("<", "5"):
@@ -612,6 +692,7 @@ ARCH_TO_MODEL_CLASS = {
     "qwen3_moe": "OVModelForCausalLM",
     "llama4": "OVModelForCausalLM",
     "llava": "OVModelForVisualCausalLM",
+    "molmo2": "OVModelForVisualCausalLM",
     "qwen3_5_moe": "OVModelForVisualCausalLM",
     "gemma4_moe": "OVModelForVisualCausalLM",
     "gemma4_unified": "OVModelForVisualCausalLM",


### PR DESCRIPTION
# What does this PR do?

Adds OpenVINO export and inference support for [`allenai/MolmoWeb-4B`](https://huggingface.co/allenai/MolmoWeb-4B) and the **Molmo2** model family (`model_type="molmo2"`, text sub-model `model_type="molmo2_text"`).

Molmo2 is a multimodal VLM (SigLIP-2-style ViT + pooling adapter + Qwen3-like LLM with bidirectional image-token attention driven by `token_type_ids`), architecturally close to Gemma3. The model is exported as three OpenVINO subgraphs:

- **vision_embeddings** — `Molmo2VisionBackbone(images, pooled_patches_idx) → (last_hidden_state, valid_token_mask)`
- **text_embeddings** — token embedding (`wte`)
- **language_model** — decoder + LM head, stateful KV-cache

## Installation instructions

```sh
pip install git+https://github.com/mlukasze/optimum-intel.git@enable/allenai-MolmoWeb-4B
pip install -U openvino openvino-tokenizers nncf
pip install "transformers>=4.55,<5.0" einops torchvision accelerate pillow
```

## Exporting cmd-line

```sh
optimum-cli export openvino -m allenai/MolmoWeb-4B ov_molmoweb4b_fp16 \
    --task image-text-to-text --trust-remote-code
```

INT8 / INT4 weight compression:

```sh
optimum-cli export openvino -m allenai/MolmoWeb-4B ov_molmoweb4b_int8 \
    --task image-text-to-text --weight-format int8 --trust-remote-code

optimum-cli export openvino -m allenai/MolmoWeb-4B ov_molmoweb4b_int4 \
    --task image-text-to-text --weight-format int4 --trust-remote-code
```

## Inference script

```python
from PIL import Image
import requests
from optimum.intel import OVModelForVisualCausalLM
from transformers import AutoProcessor

model_dir = "ov_molmoweb4b_fp16"  # or int8 / int4

processor = AutoProcessor.from_pretrained(model_dir, trust_remote_code=True)
model = OVModelForVisualCausalLM.from_pretrained(model_dir, trust_remote_code=True)

image_url = "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/tasks/car.jpg"
image = Image.open(requests.get(image_url, stream=True).raw).convert("RGB")

conversation = [
    {"role": "user", "content": [
        {"type": "image"},
        {"type": "text", "text": "Describe this image."}
    ]}
]
text_prompt = processor.apply_chat_template(
    conversation, add_generation_prompt=True, tokenize=False
)
inputs = processor(text=text_prompt, images=[image], return_tensors="pt")

outputs = model.generate(**inputs, max_new_tokens=200, do_sample=False)
response = processor.decode(
    outputs[0][inputs["input_ids"].shape[1]:], skip_special_tokens=True
)
print(response)
```

## Validation (real 4B weights, OpenVINO 2026.2.1 / transformers 4.57.3)

**Export** — all three subgraphs succeed at FP16, INT8, and INT4 (group_size=128).

**Parity — OV FP16 (CPU) vs PyTorch FP32**

| Metric | Value |
| :-- | :-- |
| Logits cosine similarity (mean) | 0.999999 |
| Argmax match | 99.10 % |
| Generated text | identical to PyTorch reference ✅ |

**Inference — TTFT / ITL (ms), 32 new tokens, single image (Intel Core Ultra 9 285K + Arc Pro B60)**

| Precision | CPU | iGPU | Arc Pro B60 (dGPU) |
| :-- | :-- | :-- | :-- |
| FP16 | 10 974 / 145.5 | 9 104 / 161.0 | **264 / 26.6** |
| INT8 | 5 327 / 76.7 | 6 480 / 98.4 | **231 / 15.7** |
| INT4 | 5 582 / 54.9 | 5 087 / 72.1 | **234 / 12.7** |

All 9 device × precision combinations produce correct image descriptions. dGPU TTFT is ~13–24× faster than CPU.

## Notes

- `transformers>=4.55,<5.0` required — Molmo2 uses remote code not yet compatible with transformers 5.x.
- `trust_remote_code=True` is required for both export and inference.
- NPU is not supported (stateful KV-cache LLM).

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
