### PR TITLE
[EXPERIMENT][WIP] Add Cosmos3Omni (Reasoner) VLM support, reusing Qwen3-VL code path

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -40,6 +40,7 @@ Here is the list of the supported architectures :
 - Cohere2
 - ConvBERT
 - ConvNeXt
+- Cosmos3 (Reasoner surface only; architecturally identical to Qwen3-VL)
 - DBRX
 - Data2VecAudio
 - Data2VecText

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -6392,6 +6392,47 @@ class Qwen3_5TextOpenVINOConfig(Qwen3VLTextOpenVINOConfig):
 
 
 @register_in_tasks_manager(
+    "cosmos3_omni",
+    *["image-text-to-text", "feature-extraction", "feature-extraction-with-past"],
+    library_name="transformers",
+)
+class Cosmos3OmniOpenVINOConfig(Qwen3VLOpenVINOConfig):
+    # Cosmos3Omni's Reasoner surface is architecturally identical to Qwen3-VL (upstream
+    # `transformers` defines `Cosmos3OmniForConditionalGeneration(Qwen3VLForConditionalGeneration): pass`,
+    # only the `model_type` string and released checkpoint differ). Native support first
+    # appears in `transformers` v5.11.0.
+    SUPPORTED_BEHAVIORS = [model_type.value for model_type in QwenVLConfigBehavior]
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3VLVisionEmbedInputGenerator,)
+    # `Qwen3VLOpenVINOConfig` (parent) caps MAX_TRANSFORMERS_VERSION at "5.0", which predates
+    # cosmos3_omni's introduction in transformers 5.11.0 -- override the range to the versions
+    # this config has actually been verified against.
+    MIN_TRANSFORMERS_VERSION = "5.11.0"
+    MAX_TRANSFORMERS_VERSION = "5.13.99"
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: QwenVLConfigBehavior = QwenVLConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+            behavior=behavior,
+        )
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS_POS and hasattr(config, "vision_config"):
+            self._config = config.vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+            self._normalized_config.use_embed_dim = True
+
+
+@register_in_tasks_manager(
     "qwen3_5",
     *["image-text-to-text"],
     library_name="transformers",

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -326,6 +326,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "qwen3_vl",
     "qwen3_5",
     "qwen3_5_moe",
+    "cosmos3_omni",
     "got_ocr2",
     "gemma3",
     "gemma3n",

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -220,8 +220,10 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
 
             if self.config.model_type in ["qwen3_5", "qwen3_5_moe"] and position_ids.ndim != 3:
                 position_ids = np.repeat(np.expand_dims(position_ids, 0), 4, axis=0)
-            elif (self.config.model_type in ["qwen2_vl", "qwen2_5_vl", "qwen3_vl"]) and position_ids.ndim == 2:
-                # Qwen2-VL and Qwen3-VL use 3D mrope (3 spatial dimensions)
+            elif (
+                self.config.model_type in ["qwen2_vl", "qwen2_5_vl", "qwen3_vl", "cosmos3_omni"]
+            ) and position_ids.ndim == 2:
+                # Qwen2-VL, Qwen3-VL, and Cosmos3Omni (identical arch to Qwen3-VL) use 3D mrope (3 spatial dimensions)
                 position_ids = np.repeat(np.expand_dims(position_ids, 0), 3, axis=0)
             elif self.config.model_type == "qwen3_omni_moe" and position_ids.ndim == 2:
                 # Qwen3-Omni uses 4D mrope (temporal + 3 spatial dimensions)
@@ -1194,7 +1196,7 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
 
         # Prepare additional kwargs for qwen3_vl models
         additional_kwargs = {}
-        if self.config.model_type in ("qwen3_vl", "qwen3_omni_moe") and extra_outputs:
+        if self.config.model_type in ("qwen3_vl", "qwen3_omni_moe", "cosmos3_omni") and extra_outputs:
             additional_kwargs["visual_pos_masks"] = extra_outputs[0]
             additional_kwargs["deepstack_visual_embeds"] = extra_outputs[1]
 
@@ -7370,6 +7372,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "phi4_multimodal": _OVPhi4MMForCausalLM,
     "llama4": _OVLlama4ForCausalLM,
     "qwen3_vl": _OVQwen3VLForCausalLM,
+    "cosmos3_omni": _OVQwen3VLForCausalLM,  # architecturally identical to Qwen3-VL
     "qwen3_5": _OVQwen3_5ForCausalLM,
     "qwen3_5_text": _OVQwen3_5ForCausalLM,
     "qwen3_5_moe": _OVQwen3_5ForCausalLM,

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ INSTALL_REQUIRE = [
     "torch>=2.1",
     "safetensors<0.8.0",
     "optimum@git+https://github.com/huggingface/optimum.git",
-    "transformers>=4.51,<5.6",
+    "transformers>=4.51,<5.14",
     "setuptools",
     "huggingface-hub>=0.23.2,<1.22",
     "nncf>=2.19.0",

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -697,8 +697,16 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         "qwen3_5",
         "qwen3_5_moe",
         "qwen3_omni_moe",
+        "cosmos3_omni",
     ]
-    SUPPORT_VIDEO = ["llava_next_video", "qwen2_vl", "qwen2_5_vl", "qwen3_vl", "videochat_flash_qwen"]
+    SUPPORT_VIDEO = [
+        "llava_next_video",
+        "qwen2_vl",
+        "qwen2_5_vl",
+        "qwen3_vl",
+        "videochat_flash_qwen",
+        "cosmos3_omni",
+    ]
     SUPPORT_AUDIO = ["qwen3_omni_moe"]
     # "llama" is registered for image-text-to-text
     # to support VLM Eagle3 draft models (tested separately in test_genai.py).
@@ -758,6 +766,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
             "qwen3_5",
             "qwen3_5_moe",
             "gemma4_unified",
+            "cosmos3_omni",
         ]:
             from transformers import AutoModelForImageTextToText
 
@@ -816,7 +825,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
             self.skipTest("CVS-185350: OpenVINO 2026.1.0 inference results mismatch")
 
         if (
-            model_arch in ("qwen3_vl", "llava", "llava_next", "llava_next_mistral")
+            model_arch in ("qwen3_vl", "cosmos3_omni", "llava", "llava_next", "llava_next_mistral")
             and is_openvino_version(">=", "2026.1.0")
             and is_transformers_version(">=", "5.0")
         ):

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -300,6 +300,7 @@ HUB_MODEL_NAMES = {
     "qwen3_moe": "optimum-intel-internal-testing/tiny-random-qwen3moe",
     "qwen3_vl": "optimum-intel-internal-testing/tiny-random-qwen3-vl",
     "qwen3_vl_embedding": "optimum-intel-internal-testing/tiny-random-qwen3-vl-embedding",
+    "cosmos3_omni": "optimum-intel-internal-testing/tiny-random-cosmos3-omni",
     "qwen3_omni_moe": "optimum-intel-internal-testing/tiny-random-qwen3-omni",
     "qwen3_next": "optimum-intel-internal-testing/tiny-random-qwen3-next",
     "qwen3_5": "optimum-intel-internal-testing/tiny-random-qwen3.5",


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

## Summary

Adds OpenVINO export support for the **Reasoner** (autoregressive text+vision understanding)
tower of `nvidia/Cosmos3-Nano` and `nvidia/Cosmos3-Super` — `Cosmos3OmniForConditionalGeneration`,
`model_type=cosmos3_omni`. Internally this architecture reuses the Qwen3-VL text/vision configs
and code path, so this change follows the same pattern as the existing Qwen3-VL OpenVINO config.

## Scope

Cosmos3 is a Mixture-of-Transformers (MoT) omnimodal world model with two towers sharing the
same HF repo:
- **Reasoner** — autoregressive, text+vision understanding — **covered by this PR**.
- **Generator** — diffusion transformer for image/video/audio/action synthesis
  (`Cosmos3OmniDiffusersPipeline`, separate `transformer/`/`vae/`/`scheduler/`/`sound_tokenizer/`
  weights) — **explicitly out of scope**. There is no OpenVINO GenAI pipeline equivalent for a
  joint MoT diffusion + video-VAE + audio-tokenizer stack; enabling it would be a materially
  larger, separate effort (logged in the enablement ticket as a follow-up, not addressed here).

## Changes

- `Cosmos3OmniOpenVINOConfig`, reusing the Qwen3-VL export path (text backbone + vision encoder).
- `--library transformers` note: the HF repo's root `model_index.json` (a diffusers pipeline
  marker needed for the Generator side of the same repo) causes `optimum-cli`'s automatic
  library detection to otherwise mis-pick `diffusers` for this repo. No code change was needed
  for this — it's a user-facing CLI flag requirement, documented in the enablement notebook.

## Validation

Exported and validated against the **real** `nvidia/Cosmos3-Nano` checkpoint (not a synthetic
fixture) to FP16/INT8/INT4 IR; confirmed coherent generation via `OVModelForVisualCausalLM` on
CPU, iGPU, and dGPU (Intel Arc Pro B60). Full accuracy matrix (WhoWhatBenchmark `visual-text`
similarity, 3 precisions × 3 devices) and timing results are in the enablement ticket:
https://github.com/openvinotoolkit/omega/issues/62

**Additional local re-verification (this update):** since `optimum-intel-internal-testing/tiny-random-cosmos3-omni`
(referenced in `tests/openvino/utils_tests.py`) isn't published on the Hub yet, a tiny random
`Cosmos3OmniForConditionalGeneration` was built locally (text/vision sub-configs mirrored from
`tiny-random-qwen3-vl`) to re-run the full pipeline after the `transformers` pin fix below:
- `optimum-cli export openvino --model <tiny> --task image-text-to-text --library transformers --weight-format int8` — succeeds, produces language/vision/embeddings/tokenizer IRs.
  (`--weight-format int4` on this tiny model hits an NNCF group-size error because the toy `hidden_size` is too small for group-wise int4 — not expected on the real, full-size checkpoint.)
- `OVModelForVisualCausalLM.generate(...)` on the exported IR — runs end-to-end.
- `pytest tests/openvino/test_seq2seq.py -k cosmos3_omni` (fixture temporarily pointed at the local tiny model, reverted before commit) — **2 passed, 1 skipped** (audio, correctly unsupported for `cosmos3_omni`).

## Installation instructions

```bash
pip install git+https://github.com/mlukasze/optimum-intel.git@enable/nvidia-cosmos3
pip install --pre -U openvino openvino-tokenizers nncf --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
```

> **Fix included:** `setup.py`'s `transformers` pin was `<5.6`, which predates native
> `cosmos3_omni` support (`transformers>=5.11.0`) required by `Cosmos3OmniOpenVINOConfig`.
> The plain `pip install` above previously silently resolved to a `transformers` version
> that doesn't even define the `cosmos3_omni` model type, failing with a confusing raw
> `transformers` error instead of a working export. The pin has been widened to `<5.14`
> (matching `MAX_TRANSFORMERS_VERSION = "5.13.99"` on the config) so the documented
> install command now works as-is, no extra manual `transformers` upgrade needed.

## Exporting cmd-line

```bash
optimum-cli export openvino --model nvidia/Cosmos3-Nano --task image-text-to-text --library transformers --weight-format int4 ov_model/
```

> `--library transformers` is required: the repo also ships a `model_index.json` (diffusers
> pipeline marker for the out-of-scope Generator tower), which would otherwise make
> `optimum-cli`'s auto-detection mis-pick `diffusers` for this repo.

## Inference script

```python
from transformers import AutoProcessor
from optimum.intel import OVModelForVisualCausalLM
from PIL import Image
import requests

model_id = "nvidia/Cosmos3-Nano"
processor = AutoProcessor.from_pretrained(model_id)
model = OVModelForVisualCausalLM.from_pretrained("ov_model/", device="CPU")

image = Image.open(requests.get("http://images.cocodataset.org/val2017/000000039769.jpg", stream=True).raw)
messages = [
    {
        "role": "user",
        "content": [
            {"type": "image"},
            {"type": "text", "text": "Describe this image."},
        ],
    }
]
prompt = processor.apply_chat_template(messages, add_generation_prompt=True)
inputs = processor(text=prompt, images=image, return_tensors="pt")

generated_ids = model.generate(**inputs, max_new_tokens=100)
output = processor.batch_decode(
    generated_ids[:, inputs["input_ids"].shape[1]:], skip_special_tokens=True
)
print(output[0])
```

## Related

- Companion openvino.genai PR (VLMPipeline C++ support): (link added once created)
- Tracking ticket: https://github.com/openvinotoolkit/omega/issues/62
