### PR TITLE
[EXPERIMENT][WIP] Fix Eagle3 VLM draft model export/load (qwen3_vl_eagle3)

### DIFF
--- a/optimum/exporters/openvino/base.py
+++ b/optimum/exporters/openvino/base.py
@@ -352,9 +352,11 @@ class OpenVINOConfigWithPast(OpenVINOConfig, ABC):
             and self.PAD_ATTENTION_MASK_TO_PAST
             and self.use_cache_branch is not False
             and "attention_mask" in dummy_inputs
-            and self.task == "text-generation"
+            and self.task in ("text-generation", "image-text-to-text")
         ):
-            seq_len = dummy_inputs["input_ids"].shape[1]
+            # VLM Eagle3 uses inputs_embeds instead of input_ids
+            main_input = dummy_inputs.get("input_ids", dummy_inputs.get("inputs_embeds"))
+            seq_len = main_input.shape[1]
             past_seq_len = dummy_inputs["past_key_values"][0][1].shape[-2]
             dummy_inputs["attention_mask"] = DummyInputGenerator.pad_input_on_dim(
                 dummy_inputs["attention_mask"], desired_length=past_seq_len + seq_len, dim=1

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -895,6 +895,19 @@ class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
             trust_remote_code (`bool`, *optional*, defaults to `False`):
                 Whether to trust remote code when loading model tokenizer/processor during quantization.
         """
+        if config.model_type not in MODEL_TYPE_TO_CLS_MAPPING:
+            archs = getattr(config, "architectures", None) or []
+            if archs and "eagle3" in archs[0].lower():
+                raise ValueError(
+                    f"Model with architecture '{archs[0]}' (model_type='{config.model_type}') is a standalone "
+                    "Eagle3 speculative-decoding draft model, not a multi-component VLM, even though its "
+                    "config declares a VLM-oriented `modal_type`/`target_model_type`. Please load it with "
+                    "`OVModelForCausalLM` instead of `OVModelForVisualCausalLM`."
+                )
+            raise ValueError(
+                f"Unsupported model_type '{config.model_type}' for `OVModelForVisualCausalLM`. Supported "
+                f"model types are: {sorted(MODEL_TYPE_TO_CLS_MAPPING)}."
+            )
         model_cls = MODEL_TYPE_TO_CLS_MAPPING[config.model_type]
         model_file_names = model_cls._all_ov_model_paths.copy()
         for k in tuple(model_file_names):

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -1114,6 +1114,32 @@ class OVCLIExportTestCase(unittest.TestCase):
                 del expected_int8["decoder_with_past"]
             check_compression_state_per_model(self, model.ov_models, expected_int8)
 
+    @parameterized.expand(["fp16", "int8", "int4"])
+    def test_exporters_cli_eagle3_vlm_quantization(self, weight_format: str):
+        # Regression test: exporting the VLM-flavored Eagle3 draft model (e.g. AngelSlim's
+        # Qwen3-VL eagle3 checkpoints) with any weight format used to fail with
+        # `KeyError: 'input_ids'` in `generate_dummy_inputs` because `eagle3_vlm` configs
+        # replace `input_ids` with `inputs_embeds` (see model_configs.py LlamaOpenVINOConfig).
+        model_type = "qwen3_vl_eagle3"
+        task = "text-generation-with-past"
+        with TemporaryDirectory() as tmpdir:
+            add_ops = "--group-size 16" if weight_format == "int4" else ""
+            subprocess.run(
+                f"optimum-cli export openvino --model {MODEL_NAMES[model_type]} --task {task} "
+                f"--trust-remote-code --weight-format {weight_format} {add_ops} {tmpdir}",
+                shell=True,
+                check=True,
+            )
+            # Must be loaded with OVModelForCausalLM: it is a standalone draft causal LM,
+            # not a multi-component VLM, even though its config carries VLM-oriented fields.
+            model = OVModelForCausalLM.from_pretrained(tmpdir, use_cache=True)
+            self.assertTrue(model.stateful)
+
+            # Loading the same export with OVModelForVisualCausalLM must raise a clear,
+            # actionable error instead of a bare `KeyError: 'llama'`.
+            with self.assertRaisesRegex(ValueError, "OVModelForCausalLM"):
+                OVModelForVisualCausalLM.from_pretrained(tmpdir, use_cache=True)
+
     @parameterized.expand(SUPPORTED_SD_HYBRID_ARCHITECTURES)
     def test_exporters_cli_hybrid_quantization(
         self, model_type: str, expected_fake_nodes: int, expected_int8_nodes: int


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

# What does this PR do?

Fixes two regressions that block exporting/loading the Eagle3 speculative-decoding draft
model [`AngelSlim/Qwen3-VL-4B-Instruct_eagle3`](https://huggingface.co/AngelSlim/Qwen3-VL-4B-Instruct_eagle3)
for `Qwen/Qwen3-VL-4B-Instruct`, as reported in
[openvinotoolkit/omega#78](https://github.com/openvinotoolkit/omega/issues/78).

## Bug 1 — `KeyError: 'input_ids'` at export time

`OpenVINOConfigWithPast.generate_dummy_inputs` (in `optimum/exporters/openvino/base.py`)
assumed the dummy input dict always contains `input_ids`, and only ran its attention-mask
padding logic for `task == "text-generation"`. The Eagle3 draft model exports as a VLM
component with `task == "image-text-to-text"` and produces `inputs_embeds` instead of
`input_ids`. Fix: fall back to `inputs_embeds` when `input_ids` is absent, and extend the
task check to include `"image-text-to-text"`.

## Bug 2 — `KeyError: 'llama'` at load time

`OVModelForVisualCausalLM._from_pretrained` (in `optimum/intel/openvino/modeling_visual_language.py`)
does a direct `MODEL_TYPE_TO_CLS_MAPPING[config.model_type]` lookup. The Eagle3 draft model's
`config.json` sets `model_type` to the *target* model's type (`"llama"`/`"qwen3_vl"` family)
rather than a VLM-registered type, causing an opaque `KeyError`. Fix: add a pre-check that
raises a clear `ValueError` explaining that Eagle3 draft models should be loaded with
`OVModelForCausalLM`, not `OVModelForVisualCausalLM` (matching the exact error reported in
the ticket, now actionable instead of an opaque `KeyError`).

## Testing

Added `test_exporters_cli_eagle3_vlm_quantization` to `tests/openvino/test_exporters_cli.py`,
covering fp16/int8/int4 export + load + the new error message, using the existing tiny CI
fixture `optimum-intel-internal-testing/tiny-random-qwen3-vl-eagle3`. All 3 variants pass.

Verified no regression on the existing non-VLM eagle3 export/load test.

Full end-to-end validation performed downstream (VLM + Eagle3 speculative decoding via
`openvino_genai.VLMPipeline`, on CPU/iGPU/dGPU, fp16/int8/int4, WWB accuracy + TTFT/TPOT
perf) — see openvinotoolkit/omega#78 for the full report.

## Scope

Minimal, surgical fix — no unrelated changes. Both hunks are guarded by narrow conditions
(`inputs_embeds` fallback only when `input_ids` missing; VLM `model_type` pre-check only
triggers before the existing dict lookup).

Fixes reported issue in openvinotoolkit/omega#78

## Before submitting
- [x] Did you write any new necessary tests?
- [ ] Did you make sure to update the documentation with your changes? (not applicable — internal export/load fix, no public API change)
