### PR TITLE
Add missing compression parameter

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -314,6 +314,7 @@ def no_compression_parameter_provided(args):
                 args.lora_correction,
                 args.sensitivity_metric,
                 args.backup_precision,
+                args.group_size_fallback,
             )
         )
     )


### PR DESCRIPTION
# What does this PR do?

Add the missing `group_size_fallback` parameters, which should be treated as compression parameters.

Fixes:

- CVS-184342

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

