### PR TITLE
CI: use local cached models to avoid rate limit for fork PRs

### DIFF
--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -28,7 +28,7 @@ from diffusers import (
 from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from diffusers.utils import load_image
 from parameterized import parameterized
-from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, SEED
+from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, SEED, HUB_MODEL_NAMES
 
 from optimum.intel.openvino import (
     OVDiffusionPipeline,
@@ -117,7 +117,7 @@ class OVPipelineForText2ImageTest(unittest.TestCase):
     @require_diffusers
     def test_load_vanilla_model_which_is_not_supported(self):
         with self.assertRaises(Exception) as context:
-            _ = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES["bert"], export=True, device=OPENVINO_DEVICE)
+            _ = self.OVMODEL_CLASS.from_pretrained(HUB_MODEL_NAMES["bert"], export=True, device=OPENVINO_DEVICE)
 
         self.assertIn(f"does not appear to have a file named {self.OVMODEL_CLASS.config_name}", str(context.exception))
 
@@ -534,7 +534,7 @@ class OVPipelineForImage2ImageTest(unittest.TestCase):
     @require_diffusers
     def test_load_vanilla_model_which_is_not_supported(self):
         with self.assertRaises(Exception) as context:
-            _ = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES["bert"], export=True, device=OPENVINO_DEVICE)
+            _ = self.OVMODEL_CLASS.from_pretrained(HUB_MODEL_NAMES["bert"], export=True, device=OPENVINO_DEVICE)
 
         self.assertIn(f"does not appear to have a file named {self.OVMODEL_CLASS.config_name}", str(context.exception))
 
@@ -798,7 +798,7 @@ class OVPipelineForInpaintingTest(unittest.TestCase):
     @require_diffusers
     def test_load_vanilla_model_which_is_not_supported(self):
         with self.assertRaises(Exception) as context:
-            _ = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES["bert"], export=True, device=OPENVINO_DEVICE)
+            _ = self.OVMODEL_CLASS.from_pretrained(HUB_MODEL_NAMES["bert"], export=True, device=OPENVINO_DEVICE)
 
         self.assertIn(f"does not appear to have a file named {self.OVMODEL_CLASS.config_name}", str(context.exception))
 
@@ -1071,7 +1071,7 @@ class OVPipelineForText2VideoTest(unittest.TestCase):
     @require_diffusers
     def test_load_vanilla_model_which_is_not_supported(self):
         with self.assertRaises(Exception) as context:
-            _ = self.OVMODEL_CLASS.from_pretrained(MODEL_NAMES["bert"], export=True, device=OPENVINO_DEVICE)
+            _ = self.OVMODEL_CLASS.from_pretrained(HUB_MODEL_NAMES["bert"], export=True, device=OPENVINO_DEVICE)
 
         self.assertIn(f"does not appear to have a file named {self.OVMODEL_CLASS.config_name}", str(context.exception))
 

--- a/tests/openvino/test_diffusion.py
+++ b/tests/openvino/test_diffusion.py
@@ -28,7 +28,7 @@ from diffusers import (
 from diffusers.pipelines.stable_diffusion import StableDiffusionSafetyChecker
 from diffusers.utils import load_image
 from parameterized import parameterized
-from utils_tests import MODEL_NAMES, OPENVINO_DEVICE, SEED, HUB_MODEL_NAMES
+from utils_tests import HUB_MODEL_NAMES, MODEL_NAMES, OPENVINO_DEVICE, SEED
 
 from optimum.intel.openvino import (
     OVDiffusionPipeline,

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -29,6 +29,7 @@ from transformers import (
 from utils_tests import (
     _ARCHITECTURES_TO_EXPECTED_INT8,
     MODEL_NAMES,
+    HUB_MODEL_NAMES,
     OPENVINO_DEVICE,
     REMOTE_CODE_MODELS,
     TEST_NAME_TO_MODEL_TYPE,
@@ -1178,7 +1179,7 @@ class OVCLIExportTestCase(unittest.TestCase):
     ):
         with TemporaryDirectory() as tmpdir:
             subprocess.run(
-                f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} --dataset laion/filtered-wit --weight-format int8 {tmpdir}",
+                f"optimum-cli export openvino --model {HUB_MODEL_NAMES[model_type]} --dataset laion/filtered-wit --weight-format int8 {tmpdir}",
                 shell=True,
                 check=True,
             )

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -28,8 +28,8 @@ from transformers import (
 )
 from utils_tests import (
     _ARCHITECTURES_TO_EXPECTED_INT8,
-    MODEL_NAMES,
     HUB_MODEL_NAMES,
+    MODEL_NAMES,
     OPENVINO_DEVICE,
     REMOTE_CODE_MODELS,
     TEST_NAME_TO_MODEL_TYPE,

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -56,7 +56,15 @@ from transformers import (
 )
 from transformers.testing_utils import slow
 from transformers.utils import http_user_agent
-from utils_tests import F32_CONFIG, MODEL_NAMES, OPENVINO_DEVICE, SEED, TENSOR_ALIAS_TO_TYPE, TEST_IMAGE_URL, HUB_MODEL_NAMES
+from utils_tests import (
+    F32_CONFIG,
+    HUB_MODEL_NAMES,
+    MODEL_NAMES,
+    OPENVINO_DEVICE,
+    SEED,
+    TENSOR_ALIAS_TO_TYPE,
+    TEST_IMAGE_URL,
+)
 
 from optimum.intel import (
     OVDiffusionPipeline,

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -56,7 +56,7 @@ from transformers import (
 )
 from transformers.testing_utils import slow
 from transformers.utils import http_user_agent
-from utils_tests import F32_CONFIG, MODEL_NAMES, OPENVINO_DEVICE, SEED, TENSOR_ALIAS_TO_TYPE, TEST_IMAGE_URL
+from utils_tests import F32_CONFIG, MODEL_NAMES, OPENVINO_DEVICE, SEED, TENSOR_ALIAS_TO_TYPE, TEST_IMAGE_URL, HUB_MODEL_NAMES
 
 from optimum.intel import (
     OVDiffusionPipeline,
@@ -628,7 +628,7 @@ class OVModelIntegrationTest(unittest.TestCase):
     @parameterized.expand(("stable-diffusion", "stable-diffusion-openvino"))
     def test_find_files_matching_pattern_sd(self, model_arch):
         pattern = r"(.*)?openvino(.*)?\_model(.*)?.xml$"
-        model_id = MODEL_NAMES[model_arch]
+        model_id = HUB_MODEL_NAMES[model_arch]
         # hub model
         ov_files = _find_files_matching_pattern(model_id, pattern=pattern)
         self.assertTrue(len(ov_files) > 0 if "openvino" in model_id else len(ov_files) == 0)
@@ -1630,8 +1630,8 @@ class OVModelForCustomTasksIntegrationTest(unittest.TestCase):
 
 
 class OVModelForOpenCLIPZeroShortImageClassificationTest(unittest.TestCase):
-    OV_MODEL_ID = MODEL_NAMES["open-clip"]
-    OV_MODEL_ID_IR = MODEL_NAMES["open-clip-ov"]
+    OV_MODEL_ID = HUB_MODEL_NAMES["open-clip"]
+    OV_MODEL_ID_IR = HUB_MODEL_NAMES["open-clip-ov"]
 
     def _get_sample_image(self):
         url = TEST_IMAGE_URL

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -90,6 +90,7 @@ from utils_tests import (
     get_supported_model_for_library,
     TEST_NAME_TO_MODEL_TYPE,
     OPENVINO_DEVICE,
+    HUB_MODEL_NAMES,
 )
 
 _TASK_TO_DATASET = {
@@ -1494,11 +1495,11 @@ class OVWeightCompressionTest(unittest.TestCase):
     def test_ovmodel_default_ignored_scope(self, model_cls, model_type, expected_ignored_scope_per_model):
         with unittest.mock.patch.dict(
             "optimum.intel.openvino.configuration._DEFAULT_IGNORED_SCOPE_CONFIGS",
-            {MODEL_NAMES[model_type]: expected_ignored_scope_per_model},
+            {HUB_MODEL_NAMES[model_type]: expected_ignored_scope_per_model},
             clear=False,
         ):
             with TemporaryDirectory() as tmp_dir:
-                model_id = MODEL_NAMES[model_type]
+                model_id = HUB_MODEL_NAMES[model_type]
                 model = model_cls.from_pretrained(
                     model_id,
                     export=True,

--- a/tests/openvino/test_transformations.py
+++ b/tests/openvino/test_transformations.py
@@ -19,7 +19,7 @@ import textwrap
 import unittest
 
 from parameterized import parameterized
-from utils_tests import ARCH_TO_MODEL_CLASS, MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS
+from utils_tests import ARCH_TO_MODEL_CLASS, MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS, HUB_MODEL_NAMES
 
 from optimum.intel.utils.import_utils import is_openvino_version, is_transformers_version
 

--- a/tests/openvino/test_transformations.py
+++ b/tests/openvino/test_transformations.py
@@ -19,7 +19,7 @@ import textwrap
 import unittest
 
 from parameterized import parameterized
-from utils_tests import ARCH_TO_MODEL_CLASS, MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS, HUB_MODEL_NAMES
+from utils_tests import ARCH_TO_MODEL_CLASS, MODEL_NAMES, OPENVINO_DEVICE, REMOTE_CODE_MODELS
 
 from optimum.intel.utils.import_utils import is_openvino_version, is_transformers_version
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -23,6 +23,7 @@ from typing import Dict, Optional
 import numpy as np
 import openvino as ov
 import torch
+from huggingface_hub import constants, scan_cache_dir
 
 from optimum.exporters.tasks import TasksManager
 from optimum.intel.utils.import_utils import is_transformers_version
@@ -150,7 +151,7 @@ TENSOR_ALIAS_TO_TYPE = {"pt": torch.Tensor, "np": np.ndarray}
 
 OPENVINO_DEVICE = os.getenv("OPENVINO_TEST_DEVICE", "CPU")
 
-MODEL_NAMES = {
+HUB_MODEL_NAMES = {
     "afmoe": "optimum-intel-internal-testing/tiny-random-trinity",
     "albert": "optimum-intel-internal-testing/tiny-random-albert",
     "aquila": "optimum-intel-internal-testing/tiny-random-aquilachat",
@@ -359,6 +360,24 @@ MODEL_NAMES = {
     "qwen3_vl_eagle3": "optimum-intel-internal-testing/tiny-random-qwen3-vl-eagle3",
     "videochat_flash_qwen": "optimum-intel-internal-testing/tiny-videochat-flash-qwen",
 }
+
+
+def _resolve_cached_model_paths(model_names: dict) -> dict:
+    try:
+        if not os.path.exists(constants.HF_HUB_CACHE):
+            return model_names
+
+        repo_id_to_local_paths = {
+            repo.repo_id: str(next(iter(repo.revisions)).snapshot_path)
+            for repo in scan_cache_dir().repos
+            if repo.revisions
+        }
+        return {k: repo_id_to_local_paths.get(v, v) for k, v in model_names.items()}
+    except Exception:
+        return model_names
+
+
+MODEL_NAMES = _resolve_cached_model_paths(HUB_MODEL_NAMES)
 
 EAGLE3_MODELS = {"qwen3_eagle3": ("AngelSlim/Qwen3-1.7B_eagle3", "Qwen/Qwen3-1.7B")}
 

--- a/tests/scripts/download_cached_models.py
+++ b/tests/scripts/download_cached_models.py
@@ -20,7 +20,7 @@ from huggingface_hub import HfApi, constants, scan_cache_dir, snapshot_download
 
 sys.path.insert(0, str(Path(__file__).parents[1] / "openvino"))
 
-from utils_tests import MODEL_NAMES
+from utils_tests import HUB_MODEL_NAMES
 
 
 # github actions repo cache limit is 10 GB so using 9 GB
@@ -41,7 +41,7 @@ def hub_size(api: HfApi, repo_id: str) -> int:
 def main() -> None:
     api = HfApi()
     candidates = {}
-    for name, repo_id in MODEL_NAMES.items():
+    for name, repo_id in HUB_MODEL_NAMES.items():
         if not isinstance(repo_id, str) or not repo_id or repo_id.startswith("/"):
             continue
         candidates[repo_id] = name
@@ -93,8 +93,8 @@ def main() -> None:
     print(f"Actual cache        : {actual_size:.2f} GB, sum_repo_size {sum_repo_size / 10**9:.0f} GB")
 
     final_cached_repos = {repo.repo_id for repo in final_cache_info.repos}
-    name_of = {repo_id: name for name, repo_id in MODEL_NAMES.items()}
-    downloaded_repo_ids = {repo_id for name, repo_id in MODEL_NAMES.items() if name in set(downloaded)}
+    name_of = {repo_id: name for name, repo_id in HUB_MODEL_NAMES.items()}
+    downloaded_repo_ids = {repo_id for name, repo_id in HUB_MODEL_NAMES.items() if name in set(downloaded)}
 
     in_cache_not_downloaded = final_cached_repos - downloaded_repo_ids
     in_downloaded_not_in_cache = downloaded_repo_ids - final_cached_repos


### PR DESCRIPTION
This PR separates the single `MODEL_NAMES` dict into two levels: `HUB_MODEL_NAMES` (using only hub repo ids) and a new `MODEL_NAMES` that resolve ids to local hf cache paths at import time via `_resolve_cached_model_paths()`

This is needed to avoid rate limit errors when PRs are opened from forks (following https://github.com/huggingface/optimum-intel/pull/1817) as `huggingface_hub` makes request to the hf hub even for cached models (to verify that the locally cached revision is still the latest)
