### PR TITLE
Sync built docs to the hf-doc-build bucket

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -56,14 +56,28 @@ jobs:
 
       - name: Make documentation
         shell: bash
+        run: |
+          make doc BUILD_DIR=./build_dir VERSION=${{ env.VERSION }}
+          cd build_dir
+          mv ./optimum.intel ./optimum-intel
+          cd ..
+
+      - name: Sync to bucket
         env:
-          HF_DOC_BUILD_TOKEN: ${{ secrets.HF_DOC_BUILD_PUSH }}
+          HF_TOKEN: ${{ secrets.HF_DOC_BUILD_PUSH }}
+        run: |
+          cd build_dir
+          uvx --from huggingface_hub hf sync ./optimum-intel hf://buckets/hf-doc-build/doc/optimum-intel
+          cd ..
+
+      - name: Push to dataset (legacy)
+        env:
           HF_TOKEN: ${{ secrets.HF_DOC_BUILD_PUSH }}
           COMMIT_MSG: "Updated with commit ${{ env.COMMIT_SHA }} See: https://github.com/huggingface/optimum-intel/commit/${{ env.COMMIT_SHA }}"
         run: |
-          make doc BUILD_DIR=./doc-build VERSION=${{ env.VERSION }}
-          mv ./doc-build/optimum.intel optimum-intel
+          cd build_dir
           doc-builder push optimum-intel \
             --doc_build_repo_id "hf-doc-build/doc-build" \
             --commit_msg "${COMMIT_MSG}" \
             --n_retries 5
+          cd ..


### PR DESCRIPTION
build_main_documentation.yml workflow switched to syncing built docs into a bucket https://github.com/huggingface/doc-builder/blob/main/.github/workflows/build_main_documentation.yml#L212

optimum intel documentation https://huggingface.co/docs/optimum-intel/index is not updated [since 15/04](https://github.com/huggingface/doc-builder/pull/780/changes)


cc @mishig25