### PR TITLE
Remove login ci token to avoid rate limit errors for fork PRs

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -90,11 +90,6 @@ jobs:
         run: |
           uv pip install auto-gptq "autoawq<0.2.8"
 
-      - name: Login with fork PRs CI token
-        if: ${{ env.HF_TOKEN == '' }}
-        run: |
-          python tests/scripts/login_with_ci_token.py
-
       - name: Test with Pytest
         run: |
           pytest tests/openvino/${{ matrix.test-pattern }} --durations=0

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -90,6 +90,11 @@ jobs:
         run: |
           uv pip install auto-gptq "autoawq<0.2.8"
 
+      - name: Login with fork PRs CI token
+        if: ${{ env.HF_TOKEN == '' }}
+        run: |
+          python tests/scripts/login_with_ci_token.py
+
       - name: Test with Pytest
         run: |
           pytest tests/openvino/${{ matrix.test-pattern }} --durations=0

--- a/tests/scripts/login_with_ci_token.py
+++ b/tests/scripts/login_with_ci_token.py
@@ -14,3 +14,4 @@ token_path.parent.mkdir(parents=True, exist_ok=True)
 token_path.write_text(CI_TOKEN)
 
 assert get_token() == CI_TOKEN, f"Token was not saved correctly to {constants.HF_TOKEN_PATH}"
+print(get_token(), CI_TOKEN)

--- a/tests/scripts/login_with_ci_token.py
+++ b/tests/scripts/login_with_ci_token.py
@@ -1,4 +1,4 @@
-from huggingface_hub import login
+from huggingface_hub.utils._auth import _save_token
 
 
 # fmt: off
@@ -6,4 +6,5 @@ from huggingface_hub import login
 CI_TOKEN = "".join(['h', 'f', '_', 'X', 'N', 'C', 'O', 'g', 'A', 'O', 'g', 'S', 'H', 'W', 'Y', 'B', 'H', 'g', 'L', 'J', 'n', 'C', 'U', 'f', 'i', 'O', 'D', 'n', 'm', 'N', 'n', 'V', 'Q', 'Q', 'N', 'y', 'c'])
 # fmt: on
 
-login(token=CI_TOKEN)
+# save token directly to avoid whoami api call that causes rate limiting when many CI jobs run in parallel
+_save_token(CI_TOKEN)

--- a/tests/scripts/login_with_ci_token.py
+++ b/tests/scripts/login_with_ci_token.py
@@ -14,4 +14,3 @@ token_path.parent.mkdir(parents=True, exist_ok=True)
 token_path.write_text(CI_TOKEN)
 
 assert get_token() == CI_TOKEN, f"Token was not saved correctly to {constants.HF_TOKEN_PATH}"
-print(get_token(), CI_TOKEN)

--- a/tests/scripts/login_with_ci_token.py
+++ b/tests/scripts/login_with_ci_token.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 from huggingface_hub import constants
-from huggingface_hub.utils._auth import _write_secret
 
 
 # fmt: off
@@ -10,4 +9,6 @@ CI_TOKEN = "".join(['h', 'f', '_', 'X', 'N', 'C', 'O', 'g', 'A', 'O', 'g', 'S', 
 # fmt: on
 
 # save token directly to avoid whoami api call that causes rate limiting when many CI jobs run in parallel
-_write_secret(Path(constants.HF_TOKEN_PATH), CI_TOKEN)
+token_path = Path(constants.HF_TOKEN_PATH)
+token_path.parent.mkdir(parents=True, exist_ok=True)
+token_path.write_text(CI_TOKEN)

--- a/tests/scripts/login_with_ci_token.py
+++ b/tests/scripts/login_with_ci_token.py
@@ -1,4 +1,7 @@
-from huggingface_hub.utils._auth import _save_token
+from pathlib import Path
+
+from huggingface_hub import constants
+from huggingface_hub.utils._auth import _write_secret
 
 
 # fmt: off
@@ -7,4 +10,4 @@ CI_TOKEN = "".join(['h', 'f', '_', 'X', 'N', 'C', 'O', 'g', 'A', 'O', 'g', 'S', 
 # fmt: on
 
 # save token directly to avoid whoami api call that causes rate limiting when many CI jobs run in parallel
-_save_token(CI_TOKEN)
+_write_secret(Path(constants.HF_TOKEN_PATH), CI_TOKEN)

--- a/tests/scripts/login_with_ci_token.py
+++ b/tests/scripts/login_with_ci_token.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from huggingface_hub import constants
+from huggingface_hub import constants, get_token
 
 
 # fmt: off
@@ -12,3 +12,5 @@ CI_TOKEN = "".join(['h', 'f', '_', 'X', 'N', 'C', 'O', 'g', 'A', 'O', 'g', 'S', 
 token_path = Path(constants.HF_TOKEN_PATH)
 token_path.parent.mkdir(parents=True, exist_ok=True)
 token_path.write_text(CI_TOKEN)
+
+assert get_token() == CI_TOKEN, f"Token was not saved correctly to {constants.HF_TOKEN_PATH}"


### PR DESCRIPTION
Replace login() and save token directly instead to avoid whoami api call that causes rate limiting when many CI jobs run in parallel 
