### PR TITLE
Added possibility to specify output tensor aliases

### DIFF
--- a/optimum/exporters/openvino/base.py
+++ b/optimum/exporters/openvino/base.py
@@ -315,6 +315,18 @@ class OpenVINOConfigWithPast(OpenVINOConfig, ABC):
         return common_outputs
 
     @property
+    def output_name_aliases(self) -> dict[str, list[str]]:
+        """Additional (secondary) tensor names to attach to exported OpenVINO output tensors.
+
+        Maps a primary output name (a key of `outputs`) to a list of extra tensor names that
+        should be added to the *same* OpenVINO output tensor.
+
+        Returns:
+            `Dict[str, List[str]]`: A mapping of primary output name to a list of alias names.
+        """
+        return {}
+
+    @property
     def values_override(self) -> dict[str, Any] | None:
         if hasattr(self._config, "use_cache"):
             return {"use_cache": self.use_past}

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -384,9 +384,12 @@ def export_pytorch(
         ov_model.validate_nodes_and_infer_types()  # TODO: remove as unnecessary validation?
 
         output_names = list(config.outputs.keys())
+        output_name_aliases = getattr(config, "output_name_aliases", {})
         for idx, out_tensor in enumerate(ov_model.outputs):
             if idx < len(output_names):
-                out_tensor.get_tensor().set_names({output_names[idx]})
+                primary_name = output_names[idx]
+                tensor_names = {primary_name, *output_name_aliases.get(primary_name, [])}
+                out_tensor.get_tensor().set_names(tensor_names)
 
         input_names = [item.name for item in input_info]
         for idx, inp_tensor in enumerate(ov_model.inputs):

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -6239,6 +6239,12 @@ class KokoroOpenVINOConfig(OpenVINOConfig):
             "phonemes": {0: "batch_size", 1: "phoneme_length"},
         }
 
+    @property
+    def output_name_aliases(self) -> Dict[str, List[str]]:
+        # The second output is the predicted phoneme durations returned by
+        # KModel.forward_with_tokens (pred_dur)
+        return {"phonemes": ["pred_dur"]}
+
 
 @register_in_tasks_manager(
     "trocr",


### PR DESCRIPTION
# What does this PR do?

- Added possibility to specify output tensor aliases
- used it to specify pred_dur alias for Kokoro's phonemes output
  - pred_dur is the original tensor name from kokoro python package by hexgrad:

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # E-225248 / C-187702


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

