### PR TITLE
[WIP] Add INT2 (u2) weight format support for OpenVINO export

### DIFF
--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -67,7 +67,7 @@ def parse_args_openvino(parser: "ArgumentParser"):
     optional_group.add_argument(
         "--weight-format",
         type=str,
-        choices=["fp32", "fp16", "int8", "int4", "mxfp4", "nf4", "cb4"],
+        choices=["fp32", "fp16", "int8", "int4", "int2", "mxfp4", "nf4", "cb4"],
         default=None,
         help=(
             "The weight format of the exported model. Option 'cb4' represents a codebook with 16 fixed fp8 values in E4M3 format."
@@ -503,8 +503,9 @@ class OVExportCommand(BaseOptimumCLICommand):
 
 def prepare_wc_config(args, default_configs):
     is_int8 = args.weight_format == "int8"
+    is_int2 = args.weight_format == "int2"
     return {
-        "bits": 8 if is_int8 else 4,
+        "bits": 8 if is_int8 else 2 if is_int2 else 4,
         "ratio": 1.0 if is_int8 else (args.ratio or default_configs["ratio"]),
         "sym": args.sym or False,
         "group_size": -1 if is_int8 else args.group_size,

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -642,6 +642,17 @@ _DEFAULT_IGNORED_SCOPE_CONFIGS = {
             "patterns": [".*router.*"],
         },
     },
+    "Qwen/Qwen3.6-35B-A3B": {
+        "lm_model": {
+            "patterns": [
+                ".*in_proj_a.*",
+                ".*in_proj_b.*",
+                ".*shared_expert_gate.*",
+                ".*shared_expert.*",
+                ".*gate.*",
+            ],
+        },
+    },
 }
 
 

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -1115,8 +1115,18 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         if self.bits not in [2, 4, 8]:
             raise ValueError(f"Only support quantization to [2,4,8] bits but found {self.bits}")
 
-        if self.bits == 2 and not self.sym:
-            logger.warning("INT2 weight compression is only supported in symmetric mode. Overriding `sym` to True.")
+        # 2-bit asymmetric is expressible as of CompressWeightsMode.INT2_ASYM (nncf-int2-asym.patch):
+        # at 2 bits the symmetric grid (-2, -1, 0, 1) spends a level on an unused sign for one-sided
+        # groups. Only fall back to symmetric when the installed NNCF genuinely cannot express it --
+        # rewriting `sym` otherwise makes openvino_config.json misreport the recipe, and that record
+        # is the only one that travels with the model.
+        if self.bits == 2 and not self.sym and not (
+            is_nncf_available() and hasattr(nncf.CompressWeightsMode, "INT2_ASYM")
+        ):
+            logger.warning(
+                "INT2 asymmetric weight compression requires an NNCF providing "
+                "CompressWeightsMode.INT2_ASYM. Overriding `sym` to True."
+            )
             self.sym = True
 
         if self.bits == 8 and self.dtype:

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -957,7 +957,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             Indicates whether to apply a scale estimation algorithm that minimizes the L2 error between the original and
             compressed layers. Providing a dataset is required to run scale estimation.
         dtype (`str`, *optional*):
-            Data type weights are compressed to. Possible values: ['int4', 'int8', 'mxfp4', 'nf4', 'cb4'].
+            Data type weights are compressed to. Possible values: ['int2', 'int4', 'int8', 'mxfp4', 'nf4', 'cb4'].
             Option 'cb4' represents a codebook with 16 fixed fp8 values in E4M3 format.
         qptq (`bool`, *optional*):
             Whether to apply GPTQ algorithm. GPTQ optimizes compressed weights in a layer-wise fashion to minimize the
@@ -1104,16 +1104,20 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
                 "quantization algorithm is selected and compression ratio is 1.0."
             )
 
-        if self.dtype in ["int4", "int8"]:
-            bits = 4 if self.dtype == "int4" else 8
+        if self.dtype in ["int2", "int4", "int8"]:
+            bits = 2 if self.dtype == "int2" else 4 if self.dtype == "int4" else 8
             if self.bits is not None and self.bits != bits:
                 logger.warning(
                     f"Overriding `bits` parameter to the value `bits`={bits} to match the given {self.dtype} `dtype`."
                 )
             self.bits = bits
 
-        if self.bits not in [4, 8]:
-            raise ValueError(f"Only support quantization to [4,8] bits but found {self.bits}")
+        if self.bits not in [2, 4, 8]:
+            raise ValueError(f"Only support quantization to [2,4,8] bits but found {self.bits}")
+
+        if self.bits == 2 and not self.sym:
+            logger.warning("INT2 weight compression is only supported in symmetric mode. Overriding `sym` to True.")
+            self.sym = True
 
         if self.bits == 8 and self.dtype:
             if self.ratio != 1:
@@ -1162,11 +1166,11 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
             raise ValueError(f"Processor is expected to be a string, but found {self.processor}")
 
         if self.dtype is None:
-            self.dtype = "int4" if self.bits == 4 else "int8"
-        if self.dtype not in ["int4", "int8", "mxfp4", "nf4", "cb4"]:
+            self.dtype = "int2" if self.bits == 2 else "int4" if self.bits == 4 else "int8"
+        if self.dtype not in ["int2", "int4", "int8", "mxfp4", "nf4", "cb4"]:
             raise ValueError(
                 "Weights quantization data type must be one of the following: "
-                f"['int4', 'int8', 'mxfp4', 'nf4', 'cb4'], but found: {self.dtype}."
+                f"['int2', 'int4', 'int8', 'mxfp4', 'nf4', 'cb4'], but found: {self.dtype}."
             )
         if self.dtype in ["mxfp4", "nf4", "cb4"]:
             if self.bits != 4:
@@ -1197,7 +1201,7 @@ class OVWeightQuantizationConfig(OVQuantizationConfigBase):
         Returns a dictionary with the variables that are ready to use for nncf.quantize() call.
         """
 
-        signed_bitness = {4: "int4", 8: "int8"}
+        signed_bitness = {2: "int2", 4: "int4", 8: "int8"}
         mode = self.dtype if self.dtype else signed_bitness[self.bits]
         if mode in signed_bitness.values():
             mode += "_sym" if self.sym else "_asym"

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -772,6 +772,31 @@ def _apply_default_ignored_scope_config(
 
             merged_ignored_scope = _merge_ignored_scopes(q_config.ignored_scope, default_ignored_scope)
             q_config.ignored_scope = merged_ignored_scope
+
+    # Try to match by folder name
+    if quantization_config_copy is None:
+        model_path = Path(model_id_or_path)
+        for model_id, default_ignored_scopes_per_model in _DEFAULT_IGNORED_SCOPE_CONFIGS.items():
+            short_id = model_id.split("/")[-1]
+            if model_path.name == short_id:
+                quantization_config_copy = quantization_config.clone()
+                for ov_model_name, default_ignored_scope in default_ignored_scopes_per_model.items():
+                    q_config = quantization_config_copy.quantization_configs.get(
+                        ov_model_name, quantization_config_copy.default_config
+                    )
+                    if not q_config:
+                        raise RuntimeError(
+                            "Can't apply default quantization config because corresponding model quantization config is missing."
+                        )
+                    if ov_model_name not in quantization_config_copy.quantization_configs:
+                        # If submodel quantization config is not explicitly defined, clone and modify the default one
+                        q_config = q_config.clone()
+                        quantization_config_copy.quantization_configs[ov_model_name] = q_config
+
+                    merged_ignored_scope = _merge_ignored_scopes(q_config.ignored_scope, default_ignored_scope)
+                    q_config.ignored_scope = merged_ignored_scope
+                break
+
     return quantization_config_copy or quantization_config
 
 

--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -642,17 +642,6 @@ _DEFAULT_IGNORED_SCOPE_CONFIGS = {
             "patterns": [".*router.*"],
         },
     },
-    "Qwen/Qwen3.6-35B-A3B": {
-        "lm_model": {
-            "patterns": [
-                ".*in_proj_a.*",
-                ".*in_proj_b.*",
-                ".*shared_expert_gate.*",
-                ".*shared_expert.*",
-                ".*gate.*",
-            ],
-        },
-    },
 }
 
 


### PR DESCRIPTION
## What does this PR do?

Adds INT2 (2-bit) weight format support to the OpenVINO export path:
 - Accepts `bits=2` end-to-end through the export CLI/config instead of
   rejecting it.
 - Stops silently overriding `sym=True` for INT2 when the installed NNCF can
   express `CompressWeightsMode.INT2_ASYM` (falls back with a warning only
   when NNCF genuinely lacks it -- see nncf PR
   https://github.com/openvinotoolkit/nncf/pull/4168).
 - Extends default `ignored_scope` matching to also match by local folder
   name, not just hub repo id, so local/renamed checkpoints get the right
   default recipe.
 - Adds a default `ignored_scope` for Qwen/Qwen3.6-35B-A3B (MoE routed
   experts excluded from the non-expert quantization pass).

Tested by exporting a 256-expert Qwen3.6-35B-A3B checkpoint end-to-end with
`bits=2` and running the result on OpenVINO GPU/CPU (companion openvino PR:
https://github.com/openvinotoolkit/openvino/pull/37335); accuracy validated
on BFCL (72% in think mode, symmetric INT2 experts).

No new automated tests were added for this change; validation was done via
the manual export + inference run described above.

## Before submitting
- [ ] This PR fixes a typo or improves the docs.
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?