### PR TITLE
Test FunASR export and auto-compression cases

### DIFF
--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -126,7 +126,11 @@ class ExportModelTest(unittest.TestCase):
         model_type: model_cls
         for model_type, model_cls in SUPPORTED_ARCHITECTURES.items()
         if TEST_NAME_TO_MODEL_TYPE.get(model_type, model_type)
-        in get_supported_model_for_library("transformers") | get_supported_model_for_library("diffusers")
+        in (
+            get_supported_model_for_library("transformers")
+            | get_supported_model_for_library("diffusers")
+            | get_supported_model_for_library("funasr")
+        )
     }
 
     EXPECTED_DIFFUSERS_SCALE_FACTORS = {

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1191,7 +1191,8 @@ class OVWeightCompressionTest(unittest.TestCase):
     SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION = [
         config
         for config in SUPPORTED_ARCHITECTURES_WITH_AUTO_COMPRESSION
-        if TEST_NAME_TO_MODEL_TYPE.get(config[1], config[1]) in get_supported_model_for_library("transformers")
+        if TEST_NAME_TO_MODEL_TYPE.get(config[1], config[1])
+        in get_supported_model_for_library("transformers") | get_supported_model_for_library("funasr")
     ]
 
     SUPPORTED_ARCHITECTURES_WITH_HYBRID_QUANTIZATION = [


### PR DESCRIPTION
## Summary

- include the third-party `funasr` registry when building the OpenVINO export test matrix
- include the same registry in the auto-compression test matrix

## Why

This is a test-coverage follow-up to #1801. That PR registered `fun_asr` under the `funasr` library, but the generic test filters only retained architectures from `transformers` (and `diffusers` for export). As a result, the FunASR cases were present in the initial matrices and then silently filtered out during test collection.

This change only restores those existing test cases; it does not modify runtime behavior.

## Validation

- red/green AST assertion: `funasr` absent from both filters before the patch and present after it
- collection: 1 FunASR export case, 1 ASR parity case, and 2 FunASR quantization cases
- focused FunASR suite: 4 passed
- paired export suite (`qwen3_asr` + `fun_asr`): 2 passed
- paired ASR parity suite (`qwen3_asr` + `fun_asr`): 2 passed
- `black --check`
- `ruff check`
- `py_compile`
- `git diff --check`
