### PR TITLE
[OpenVINO] Set dynamic sequence length for Flux.2

### DIFF
--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -745,7 +745,6 @@ class DummyFluxTransformerInputGenerator(DummyVisionInputGenerator):
         if input_name == "img_ids":
             img_ids_height = self.height // 2
             img_ids_width = self.width // 2
-            img_ids_shape = [self.batch_size, img_ids_height * img_ids_width, 3]
             img_ids_shape = (
                 [self.batch_size, img_ids_height * img_ids_width, 3]
                 if is_diffusers_version("<", "0.31.0")

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2507,7 +2507,9 @@ class FluxTransformerOpenVINOConfig(SD3TransformerOpenVINOConfig):
 
         common_inputs["hidden_states"] = {0: "batch_size", 1: "packed_height_width"}
         common_inputs["txt_ids"] = (
-            {0: "batch_size", 1: "sequence_length"} if is_diffusers_version("<", "0.31.0") or self.is_flux2 else {0: "sequence_length"}
+            {0: "batch_size", 1: "sequence_length"}
+            if is_diffusers_version("<", "0.31.0") or self.is_flux2
+            else {0: "sequence_length"}
         )
         common_inputs["img_ids"] = (
             {0: "batch_size", 1: "packed_height_width"}

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2507,11 +2507,11 @@ class FluxTransformerOpenVINOConfig(SD3TransformerOpenVINOConfig):
 
         common_inputs["hidden_states"] = {0: "batch_size", 1: "packed_height_width"}
         common_inputs["txt_ids"] = (
-            {0: "batch_size", 1: "sequence_length"} if is_diffusers_version("<", "0.31.0") else {0: "sequence_length"}
+            {0: "batch_size", 1: "sequence_length"} if is_diffusers_version("<", "0.31.0") or self.is_flux2 else {0: "sequence_length"}
         )
         common_inputs["img_ids"] = (
             {0: "batch_size", 1: "packed_height_width"}
-            if is_diffusers_version("<", "0.31.0")
+            if is_diffusers_version("<", "0.31.0") or self.is_flux2
             else {0: "packed_height_width"}
         )
         if getattr(self._normalized_config, "guidance_embeds", False):


### PR DESCRIPTION
# What does this PR do?

It will generate transformer IR with dynamic sequence length to avoid extra reshape before generation.

Fixes # (issue)


## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [N/A] Did you make sure to update the documentation with your changes?
- [] Did you write any new necessary tests? Manual test

