### PR TITLE
Fix export for encoder-decoder models with unnamed tensor

### DIFF
--- a/optimum/exporters/openvino/stateful.py
+++ b/optimum/exporters/openvino/stateful.py
@@ -253,8 +253,12 @@ def insert_state_for_nodes(model: ov.Model, nodes):
     outputs = sum((node.outputs() for node in nodes), [])
     for output in outputs:
         consumers = output.get_target_inputs()
-        # FIXME: get_any_name is not reliable as tensor may not have any names
-        variable_id = output.get_any_name()
+        if output.get_names():
+            variable_id = output.get_any_name()
+        else:
+            variable_id = f"{output.get_node().get_friendly_name()}.{output.get_index()}"
+            # set tensor name when tensor has no name
+            output.get_tensor().set_names({variable_id})
         read_value = ov.opset13.read_value(output, variable_id)
         for consumer in consumers:
             consumer.replace_source_output(read_value.output(0))


### PR DESCRIPTION
Fix https://github.com/huggingface/optimum-intel/actions/runs/28857771168/job/85588501704?pr=1855 happening with openvino-nightly when calling `output.get_any_name` raise RuntimeError (happening for tensors when no name associated)

```
FAILED tests/openvino/test_modeling_basic.py::OVModelBasicIntegrationTest::test_pipeline_4_hf_internal_testing_tiny_random_t5 - RuntimeError: Check '!get_names().empty()' failed at src/core/src/descriptor/tensor.cpp:102:
Attempt to get a name for a Tensor without names
```
