### PR TITLE
[OpenVINO] Support Youtu-VL-4B-Instruct with task image-text-to-text

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -175,6 +175,7 @@ Here is the list of the supported architectures :
 - XLM
 - XLM-RoBERTa
 - XVERSE
+- Youtu-VL
 - Zamba2
 
 ## [Diffusers](https://huggingface.co/docs/diffusers/index)

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -1396,6 +1396,103 @@ class DummyQwen3VLVisionEmbedInputGenerator(DummyQwen2VLVisionEmbedInputGenerato
             )
 
 
+class YoutuVLDummyVisionEmbedInputGenerator(DummyVisionInputGenerator):
+    """Dummy input generator for the youtu_vl vision embeddings submodel.
+
+    The youtu_vl vision tower is a siglip2-based encoder that consumes already-patchified pixel
+    values of shape (batch_size, num_patches, num_channels * patch_size * patch_size).
+    """
+
+    SUPPORTED_INPUT_NAMES = ("pixel_values",)
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = 1,
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        width: int = 64,
+        height: int = 64,
+        **kwargs,
+    ):
+        self.task = task
+        self.batch_size = batch_size
+        self.num_channels = normalized_config.config.num_channels
+        self.patch_size = normalized_config.config.patch_size
+        in_features = getattr(normalized_config.config, "in_features", -1)
+        if in_features is not None and in_features > 0:
+            self.in_features = in_features
+        else:
+            self.in_features = self.num_channels * self.patch_size * self.patch_size
+        spatial_merge_size = getattr(normalized_config.config, "spatial_merge_size", 2)
+        grid = max(spatial_merge_size * 2, 4)
+        self.num_patches = grid * grid
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "pixel_values":
+            return self.random_float_tensor(
+                [self.batch_size, self.num_patches, self.in_features], framework=framework, dtype=float_dtype
+            )
+
+
+class YoutuVLDummyVisionMergerInputGenerator(DummyVisionInputGenerator):
+    """Dummy input generator for the youtu_vl vision embeddings merger submodel.
+
+    Mirrors the Qwen2.5-VL windowed-attention merger inputs: encoder hidden states plus the
+    precomputed full/window attention masks, window index and rotary position embeddings.
+    """
+
+    SUPPORTED_INPUT_NAMES = (
+        "hidden_states",
+        "attention_mask",
+        "window_attention_mask",
+        "window_index",
+        "rotary_pos_emb",
+    )
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = 1,
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        width: int = 64,
+        height: int = 64,
+        **kwargs,
+    ):
+        self.task = task
+        self.batch_size = batch_size
+        self.hidden_size = normalized_config.config.hidden_size
+        self.num_heads = normalized_config.config.num_attention_heads
+        self.spatial_merge_size = getattr(normalized_config.config, "spatial_merge_size", 2)
+        grid = max(self.spatial_merge_size * 2, 4)
+        self.seq_len = grid * grid
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "hidden_states":
+            return self.random_float_tensor([self.seq_len, self.hidden_size], framework=framework, dtype=float_dtype)
+
+        if input_name in ["attention_mask", "window_attention_mask"]:
+            return self.random_mask_tensor([1, self.seq_len, self.seq_len], framework=framework, dtype=float_dtype)
+
+        if input_name == "rotary_pos_emb":
+            dim = self.hidden_size // self.num_heads // 2
+            return self.random_float_tensor([self.seq_len, dim], framework=framework, dtype=float_dtype)
+
+        if input_name == "window_index":
+            spatial_merge_unit = self.spatial_merge_size * self.spatial_merge_size
+            length = self.seq_len // spatial_merge_unit
+            return self.random_int_tensor([length], max_value=length)
+
+
+class YoutuVLDummyPastKeyValuesGenerator(OVMiniCPM3DummyPastKeyValuesGenerator):
+    """Past-key-values generator for the youtu_vl MLA (multi-head latent attention) language model.
+
+    The cache stores per-head keys of dim (qk_nope_head_dim + qk_rope_head_dim) and values of
+    dim v_head_dim, identical in layout to the MiniCPM3/DeepSeek-V2 MLA cache.
+    """
+
+
 class Qwen3ASRDummySeq2SeqPastKeyValuesGenerator(DummySeq2SeqPastKeyValuesGenerator):
     """Custom KV cache generator for Qwen3-ASR with GQA (num_key_value_heads != num_attention_heads).
     Qwen3-ASR has no cross-attention, so only self-attention KV cache is generated (2 per layer)."""

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -93,6 +93,9 @@ from optimum.exporters.openvino.input_generators import (
     Qwen3ASRDummySeq2SeqPastKeyValuesGenerator,
     Qwen3NextDummyPastKeyValuesGenerator,
     QwenDummyPastKeyValuesGenerator,
+    YoutuVLDummyPastKeyValuesGenerator,
+    YoutuVLDummyVisionEmbedInputGenerator,
+    YoutuVLDummyVisionMergerInputGenerator,
     Zamba2DummyPastKeyValuesGenerator,
 )
 from optimum.exporters.openvino.model_patcher import (
@@ -187,6 +190,9 @@ from optimum.exporters.openvino.model_patcher import (
     SpeechT5ModelPatcher,
     VideoChatFlashQwenVisionEmbeddingModelPatcher,
     XverseModelPatcher,
+    YoutuVLLanguageModelPatcher,
+    YoutuVLModelPatcher,
+    YoutuVLVisionEmbMergerPatcher,
     Zamba2ModelPatcher,
     _get_model_attribute,
 )
@@ -3595,6 +3601,146 @@ class Qwen2_5_VLOpenVINOConfig(Qwen2VLOpenVINOConfig):
         return super().patch_model_for_export(model, model_kwargs)
 
 
+@register_in_tasks_manager("youtu_vl", *["image-text-to-text"], library_name="transformers")
+class YoutuVLOpenVINOConfig(BaseVLMOpenVINOConfig):
+    SUPPORTED_BEHAVIORS = [
+        model_type.value for model_type in QwenVLConfigBehavior if model_type.value != "vision_embeddings_pos"
+    ]
+    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
+    DUMMY_INPUT_GENERATOR_CLASSES = (YoutuVLDummyVisionEmbedInputGenerator,)
+    MIN_TRANSFORMERS_VERSION = "4.57"
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: QwenVLConfigBehavior = QwenVLConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        self._behavior = behavior
+        self._orig_config = config
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            self._config = config.vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+            self.DUMMY_INPUT_GENERATOR_CLASSES = (YoutuVLDummyVisionEmbedInputGenerator,)
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS_MERGER and hasattr(config, "vision_config"):
+            self._config = config.vision_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)
+            self.DUMMY_INPUT_GENERATOR_CLASSES = (YoutuVLDummyVisionMergerInputGenerator,)
+
+    @staticmethod
+    def get_model_for_behavior(model, behavior: Union[str, QwenVLConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, QwenVLConfigBehavior):
+            behavior = QwenVLConfigBehavior(behavior)
+
+        if behavior == QwenVLConfigBehavior.LANGUAGE:
+            return model
+
+        if behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS:
+            vision_embeddings = model.siglip2.vision_model.embeddings
+            vision_embeddings.config = model.config.vision_config
+            return vision_embeddings
+
+        if behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS_MERGER:
+            # The merger patcher runs the siglip2 encoder + post_layernorm + patch merger, all of
+            # which are reachable from the top-level model, so we return the whole model here.
+            model.config.vision_config.torchscript = True
+            return model
+
+        if behavior == QwenVLConfigBehavior.TEXT_EMBEDDINGS:
+            text_embedding = model.model.embed_tokens
+            text_embedding.config = model.config
+            return text_embedding
+
+    def with_behavior(
+        self,
+        behavior: Union[str, QwenVLConfigBehavior],
+    ):
+        """
+        Creates a config for different behaviour.
+        Args:
+            behavior ([`ConfigBehavior`]):
+                The behavior to use for the new instance.
+        """
+        if isinstance(behavior, str) and not isinstance(behavior, QwenVLConfigBehavior):
+            behavior = QwenVLConfigBehavior(behavior)
+
+        if behavior == QwenVLConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config(
+                "youtu_vl_text",
+                self._orig_config,
+                self.int_dtype,
+                self.float_dtype,
+            )
+
+        if behavior == QwenVLConfigBehavior.LANGUAGE:
+            return get_vlm_text_generation_config(
+                "youtu_vl_text",
+                self._orig_config,
+                self.int_dtype,
+                self.float_dtype,
+                model_patcher=YoutuVLLanguageModelPatcher,
+            )
+
+        if behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS:
+            return self.__class__(
+                self._orig_config,
+                task=self.task,
+                int_dtype=self.int_dtype,
+                float_dtype=self.float_dtype,
+                behavior=behavior,
+                preprocessors=self._preprocessors,
+            )
+        if behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS_MERGER:
+            return self.__class__(
+                self._orig_config,
+                task=self.task,
+                int_dtype=self.int_dtype,
+                float_dtype=self.float_dtype,
+                behavior=behavior,
+                preprocessors=self._preprocessors,
+            )
+
+    def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
+        model_kwargs = model_kwargs or {}
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS_MERGER:
+            return YoutuVLVisionEmbMergerPatcher(self, model, model_kwargs)
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS:
+            return ModelPatcher(self, model, model_kwargs=model_kwargs)
+        return super().patch_model_for_export(model, model_kwargs)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS:
+            return {"pixel_values": {0: "batch_size", 1: "num_patches"}}
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS_MERGER:
+            return {
+                "hidden_states": {0: "sequence_length"},
+                "attention_mask": {1: "sequence_length", 2: "sequence_length"},
+                "window_attention_mask": {1: "sequence_length", 2: "sequence_length"},
+                "window_index": {0: "unit_sequence_length"},
+                "rotary_pos_emb": {0: "sequence_length"},
+            }
+        return {}
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS:
+            return {"last_hidden_state": {0: "sequence_length"}}
+        if self._behavior == QwenVLConfigBehavior.VISION_EMBEDDINGS_MERGER:
+            return {"last_hidden_state": {0: "seq_len"}}
+        return {}
+
+
 @register_in_tasks_manager(
     "qwen3_vl",
     *[
@@ -4585,6 +4731,20 @@ class DeepseekOpenVINOConfig(MiniCPM3OpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "4.51.0"
     MAX_TRANSFORMERS_VERSION = "4.53.3"
     _MODEL_PATCHER = DeepseekPatcher
+
+
+@register_in_tasks_manager(
+    "youtu_vl_text", *["text-generation", "text-generation-with-past"], library_name="transformers"
+)
+class YoutuVLTextOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
+    # youtu_vl language model: DeepSeek-V2 style multi-head latent attention (MLA) with a standard
+    # (dense) MLP. Its KV cache stores per-head keys of dim (qk_nope_head_dim + qk_rope_head_dim)
+    # and values of dim v_head_dim, identical in layout to the MiniCPM3/DeepSeek-V2 MLA cache.
+    MIN_TRANSFORMERS_VERSION = "4.57"
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyTextInputGenerator, YoutuVLDummyPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = YoutuVLDummyPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+    _MODEL_PATCHER = YoutuVLModelPatcher
 
 
 @register_in_tasks_manager("got_ocr2", *["image-to-text", "image-text-to-text"], library_name="transformers")

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -4125,6 +4125,202 @@ class Qwen2_5_VLVisionEmbMergerPatcher(ModelPatcher):
             block.attn.forward = block.attn._orig_forward
 
 
+def patch_youtu_vl_vision_blocks(model):
+    # youtu_vl reuses a Qwen2.5-VL-style windowed vision encoder built on top of siglip2.
+    # The per-layer attention (`Vision_SDPAAttention` / `Vision_EagerAttention`) builds its
+    # attention mask internally from `cu_seqlens` with a python loop, which is not traceable.
+    # We replace it with an attention that consumes a precomputed `attention_mask`.
+    def sdpa_attn_forward(
+        self,
+        hidden_states: torch.Tensor,
+        attention_mask: torch.Tensor,
+        cu_seqlens: torch.Tensor = None,
+        rotary_pos_emb: torch.Tensor = None,
+        position_embeddings: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+    ):
+        def rotate_half(x):
+            x1 = x[..., : x.shape[-1] // 2]
+            x2 = x[..., x.shape[-1] // 2 :]
+            return torch.cat((-x2, x1), dim=-1)
+
+        def apply_rotary_pos_emb_vision(q, k, cos, sin):
+            orig_q_dtype = q.dtype
+            orig_k_dtype = k.dtype
+            q, k = q.float(), k.float()
+            cos, sin = cos.unsqueeze(-2).float(), sin.unsqueeze(-2).float()
+            q_embed = (q * cos) + (rotate_half(q) * sin)
+            k_embed = (k * cos) + (rotate_half(k) * sin)
+            q_embed = q_embed.to(orig_q_dtype)
+            k_embed = k_embed.to(orig_k_dtype)
+            return q_embed, k_embed
+
+        seq_length = hidden_states.shape[0]
+        q = self.q_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+        k = self.k_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+        v = self.v_proj(hidden_states).reshape(seq_length, self.num_heads, -1)
+        if position_embeddings is None:
+            emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+            cos = emb.cos()
+            sin = emb.sin()
+        else:
+            cos, sin = position_embeddings
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
+        q = q.transpose(0, 1).unsqueeze(0)
+        k = k.transpose(0, 1).unsqueeze(0)
+        v = v.transpose(0, 1).unsqueeze(0)
+        attn_output = torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=attention_mask)
+        attn_output = attn_output.squeeze(0).transpose(0, 1).reshape(seq_length, -1).to(hidden_states.dtype)
+        attn_output = self.out_proj(attn_output)
+        return attn_output, None
+
+    def layer_forward(
+        self,
+        hidden_states,
+        attention_mask,
+        cu_seqlens=None,
+        rotary_pos_emb=None,
+        position_embeddings=None,
+        output_attentions=False,
+    ):
+        residual = hidden_states
+        hidden_states = self.layer_norm1(hidden_states)
+        hidden_states, _ = self.self_attn(
+            hidden_states=hidden_states,
+            attention_mask=attention_mask,
+            rotary_pos_emb=rotary_pos_emb,
+            position_embeddings=position_embeddings,
+        )
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = self.layer_norm2(hidden_states)
+        hidden_states = self.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+        return (hidden_states,)
+
+    for layer in model.layers:
+        layer._orig_forward = layer.forward
+        layer.forward = types.MethodType(layer_forward, layer)
+        layer.self_attn._orig_forward = layer.self_attn.forward
+        layer.self_attn.forward = types.MethodType(sdpa_attn_forward, layer.self_attn)
+
+
+class YoutuVLVisionEmbMergerPatcher(ModelPatcher):
+    # The model wrapped here is the top-level YoutuVLForConditionalGeneration; we patch its forward
+    # to run the siglip2 vision encoder (windowed attention) + post_layernorm + patch merger with
+    # precomputed attention masks / window index / rotary pos emb (all data-dependent parts are
+    # computed at runtime in the OpenVINO model class, outside the traced graph).
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Dict[str, Any] = None,
+    ):
+        model.__orig_forward = model.forward
+        encoder = model.siglip2.vision_model.encoder
+        spatial_merge_unit = encoder.spatial_merge_unit
+        num_layers = len(encoder.layers)
+        # Reproduces the block-level full-vs-window attention selection in Siglip2Encoder.forward:
+        # every 8th layer (1-indexed) and the last layer use full attention.
+        fullatt_block_indexes = [i for i in range(num_layers) if ((i + 1) % 8 == 0 or i == num_layers - 1)]
+
+        def image_embed_forward(
+            self,
+            hidden_states: torch.Tensor,
+            attention_mask: torch.Tensor,
+            window_attention_mask: torch.Tensor,
+            window_index: torch.Tensor,
+            rotary_pos_emb: torch.Tensor,
+        ) -> torch.Tensor:
+            enc = self.siglip2.vision_model.encoder
+            seq_len = hidden_states.shape[0]
+            hidden_states = hidden_states.reshape(seq_len // spatial_merge_unit, spatial_merge_unit, -1)
+            hidden_states = hidden_states[window_index, :, :]
+            hidden_states = hidden_states.reshape(seq_len, -1)
+            rotary_pos_emb = rotary_pos_emb.reshape(seq_len // spatial_merge_unit, spatial_merge_unit, -1)
+            rotary_pos_emb = rotary_pos_emb[window_index, :, :]
+            rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+            emb = torch.cat((rotary_pos_emb, rotary_pos_emb), dim=-1)
+            position_embeddings = (emb.cos(), emb.sin())
+            for layer_num, blk in enumerate(enc.layers):
+                attention_mask_now = attention_mask if layer_num in fullatt_block_indexes else window_attention_mask
+                hidden_states = blk(
+                    hidden_states, attention_mask=attention_mask_now, position_embeddings=position_embeddings
+                )[0]
+            reverse_indices = torch.argsort(window_index)
+            hidden_states = hidden_states.reshape(seq_len // spatial_merge_unit, spatial_merge_unit, -1)
+            hidden_states = hidden_states[reverse_indices, :, :]
+            hidden_states = hidden_states.reshape(seq_len, -1)
+            hidden_states = self.siglip2.vision_model.post_layernorm(hidden_states)
+            hidden_states = self.merger(hidden_states, None)
+            return hidden_states
+
+        model.forward = types.MethodType(image_embed_forward, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __enter__(self):
+        patch_youtu_vl_vision_blocks(self._model.siglip2.vision_model.encoder)
+        super().__enter__()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+        for layer in self._model.siglip2.vision_model.encoder.layers:
+            layer.forward = layer._orig_forward
+            layer.self_attn.forward = layer.self_attn._orig_forward
+
+
+class YoutuVLModelPatcher(OVDecoderModelPatcher):
+    # Text-generation patcher for the youtu_vl MLA (multi-head latent attention) language model.
+    # The stock YoutuMLAttention forward already traces with standard tensor ops, so we only rely
+    # on the common decoder patching (stateful cache handling) from OVDecoderModelPatcher.
+    pass
+
+
+class YoutuVLLanguageModelPatcher(OVDecoderModelPatcher):
+    # Wraps the youtu_vl language model forward to accept `inputs_embeds` produced by the vision
+    # merge step, converting the legacy cache to a DynamicCache like the Qwen2-VL LM patcher.
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Dict[str, Any] = None,
+    ):
+        model.__orig_forward = model.forward
+
+        def forward_wrap(
+            self,
+            attention_mask,
+            position_ids=None,
+            past_key_values=None,
+            inputs_embeds=None,
+            input_ids=None,
+            use_cache=True,
+        ):
+            if is_transformers_version("<", "5"):
+                new_past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+            else:
+                new_past_key_values = DynamicCache(past_key_values)
+
+            result = self.__orig_forward(
+                input_ids=input_ids,
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=new_past_key_values,
+                inputs_embeds=inputs_embeds,
+                use_cache=use_cache,
+            )
+            if past_key_values is not None:
+                result["past_key_values"] = postprocess_past_key_values(result["past_key_values"])
+            return result
+
+        model.forward = types.MethodType(forward_wrap, model)
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        self._model.forward = self._model.__orig_forward
+
+
 class Qwen3VLVisionEmbMergerPatcher(ModelPatcher):
     def __init__(
         self,

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -339,6 +339,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "minicpmo",
     "videochat_flash_qwen",
     "qwen3_omni_moe",
+    "youtu_vl",
 ]
 
 SSM_MODELS = [

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -3676,6 +3676,280 @@ if is_transformers_version(">=", "4.57"):
     _OVQwen2_5_VLForCausalLM.get_vision_position_ids = getattr(Qwen2_5_VLModel, "get_vision_position_ids", None)
 
 
+class _OVYoutuVLForCausalLM(OVModelForVisualCausalLM):
+    additional_parts = ["vision_embeddings_merger"]
+
+    def __init__(
+        self,
+        language_model: ov.Model,
+        text_embeddings: ov.Model,
+        vision_embeddings: ov.Model,
+        config: PretrainedConfig = None,
+        device: str = "CPU",
+        dynamic_shapes: bool = None,
+        ov_config: Optional[Dict[str, str]] = None,
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
+        **kwargs,
+    ):
+        if is_transformers_version("<", "4.57"):
+            raise Exception("YoutuVL is not supported in transformers versions earlier than 4.57.")
+
+        super().__init__(
+            language_model=language_model,
+            text_embeddings=text_embeddings,
+            vision_embeddings=vision_embeddings,
+            config=config,
+            device=device,
+            dynamic_shapes=dynamic_shapes,
+            ov_config=ov_config,
+            model_save_dir=model_save_dir,
+            quantization_config=quantization_config,
+            **kwargs,
+        )
+
+        class VisionRotaryEmbedding(torch.nn.Module):
+            def __init__(self, dim: int, theta: float = 10000.0) -> None:
+                super().__init__()
+                inv_freq = 1.0 / (theta ** (torch.arange(0, dim, 2, dtype=torch.float) / dim))
+                self.register_buffer("inv_freq", inv_freq, persistent=False)
+
+            def forward(self, seqlen: int) -> torch.Tensor:
+                seq = torch.arange(seqlen, device=self.inv_freq.device, dtype=self.inv_freq.dtype)
+                freqs = torch.outer(seq, self.inv_freq)
+                return freqs
+
+        vision_config = config.vision_config
+        head_dim = vision_config.hidden_size // vision_config.num_attention_heads
+        self._rotary_pos_emb = VisionRotaryEmbedding(head_dim // 2)
+        self._spatial_merge_size = 2
+        self._patch_size = vision_config.patch_size
+        # window_size = patch_size * 2 * 8 in Siglip2Encoder
+        self._window_size = self._patch_size * 2 * 8
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        cache_position=None,
+        position_ids=None,
+        use_cache=True,
+        pixel_values=None,
+        pixel_attention_mask=None,
+        spatial_shapes=None,
+        is_first_iteration=False,
+        next_sequence_length=None,
+        **kwargs,
+    ):
+        if is_transformers_version(">=", "5.3") and (
+            cache_position is None or (not is_first_iteration and cache_position[0] == 0)
+        ):
+            if next_sequence_length is not None:
+                past_len = input_ids.shape[1] - next_sequence_length
+                cache_position = torch.arange(past_len, past_len + next_sequence_length, device=input_ids.device)
+            elif not is_first_iteration and attention_mask is not None:
+                past_len = attention_mask.shape[1] - 1
+                cache_position = torch.tensor([past_len], device=input_ids.device)
+            else:
+                cache_position = torch.arange(input_ids.shape[1], device=input_ids.device)
+
+        if past_key_values is not None:
+            if inputs_embeds is not None and input_ids.shape[1] == 0:
+                inputs_embeds = inputs_embeds[:, -cache_position.shape[0] :]
+            elif inputs_embeds is not None:
+                input_ids = input_ids[:, -cache_position.shape[0] :]
+            elif input_ids.shape[1] != cache_position.shape[0]:
+                input_ids = input_ids[:, cache_position]
+
+        if cache_position[0] != 0:
+            pixel_values = None
+
+        if inputs_embeds is not None and len(cache_position) == inputs_embeds.shape[1]:
+            model_inputs = {"inputs_embeds": inputs_embeds, "input_ids": None}
+        else:
+            model_inputs = {"input_ids": input_ids, "inputs_embeds": None}
+
+        model_inputs.update(
+            {
+                "position_ids": position_ids,
+                "past_key_values": past_key_values,
+                "use_cache": use_cache,
+                "attention_mask": attention_mask,
+                "pixel_values": pixel_values,
+                "pixel_attention_mask": pixel_attention_mask,
+                "spatial_shapes": spatial_shapes,
+                "cache_position": cache_position,
+            }
+        )
+        return model_inputs
+
+    def rot_pos_emb(self, spatial_shapes):
+        pos_ids = []
+        merge = self._spatial_merge_size
+        for h, w in spatial_shapes:
+            h = int(h)
+            w = int(w)
+            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
+            hpos_ids = hpos_ids.reshape(h // merge, merge, w // merge, merge)
+            hpos_ids = hpos_ids.permute(0, 2, 1, 3).flatten()
+            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
+            wpos_ids = wpos_ids.reshape(h // merge, merge, w // merge, merge)
+            wpos_ids = wpos_ids.permute(0, 2, 1, 3).flatten()
+            pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1))
+        pos_ids = torch.cat(pos_ids, dim=0)
+        max_grid_size = int(spatial_shapes.max())
+        rotary_pos_emb_full = self._rotary_pos_emb(max_grid_size)
+        rotary_pos_emb = rotary_pos_emb_full[pos_ids].flatten(1)
+        return rotary_pos_emb
+
+    def get_window_index(self, spatial_shapes):
+        window_index: list = []
+        cu_window_seqlens: list = [0]
+        window_index_id = 0
+        merge = self._spatial_merge_size
+        spatial_merge_unit = merge * merge
+        vit_merger_window_size = self._window_size // merge // self._patch_size
+
+        for grid_h, grid_w in spatial_shapes:
+            grid_h = int(grid_h)
+            grid_w = int(grid_w)
+            grid_t = 1
+            llm_grid_h, llm_grid_w = grid_h // merge, grid_w // merge
+            index = torch.arange(grid_t * llm_grid_h * llm_grid_w).reshape(grid_t, llm_grid_h, llm_grid_w)
+            pad_h = (vit_merger_window_size - llm_grid_h % vit_merger_window_size) % vit_merger_window_size
+            pad_w = (vit_merger_window_size - llm_grid_w % vit_merger_window_size) % vit_merger_window_size
+            num_windows_h = (llm_grid_h + pad_h) // vit_merger_window_size
+            num_windows_w = (llm_grid_w + pad_w) // vit_merger_window_size
+            index_padded = torch.nn.functional.pad(index, (0, pad_w, 0, pad_h), "constant", -100)
+            index_padded = index_padded.reshape(
+                grid_t, num_windows_h, vit_merger_window_size, num_windows_w, vit_merger_window_size
+            )
+            index_padded = index_padded.permute(0, 1, 3, 2, 4).reshape(
+                grid_t, num_windows_h * num_windows_w, vit_merger_window_size, vit_merger_window_size
+            )
+            seqlens = (index_padded != -100).sum([2, 3]).reshape(-1)
+            index_padded = index_padded.reshape(-1)
+            index_new = index_padded[index_padded != -100]
+            window_index.append(index_new + window_index_id)
+            cu_seqlens_tmp = seqlens.cumsum(0) * spatial_merge_unit + cu_window_seqlens[-1]
+            cu_window_seqlens.extend(cu_seqlens_tmp.tolist())
+            window_index_id += grid_t * llm_grid_h * llm_grid_w
+        window_index = torch.cat(window_index, dim=0)
+        return window_index, cu_window_seqlens
+
+    def get_vision_embeddings(self, pixel_values, spatial_shapes=None, **kwargs):
+        if not isinstance(spatial_shapes, torch.Tensor):
+            spatial_shapes = torch.as_tensor(spatial_shapes)
+        spatial_shapes = spatial_shapes.to(torch.long)
+
+        hidden_states = torch.from_numpy(self.vision_embeddings(pixel_values=pixel_values)[0])
+        rotary_pos_emb = self.rot_pos_emb(spatial_shapes)
+        window_index, cu_window_seqlens = self.get_window_index(spatial_shapes)
+        cu_window_seqlens = torch.tensor(cu_window_seqlens, dtype=torch.int32)
+        cu_window_seqlens = torch.unique_consecutive(cu_window_seqlens)
+
+        cu_seqlens = torch.repeat_interleave(spatial_shapes[:, 0] * spatial_shapes[:, 1], 1).cumsum(
+            dim=0, dtype=torch.int32
+        )
+        cu_seqlens = torch.nn.functional.pad(cu_seqlens, (1, 0), value=0)
+
+        seq_len = hidden_states.shape[0]
+        attention_bool = torch.zeros((1, seq_len, seq_len), dtype=torch.bool)
+        for i in range(1, len(cu_seqlens)):
+            attention_bool[..., cu_seqlens[i - 1] : cu_seqlens[i], cu_seqlens[i - 1] : cu_seqlens[i]] = True
+        causal_mask = torch.zeros((1, seq_len, seq_len), dtype=torch.float32)
+        causal_mask.masked_fill_(torch.logical_not(attention_bool), float("-inf"))
+
+        window_bool = torch.zeros((1, seq_len, seq_len), dtype=torch.bool)
+        for i in range(1, len(cu_window_seqlens)):
+            window_bool[
+                ..., cu_window_seqlens[i - 1] : cu_window_seqlens[i], cu_window_seqlens[i - 1] : cu_window_seqlens[i]
+            ] = True
+        window_causal_mask = torch.zeros((1, seq_len, seq_len), dtype=torch.float32)
+        window_causal_mask.masked_fill_(torch.logical_not(window_bool), float("-inf"))
+
+        res = self.vision_embeddings_merger(
+            pixel_values=hidden_states,
+            attention_mask=causal_mask,
+            window_attention_mask=window_causal_mask,
+            window_index=window_index,
+            rotary_pos_emb=rotary_pos_emb,
+        )[0]
+        return res
+
+    def get_multimodal_embeddings(
+        self,
+        input_ids,
+        pixel_values=None,
+        attention_mask=None,
+        position_ids=None,
+        spatial_shapes=None,
+        cache_position=None,
+        **kwargs,
+    ):
+        inputs_embeds = torch.from_numpy(self.get_text_embeddings(input_ids))
+        if pixel_values is not None and input_ids.shape[1] != 1:
+            image_embeds = torch.from_numpy(
+                np.asarray(self.get_vision_embeddings(pixel_values, spatial_shapes=spatial_shapes))
+            )
+            n_image_tokens = (input_ids == self.config.image_token_id).sum().item()
+            n_image_features = image_embeds.shape[0]
+            if n_image_tokens != n_image_features:
+                raise ValueError(
+                    f"Image features and image tokens do not match: tokens: {n_image_tokens}, features {n_image_features}"
+                )
+            mask = input_ids == self.config.image_token_id
+            mask_unsqueezed = mask.unsqueeze(-1)
+            mask_expanded = mask_unsqueezed.expand_as(inputs_embeds)
+            image_mask = mask_expanded.to(inputs_embeds.device)
+            image_embeds = image_embeds.to(inputs_embeds.device, inputs_embeds.dtype)
+            inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_embeds)
+
+        # youtu_vl language model uses plain 1D position ids (no mRoPE).
+        if position_ids is None:
+            batch_size, seq_length = inputs_embeds.shape[:2]
+            if cache_position is not None:
+                position_ids = cache_position.view(1, -1).expand(batch_size, -1)
+            else:
+                position_ids = torch.arange(seq_length, device=inputs_embeds.device)
+                position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+
+        return inputs_embeds, attention_mask, position_ids
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None:
+            raise ValueError("Processor is required.")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+        conversation = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": text},
+                ],
+            }
+        ]
+        if image is not None:
+            conversation[0]["content"].insert(0, {"type": "image"})
+        if video is not None:
+            conversation[0]["content"].insert(0, {"type": "video"})
+
+        text_prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
+        inputs = processor(images=image, text=text_prompt, videos=video, return_tensors="pt")
+        return inputs
+
+
 class _OVQwen3VLForCausalLM(OVModelForVisualCausalLM):
     additional_parts = ["vision_embeddings_merger", "vision_embeddings_pos"]
 
@@ -7377,4 +7651,5 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "qwen3_omni_moe": _OVQwen3OmniMoeForCausalLM,
     "minicpmo": _OVMiniCPMOForCausalLM,
     "videochat_flash_qwen": _OVVideoChatFlashQwenForCausalLM,
+    "youtu_vl": _OVYoutuVLForCausalLM,
 }

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -122,6 +122,7 @@ class ExportModelTest(unittest.TestCase):
         "gemma3n": OVModelForVisualCausalLM,
         "flux.2-klein": OVFlux2KleinPipeline,
         "qwen3_omni_moe": OVModelForMultimodalLM,
+        "youtu_vl": OVModelForVisualCausalLM,
     }
     # filter architectures depending on min/max transformers supported versions
     SUPPORTED_ARCHITECTURES = {
@@ -170,6 +171,11 @@ class ExportModelTest(unittest.TestCase):
             model = MODEL_TYPE_TO_CLS_MAPPING[model_type].auto_model_class.from_pretrained(
                 model_name, **loading_kwargs
             )
+        elif model_type == "youtu_vl":
+            # youtu_vl is a remote-code VLM that only registers AutoModelForCausalLM in its auto_map.
+            from transformers import AutoModelForCausalLM
+
+            model = AutoModelForCausalLM.from_pretrained(model_name, **loading_kwargs)
         elif model_type == "qwen3_asr":
             from qwen_asr.core.transformers_backend.modeling_qwen3_asr import Qwen3ASRForConditionalGeneration
 

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -136,6 +136,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         ("text-generation-with-past", "mamba"),
         ("text-generation-with-past", "falcon_mamba"),
         ("text-to-image", "flux.2-klein"),
+        ("image-text-to-text", "youtu_vl"),
     ]
     # filter architectures depending on min/max transformers supported versions
     SUPPORTED_ARCHITECTURES = [
@@ -184,6 +185,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "smollm3": 2,
         "qwen3_vl_eagle3": 0,
         "qwen3_vl_embedding": 2,
+        "youtu_vl": 2,
     }
 
     TOKENIZER_CHAT_TEMPLATE_TESTS_MODELS = {
@@ -751,6 +753,17 @@ class OVCLIExportTestCase(unittest.TestCase):
                 "text_embeddings_model": {"int8": 1},
                 "vision_embeddings_model": {"int8": 1},
                 "vision_embeddings_merger_model": {"int8": 12},
+            },
+        ),
+        (
+            "image-text-to-text",
+            "youtu_vl",
+            "int4 --group-size 16 --ratio 0.8 --trust-remote-code",
+            {
+                "lm_model": {"int8": 12, "int4": 22},
+                "text_embeddings_model": {"int8": 1},
+                "vision_embeddings_model": {"int8": 1},
+                "vision_embeddings_merger_model": {"int8": 26},
             },
         ),
         (

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1180,6 +1180,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         (OVModelForVisualCausalLM, "qwen3_5_moe", False),
         (OVModelForVisualCausalLM, "gemma4", False),
         (OVModelForVisualCausalLM, "gemma4_moe", False),
+        (OVModelForVisualCausalLM, "youtu_vl", True),
     ]
 
     # gemma3n openvino>=2026.2.0 because it needs erfinv operation,

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -600,6 +600,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         "qwen3_5",
         "qwen3_5_moe",
         "qwen3_omni_moe",
+        "youtu_vl",
     ]
     SUPPORT_VIDEO = ["llava_next_video", "qwen2_vl", "qwen2_5_vl", "qwen3_vl", "videochat_flash_qwen"]
     SUPPORT_AUDIO = ["qwen3_omni_moe"]
@@ -633,6 +634,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         "phi4mm",
         "videochat_flash_qwen",
         "gemma3n",
+        "youtu_vl",
     ]
     IMAGE = Image.open(
         requests.get(

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 import json
 import os
+import shutil
 import tempfile
 import time
 import unittest
@@ -141,6 +142,128 @@ def _create_tiny_kokoro_model():
     voices_dir.mkdir(parents=True, exist_ok=True)
     torch.save(torch.randn(256, dtype=torch.float32), voice_file)
 
+    return str(output_dir)
+
+
+def _create_tiny_youtu_vl_model():
+    """Create (or reuse) a tiny, architecture-preserving random youtu_vl model and return its path.
+
+    The youtu_vl architecture is a remote-code VLM (`YoutuVLForConditionalGeneration`) that combines
+    a siglip2 window-attention vision tower + VLPatchMerger bridge with a DeepSeek-V2-style
+    multi-head latent attention (MLA) language decoder. Only the original config and lightweight
+    remote-code / processor assets are downloaded (no original weights); random weights are
+    instantiated through the real architecture class. The result is cached on disk so subsequent
+    calls (and test collection) are cheap.
+    """
+    original_model_id = "tencent/Youtu-VL-4B-Instruct"
+    cache_marker = "tiny_youtu_vl_v4"
+    output_dir = Path(tempfile.gettempdir()) / "optimum_intel_tiny_random_youtu_vl"
+
+    remote_code_files = [
+        "configuration_youtu_vl.py",
+        "modeling_youtu_vl.py",
+        "processing_youtu_vl.py",
+        "configuration_siglip2.py",
+        "modeling_siglip2.py",
+        "image_processing_siglip2_fast.py",
+        "__init__.py",
+    ]
+    asset_files = [
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "special_tokens_map.json",
+        "chat_template.json",
+        "preprocessor_config.json",
+        "generation_config.json",
+    ]
+
+    marker_file = output_dir / ".tiny_cache_marker"
+    config_file = output_dir / "config.json"
+    if marker_file.exists() and config_file.exists():
+        try:
+            if marker_file.read_text().strip() == cache_marker:
+                cfg = json.loads(config_file.read_text())
+                if (
+                    cfg.get("model_type") == "youtu_vl"
+                    and cfg.get("architectures") == ["YoutuVLForConditionalGeneration"]
+                    and cfg.get("vision_config", {}).get("model_type") == "siglip2_vision_model"
+                    and any((output_dir / w).exists() for w in ("model.safetensors", "pytorch_model.bin"))
+                ):
+                    return str(output_dir)
+        except Exception:
+            pass
+
+    from huggingface_hub import hf_hub_download
+    from transformers import AutoConfig, AutoModelForCausalLM
+
+    if output_dir.exists():
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    torch.manual_seed(0)
+
+    config = AutoConfig.from_pretrained(original_model_id, trust_remote_code=True)
+
+    # LLM decoder (MLA) reductions.
+    config.num_hidden_layers = 2
+    config.hidden_size = 32
+    config.intermediate_size = 64
+    config.num_attention_heads = 4
+    config.num_key_value_heads = 4
+    # MLA head-dim contract: qk_head_dim = qk_nope_head_dim + qk_rope_head_dim, head_dim = qk_rope_head_dim.
+    config.qk_nope_head_dim = 16
+    config.qk_rope_head_dim = 16
+    config.v_head_dim = 16
+    config.qk_head_dim = config.qk_nope_head_dim + config.qk_rope_head_dim
+    config.head_dim = config.qk_rope_head_dim
+    config.q_lora_rank = 32
+    config.kv_lora_rank = 32
+    config.max_position_embeddings = 2048
+    config.torch_dtype = "float32"
+    if hasattr(config, "dtype"):
+        config.dtype = "float32"
+
+    # Vision tower (siglip2) reductions, preserving hidden_size % (num_heads*2) == 0,
+    # a perfect-square num_patches, and out_hidden_size coupled to the LLM hidden size.
+    vc = config.vision_config
+    vc.num_hidden_layers = 4
+    vc.hidden_size = 32
+    vc.intermediate_size = 64
+    vc.num_attention_heads = 4
+    vc.out_hidden_size = config.hidden_size
+    vc.num_patches = 256
+    vc.torch_dtype = "float32"
+    if hasattr(vc, "dtype"):
+        vc.dtype = "float32"
+    if hasattr(vc, "fullatt_block_indexes"):
+        vc.fullatt_block_indexes = [i for i in [1, 3] if i < vc.num_hidden_layers]
+
+    config.use_cache = True
+
+    model = AutoModelForCausalLM.from_config(config, trust_remote_code=True).to(torch.float32)
+
+    # Reinitialize the tied embedding/lm_head with equalized row norms and perturb the MLP layers
+    # so greedy decoding produces diverse (non-collapsed) tokens for HF-vs-OpenVINO comparison.
+    with torch.no_grad():
+        emb = model.get_input_embeddings()
+        emb.weight.normal_(mean=0.0, std=0.2)
+        norms = emb.weight.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+        emb.weight.div_(norms)
+        for name, p in model.named_parameters():
+            if "mlp" in name and p.dim() == 2:
+                p.normal_(mean=0.0, std=0.5)
+    model.tie_weights()
+    model.eval()
+
+    model.save_pretrained(output_dir, safe_serialization=True)
+    for fname in remote_code_files + asset_files:
+        try:
+            src = hf_hub_download(original_model_id, fname)
+            shutil.copy(src, output_dir / os.path.basename(fname))
+        except Exception:
+            pass
+
+    marker_file.write_text(cache_marker)
     return str(output_dir)
 
 
@@ -367,6 +490,7 @@ HUB_MODEL_NAMES = {
     "flux.2-klein": "optimum-intel-internal-testing/tiny-random-flux.2-klein",
     "qwen3_vl_eagle3": "optimum-intel-internal-testing/tiny-random-qwen3-vl-eagle3",
     "videochat_flash_qwen": "optimum-intel-internal-testing/tiny-videochat-flash-qwen",
+    "youtu_vl": _create_tiny_youtu_vl_model(),
 }
 
 
@@ -554,6 +678,12 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "code_predictor_model": 16,
         "code2wav_model": 53,
     },
+    "youtu_vl": {
+        "lm_model": 34,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 1,
+        "vision_embeddings_merger_model": 26,
+    },
     "sana": {
         "transformer": 58,
         "vae_decoder": 28,
@@ -667,6 +797,7 @@ REMOTE_CODE_MODELS = (
     "qwen3_asr",
     "fun_asr",
     "videochat_flash_qwen",
+    "youtu_vl",
 )
 
 if is_transformers_version("<", "5"):


### PR DESCRIPTION
## Description

Added native OpenVINO export+inference support for youtu_vl (YoutuVLForConditionalGeneration): registered in MULTI_MODAL_TEXT_GENERATION_MODELS, added YoutuVL text + VLM export configs, vision-merger/LM patchers (windowed siglip2 encoder made traceable + MLA language model), dummy input generators, and the _OVYoutuVLForCausalLM runtime class (spatial_shapes-driven window index/rotary, 1D position ids, masked_scatter image merge). Tiny fixture helper _create_tiny_youtu_vl_model() added and wired into all VLM test matrices. Export produced 4 submodels; OpenVINO generation exactly matches the HF reference (10-token greedy) on two distinct image+text prompts. Targeted repository tests pass; transformers stayed 4.57.6.

## Conversion

```bash
optimum-cli export openvino --model tencent/Youtu-VL-4B-Instruct output_dir --task image-text-to-text --trust-remote-code
```

## Reproduce generation

```python
from PIL import Image
from transformers import AutoProcessor
from optimum.intel.openvino import OVModelForVisualCausalLM

model_dir = "output_dir"
processor = AutoProcessor.from_pretrained(model_dir, trust_remote_code=True)
model = OVModelForVisualCausalLM.from_pretrained(model_dir, device="CPU")
image = Image.new("RGB", (64, 64), "white")
inputs = processor(images=image, text="Describe this image.", return_tensors="pt")
output_ids = model.generate(**inputs, max_new_tokens=10)
print(processor.batch_decode(output_ids, skip_special_tokens=True)[0])
```

## Validation

- WWB similarity: **1.0**

## Related model-support PRs

- OpenVINO GenAI: https://github.com/openvinotoolkit/openvino.genai/pull/4210

## Before submitting

- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
