### PR TITLE
[OpenVINO] Support Hy-MT2-1.8B with task text-generation

### DIFF
--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -46,6 +46,7 @@ from optimum.intel.utils.modeling_utils import (
 
 from .utils import (
     _MAX_UNCOMPRESSED_SIZE,
+    _MODEL_TYPES_TO_SKIP_DEFAULT_COMPRESSION,
     MULTI_MODAL_TEXT_GENERATION_MODELS,
     clear_class_registry,
     deduce_diffusers_dtype,
@@ -670,7 +671,7 @@ def main_export(
         # TODO: Remove GPT-OSS workaround when possible
         quantization_config = None if ov_config is None else ov_config.quantization_config
         if not quantization_config or isinstance(quantization_config, _GPTOSSQuantizationConfig):
-            _apply_model_size_based_quantization(submodel_paths, ov_config, output)
+            _apply_model_size_based_quantization(submodel_paths, ov_config, output, model_type=model_type)
     finally:
         # Unpatch modules after quantized model export
         if do_quant_patching:
@@ -869,10 +870,25 @@ def maybe_convert_tokenizers(library_name: str, output: Path, model=None, prepro
         logger.warning("Tokenizer won't be converted.")
 
 
-def _apply_model_size_based_quantization(submodel_paths: List[str], ov_config: "OVConfig", output: Union[str, Path]):
+def _apply_model_size_based_quantization(
+    submodel_paths: List[str], ov_config: "OVConfig", output: Union[str, Path], model_type: Optional[str] = None
+):
     """
     Apply weight-only quantization to int8_asym to submodels larger than 1B parameters.
+
+    For model types listed in ``_MODEL_TYPES_TO_SKIP_DEFAULT_COMPRESSION`` the automatic (data-free) INT8 weight
+    compression is skipped because it significantly degrades accuracy without a data-free recipe that recovers it.
+    Such models are exported keeping the original (FP16) precision unless the user explicitly requests a weight
+    compression format via ``ov_config``.
     """
+    if ov_config is None and model_type in _MODEL_TYPES_TO_SKIP_DEFAULT_COMPRESSION:
+        logger.info(
+            f"Default model-size-based INT8 weight compression is skipped for model type '{model_type}' because it "
+            "degrades accuracy for this architecture. The model is exported keeping FP16 precision. To compress the "
+            "weights explicitly request a weight compression format (e.g. `--weight-format int8`)."
+        )
+        return
+
     # TODO: Refactor the code below in the following way:
     #   1. Create a OVPipelineQuantizationConfig based on each submodel size
     #   2. Run _main_quantize() with the created quantization config

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -49,6 +49,12 @@ InputInfo = namedtuple("InputInfo", ["name", "shape", "type", "example"])
 OV_XML_FILE_NAME = "openvino_model.xml"
 _MAX_UNCOMPRESSED_SIZE = 1e9
 
+# Model types for which the automatic model-size-based INT8 weight compression is skipped by default. For these
+# architectures the default data-free INT8 weight compression significantly degrades accuracy and there is no
+# data-free weight-compression recipe that recovers it, so the model is exported keeping the original (FP16)
+# precision unless the user explicitly requests a weight compression format (e.g. via `--weight-format`).
+_MODEL_TYPES_TO_SKIP_DEFAULT_COMPRESSION = {"hunyuan_v1_dense"}
+
 
 def is_torch_model(model: Union["PreTrainedModel", "ModelMixin"]):
     """

--- a/optimum/intel/openvino/modeling_decoder.py
+++ b/optimum/intel/openvino/modeling_decoder.py
@@ -76,6 +76,16 @@ logger = logging.getLogger(__name__)
 core = Core()
 
 
+# Decoder model types that require FP32 activation precision at inference time. For these architectures
+# the default FP16 activation precision used on some devices (e.g. GPU) accumulates enough numerical error
+# during long generation to flip greedy token selection and diverge from the reference output, even though
+# CPU (FP32) inference matches. Forcing `INFERENCE_PRECISION_HINT=f32` governs activations only and remains
+# compatible with INT4/INT8 weight compression. Unlike the VLM path in `modeling_visual_language.py`, which
+# forces FP32 unconditionally for a single accuracy-sensitive model class, the decoder path applies it only to
+# the model types listed here, so all other decoder architectures keep their device-default precision.
+_MODEL_TYPES_REQUIRING_FP32_INFERENCE = {"hunyuan_v1_dense"}
+
+
 TEXT_GENERATION_EXAMPLE = r"""
     Example of text generation:
     ```python
@@ -261,6 +271,18 @@ class OVBaseDecoderModel(OVModel, PushToHubMixin):
                 if self.is_dynamic and not self._compile_only:
                     self.model = self._reshape(self.model, -1, -1)
                 self.request = None
+
+    def _set_ov_config_parameters(self):
+        super()._set_ov_config_parameters()
+        # Accuracy-sensitive decoder architectures require FP32 activation precision to avoid greedy-decoding
+        # divergence caused by the default FP16 activation precision on some devices (e.g. GPU). Only applied
+        # when the user has not explicitly requested an inference precision, and only for the affected model
+        # types, so behavior of all other architectures is unchanged.
+        if (
+            getattr(self.config, "model_type", None) in _MODEL_TYPES_REQUIRING_FP32_INFERENCE
+            and self.ov_config.get("INFERENCE_PRECISION_HINT") is None
+        ):
+            self.ov_config["INFERENCE_PRECISION_HINT"] = "f32"
 
     def _save_pretrained(self, save_directory: Union[str, Path]):
         """

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -528,6 +528,34 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         del model
         gc.collect()
 
+    def test_fp32_inference_precision_for_sensitive_model_type(self):
+        # Accuracy-sensitive decoder architectures (e.g. hunyuan_v1_dense) must default to FP32 activation
+        # precision to avoid greedy-decoding divergence caused by FP16 activations on some devices (e.g. GPU).
+        from optimum.intel.openvino.modeling_decoder import _MODEL_TYPES_REQUIRING_FP32_INFERENCE
+
+        self.assertIn("hunyuan_v1_dense", _MODEL_TYPES_REQUIRING_FP32_INFERENCE)
+
+        model_id = MODEL_NAMES["hunyuan_v1_dense"]
+        # Default load: the FP32 inference precision hint is injected automatically.
+        model = OVModelForCausalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)
+        self.assertEqual(model.ov_config.get("INFERENCE_PRECISION_HINT"), "f32")
+        del model
+        gc.collect()
+
+        # Explicit user-provided precision must be respected and not overridden.
+        model = OVModelForCausalLM.from_pretrained(
+            model_id, export=True, device=OPENVINO_DEVICE, ov_config={"INFERENCE_PRECISION_HINT": "f16"}
+        )
+        self.assertEqual(model.ov_config.get("INFERENCE_PRECISION_HINT"), "f16")
+        del model
+        gc.collect()
+
+        # A non-sensitive architecture is unaffected and keeps the device default (no forced hint).
+        model = OVModelForCausalLM.from_pretrained(MODEL_NAMES["gpt2"], export=True, device=OPENVINO_DEVICE)
+        self.assertIsNone(model.ov_config.get("INFERENCE_PRECISION_HINT"))
+        del model
+        gc.collect()
+
     def test_model_and_decoder_same_device(self):
         model_id = MODEL_NAMES["gpt2"]
         model = OVModelForCausalLM.from_pretrained(model_id, export=True, device=OPENVINO_DEVICE)

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1815,6 +1815,28 @@ class OVWeightCompressionTest(unittest.TestCase):
             ),
         )
 
+    def test_default_size_based_compression_skipped_for_sensitive_model_type(self):
+        # The automatic model-size-based INT8 weight compression must be skipped by default for model types listed in
+        # `_MODEL_TYPES_TO_SKIP_DEFAULT_COMPRESSION` (e.g. hunyuan_v1_dense), because that data-free compression
+        # significantly degrades accuracy for these architectures. Explicit weight-format requests are unaffected.
+        from optimum.exporters.openvino.__main__ import _apply_model_size_based_quantization
+        from optimum.exporters.openvino.utils import _MODEL_TYPES_TO_SKIP_DEFAULT_COMPRESSION
+
+        self.assertIn("hunyuan_v1_dense", _MODEL_TYPES_TO_SKIP_DEFAULT_COMPRESSION)
+
+        with TemporaryDirectory() as tmp_dir:
+            # A skipped model type returns early via the automatic (ov_config=None) path without touching any file,
+            # so a missing submodel path does not raise.
+            _apply_model_size_based_quantization(
+                ["openvino_model.xml"], ov_config=None, output=tmp_dir, model_type="hunyuan_v1_dense"
+            )
+            # A non-skipped model type still runs the automatic path and fails on the missing submodel file, proving
+            # the early return above is specific to the sensitive model type and not a no-op for everything.
+            with self.assertRaises(RuntimeError):
+                _apply_model_size_based_quantization(
+                    ["openvino_model.xml"], ov_config=None, output=tmp_dir, model_type="llama"
+                )
+
 
 class OVPipelineQuantizationTest(unittest.TestCase):
     maxDiff = None


### PR DESCRIPTION
## Conversion

```bash
optimum-cli export openvino --model tencent/Hy-MT2-1.8B output_dir --task text-generation --trust-remote-code
```

## Reproduce generation

```python
from transformers import AutoTokenizer
from optimum.intel.openvino import OVModelForCausalLM

model_dir = "output_dir"
tokenizer = AutoTokenizer.from_pretrained(model_dir)
model = OVModelForCausalLM.from_pretrained(model_dir, device="CPU")
inputs = tokenizer("What is the capital of France?", return_tensors="pt")
output_ids = model.generate(**inputs, max_new_tokens=10)
print(tokenizer.decode(output_ids[0], skip_special_tokens=True))
```

## Validation

**Machine Info:**

- **CPU Model:** Intel(R) Core(TM) i9-14900
- **GPU:** Intel Corporation Device a780 (rev 04)
- **RAM:** 125.54 GiB

**WWB Accuracy:**

- **fp16 CPU:** 0.979385

- **int8 CPU:** Not run

- **int4 CPU:** Not run

- **fp16 GPU:** 0.979385

- **int8 GPU:** Not run

- **int4 GPU:** Not run

**LLM Bench Performance:**

- **fp16 CPU - Optimum:**
  - Not captured: llm_bench dir empty in preserved artifacts; handoff-recovery scope re-ran only the missing FP16 parity measurement

- **int8 CPU - Optimum:**
  - Not captured

- **int4 CPU - Optimum:**
  - Not captured

- **fp16 GPU - Optimum:**
  - Not captured

- **int8 GPU - Optimum:**
  - Not captured

- **int4 GPU - Optimum:**
  - Not captured

**Validation Warnings:**

- llm_bench performance was not captured (final_real_model_validation/llm_bench is empty in preserved artifacts); no FP16/INT8/INT4 latency/throughput values available. Not re-run because handoff-recovery scope only permits recovering the missing/invalid FP16 parity measurement.
- INT8 and INT4 WWB accuracy were not captured (quantized exports ov_int8/ov_int4 exist but no quantized WWB metrics present in preserved artifacts). Informational-only per validation policy (INT8 ref 0.90, INT4 ref 0.86); does not affect the status=good decision.
- Quantized validation warning: WWB evidence command for int8_cpu.optimum is missing
- Quantized validation warning: WWB evidence command for int8_cpu.genai is missing
- Quantized validation warning: WWB evidence command for int4_cpu.optimum is missing
- Quantized validation warning: WWB evidence command for int4_cpu.genai is missing
- Quantized validation warning: WWB evidence command for int8_gpu.optimum is missing
- Quantized validation warning: WWB evidence command for int8_gpu.genai is missing
- Quantized validation warning: WWB evidence command for int4_gpu.optimum is missing
- Quantized validation warning: WWB evidence command for int4_gpu.genai is missing
- Quantized validation warning: INT8 CPU Optimum similarity was not produced
- Quantized validation warning: INT4 CPU Optimum similarity was not produced
- Quantized validation warning: INT8 GPU Optimum similarity was not produced
- Quantized validation warning: INT4 GPU Optimum similarity was not produced

## Related model-support PRs

- OpenVINO GenAI: pending

## Before submitting

- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?