### PR TITLE
Pin huggingface_hub to <1.22 to fix offline loading

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ INSTALL_REQUIRE = [
     "optimum~=2.2.0",
     "transformers>=4.45,<5.1",
     "setuptools",
-    "huggingface-hub>=0.23.2,<2.0",
+    "huggingface-hub>=0.23.2,<1.22",
     "nncf>=2.19.0",
     "openvino>=2026.0",
     "openvino-tokenizers>=2026.0",


### PR DESCRIPTION

huggingface_hub>=1.22 https://github.com/huggingface/huggingface_hub/releases/tag/v1.22.0 introduces a stricter completeness check for cached model loading : when the hub can't be reached and the local snapshot is missing requested files, snapshot_download now raises IncompleteSnapshotError instead of silently returning a partial folder.

When loading OV models we set allow_patterns to only load what we need https://github.com/huggingface/optimum-intel/blob/e89617ffca89a106631a15b68dd95d0091a75daa/optimum/intel/openvino/modeling_diffusion.py#L458 this results in our offline tests to fail with IncompleteSnapshotError, even though every file actually required to load the model is present locally.

https://github.com/huggingface/optimum-intel/actions/runs/28796611403/job/85388642804

For now proposed solution is to pin huggingface_hub < v1.22 for the incoming optimum-intel release, we will need to change the model loading logic if we want to enable support for higher version (while keeping compatibility for offline loading)
