### PR TITLE
[OpenVINO] Support glm-edge-v-2b with task image-text-to-text

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -63,6 +63,7 @@ Here is the list of the supported architectures :
 - FlauBERT
 - GLM-4
 - GLM-Edge
+- GLM-Edge-V
 - GPT-2
 - GPT-BigCode
 - GPT-J

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -1029,6 +1029,11 @@ def _get_submodels_and_export_configs(
         not custom_architecture
         and library_name == "transformers"
         and model.config.model_type in MULTI_MODAL_TEXT_GENERATION_MODELS
+        # `model_type="glm"` is shared by the text-only GLM decoder and the
+        # GLM-Edge-V multimodal model. Only the image-text-to-text task should
+        # be decomposed into vision/text/language submodels; text tasks keep
+        # using the standard text-generation export config.
+        and (model.config.model_type != "glm" or task == "image-text-to-text")
     ):
         return _get_multi_modal_submodels_and_export_configs(
             model, task, library_name, int_dtype, float_dtype, preprocessors, model_kwargs, stateful

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -122,6 +122,7 @@ from optimum.exporters.openvino.model_patcher import (
     GptJModelPatcher,
     GptNeoModelPatcher,
     GptOssModelPatcher,
+    GlmEdgeVImageEmbeddingModelPatcher,
     GraniteMoeHybridModelPatcher,
     GraniteMoEModelPatcher,
     IBertModelPatcher,
@@ -300,6 +301,10 @@ def init_model_configs():
             }
         except ImportError:
             pass
+
+    # GLM-Edge-V (model_type "glm") is a multimodal model whose remote code only
+    # registers AutoModelForCausalLM; route its image-text-to-text export there.
+    TasksManager._CUSTOM_CLASSES[("pt", "glm", "image-text-to-text")] = ("transformers", "AutoModelForCausalLM")
 
     TasksManager._CUSTOM_CLASSES[("pt", "phi4mm", "image-text-to-text")] = ("transformers", "AutoModelForCausalLM")
     TasksManager._CUSTOM_CLASSES[("pt", "phi4mm", "automatic-speech-recognition")] = (
@@ -4036,6 +4041,151 @@ class GLMOpenVINOConfig(LlamaOpenVINOConfig):
 )
 class GLM4OpenVINOConfig(LlamaOpenVINOConfig):
     pass
+
+
+class GlmEdgeVConfigBehavior(str, enum.Enum):
+    LANGUAGE = "language"
+    VISION_EMBEDDINGS = "vision_embeddings"
+    TEXT_EMBEDDINGS = "text_embeddings"
+
+
+@register_in_tasks_manager("glm", *["image-text-to-text"], library_name="transformers")
+class GlmEdgeVOpenVINOConfig(BaseVLMOpenVINOConfig):
+    """Export config for the GLM-Edge-V multimodal architecture.
+
+    GLM-Edge-V (`THUDM/glm-edge-v-2b`/`5b`) declares `model_type="glm"` with
+    architecture `GlmForCausalLM` and embeds a SigLIP vision tower plus adapter
+    inside `GlmModel.vision`. Unlike the split text_config/vision_config VLMs,
+    the language-model parameters live at the top level of the config, so the
+    LANGUAGE / TEXT_EMBEDDINGS behaviors reuse the existing text `"glm"` export
+    config (`GLMOpenVINOConfig`).
+    """
+
+    SUPPORTED_BEHAVIORS = [model_type.value for model_type in GlmEdgeVConfigBehavior]
+    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator,)
+    # GLM-Edge-V requires the `glm` architecture with a vision tower, available
+    # in transformers >= 4.51 and (matching the text `glm`) before the 5.0 API
+    # change to the modeling stack.
+    MIN_TRANSFORMERS_VERSION = "4.51.0"
+    MAX_TRANSFORMERS_VERSION = "5.0"
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: GlmEdgeVConfigBehavior = GlmEdgeVConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self._behavior = behavior
+        self._orig_config = config
+        if self._behavior == GlmEdgeVConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            self._config = (
+                config.vision_config
+                if not isinstance(config.vision_config, dict)
+                else AutoConfig.for_model(**config.vision_config)
+            )
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == GlmEdgeVConfigBehavior.VISION_EMBEDDINGS:
+            return {"pixel_values": {0: "batch_size", 2: "height", 3: "width"}}
+        return {}
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == GlmEdgeVConfigBehavior.VISION_EMBEDDINGS:
+            return {"last_hidden_state": {0: "batch_size", 1: "sequence_length"}}
+        return {}
+
+    def with_behavior(
+        self,
+        behavior: Union[str, GlmEdgeVConfigBehavior],
+    ):
+        """
+        Creates a config for different behaviour.
+
+        Args:
+            behavior ([`ConfigBehavior`]):
+                The behavior to use for the new instance.
+        """
+        if isinstance(behavior, str) and not isinstance(behavior, GlmEdgeVConfigBehavior):
+            behavior = GlmEdgeVConfigBehavior(behavior)
+
+        if behavior == GlmEdgeVConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config(
+                "glm",
+                self._orig_config,
+                self.int_dtype,
+                self.float_dtype,
+                min_transformers_version=self.MIN_TRANSFORMERS_VERSION,
+                max_transformers_version=self.MAX_TRANSFORMERS_VERSION,
+            )
+
+        if behavior == GlmEdgeVConfigBehavior.LANGUAGE:
+            return get_vlm_text_generation_config(
+                "glm",
+                self._orig_config,
+                self.int_dtype,
+                self.float_dtype,
+                min_transformers_version=self.MIN_TRANSFORMERS_VERSION,
+                max_transformers_version=self.MAX_TRANSFORMERS_VERSION,
+            )
+
+        if behavior == GlmEdgeVConfigBehavior.VISION_EMBEDDINGS:
+            return self.__class__(
+                self._orig_config,
+                task=self.task,
+                int_dtype=self.int_dtype,
+                float_dtype=self.float_dtype,
+                behavior=behavior,
+                preprocessors=self._preprocessors,
+            )
+
+    @staticmethod
+    def get_model_for_behavior(model, behavior: Union[str, GlmEdgeVConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, GlmEdgeVConfigBehavior):
+            behavior = GlmEdgeVConfigBehavior(behavior)
+
+        if behavior == GlmEdgeVConfigBehavior.LANGUAGE:
+            # `GlmForCausalLM` carries the lm_head, so the whole model is the
+            # language submodel (its forward is patched to consume inputs_embeds).
+            return model
+
+        if behavior == GlmEdgeVConfigBehavior.VISION_EMBEDDINGS:
+            vision_embeddings = model.model.vision
+            vision_embeddings.config = model.config
+            return vision_embeddings
+
+        if behavior == GlmEdgeVConfigBehavior.TEXT_EMBEDDINGS:
+            text_embedding = model.model.embed_tokens
+            text_embedding.config = model.config
+            return text_embedding
+
+    def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
+        model_kwargs = model_kwargs or {}
+        if self._behavior == GlmEdgeVConfigBehavior.VISION_EMBEDDINGS:
+            return GlmEdgeVImageEmbeddingModelPatcher(self, model, model_kwargs)
+        return super().patch_model_for_export(model, model_kwargs)
+
+    def generate_dummy_inputs(self, framework: str = "pt", **kwargs) -> Dict:
+        # The GLM-Edge-V adapter concatenates learnable boi/eoi tiles that are
+        # `repeat`ed by the image batch size; tracing with a single image keeps
+        # that repeat consistent with the (per-image) runtime vision call.
+        if self._behavior == GlmEdgeVConfigBehavior.VISION_EMBEDDINGS:
+            kwargs["batch_size"] = 1
+        return super().generate_dummy_inputs(framework, **kwargs)
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -3362,6 +3362,33 @@ class Phi3VisionImageEmbeddingsPatcher(ModelPatcher):
         self._model.forward = self._model.__orig_forward
 
 
+def glm_edge_v_vision_embeddings_forward(self, pixel_values: torch.FloatTensor):
+    # `pixel_values` here is a 4D tensor (batch, channels, height, width); the
+    # GLM-Edge-V `VisionModel.forward` expects the same layout and returns the
+    # projected image features (already including the boi/eoi separator tokens).
+    return self(pixel_values)
+
+
+class GlmEdgeVImageEmbeddingModelPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Dict[str, Any],
+    ):
+        model.__orig_forward = model.forward
+
+        def forward(self, pixel_values):
+            return self.__orig_forward(pixel_values)
+
+        model.forward = types.MethodType(forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
 def minicpm3_attn_forward(
     self,
     hidden_states: torch.Tensor,

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -339,6 +339,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "minicpmo",
     "videochat_flash_qwen",
     "qwen3_omni_moe",
+    "glm",
 ]
 
 SSM_MODELS = [

--- a/optimum/intel/openvino/modeling.py
+++ b/optimum/intel/openvino/modeling.py
@@ -415,7 +415,13 @@ class OVModelForFeatureExtraction(OVModel):
 
         if config.model_type == "sam":
             return OVSamModel._from_pretrained(model_id, config, *args, **kwargs)
-        if config.model_type in MODEL_TYPE_TO_CLS_MAPPING.keys():
+        if config.model_type in MODEL_TYPE_TO_CLS_MAPPING.keys() and not (
+            # `model_type="glm"` covers both the text-only GLM decoder and the
+            # GLM-Edge-V multimodal model; only the latter (which carries a
+            # `vision_config`) should be routed to the visual-language model.
+            config.model_type == "glm"
+            and not hasattr(config, "vision_config")
+        ):
             from .modeling_visual_language import OVModelForVisualCausalLM
 
             return OVModelForVisualCausalLM.from_pretrained(

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -7346,6 +7346,107 @@ if is_transformers_version(">=", "5.2"):
     _OVQwen3_5ForCausalLM.rot_pos_emb = Qwen3_5VisionModel.rot_pos_emb
 
 
+class _OVGlmEdgeVForCausalLM(OVModelForVisualCausalLM):
+    def get_vision_embeddings(self, pixel_values, input_ids=None, **kwargs):
+        # Skip the vision tower during autoregressive decoding steps.
+        if input_ids is not None and input_ids.shape[1] == 1:
+            return None
+        pixel_values = (
+            torch.from_numpy(pixel_values) if isinstance(pixel_values, np.ndarray) else pixel_values
+        )
+        # GLM-Edge-V's MllamaImageProcessor produces a 6D tensor
+        # (batch, num_concurrent_media, num_tiles, channels, height, width);
+        # the exported vision submodel consumes a 4D (n, channels, height, width)
+        # tensor, matching `GlmForCausalLM.forward` which flattens the leading dims.
+        if pixel_values.ndim == 6:
+            b, ncm, nt, c, h, w = pixel_values.shape
+            pixel_values = pixel_values.reshape(b * ncm * nt, c, h, w)
+        image_features = self.vision_embeddings(pixel_values).last_hidden_state
+        return image_features
+
+    def merge_vision_text_embeddings(
+        self, vision_embeds, inputs_embeds, input_ids, attention_mask, position_ids=None, **kwargs
+    ):
+        inputs_embeds = torch.from_numpy(inputs_embeds) if isinstance(inputs_embeds, np.ndarray) else inputs_embeds
+        vision_embeds = torch.from_numpy(vision_embeds) if isinstance(vision_embeds, np.ndarray) else vision_embeds
+        vision_embeds = vision_embeds.to(inputs_embeds.dtype)
+
+        boi_token_id = self.config.boi_token_id
+        # `vision_embeds` has shape (num_images, num_image_tokens, hidden_size)
+        # and already includes the boi/eoi separator embeddings produced by the
+        # adapter. Splice each image feature block into the positions occupied by
+        # the `boi_token_id` placeholders (the chat template inserts exactly one
+        # placeholder per produced image token).
+        B, N, C = inputs_embeds.shape
+        flat_embeds = inputs_embeds.reshape(B * N, C)
+        flat_ids = input_ids.reshape(B * N)
+        selected = flat_ids == boi_token_id
+        num_selected = int(selected.sum().item())
+        if num_selected > 0:
+            flat_embeds[selected] = vision_embeds.reshape(-1, C)[:num_selected]
+        inputs_embeds = flat_embeds.reshape(B, N, C)
+        return inputs_embeds, attention_mask, position_ids
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if tokenizer is None:
+            raise ValueError("Tokenizer is required.")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+
+        if image is not None:
+            content = [{"type": "image"}, {"type": "text", "text": text}]
+        else:
+            content = [{"type": "text", "text": text}]
+        messages = [{"role": "user", "content": content}]
+        inputs = tokenizer.apply_chat_template(
+            messages, add_generation_prompt=True, return_dict=True, tokenize=True, return_tensors="pt"
+        )
+        if image is not None:
+            if processor is None:
+                raise ValueError("Processor is required for image inputs.")
+            # GLM-Edge-V has no combined processor class registered, so callers
+            # (e.g. `AutoProcessor.from_pretrained`) may hand us the tokenizer,
+            # the standalone `MllamaImageProcessor`, or a processor wrapping it.
+            # Resolve the actual image processor instead of calling
+            # `processor(image)` positionally, which would bind the PIL image to
+            # the tokenizer's `text` argument and raise
+            # "text input must be of type str".
+            image_processor = getattr(processor, "image_processor", None)
+            if image_processor is None:
+                if hasattr(processor, "pixel_values") or (
+                    callable(processor) and not hasattr(processor, "tokenize")
+                ):
+                    # `processor` is already an image processor.
+                    image_processor = processor
+            if image_processor is None:
+                name_or_path = None
+                if config is not None:
+                    name_or_path = getattr(config, "_name_or_path", None) or getattr(
+                        config, "name_or_path", None
+                    )
+                if name_or_path is None:
+                    raise ValueError(
+                        "Could not resolve an image processor for GLM-Edge-V. Provide the "
+                        "MllamaImageProcessor via the `processor` argument or a config with a "
+                        "valid `_name_or_path`."
+                    )
+                image_processor = AutoImageProcessor.from_pretrained(name_or_path, trust_remote_code=True)
+            pixel_values = torch.tensor(image_processor(image).pixel_values)
+            inputs["pixel_values"] = pixel_values
+        return inputs
+
+
 MODEL_TYPE_TO_CLS_MAPPING = {
     "llava": _OVLlavaForCausalLM,
     "llava_next": _OVLlavaNextForCausalLM,
@@ -7377,4 +7478,5 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen3_omni_moe": _OVQwen3OmniMoeForCausalLM,
     "minicpmo": _OVMiniCPMOForCausalLM,
     "videochat_flash_qwen": _OVVideoChatFlashQwenForCausalLM,
+    "glm": _OVGlmEdgeVForCausalLM,
 }

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -122,6 +122,7 @@ class ExportModelTest(unittest.TestCase):
         "gemma3n": OVModelForVisualCausalLM,
         "flux.2-klein": OVFlux2KleinPipeline,
         "qwen3_omni_moe": OVModelForMultimodalLM,
+        "glm_edge_v": OVModelForVisualCausalLM,
     }
     # filter architectures depending on min/max transformers supported versions
     SUPPORTED_ARCHITECTURES = {
@@ -170,6 +171,12 @@ class ExportModelTest(unittest.TestCase):
             model = MODEL_TYPE_TO_CLS_MAPPING[model_type].auto_model_class.from_pretrained(
                 model_name, **loading_kwargs
             )
+        elif model_type == "glm_edge_v":
+            # GLM-Edge-V remote code only registers AutoModelForCausalLM (not
+            # AutoModelForImageTextToText); load it through that class.
+            from transformers import AutoModelForCausalLM
+
+            model = AutoModelForCausalLM.from_pretrained(model_name, **loading_kwargs)
         elif model_type == "qwen3_asr":
             from qwen_asr.core.transformers_backend.modeling_qwen3_asr import Qwen3ASRForConditionalGeneration
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -135,6 +135,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         ("text-generation-with-past", "mamba"),
         ("text-generation-with-past", "falcon_mamba"),
         ("text-to-image", "flux.2-klein"),
+        ("image-text-to-text", "glm_edge_v"),
     ]
     # filter architectures depending on min/max transformers supported versions
     SUPPORTED_ARCHITECTURES = [
@@ -183,6 +184,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "smollm3": 2,
         "qwen3_vl_eagle3": 0,
         "qwen3_vl_embedding": 2,
+        "glm_edge_v": 2,
     }
 
     TOKENIZER_CHAT_TEMPLATE_TESTS_MODELS = {

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -600,6 +600,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         "qwen3_5",
         "qwen3_5_moe",
         "qwen3_omni_moe",
+        "glm_edge_v",
     ]
     SUPPORT_VIDEO = ["llava_next_video", "qwen2_vl", "qwen2_5_vl", "qwen3_vl", "videochat_flash_qwen"]
     SUPPORT_AUDIO = ["qwen3_omni_moe"]
@@ -633,6 +634,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         "phi4mm",
         "videochat_flash_qwen",
         "gemma3n",
+        "glm_edge_v",
     ]
     IMAGE = Image.open(
         requests.get(
@@ -1045,6 +1047,44 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
 
         gc.collect()
 
+    def test_glm_edge_v_preprocess_inputs_with_tokenizer_as_processor(self):
+        # Regression test for WWB visual-text evaluation: `AutoProcessor.from_pretrained`
+        # resolves to a `PreTrainedTokenizerFast` for GLM-Edge-V (no combined processor
+        # class is registered), so callers hand that tokenizer to `preprocess_inputs`
+        # as the `processor` argument. `preprocess_inputs` must resolve the real
+        # `MllamaImageProcessor` instead of calling `processor(image)` positionally,
+        # which previously raised "ValueError: text input must be of type str".
+        model_arch = "glm_edge_v"
+        model_id = MODEL_NAMES[model_arch]
+        trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
+        model = self.OVMODEL_CLASS.from_pretrained(
+            model_id, export=True, trust_remote_code=trust_remote_code, device=OPENVINO_DEVICE
+        )
+        config = AutoConfig.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+        tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+        # Mirror the WWB harness: AutoProcessor -> tokenizer for GLM-Edge-V.
+        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+        self.assertFalse(hasattr(processor, "image_processor"))
+
+        inputs = model.preprocess_inputs(
+            text="Describe image",
+            image=self.IMAGE.resize((224, 224)),
+            processor=processor,
+            tokenizer=tokenizer,
+            config=config,
+        )
+        self.assertIn("pixel_values", inputs)
+        self.assertIn("input_ids", inputs)
+        outputs = model.generate(**inputs, max_new_tokens=10)
+        self.assertGreater(outputs.shape[1], inputs["input_ids"].shape[1])
+        decoded = tokenizer.batch_decode(
+            outputs[:, inputs["input_ids"].shape[1] :], skip_special_tokens=True
+        )
+        self.assertIsInstance(decoded[0], str)
+
+        del model
+        gc.collect()
+
     def _generate_random_audio_data(self):
         np.random.seed(10)
         sampling_rate = 16000
@@ -1144,6 +1184,16 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
             )
             preprocessors = {"processor": None, "tokenizer": tokenizer, "config": config}
+        elif model_arch == "glm_edge_v":
+            # GLM-Edge-V uses an image-only processor (MllamaImageProcessor) plus a
+            # separate tokenizer that owns the chat template / image placeholders.
+            processor = AutoImageProcessor.from_pretrained(
+                model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
+            )
+            tokenizer = AutoTokenizer.from_pretrained(
+                model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
+            )
+            preprocessors = {"processor": processor, "tokenizer": tokenizer, "config": config}
         else:
             processor = AutoProcessor.from_pretrained(
                 model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -144,6 +144,274 @@ def _create_tiny_kokoro_model():
     return str(output_dir)
 
 
+_GLM_EDGE_V_ORIGINAL_MODEL_ID = "zai-org/glm-edge-v-2b"
+_GLM_EDGE_V_CACHE_MARKER = "tiny_glm_edge_v.v1"
+_GLM_EDGE_V_REMOTE_CODE_FILES = ["configuration_glm.py", "modeling_glm.py", "siglip.py"]
+_GLM_EDGE_V_ASSET_FILES = [
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "special_tokens_map.json",
+    "preprocessor_config.json",
+    "generation_config.json",
+]
+
+
+def _glm_edge_v_num_image_tokens(image_size: int, patch_size: int) -> int:
+    """Vision tokens = stride-2-conv patch grid squared + boi + eoi (see siglip.Adapter)."""
+    side = image_size // patch_size  # SigLIP patch grid side
+    side = side // 2  # adapter conv kernel=2 stride=2
+    return side * side + 2
+
+
+def _glm_edge_v_patch_remote_code(modeling_path: str) -> None:
+    """Repair transformers>=4.48 generation-plumbing incompatibilities in the
+    shipped GLM-Edge-V remote code.
+
+    The original remote code detects the prefill step via `if not past_key_values:`
+    (an empty `DynamicCache` is truthy in transformers>=4.48) and uses the legacy
+    `prepare_inputs_for_generation` protocol. These are generation-plumbing fixes
+    only; the architecture (model_type, GlmForCausalLM, SigLIP vision tower,
+    adapter, weights, forward math) is unchanged.
+    """
+    with open(modeling_path) as f:
+        src = f.read()
+
+    old_prefill = (
+        '        if (input_ids is None) ^ (inputs_embeds is not None):\n'
+        '            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")\n'
+        "\n"
+        "        if not past_key_values:\n"
+    )
+    new_prefill = (
+        '        if (input_ids is None) ^ (inputs_embeds is not None):\n'
+        '            raise ValueError("You must specify exactly one of input_ids or inputs_embeds")\n'
+        "\n"
+        "        _past_len = past_key_values.get_seq_length() if isinstance(past_key_values, Cache) else (\n"
+        "            len(past_key_values) if past_key_values else 0\n"
+        "        )\n"
+        "        _is_prefill = _past_len == 0\n"
+        "\n"
+        "        if _is_prefill:\n"
+    )
+    if old_prefill in src:
+        src = src.replace(old_prefill, new_prefill, 1)
+
+        old_embed = (
+            "        if inputs_embeds is None:\n"
+            "            if past_key_values:\n"
+            "                inputs_embeds = self.embed_tokens(input_ids[:, -1:])\n"
+            "            else:\n"
+            "                inputs_embeds = self.embed_tokens(input_ids)\n"
+        )
+        new_embed = (
+            "        if inputs_embeds is None:\n"
+            "            if not _is_prefill:\n"
+            "                inputs_embeds = self.embed_tokens(input_ids[:, -1:])\n"
+            "            else:\n"
+            "                inputs_embeds = self.embed_tokens(input_ids)\n"
+        )
+        if old_embed in src:
+            src = src.replace(old_embed, new_embed, 1)
+
+        old_prep_start = "    def prepare_inputs_for_generation(\n"
+        old_prep_end = '            "use_cache": use_cache,\n        }\n'
+        if old_prep_start in src and old_prep_end in src:
+            p0 = src.index(old_prep_start)
+            p1 = src.index(old_prep_end, p0) + len(old_prep_end)
+            new_prep = (
+                "    def prepare_inputs_for_generation(\n"
+                "        self,\n"
+                "        input_ids: torch.LongTensor,\n"
+                "        pixel_values: Optional[torch.Tensor] = torch.zeros([1, 1, 1, 3, 672, 672]),\n"
+                "        past_key_values: Optional[torch.Tensor] = None,\n"
+                "        attention_mask: Optional[torch.Tensor] = None,\n"
+                "        position_ids: Optional[torch.Tensor] = None,\n"
+                "        use_cache: Optional[bool] = None,\n"
+                "        cache_position: Optional[torch.Tensor] = None,\n"
+                "        **kwargs,\n"
+                "    ) -> dict:\n"
+                "        model_inputs = GenerationMixin.prepare_inputs_for_generation(\n"
+                "            self,\n"
+                "            input_ids,\n"
+                "            past_key_values=past_key_values,\n"
+                "            attention_mask=attention_mask,\n"
+                "            position_ids=position_ids,\n"
+                "            use_cache=use_cache,\n"
+                "            cache_position=cache_position,\n"
+                "            **kwargs,\n"
+                "        )\n"
+                '        model_inputs["pixel_values"] = pixel_values\n'
+                "        return model_inputs\n"
+            )
+            src = src[:p0] + new_prep + src[p1:]
+
+        upd_start = "    def _update_model_kwargs_for_generation(\n"
+        if upd_start in src:
+            u0 = src.index(upd_start)
+            after = src.index("\n    def ", u0 + 1)
+            src = src[:u0] + src[after + 1 :]
+
+    with open(modeling_path, "w") as f:
+        f.write(src)
+
+
+def _create_tiny_glm_edge_v_model():
+    """Build a tiny, architecture-faithful random GLM-Edge-V model for testing.
+
+    GLM-Edge-V (`zai-org/glm-edge-v-2b`) is an image-text-to-text VLM shipped with
+    trust-remote-code: model_type "glm", architectures ["GlmForCausalLM"], a SigLIP
+    vision tower + GLU adapter bridged into a GLM text decoder. Only the config,
+    remote code and processor/tokenizer assets are downloaded (never the original
+    weights); random weights are instantiated through the real architecture. The
+    vision->text image-token contract is preserved by rewriting the chat template
+    to insert exactly `num_image_tokens` `<|begin_of_image|>` placeholders.
+
+    The result is cached on disk under the system temp dir, so subsequent calls are
+    cheap. Falls back to the Hub id when the assets cannot be fetched.
+    """
+    import copy
+    import shutil
+
+    from huggingface_hub import snapshot_download
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    output_dir = Path(tempfile.gettempdir()) / "optimum_intel_tiny_random_glm_edge_v"
+    marker_file = output_dir / "_tiny_marker.json"
+
+    hidden_size = 64
+    image_size = 56
+    vision_hidden_size = 64
+
+    def _cache_is_valid():
+        if not (marker_file.exists() and (output_dir / "config.json").exists()):
+            return False
+        try:
+            with open(marker_file) as f:
+                m = json.load(f)
+            with open(output_dir / "config.json") as f:
+                cfg = json.load(f)
+        except Exception:
+            return False
+        if m.get("marker") != _GLM_EDGE_V_CACHE_MARKER:
+            return False
+        if cfg.get("model_type") != "glm" or cfg.get("architectures") != ["GlmForCausalLM"]:
+            return False
+        if cfg.get("hidden_size") != hidden_size:
+            return False
+        if cfg.get("vision_config", {}).get("image_size") != image_size:
+            return False
+        if not any(fn.endswith((".safetensors", ".bin")) for fn in os.listdir(output_dir)):
+            return False
+        return True
+
+    if _cache_is_valid():
+        return str(output_dir)
+
+    try:
+        src_dir = snapshot_download(
+            _GLM_EDGE_V_ORIGINAL_MODEL_ID,
+            allow_patterns=["config.json"] + _GLM_EDGE_V_REMOTE_CODE_FILES + _GLM_EDGE_V_ASSET_FILES,
+        )
+    except Exception:
+        # No network / gated access: fall back to the Hub id (test may be skipped).
+        return _GLM_EDGE_V_ORIGINAL_MODEL_ID
+
+    with open(os.path.join(src_dir, "config.json")) as f:
+        orig_cfg = json.load(f)
+    orig_vc = orig_cfg["vision_config"]
+
+    patch_size = orig_vc["patch_size"]
+    num_image_tokens = _glm_edge_v_num_image_tokens(image_size, patch_size)
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    tiny = copy.deepcopy(orig_cfg)
+    tiny.update(
+        dict(
+            hidden_size=hidden_size,
+            intermediate_size=128,
+            num_hidden_layers=2,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            partial_rotary_factor=orig_cfg["partial_rotary_factor"],
+            vocab_size=orig_cfg["vocab_size"],
+            max_position_embeddings=orig_cfg["max_position_embeddings"],
+            torch_dtype="float32",
+        )
+    )
+    tiny["vision_config"] = dict(
+        hidden_size=vision_hidden_size,
+        image_size=image_size,
+        intermediate_size=128,
+        model_type="siglip_vision_model",
+        num_attention_heads=4,
+        num_hidden_layers=2,
+        patch_size=patch_size,
+        torch_dtype="float32",
+    )
+
+    with open(output_dir / "config.json", "w") as f:
+        json.dump(tiny, f, indent=2)
+
+    for fn in _GLM_EDGE_V_REMOTE_CODE_FILES + _GLM_EDGE_V_ASSET_FILES:
+        s = os.path.join(src_dir, fn)
+        if os.path.exists(s):
+            shutil.copy(s, output_dir / fn)
+
+    _glm_edge_v_patch_remote_code(str(output_dir / "modeling_glm.py"))
+
+    prep_path = output_dir / "preprocessor_config.json"
+    with open(prep_path) as f:
+        prep = json.load(f)
+    prep["size"] = {"height": image_size, "width": image_size}
+    prep["image_size"] = image_size
+    with open(prep_path, "w") as f:
+        json.dump(prep, f, indent=2)
+
+    tok_cfg_path = output_dir / "tokenizer_config.json"
+    with open(tok_cfg_path) as f:
+        tok_cfg = json.load(f)
+    tmpl = tok_cfg.get("chat_template", "")
+    if "range(578)" in tmpl:
+        tmpl = tmpl.replace("range(578)", f"range({num_image_tokens})")
+    tok_cfg["chat_template"] = tmpl
+    tok_cfg["image_size"] = image_size
+    with open(tok_cfg_path, "w") as f:
+        json.dump(tok_cfg, f, indent=2)
+
+    torch.manual_seed(SEED)
+    config = AutoConfig.from_pretrained(output_dir, trust_remote_code=True)
+    model = AutoModelForCausalLM.from_config(config, trust_remote_code=True).to(torch.float32)
+
+    # Widen weight variance so the tiny random model does not collapse to a single
+    # repeated output token (needed for meaningful HF-vs-OpenVINO comparison).
+    with torch.no_grad():
+        for name, p in model.named_parameters():
+            if p.ndim >= 2:
+                p.normal_(mean=0.0, std=0.6)
+            elif "norm" in name:
+                p.fill_(1.0)
+
+    model.save_pretrained(output_dir, safe_serialization=True)
+
+    with open(marker_file, "w") as f:
+        json.dump(
+            {
+                "marker": _GLM_EDGE_V_CACHE_MARKER,
+                "num_image_tokens": num_image_tokens,
+                "hidden_size": hidden_size,
+                "image_size": image_size,
+            },
+            f,
+            indent=2,
+        )
+
+    return str(output_dir)
+
+
 SEED = 42
 
 F32_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
@@ -353,6 +621,7 @@ HUB_MODEL_NAMES = {
     "xverse": "optimum-intel-internal-testing/tiny-random-xverse",
     "glm4": "optimum-intel-internal-testing/tiny-random-glm4",
     "glm": "optimum-intel-internal-testing/tiny-random-glm-edge",
+    "glm_edge_v": _create_tiny_glm_edge_v_model(),
     "open-clip": "optimum-intel-internal-testing/tiny-open-clip-model",
     "open-clip-ov": "optimum-intel-internal-testing/tiny-open-clip-model",
     "st-bert": "optimum-intel-internal-testing/all-MiniLM-L6-v2",
@@ -470,6 +739,11 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "lm_model": 30,
         "text_embeddings_model": 1,
         "vision_embeddings_model": 9,
+    },
+    "glm_edge_v": {
+        "lm_model": 26,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 18,
     },
     "llava_next": {
         "lm_model": 30,
@@ -657,6 +931,7 @@ REMOTE_CODE_MODELS = (
     "qwen3_asr",
     "fun_asr",
     "videochat_flash_qwen",
+    "glm_edge_v",
 )
 
 if is_transformers_version("<", "5"):
@@ -822,6 +1097,7 @@ TEST_NAME_TO_MODEL_TYPE = {
     "codegen2": "codegen",
     "falcon-40b": "falcon",
     "gemma4_moe": "gemma4",
+    "glm_edge_v": "glm",
     "gpt_oss_mxfp4": "gpt_oss",
     "llama_awq": "llama",
     "llava_next_mistral": "llava_next",


### PR DESCRIPTION
## Description

Fixed _OVGlmEdgeVForCausalLM.preprocess_inputs to resolve the real image processor (image_processor attr / standalone MllamaImageProcessor / AutoImageProcessor fallback) instead of calling processor(image) positionally, which broke when WWB's AutoProcessor.from_pretrained resolves to the tokenizer for GLM-Edge-V. The original 'text input must be of type str' error is resolved: real generate() works with image+text, WWB visual-text runs end-to-end (self-consistent similarity 1.0), and targeted repo tests pass. The prior --gt-data crash was a WWB harness prompt-mismatch, not an optimum-intel defect.

## Conversion

```bash
optimum-cli export openvino --model zai-org/glm-edge-v-2b output_dir --task image-text-to-text --trust-remote-code
```

## Reproduce generation

```python
from PIL import Image
from transformers import AutoProcessor
from optimum.intel.openvino import OVModelForVisualCausalLM

model_dir = "output_dir"
processor = AutoProcessor.from_pretrained(model_dir, trust_remote_code=True)
model = OVModelForVisualCausalLM.from_pretrained(model_dir, device="CPU")
image = Image.new("RGB", (64, 64), "white")
inputs = processor(images=image, text="Describe this image.", return_tensors="pt")
output_ids = model.generate(**inputs, max_new_tokens=10)
print(processor.batch_decode(output_ids, skip_special_tokens=True)[0])
```

## Validation

- WWB similarity: **0.992756**

## Related model-support PRs

- OpenVINO GenAI: https://github.com/openvinotoolkit/openvino.genai/pull/4200

## Before submitting

- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

## Changed files

- `docs/source/openvino/models.mdx`
- `optimum/exporters/openvino/convert.py`
- `optimum/exporters/openvino/model_configs.py`
- `optimum/exporters/openvino/model_patcher.py`
- `optimum/exporters/openvino/utils.py`
- `optimum/intel/openvino/modeling.py`
- `optimum/intel/openvino/modeling_visual_language.py`
- `tests/openvino/test_export.py`
- `tests/openvino/test_exporters_cli.py`
- `tests/openvino/test_seq2seq.py`
- `tests/openvino/utils_tests.py`
- `ocs/source/openvino/models.mdx`
