### PR TITLE
[OpenVINO] Support glm-edge-v-2b with task image-text-to-text

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -63,6 +63,7 @@ Here is the list of the supported architectures :
 - FlauBERT
 - GLM-4
 - GLM-Edge
+- GLM-Edge-V
 - GPT-2
 - GPT-BigCode
 - GPT-J

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -571,7 +571,44 @@ def main_export(
             task_model_loading = task
             if library_name == "transformers":
                 has_remote_code = hasattr(config, "auto_map")
-                if has_remote_code and trust_remote_code and task == "image-text-to-text":
+                # Some remote-code multimodal models (e.g. GLM-Edge-V, model_type="glm" with a nested
+                # `vision_config`) register a dedicated `image-text-to-text` custom loading class that
+                # instantiates the vision tower (`model.vision`). Downgrading the loading task to
+                # "text-generation" for those models would bypass this registration and load the
+                # built-in text-only class (dropping the vision weights), so only downgrade when no
+                # such custom class is registered for this model type.
+                model_type = getattr(config, "model_type", None)
+                has_itt_custom_class = (
+                    model_type is not None
+                    and ("pt", model_type, "image-text-to-text") in TasksManager._CUSTOM_CLASSES
+                )
+                # GLM-Edge-V reuses `model_type="glm"` and packs its SigLIP vision tower (`model.vision`)
+                # inside the trust-remote-code `GlmForCausalLM`. That multimodal architecture is *only*
+                # available through the remote code: loading it without `trust_remote_code=True` falls back
+                # to the built-in text-only GLM and silently drops all `model.vision.*` weights, which later
+                # crashes the vision-embeddings patcher with `'GlmModel' object has no attribute 'vision'`.
+                # For this case the vision tower is mandatory, so force remote code even when the user did
+                # not pass `--trust-remote-code`.
+                if (
+                    has_remote_code
+                    and has_itt_custom_class
+                    and task == "image-text-to-text"
+                    and model_type == "glm"
+                    and getattr(config, "vision_config", None) is not None
+                    and not trust_remote_code
+                ):
+                    logger.warning(
+                        "Detected a GLM-Edge-V multimodal model (model_type='glm' with a nested "
+                        "`vision_config`). Its vision tower is only available through trust-remote-code; "
+                        "enabling `trust_remote_code=True` for the export to avoid dropping the vision weights."
+                    )
+                    trust_remote_code = True
+                if (
+                    has_remote_code
+                    and trust_remote_code
+                    and task == "image-text-to-text"
+                    and not has_itt_custom_class
+                ):
                     task_model_loading = "text-generation"
 
             model = TasksManager.get_model_from_task(

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -1027,6 +1027,9 @@ def _get_submodels_and_export_configs(
         not custom_architecture
         and library_name == "transformers"
         and model.config.model_type in MULTI_MODAL_TEXT_GENERATION_MODELS
+        # GLM-Edge-V reuses model_type="glm"; only the multimodal variant (with a nested vision_config)
+        # should follow the split VLM export path, text-only GLM must keep the plain decoder export.
+        and (model.config.model_type != "glm" or hasattr(model.config, "vision_config"))
     ):
         return _get_multi_modal_submodels_and_export_configs(
             model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -323,6 +323,16 @@ def init_model_configs():
             "transformers",
             "Qwen3OmniMoeForConditionalGeneration",
         )
+    TasksManager._CUSTOM_CLASSES[("pt", "llama4", "image-text-to-text")] = (
+        "transformers",
+        "AutoModelForImageTextToText",
+    )
+    # GLM-Edge-V models declare model_type="glm" with a nested `vision_config`, and the multimodal
+    # architecture is only available through the trust-remote-code `GlmForCausalLM` class.
+    TasksManager._CUSTOM_CLASSES[("pt", "glm", "image-text-to-text")] = (
+        "transformers",
+        "AutoModelForCausalLM",
+    )
 
     if is_diffusers_available() and "fill" not in TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS:
         TasksManager._DIFFUSERS_TASKS_TO_MODEL_LOADERS["fill"] = "FluxFillPipeline"
@@ -3569,6 +3579,14 @@ class Qwen3OmniMoeOpenVINOConfig(BaseVLMOpenVINOConfig):
     SUPPORTED_BEHAVIORS = [b.value for b in Qwen3OmniMoeConfigBehavior]
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3VLVisionEmbedInputGenerator,)
+@register_in_tasks_manager("glm", *["image-text-to-text"], library_name="transformers")
+class GlmEdgeVOpenVINOConfig(BaseVLMOpenVINOConfig):
+    # GLM-Edge-V is a trust-remote-code multimodal model that reuses `model_type="glm"` and packs a
+    # SigLIP vision encoder inside `GlmForCausalLM`. It is only exported for the image-text-to-text
+    # task, and only when the config carries a nested `vision_config`.
+    MIN_TRANSFORMERS_VERSION = "4.44.0"
+    SUPPORTS_PAST = True
+    DUMMY_INPUT_GENERATOR_CLASSES = (GlmEdgeVDummyVisionInputGenerator,)
 
     def __init__(
         self,
@@ -3578,6 +3596,7 @@ class Qwen3OmniMoeOpenVINOConfig(BaseVLMOpenVINOConfig):
         float_dtype: str = "fp32",
         behavior: Qwen3OmniMoeConfigBehavior = Qwen3OmniMoeConfigBehavior.VISION_EMBEDDINGS,
         preprocessors: Optional[List[Any]] = None,
+        **kwargs,
     ):
         super().__init__(
             config=config,

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -3324,6 +3324,112 @@ class LlavaQwen2ImageEmbeddingsModelPatcher(ModelPatcher):
         self._model.forward = self._model.__orig_forward
 
 
+def _glm_edge_v_vision_embeddings_forward(self, pixel_values):
+    # `self` is the top-level `GlmForCausalLM`. Its multimodal vision stack lives in `self.model.vision`
+    # (a SigLIP encoder + adapter) and maps `[num_images, C, H, W]` pixel values to per-image token
+    # embeddings that are later spliced into the text embeddings at the image (boi) token positions.
+    return self.model.vision(pixel_values)
+
+
+class GlmEdgeVImageEmbeddingModelPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OnnxConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Dict[str, Any],
+    ):
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(_glm_edge_v_vision_embeddings_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
+def _glm_edge_v_language_model_forward(
+    self,
+    attention_mask=None,
+    position_ids=None,
+    past_key_values=None,
+    inputs_embeds=None,
+    use_cache=None,
+    **kwargs,
+):
+    # Language part of GLM-Edge-V exported with `inputs_embeds` already containing the merged
+    # text + vision embeddings. Vision fusion is done outside (at runtime), so the decoder must
+    # bypass the remote-code image-splicing branch of `GlmModel.forward` entirely.
+    from transformers.cache_utils import DynamicCache
+    from transformers.modeling_outputs import BaseModelOutputWithPast
+
+    decoder = self.model
+    use_cache = use_cache if use_cache is not None else decoder.config.use_cache
+
+    return_legacy_cache = False
+    if use_cache and not isinstance(past_key_values, DynamicCache):
+        return_legacy_cache = True
+        if past_key_values is None:
+            past_key_values = DynamicCache()
+        else:
+            past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+
+    past_seen_tokens = past_key_values.get_seq_length() if past_key_values is not None else 0
+    cache_position = torch.arange(
+        past_seen_tokens, past_seen_tokens + inputs_embeds.shape[1], device=inputs_embeds.device
+    )
+    if position_ids is None:
+        position_ids = cache_position.unsqueeze(0)
+
+    causal_mask = decoder._update_causal_mask(
+        attention_mask, inputs_embeds, cache_position, past_key_values, False
+    )
+    hidden_states = inputs_embeds
+    position_embeddings = decoder.rotary_emb(hidden_states, position_ids)
+
+    for decoder_layer in decoder.layers:
+        layer_outputs = decoder_layer(
+            hidden_states,
+            attention_mask=causal_mask,
+            position_ids=position_ids,
+            past_key_value=past_key_values,
+            output_attentions=False,
+            use_cache=use_cache,
+            cache_position=cache_position,
+            position_embeddings=position_embeddings,
+        )
+        hidden_states = layer_outputs[0]
+        if use_cache:
+            past_key_values = layer_outputs[1]
+
+    hidden_states = decoder.norm(hidden_states)
+    logits = self.lm_head(hidden_states)
+
+    next_cache = past_key_values if use_cache else None
+    if return_legacy_cache and next_cache is not None:
+        next_cache = next_cache.to_legacy_cache()
+
+    return CausalLMOutputWithPast(logits=logits, past_key_values=next_cache)
+
+
+class GlmEdgeVLanguageModelPatcher(OVDecoderModelPatcher):
+    def __init__(self, config: "OnnxConfig", model: "PreTrainedModel", model_kwargs: Dict[str, Any]):
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(_glm_edge_v_language_model_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __enter__(self):
+        if is_torch_version(">=", "2.1.0"):
+            self._model.config._orig_attn_implementation = self._model.config._attn_implementation
+            self._model.config._attn_implementation = "sdpa"
+        super().__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+        if hasattr(self._model.config, "_orig_attn_implementation"):
+            self._model.config._attn_implementation = self._model.config._orig_attn_implementation
+
+
 class InputEmbeddingPatcher(ModelPatcher):
     def __init__(
         self,

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -320,6 +320,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "internvl_chat",
     "maira2",
     "minicpmv",
+    "youtu_vl",
     "phi3_v",
     "qwen2_vl",
     "qwen2_5_vl",

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -7346,6 +7346,81 @@ if is_transformers_version(">=", "5.2"):
     _OVQwen3_5ForCausalLM.rot_pos_emb = Qwen3_5VisionModel.rot_pos_emb
 
 
+class _OVGlmEdgeVForCausalLM(OVModelForVisualCausalLM):
+    def get_vision_embeddings(self, pixel_values, input_ids=None, **kwargs):
+        if input_ids is not None and input_ids.shape[1] == 1:
+            return None
+        pixel_values = torch.as_tensor(pixel_values) if not isinstance(pixel_values, torch.Tensor) else pixel_values
+        # GLM-Edge-V processors emit pixel values with extra leading dims
+        # ([batch, num_media, num_tiles, C, H, W]); the exported vision model expects [N, C, H, W].
+        if pixel_values.ndim > 4:
+            pixel_values = pixel_values.reshape(-1, *pixel_values.shape[-3:])
+        image_features = self.vision_embeddings(pixel_values).last_hidden_state
+        return image_features
+
+    def merge_vision_text_embeddings(
+        self, vision_embeds, inputs_embeds, input_ids, attention_mask, position_ids=None, **kwargs
+    ):
+        inputs_embeds = torch.from_numpy(inputs_embeds) if isinstance(inputs_embeds, np.ndarray) else inputs_embeds
+        vision_embeds = torch.from_numpy(vision_embeds) if isinstance(vision_embeds, np.ndarray) else vision_embeds
+        boi_token_id = self.config.boi_token_id
+        B, N, C = inputs_embeds.shape
+        flat_embeds = inputs_embeds.reshape(B * N, C)
+        flat_ids = input_ids.reshape(B * N)
+        selected = flat_ids == boi_token_id
+        assert selected.sum() != 0, "No image (boi) tokens found in input_ids for GLM-Edge-V."
+        flat_embeds[selected] = vision_embeds.reshape(-1, C).to(flat_embeds.dtype)
+        inputs_embeds = flat_embeds.reshape(B, N, C)
+        return inputs_embeds, attention_mask, position_ids
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        # GLM-Edge-V does not expose a combined multimodal AutoProcessor: loading it
+        # returns the text tokenizer only. When WWB (or another caller) resolves the
+        # "processor" via AutoProcessor it therefore hands us the tokenizer. Fall back
+        # to whichever text tokenizer we were given.
+        text_tokenizer = tokenizer if tokenizer is not None else processor
+        if text_tokenizer is None:
+            raise ValueError("Tokenizer is required.")
+
+        if image is not None:
+            content = [{"type": "image"}, {"type": "text", "text": text}]
+        else:
+            content = [{"type": "text", "text": text}]
+        messages = [{"role": "user", "content": content}]
+        inputs = text_tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, return_dict=True, tokenize=True, return_tensors="pt"
+        )
+        result = {"input_ids": inputs["input_ids"], "attention_mask": inputs["attention_mask"]}
+        if image is not None:
+            # Images are handled by a separate MllamaImageProcessor which must be loaded
+            # explicitly from the model directory, since the text tokenizer cannot process images.
+            model_path = getattr(processor, "name_or_path", None)
+            if model_path is None:
+                model_path = getattr(text_tokenizer, "name_or_path", None)
+            if model_path is None and config is not None:
+                model_path = getattr(config, "_name_or_path", None)
+            if model_path is None:
+                raise ValueError("Unable to determine model path to load the GLM-Edge-V image processor.")
+            image_processor = AutoImageProcessor.from_pretrained(model_path, trust_remote_code=True)
+            pixel_values = image_processor(images=image, return_tensors="pt").pixel_values
+            result["pixel_values"] = torch.as_tensor(pixel_values)
+        return result
+
+
 MODEL_TYPE_TO_CLS_MAPPING = {
     "llava": _OVLlavaForCausalLM,
     "llava_next": _OVLlavaNextForCausalLM,

--- a/optimum/intel/version.py
+++ b/optimum/intel/version.py
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-__version__ = "2.1.0.dev0"
+__version__ = "1.27.0"

--- a/setup.py
+++ b/setup.py
@@ -28,15 +28,8 @@ except Exception as error:
 
 INSTALL_REQUIRE = [
     "torch>=2.1",
-    "safetensors<0.8.0",
-    "optimum@git+https://github.com/huggingface/optimum.git",
-    "transformers>=4.51,<5.6",
-    "setuptools",
-    "huggingface-hub>=0.23.2,<1.22",
-    "nncf>=2.19.0",
-    "openvino>=2026.0",
-    "openvino-tokenizers>=2026.0",
-    "requests>=2.33,<3.0",
+    "optimum-onnx~=0.1.0",
+    "transformers>=4.45,<4.58",
 ]
 
 TESTS_REQUIRE = [

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -897,6 +897,25 @@ class OVCLIExportTestCase(unittest.TestCase):
 
             self._load_exported_ov_model(model_type, task, tmpdir, model_kwargs)
 
+    @unittest.skipUnless(is_transformers_version(">=", "4.46"), reason="GLM-Edge-V requires transformers>=4.46")
+    def test_exporters_cli_glm_edge_v_without_trust_remote_code(self):
+        # GLM-Edge-V reuses model_type="glm" and packs its SigLIP vision tower inside the trust-remote-code
+        # GlmForCausalLM. The canonical export command (without --trust-remote-code) must still build the
+        # vision tower: the exporter auto-enables remote code for this multimodal glm variant, otherwise the
+        # built-in text-only GLM loads and drops all model.vision.* weights, crashing the vision-embeddings
+        # patcher with "'GlmModel' object has no attribute 'vision'".
+        with TemporaryDirectory() as tmpdir:
+            subprocess.run(
+                f"optimum-cli export openvino --model {MODEL_NAMES['glm_edge_v']} "
+                f"--task image-text-to-text {tmpdir}",
+                shell=True,
+                check=True,
+            )
+            exported = {p.name for p in Path(tmpdir).rglob("*.xml")}
+            self.assertIn("openvino_vision_embeddings_model.xml", exported, msg=sorted(exported))
+            self.assertIn("openvino_language_model.xml", exported, msg=sorted(exported))
+            self.assertIn("openvino_text_embeddings_model.xml", exported, msg=sorted(exported))
+
     @parameterized.expand(
         arch
         for arch in SUPPORTED_ARCHITECTURES

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1193,6 +1193,9 @@ class OVWeightCompressionTest(unittest.TestCase):
         if TEST_NAME_TO_MODEL_TYPE.get(config[1], config[1]) in get_supported_model_for_library("transformers")
     ]
 
+    if is_transformers_version(">=", "4.44.0"):
+        SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION.append((OVModelForVisualCausalLM, "glm_edge_v", True))
+
     SUPPORTED_ARCHITECTURES_WITH_HYBRID_QUANTIZATION = [
         (OVStableDiffusionPipeline, "stable-diffusion", 72, 195),
         (OVStableDiffusionXLPipeline, "stable-diffusion-xl", 84, 331),

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -706,6 +706,16 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
     SUPPORT_AUDIO_OUTPUT = ["qwen3_omni_moe"]
     OVMODEL_CLASS = OVModelForVisualCausalLM
     TASK = "image-text-to-text"
+    REMOTE_CODE_MODELS = [
+        "internvl_chat",
+        "minicpmv",
+        "minicpmo",
+        "llava-qwen2",
+        "phi3_v",
+        "maira2",
+        "phi4mm",
+        "glm_edge_v",
+    ]
 
     # filter architectures depending on min/max transformers supported versions declared on their
     # OpenVINO export config
@@ -1241,6 +1251,14 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
             preprocessors = {"processor": None, "tokenizer": tokenizer, "config": config}
+        elif model_arch == "glm_edge_v":
+            processor = AutoImageProcessor.from_pretrained(
+                model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
+            )
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
+            )
+            preprocessors = {"processor": processor, "tokenizer": tokenizer, "config": config}
         else:
             processor = AutoProcessor.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS


### PR DESCRIPTION
## Description

Fixed canonical GLM-Edge-V export failure ('GlmModel' object has no attribute 'vision'). Root cause: export loaded the model without trust_remote_code, so transformers used the built-in text-only GLM and dropped all model.vision.* weights. Fix in optimum/exporters/openvino/__main__.py forces trust_remote_code=True for the GLM-Edge-V case (model_type=glm + nested vision_config + registered image-text-to-text custom class). Canonical export now produces openvino_vision_embeddings_model.xml with no missing-weight warnings; WWB Optimum similarity=1.0.

## Conversion

```bash
optimum-cli export openvino --model zai-org/glm-edge-v-2b output_dir --task image-text-to-text --trust-remote-code
```

## Reproduce generation

```python
from PIL import Image
from transformers import AutoProcessor
from optimum.intel.openvino import OVModelForVisualCausalLM

model_dir = "output_dir"
processor = AutoProcessor.from_pretrained(model_dir, trust_remote_code=True)
model = OVModelForVisualCausalLM.from_pretrained(model_dir, device="CPU")
image = Image.new("RGB", (64, 64), "white")
inputs = processor(images=image, text="Describe this image.", return_tensors="pt")
output_ids = model.generate(**inputs, max_new_tokens=10)
print(processor.batch_decode(output_ids, skip_special_tokens=True)[0])
```

## Validation

- WWB similarity: **1.0**

## Related model-support PRs

- OpenVINO GenAI: https://github.com/openvinotoolkit/openvino.genai/pull/4158

## Before submitting

- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Changed files

- `optimum/exporters/openvino/__main__.py`
- `tests/openvino/test_exporters_cli.py`
- `ocs/source/openvino/models.mdx`
- `optimum/exporters/openvino/convert.py`
- `optimum/exporters/openvino/model_configs.py`
- `optimum/exporters/openvino/model_patcher.py`
- `optimum/exporters/openvino/utils.py`
- `optimum/intel/openvino/modeling_visual_language.py`
- `tests/openvino/test_quantization.py`
- `tests/openvino/test_seq2seq.py`
- `tests/openvino/utils_tests.py`
- `optimum/intel/version.py`
- `setup.py`

