### PR TITLE
Fix the calibration dataset preparation for the flux.2-klein model

### DIFF
--- a/optimum/intel/openvino/quantization.py
+++ b/optimum/intel/openvino/quantization.py
@@ -1039,7 +1039,7 @@ class OVCalibrationDatasetBuilder:
                     if isinstance(item, dict)
                     else item
                 )
-                self.model(prompt, height=height, width=width)
+                self.model(prompt=prompt, height=height, width=width)
                 pbar.update(min(num_samples, len(calibration_data)) - pbar.n)
                 if len(calibration_data) >= num_samples:
                     calibration_data = calibration_data[:num_samples]


### PR DESCRIPTION
# What does this PR do?

Fix calibration dataset preparation for the Flux.2-klein model, as Flux2Klein pipelines expect prompt to be passed as a keyword argument.

https://github.com/huggingface/optimum-intel/blob/947fde418d35f851880b26511f41ba22af783e55/optimum/intel/openvino/modeling_diffusion.py#L1944-L1946

Fixes # (issue)
- CVS-191280

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

