### PR TITLE
Fix gemma4_unified chat template processing + test coverage

### DIFF
--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -4193,12 +4193,13 @@ class _OVGemma4UnifiedForCausalLM(_OVGemma3ForCausalLM):
             raise ValueError("Video input is not supported")
         if audio is not None:
             raise ValueError("Audio input is not supported")
-        # The gemma4_unified processor has no chat template, so build the prompt directly.
-        # An image is referenced by the processor's image token placeholder.
-        if image is not None:
-            image_token = getattr(processor, "image_token", "<|image|>")
-            text = f"{image_token}{text}"
-        return processor(images=image, text=text, return_tensors="pt")
+        # The base (non-instruction-tuned) checkpoint has no chat template, so build the prompt directly.
+        if getattr(processor, "chat_template", None) is None:
+            if image is not None:
+                image_token = getattr(processor, "image_token", "<|image|>")
+                text = f"{image_token}{text}"
+            return processor(images=image, text=text, return_tensors="pt")
+        return _OVGemma3ForCausalLM.preprocess_inputs(text, image, processor, tokenizer, config, video, audio)
 
     def _update_model_kwargs_for_generation(
         self,

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -897,6 +897,31 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
             if is_transformers_version(">=", "4.57.0"):
                 inputs.pop("token_type_ids")
 
+        if model_arch == "gemma4_unified":
+            # preprocess_inputs must actually apply the processor's chat_template, not silently skip it
+            conversation = [{"role": "user", "content": [{"type": "image"}, {"type": "text", "text": prompt}]}]
+            expected_text = preprocessors["processor"].apply_chat_template(
+                conversation, add_generation_prompt=True, tokenize=False
+            )
+            expected_inputs = preprocessors["processor"](images=image, text=expected_text, return_tensors="pt")
+            self.assertTrue(
+                torch.equal(inputs["input_ids"], expected_inputs["input_ids"]),
+                "preprocess_inputs must apply the processor's chat_template when one is configured",
+            )
+
+            # also cover the raw, no-chat-template fallback branch (non -it variant)
+            processor_without_template = copy.deepcopy(preprocessors["processor"])
+            processor_without_template.chat_template = None
+            no_template_inputs = ov_model.preprocess_inputs(
+                text=prompt, image=image, processor=processor_without_template
+            )
+            self.assertTrue(torch.is_tensor(no_template_inputs["input_ids"]))
+            self.assertGreater(no_template_inputs["input_ids"].shape[1], 0)
+            self.assertFalse(
+                torch.equal(no_template_inputs["input_ids"], inputs["input_ids"]),
+                "the no-chat-template fallback should not coincidentally match the chat-template output",
+            )
+
         transformers_inputs = copy.deepcopy(inputs)
         # llama4 preprocessing force bf16 dtype for pixel_values, that does not work on CPU with fp32 model
         # if past key values are not initialized, llama4 creates HybridCache with bf16 precision

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -209,7 +209,7 @@ HUB_MODEL_NAMES = {
     "gemma3n_text": "optimum-intel-internal-testing/tiny-random-gemma3n-text",
     "gemma4": "optimum-intel-internal-testing/tiny-random-gemma4",
     "gemma4_moe": "optimum-intel-internal-testing/tiny-random-gemma4-moe",
-    "gemma4_unified": "optimum-intel-internal-testing/tiny-random-gemma4-unified",
+    "gemma4_unified": "optimum-intel-internal-testing/tiny-random-gemma4-unified-it",
     "falcon": "optimum-intel-internal-testing/really-tiny-falcon-testing",
     "falcon-40b": "optimum-intel-internal-testing/tiny-random-falcon-40b",
     "falcon_mamba": "optimum-intel-internal-testing/tiny-falcon-mamba",


### PR DESCRIPTION
# What does this PR do?

Add chat template processing for gemma4_unified architecture and test coverage for both base and instruction-tuned support.

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

