### PR TITLE
[OpenVINO] Support MiniCPM-V-4.6 with task image-text-to-text

### DIFF
--- a/.github/workflows/test_openvino_preview_models.yml
+++ b/.github/workflows/test_openvino_preview_models.yml
@@ -80,3 +80,8 @@ jobs:
         run: |
           uv pip install "transformers>=5.15,<5.16"
           pytest tests/openvino/${{ matrix.test-pattern }} -k "muse_glimmer" --durations=0
+
+      - name: MiniCPM-V-4.6 Validation
+        run: |
+          uv pip install "transformers>=5.7,<5.8"
+          pytest tests/openvino/${{ matrix.test-pattern }} -k "minicpmv4_6" --durations=0

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -111,6 +111,7 @@ Here is the list of the supported architectures :
 - MiniCPM3
 - MiniCPM-o
 - MiniCPM-V
+- MiniCPM-V-4.6
 - Mistral
 - Mixtral
 - MobileBERT

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -1093,6 +1093,50 @@ class DummyMiniCPMVImageInputGenerator(DummyVisionInputGenerator):
             )
 
 
+class DummyMiniCPMV4_6VisionInputGenerator(DummyVisionInputGenerator):
+    SUPPORTED_INPUT_NAMES = ("pixel_values", "position_ids", "window_index", "merge_index")
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedVisionConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        num_channels: int = DEFAULT_DUMMY_SHAPES["num_channels"],
+        width: int = DEFAULT_DUMMY_SHAPES["width"],
+        height: int = DEFAULT_DUMMY_SHAPES["height"],
+        **kwargs,
+    ):
+        super().__init__(task, normalized_config, batch_size, num_channels, width, height)
+        vision_config = normalized_config.config.vision_config
+        self.patch_size = vision_config.patch_size
+        self.num_patches_per_side = vision_config.image_size // vision_config.patch_size
+        window_h, window_w = vision_config.window_kernel_size
+        merge_h, merge_w = normalized_config.config.merge_kernel_size
+        # Minimal dummy patch grid divisible by both the window (window merger)
+        # and the merge kernel so every spatial merge stays integral.
+        self.grid_h = window_h * merge_h
+        self.grid_w = window_w * merge_w
+        self.num_patches = self.grid_h * self.grid_w
+        # number of tokens after the intermediate window-attention merger
+        self.num_window_tokens = (self.grid_h // window_h) * (self.grid_w // window_w)
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "pixel_values":
+            return self.random_float_tensor(
+                shape=[1, self.num_channels, self.patch_size, self.patch_size * self.num_patches],
+                framework=framework,
+                dtype=float_dtype,
+            )
+        if input_name == "position_ids":
+            return self.constant_tensor(
+                shape=[1, self.num_patches], framework=framework, value=0, dtype=DTYPE_MAPPER.pt(int_dtype)
+            )
+        if input_name == "window_index":
+            return torch.arange(self.num_patches, dtype=DTYPE_MAPPER.pt(int_dtype))
+        if input_name == "merge_index":
+            return torch.arange(self.num_window_tokens, dtype=DTYPE_MAPPER.pt(int_dtype))
+
+
 class DummyMiniCPMVResampleInputGenerator(DummyVisionInputGenerator):
     SUPPORTED_INPUT_NAMES = ("image_feature", "pos_embed", "key_padding_mask")
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -49,6 +49,7 @@ from optimum.exporters.openvino.input_generators import (
     DummyGemma4VisionInputGenerator,
     DummyKokoroInputGenerator,
     DummyLLavaMultiModalProjectorInputGenerator,
+    DummyMiniCPMV4_6VisionInputGenerator,
     DummyMiniCPMVImageInputGenerator,
     DummyMiniCPMVResampleInputGenerator,
     DummyMuseGlimmerVisionInputGenerator,
@@ -155,6 +156,7 @@ from optimum.exporters.openvino.model_patcher import (
     MambaPatcher,
     MiniCPM3Patcher,
     MiniCPMModelPatcher,
+    MiniCPMV4_6VisionEmbeddingsModelPatcher,
     MiniCPMVImageEmbeddingsModelPatcher,
     MiniCPMVResamplerModelPatcher,
     MistralModelPatcher,
@@ -3265,6 +3267,61 @@ class MiniCPMOOpenVINOConfig(MiniCPMVOpenVINOConfig):
     MIN_TRANSFORMERS_VERSION = "4.51.0"
     MAX_TRANSFORMERS_VERSION = "4.51.3"
     MODEL_TYPE = "minicpmo"
+
+
+@register_in_tasks_manager("minicpmv4_6", *["image-text-to-text"], library_name="transformers")
+class MiniCPMV4_6OpenVINOConfig(BaseVLMOpenVINOConfig):
+    MIN_TRANSFORMERS_VERSION = "5.7.0"
+    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyMiniCPMV4_6VisionInputGenerator,)
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        behavior: VLMConfigBehavior = VLMConfigBehavior.VISION_EMBEDDINGS,
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            behavior=behavior,
+            preprocessors=preprocessors,
+        )
+        self._orig_config = config
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS and hasattr(config, "vision_config"):
+            # keep the full model config so the dummy generator can access both
+            # the nested ``vision_config`` and the top-level ``merge_kernel_size``
+            self._config = config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(config)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return {
+                "pixel_values": {0: "batch_size", 3: "packed_width"},
+                "position_ids": {1: "num_patches"},
+                "window_index": {0: "num_patches"},
+                "merge_index": {0: "num_window_tokens"},
+            }
+        return {}
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return {"last_hidden_state": {0: "num_tokens"}}
+        return {}
+
+    def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
+        model_kwargs = model_kwargs or {}
+        if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            return MiniCPMV4_6VisionEmbeddingsModelPatcher(self, model, model_kwargs)
+        return super().patch_model_for_export(model, model_kwargs)
 
 
 class Phi3VisionConfigBehavior(str, enum.Enum):

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -3035,6 +3035,10 @@ def maira_vision_embed_forward(self, pixel_values):
 
 
 class LlavaImageEmbeddingModelPatcher(ModelPatcher):
+    # Traced forward used to export the image-embedding submodel. Subclasses
+    # only override this to reuse the identical save/restore logic below.
+    _patched_forward = staticmethod(llava_vision_embed_forward)
+
     def __init__(
         self,
         config: "OpenVINOConfig",
@@ -3042,7 +3046,7 @@ class LlavaImageEmbeddingModelPatcher(ModelPatcher):
         model_kwargs: Dict[str, Any],
     ):
         model.__orig_forward = model.forward
-        model.forward = types.MethodType(llava_vision_embed_forward, model)
+        model.forward = types.MethodType(type(self)._patched_forward, model)
         super().__init__(config, model, model_kwargs)
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -3620,6 +3624,111 @@ class MiniCPMVImageEmbeddingsModelPatcher(ModelPatcher):
         if is_torch_version(">=", "2.0.0"):
             for layer in self._model.encoder.layers:
                 layer.self_attn.forward = layer.self_attn._orig_forward
+
+
+def _minicpmv4_6_vision_full_attention(attn, hidden_states):
+    # Full self-attention over a single packed image (one NaViT segment).
+    # Replaces the cu_seqlens-based variable length attention of
+    # MiniCPMV4_6VisionAttention which is data-dependent and not traceable.
+    batch, seq_len, _ = hidden_states.shape
+    query = attn.q_proj(hidden_states).view(batch, seq_len, -1, attn.head_dim).transpose(1, 2)
+    key = attn.k_proj(hidden_states).view(batch, seq_len, -1, attn.head_dim).transpose(1, 2)
+    value = attn.v_proj(hidden_states).view(batch, seq_len, -1, attn.head_dim).transpose(1, 2)
+    attn_output = F.scaled_dot_product_attention(query, key, value, scale=attn.scaling)
+    attn_output = attn_output.transpose(1, 2).reshape(batch, seq_len, -1)
+    return attn.out_proj(attn_output)
+
+
+def _minicpmv4_6_vision_window_attention(attn, hidden_states, window_size):
+    # Attention restricted to non-overlapping windows of `window_size` tokens.
+    # The tokens are assumed to be already grouped window-contiguous, so the
+    # windowed attention is expressed as batched full attention over
+    # (num_windows, window_size) instead of using cu_seqlens.
+    batch, seq_len, embed_dim = hidden_states.shape
+    num_windows = seq_len // window_size
+    windows = hidden_states.view(num_windows, window_size, embed_dim)
+    query = attn.q_proj(windows).view(num_windows, window_size, -1, attn.head_dim).transpose(1, 2)
+    key = attn.k_proj(windows).view(num_windows, window_size, -1, attn.head_dim).transpose(1, 2)
+    value = attn.v_proj(windows).view(num_windows, window_size, -1, attn.head_dim).transpose(1, 2)
+    attn_output = F.scaled_dot_product_attention(query, key, value, scale=attn.scaling)
+    attn_output = attn_output.transpose(1, 2).reshape(num_windows, window_size, embed_dim).reshape(batch, seq_len, embed_dim)
+    return attn.out_proj(attn_output)
+
+
+def _minicpmv4_6_vision_embeddings_forward(self, pixel_values, position_ids, window_index, merge_index):
+    """Traceable forward for the MiniCPM-V-4.6 vision tower + merger.
+
+    Runs the whole ``get_image_features`` pipeline (patch embeddings, encoder,
+    intermediate window-attention merger, remaining encoder, post layernorm and
+    the final downsample merger) for a single NaViT-packed image.
+
+    The data-dependent index tensors (``position_ids`` for the interpolated
+    position embeddings, ``window_index`` for the window-attention merger and
+    ``merge_index`` for the final merger) are precomputed on the runtime side
+    and passed as inputs, so the traced graph stays dynamic w.r.t. the number
+    of visual patches. All spatial ``reshape``/``permute`` groupings of the
+    original implementation are expressed as ``index_select`` + ``reshape`` so
+    the graph is valid for any image resolution.
+    """
+    vision_tower = self.model.vision_tower
+    merger = self.model.merger
+    window_h, window_w = vision_tower.vit_merger.window_kernel_size
+    window_size = window_h * window_w
+    merge_h, merge_w = merger.merge_kernel_size
+
+    # patch embeddings + interpolated position embeddings
+    patch_embeds = vision_tower.embeddings.patch_embedding(pixel_values)
+    hidden_states = patch_embeds.flatten(2).transpose(1, 2)
+    hidden_states = hidden_states + vision_tower.embeddings.position_embedding(position_ids)
+
+    insert_layer_id = vision_tower.config.insert_layer_id
+    for layer_index, encoder_layer in enumerate(vision_tower.encoder.layers):
+        residual = hidden_states
+        hidden_states = encoder_layer.layer_norm1(hidden_states)
+        hidden_states = _minicpmv4_6_vision_full_attention(encoder_layer.self_attn, hidden_states)
+        hidden_states = residual + hidden_states
+        residual = hidden_states
+        hidden_states = encoder_layer.layer_norm2(hidden_states)
+        hidden_states = encoder_layer.mlp(hidden_states)
+        hidden_states = residual + hidden_states
+
+        if layer_index == insert_layer_id:
+            vit_merger = vision_tower.vit_merger
+            residual = hidden_states
+            merged = vit_merger.layer_norm1(hidden_states)
+            merged = merged.index_select(1, window_index)
+            merged = _minicpmv4_6_vision_window_attention(vit_merger.self_attn, merged, window_size)
+            merged = merged.index_select(1, torch.argsort(window_index))
+            hidden_states = residual + merged
+            # channel-wise 2x2 window merge expressed as index_select + reshape
+            regrouped = hidden_states[0].index_select(0, window_index)
+            embed_dim = regrouped.shape[-1]
+            merged_tokens = regrouped.reshape(-1, window_size * embed_dim)
+            merge_residual = regrouped.reshape(-1, window_size, embed_dim).mean(dim=1)
+            merged_tokens = vit_merger.pre_norm(merged_tokens)
+            merged_tokens = vit_merger.linear_1(merged_tokens)
+            merged_tokens = vit_merger.act(merged_tokens)
+            merged_tokens = vit_merger.linear_2(merged_tokens)
+            hidden_states = (merged_tokens + merge_residual).unsqueeze(0)
+
+    hidden_states = vision_tower.post_layernorm(hidden_states)
+
+    # final downsample merger (16x mode) expressed as index_select + reshape
+    downsample_mlp = merger.mlp[0]
+    regrouped = hidden_states[0].index_select(0, merge_index)
+    embed_dim = regrouped.shape[-1]
+    merged_tokens = regrouped.reshape(-1, merge_h * merge_w * embed_dim)
+    merged_tokens = downsample_mlp.pre_norm(merged_tokens).view(-1, downsample_mlp.linear_1.in_features)
+    merged_tokens = downsample_mlp.linear_1(merged_tokens)
+    merged_tokens = downsample_mlp.act(merged_tokens)
+    merged_tokens = downsample_mlp.linear_2(merged_tokens)
+    return merged_tokens
+
+
+class MiniCPMV4_6VisionEmbeddingsModelPatcher(LlavaImageEmbeddingModelPatcher):
+    # Reuses the image-embedding save/restore logic from
+    # LlavaImageEmbeddingModelPatcher; only the traced forward differs.
+    _patched_forward = staticmethod(_minicpmv4_6_vision_embeddings_forward)
 
 
 class LlavaQwen2ImageEmbeddingsModelPatcher(ModelPatcher):
@@ -9968,7 +10077,22 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
         model: "PreTrainedModel",
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
-        from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5DynamicCache
+        # ``Qwen3_5DynamicCache`` only exists in the transformers releases the
+        # original qwen3_5 support targeted (<= 5.2.x). Starting with the
+        # transformers version required by MiniCPM-V-4.6 (>= 5.7.0) the hybrid
+        # linear/full attention cache was folded into the standard
+        # ``DynamicCache`` and the per-layer states moved to
+        # ``cache.layers[idx].conv_states``. The wrapper below only relies on a
+        # ``Cache`` base to be recognised as a cache object, so fall back to the
+        # standard ``DynamicCache`` on newer transformers.
+        try:
+            from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5DynamicCache as _Qwen3_5CacheBase
+
+            legacy_qwen3_5_cache = True
+        except ImportError:
+            from transformers.cache_utils import DynamicCache as _Qwen3_5CacheBase
+
+            legacy_qwen3_5_cache = False
 
         from openvino.frontend.pytorch import ConversionExtension, ModuleExtension
 
@@ -9985,7 +10109,7 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
             self._text_model = self._model.model
             self._text_config = self._model.model.config
 
-        class Qwen3_5DynamicCacheWrap(Qwen3_5DynamicCache):
+        class Qwen3_5DynamicCacheWrap(_Qwen3_5CacheBase):
             def __init__(self, config, conv_states, recurrent_states, key_cache, value_cache):
                 # Call parent constructor with all required arguments
                 super().__init__(config=config)
@@ -9994,6 +10118,17 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
                 self.recurrent_states = recurrent_states
                 self.key_cache = key_cache
                 self.value_cache = value_cache
+                # ``layer_types``/``transformer_layers``/``last_linear_layer`` are
+                # provided by the legacy ``Qwen3_5DynamicCache`` but not by the
+                # standard ``DynamicCache`` used on transformers >= 5.7, so derive
+                # them from the config to keep the wrapper self-contained.
+                self.layer_types = list(config.layer_types)
+                self.transformer_layers = [
+                    i for i, layer_type in enumerate(self.layer_types) if layer_type == "full_attention"
+                ]
+                self.last_linear_layer = max(
+                    i for i, layer_type in enumerate(self.layer_types) if layer_type == "linear_attention"
+                )
                 self.full_attn_mapping = {}
                 self.linear_attn_mapping = {}
                 full_attn_layer_idx = 0
@@ -10033,11 +10168,29 @@ class Qwen3_5ModelPatcher(OVDecoderModelPatcher):
                     return 0
                 return self.key_cache[layer_idx].shape[-2]
 
-            @property
-            def has_previous_state(self):
+            def get_mask_sizes(self, query_length: int, layer_idx: Optional[int] = None) -> tuple[int, int]:
+                """Return the (kv_length, kv_offset) used to build the attention mask.
+
+                Required by transformers >= 5.7 ``create_causal_mask``, which reads the
+                key-value length from the cache instead of the 2D attention mask. The
+                standard implementation would consult ``self.layers`` which this wrapper
+                bypasses, so derive the length from the tracked full-attention cache.
+                """
+                past_seen_tokens = self.get_seq_length()
+                return past_seen_tokens + query_length, 0
+
+            def _has_previous_state(self):
                 """We have a previous state if the last linear (conv) layer was already updated."""
                 layer_idx = self.linear_attn_mapping[self.last_linear_layer]
                 return self.conv_states[layer_idx] is not None
+
+            if legacy_qwen3_5_cache:
+                # transformers <= 5.2 accesses ``has_previous_state`` as a property.
+                has_previous_state = property(_has_previous_state)
+            else:
+                # transformers >= 5.7 calls ``has_previous_state(layer_idx=None)``.
+                def has_previous_state(self, layer_idx: Optional[int] = None) -> bool:
+                    return self._has_previous_state()
 
         # the patch is needed to include KV-cache, Conv, and SSM states in the inputs and outputs.
         def patched_forward(

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -320,6 +320,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "internvl_chat",
     "maira2",
     "minicpmv",
+    "minicpmv4_6",
     "phi3_v",
     "qwen2_vl",
     "qwen2_5_vl",

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -2615,6 +2615,156 @@ class _OVMiniCPMOForCausalLM(_OVMiniCPMVForCausalLM):
         return inputs
 
 
+class _OVMiniCPMV4_6ForCausalLM(OVModelForVisualCausalLM):
+    @staticmethod
+    def _position_ids(h, w, num_patches_per_side):
+        # Interpolated position ids for the vision embeddings (bucketize), see
+        # MiniCPMV4_6VisionEmbeddings.forward.
+        boundaries = torch.arange(1 / num_patches_per_side, 1.0, 1 / num_patches_per_side)
+        fractional_h = torch.arange(0, 1 - 1e-6, 1 / h)
+        fractional_w = torch.arange(0, 1 - 1e-6, 1 / w)
+        bucket_h = torch.bucketize(fractional_h, boundaries, right=True)
+        bucket_w = torch.bucketize(fractional_w, boundaries, right=True)
+        pos_ids = (bucket_h[:, None] * num_patches_per_side + bucket_w).flatten()
+        return pos_ids.unsqueeze(0)
+
+    @staticmethod
+    def _grouping_index(h, w, kernel_h, kernel_w):
+        # Permutation that groups a ``h x w`` patch grid into row-major
+        # ``kernel_h x kernel_w`` blocks. Shared by both the intermediate
+        # window-attention merger (window_index) and the final downsample
+        # merger (merge_index) since they use the same spatial grouping.
+        index = torch.arange(h * w).reshape(h, w)
+        index = index.reshape(h // kernel_h, kernel_h, w // kernel_w, kernel_w)
+        index = index.permute(0, 2, 1, 3).reshape(-1)
+        return index
+
+    def get_vision_embeddings(self, pixel_values, input_ids=None, **kwargs):
+        if input_ids is not None and input_ids.shape[1] == 1:
+            return None
+        target_sizes = kwargs.get("target_sizes")
+        if target_sizes is None or pixel_values is None:
+            return None
+        if not isinstance(target_sizes, torch.Tensor):
+            target_sizes = torch.as_tensor(target_sizes)
+        target_sizes = target_sizes.reshape(-1, 2)
+
+        vision_config = self.config.vision_config
+        patch_size = vision_config.patch_size
+        num_patches_per_side = vision_config.image_size // patch_size
+        window_h, window_w = vision_config.window_kernel_size
+        merge_h, merge_w = self.config.merge_kernel_size
+
+        features = []
+        column = 0
+        for image_index in range(target_sizes.shape[0]):
+            grid_h = int(target_sizes[image_index, 0])
+            grid_w = int(target_sizes[image_index, 1])
+            num_patches = grid_h * grid_w
+            single_pixel_values = pixel_values[:, :, :, column : column + patch_size * num_patches]
+            column += patch_size * num_patches
+            position_ids = self._position_ids(grid_h, grid_w, num_patches_per_side)
+            window_index = self._grouping_index(grid_h, grid_w, window_h, window_w)
+            # the final merger operates on the window-downsampled grid
+            merge_index = self._grouping_index(grid_h // window_h, grid_w // window_w, merge_h, merge_w)
+            output = self.vision_embeddings(
+                pixel_values=single_pixel_values,
+                position_ids=position_ids,
+                window_index=window_index,
+                merge_index=merge_index,
+            ).last_hidden_state
+            features.append(torch.from_numpy(output))
+        return features
+
+    def merge_vision_text_embeddings(
+        self, vision_embeds, inputs_embeds, input_ids=None, attention_mask=None, position_ids=None, **kwargs
+    ):
+        image_features = (
+            torch.cat(vision_embeds, dim=0) if isinstance(vision_embeds, (list, tuple)) else vision_embeds
+        )
+        if isinstance(inputs_embeds, np.ndarray):
+            inputs_embeds = torch.from_numpy(inputs_embeds)
+        image_features = image_features.to(inputs_embeds.dtype)
+        image_mask = (input_ids == self.config.image_token_id).unsqueeze(-1).expand_as(inputs_embeds)
+        inputs_embeds = inputs_embeds.masked_scatter(image_mask, image_features)
+        return inputs_embeds, attention_mask, position_ids
+
+    def forward(
+        self,
+        input_ids,
+        pixel_values=None,
+        past_key_values=None,
+        inputs_embeds=None,
+        attention_mask=None,
+        position_ids=None,
+        target_sizes=None,
+        **kwargs,
+    ):
+        # ``target_sizes`` carries the per-image NaViT patch grid required by the
+        # vision submodel. It is declared explicitly so that transformers'
+        # ``_validate_model_kwargs`` accepts it; the base ``forward`` forwards it
+        # to ``get_multimodal_embeddings`` through ``**kwargs``.
+        return super().forward(
+            input_ids,
+            pixel_values=pixel_values,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            position_ids=position_ids,
+            target_sizes=target_sizes,
+            **kwargs,
+        )
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        inputs_embeds=None,
+        pixel_values=None,
+        attention_mask=None,
+        **kwargs,
+    ):
+        model_inputs = super().prepare_inputs_for_generation(
+            input_ids=input_ids,
+            past_key_values=past_key_values,
+            inputs_embeds=inputs_embeds,
+            pixel_values=pixel_values,
+            attention_mask=attention_mask,
+            **kwargs,
+        )
+        model_inputs["target_sizes"] = kwargs.get("target_sizes")
+        return model_inputs
+
+    @staticmethod
+    def preprocess_inputs(
+        text: str,
+        image: Optional["Image"] = None,
+        processor: Optional[AutoImageProcessor] = None,
+        tokenizer: Optional[PreTrainedTokenizer] = None,
+        config: Optional[PretrainedConfig] = None,
+        video: Optional["VideoInput"] = None,
+        audio: Optional[np.ndarray] = None,
+    ):
+        if processor is None:
+            raise ValueError("Processor is required.")
+        if audio is not None:
+            raise ValueError("Audio input is not supported")
+        if video is not None:
+            raise ValueError("Video input is not supported")
+        content = [{"type": "text", "text": text}]
+        if image is not None:
+            content = [{"type": "image", "image": image}] + content
+        messages = [{"role": "user", "content": content}]
+        inputs = processor.apply_chat_template(
+            messages,
+            tokenize=True,
+            add_generation_prompt=True,
+            return_dict=True,
+            return_tensors="pt",
+        )
+        return inputs
+
+
 class _OVNanoLlavaForCausalLM(OVModelForVisualCausalLM):
     def get_vision_embeddings(self, pixel_values, input_ids=None, **kwargs):
         if input_ids is not None and input_ids.shape[1] == 1:
@@ -7596,6 +7746,7 @@ MODEL_TYPE_TO_CLS_MAPPING = {
     "llava_next": _OVLlavaNextForCausalLM,
     "llava_next_video": _OVLlavaNextVideoForCausalLM,
     "minicpmv": _OVMiniCPMVForCausalLM,
+    "minicpmv4_6": _OVMiniCPMV4_6ForCausalLM,
     "llava-qwen2": _OVNanoLlavaForCausalLM,
     "maira2": _OVMaira2ForCausalLM,
     "phi3_v": _OVPhi3VisionForCausalLM,

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -127,6 +127,7 @@ class ExportModelTest(unittest.TestCase):
         "qwen3_omni_moe": OVModelForMultimodalLM,
         "muse_glimmer": OVModelForVisualCausalLM,
         "deepseek_ocr2": OVModelForVisualCausalLM,
+        "minicpmv4_6": OVModelForVisualCausalLM,
     }
 
     # filter architectures depending on min/max transformers supported versions

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -138,6 +138,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         ("text-generation-with-past", "falcon_mamba"),
         ("text-to-image", "flux.2-klein"),
         ("image-text-to-text", "muse_glimmer"),
+        ("image-text-to-text", "minicpmv4_6"),
     ]
     # filter architectures depending on min/max transformers supported versions
     SUPPORTED_ARCHITECTURES = [
@@ -194,6 +195,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "qwen3_vl_eagle3": 0,
         "qwen3_vl_embedding": 2,
         "muse_glimmer": 2,
+        "minicpmv4_6": 2,
     }
 
     TOKENIZER_CHAT_TEMPLATE_TESTS_MODELS = {

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1182,6 +1182,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         (OVModelForVisualCausalLM, "gemma4", False),
         (OVModelForVisualCausalLM, "gemma4_moe", False),
         (OVModelForVisualCausalLM, "deepseek_ocr2", False),
+        (OVModelForVisualCausalLM, "minicpmv4_6", False),
     ]
 
     # gemma3n openvino>=2026.2.0 because it needs erfinv operation,

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -602,6 +602,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         "qwen3_omni_moe",
         "muse_glimmer",
         "deepseek_ocr2",
+        "minicpmv4_6",
     ]
     SUPPORT_VIDEO = [
         "llava_next_video",
@@ -675,6 +676,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
             "qwen3_5_moe",
             "gemma4_unified",
             "muse_glimmer",
+            "minicpmv4_6",
         ]:
             from transformers import AutoModelForImageTextToText
 

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -144,6 +144,95 @@ def _create_tiny_kokoro_model():
     return str(output_dir)
 
 
+def _create_tiny_minicpmv4_6_model():
+    """Generate a tiny random MiniCPM-V-4.6 (``minicpmv4_6``) model for testing.
+
+    The tiny model preserves the real architecture (top ``minicpmv4_6`` /
+    ``MiniCPMV4_6ForConditionalGeneration``, ``qwen3_5_text`` hybrid text
+    backbone, ``minicpmv4_6_vision`` SigLIP-NaViT vision tower, and the
+    image/video placeholder token ids). Only scale parameters are reduced; no
+    original weights are downloaded. The result is cached on disk so subsequent
+    calls are cheap. Requires ``transformers>=5.7`` (the version that ships the
+    ``minicpmv4_6`` architecture).
+    """
+    original_model_id = "openbmb/MiniCPM-V-4.6"
+    marker_version = 3
+    output_dir = Path(tempfile.gettempdir()) / "optimum_intel_tiny_random_minicpmv4_6"
+    marker_file = output_dir / ".tiny_model_marker.json"
+    config_file = output_dir / "config.json"
+    weights_file = output_dir / "model.safetensors"
+
+    def _cache_valid():
+        if not (marker_file.exists() and config_file.exists() and weights_file.exists()):
+            return False
+        try:
+            marker = json.loads(marker_file.read_text())
+            cfg = json.loads(config_file.read_text())
+        except Exception:
+            return False
+        return (
+            marker.get("marker_version") == marker_version
+            and cfg.get("model_type") == "minicpmv4_6"
+            and cfg.get("architectures") == ["MiniCPMV4_6ForConditionalGeneration"]
+            and cfg.get("image_token_id") == 248056
+            and cfg.get("text_config", {}).get("model_type") == "qwen3_5_text"
+            and cfg.get("vision_config", {}).get("model_type") == "minicpmv4_6_vision"
+        )
+
+    if _cache_valid():
+        return str(output_dir)
+
+    from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
+
+    cfg = AutoConfig.from_pretrained(original_model_id, trust_remote_code=True)
+
+    # text sub-config: qwen3_5_text (hybrid linear + full attention)
+    tc = cfg.text_config
+    tc.hidden_size = 64
+    tc.num_attention_heads = 4
+    tc.num_key_value_heads = 2
+    tc.head_dim = 32
+    tc.intermediate_size = 128
+    tc.num_hidden_layers = 4
+    tc.full_attention_interval = 4
+    tc.layer_types = ["linear_attention", "linear_attention", "linear_attention", "full_attention"]
+    tc.linear_num_key_heads = 2
+    tc.linear_num_value_heads = 2
+    tc.linear_key_head_dim = 32
+    tc.linear_value_head_dim = 32
+    tc.linear_conv_kernel_dim = 4
+    tc.mtp_num_hidden_layers = 1
+    tc.initializer_range = 0.1
+
+    # vision sub-config: minicpmv4_6_vision (SigLIP-NaViT + window merger)
+    vc = cfg.vision_config
+    vc.hidden_size = 64
+    vc.num_attention_heads = 4
+    vc.intermediate_size = 128
+    vc.num_hidden_layers = 3
+    vc.image_size = 224
+    cfg.insert_layer_id = 1
+    vc.insert_layer_id = 1
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    torch.manual_seed(SEED)
+    model = AutoModelForImageTextToText.from_config(cfg, trust_remote_code=True)
+    model.eval()
+    model.save_pretrained(output_dir, safe_serialization=True)
+
+    processor = AutoProcessor.from_pretrained(original_model_id, trust_remote_code=True)
+    processor.save_pretrained(output_dir)
+    try:
+        from transformers import GenerationConfig
+
+        GenerationConfig.from_pretrained(original_model_id).save_pretrained(output_dir)
+    except Exception:
+        pass
+
+    marker_file.write_text(json.dumps({"marker_version": marker_version}))
+    return str(output_dir)
+
+
 SEED = 42
 
 F32_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
@@ -263,6 +352,11 @@ HUB_MODEL_NAMES = {
     "minicpm": "optimum-intel-internal-testing/tiny-random-minicpm",
     "minicpm3": "optimum-intel-internal-testing/tiny-random-minicpm3",
     "minicpmv": "optimum-intel-internal-testing/tiny-random-minicpmv-2_6",
+    "minicpmv4_6": (
+        _create_tiny_minicpmv4_6_model()
+        if is_transformers_version(">=", "5.7")
+        else "optimum-intel-internal-testing/tiny-random-minicpmv4_6"
+    ),
     "minicpmo": "optimum-intel-internal-testing/tiny-random-MiniCPM-o-2_6",
     "mistral": "optimum-intel-internal-testing/tiny-random-mistral",
     "mistral-nemo": "optimum-intel-internal-testing/tiny-random-mistral-nemo",
@@ -498,6 +592,11 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "text_embeddings_model": 1,
         "vision_embeddings_model": 26,
         "resampler_model": 6,
+    },
+    "minicpmv4_6": {
+        "lm_model": 72,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 28,
     },
     "llava_next_video": {
         "lm_model": 30,


### PR DESCRIPTION
## Conversion

```bash
optimum-cli export openvino --model openbmb/MiniCPM-V-4.6 output_dir --task image-text-to-text --trust-remote-code
```

## Reproduce generation

```python
from PIL import Image
from transformers import AutoProcessor
from optimum.intel.openvino import OVModelForVisualCausalLM

model_dir = "output_dir"
processor = AutoProcessor.from_pretrained(model_dir, trust_remote_code=True)
model = OVModelForVisualCausalLM.from_pretrained(model_dir, device="CPU")
image = Image.new("RGB", (64, 64), "white")
inputs = processor(images=image, text="Describe this image.", return_tensors="pt")
output_ids = model.generate(**inputs, max_new_tokens=10)
print(processor.batch_decode(output_ids, skip_special_tokens=True)[0])
```

## Validation

**Machine Info:**

- **CPU Model:** Intel(R) Core(TM) i9-14900
- **GPU:** Intel Corporation Device a780 (rev 04)
- **RAM:** 125.54 GiB

**WWB Accuracy:**

- **fp16 CPU:** 0.994227

- **int8 CPU:** 0.982687

- **int4 CPU:** 0.850767

- **fp16 GPU:** 1.0

- **int8 GPU:** 0.99426

- **int4 GPU:** 0.861063

**OpenVINO GenAI Validation Backend:**

- **fp16 CPU GenAI:** Paged Attention
- **int8 CPU GenAI:** Paged Attention
- **int4 CPU GenAI:** Paged Attention
- **fp16 GPU GenAI:** Paged Attention
- **int8 GPU GenAI:** Paged Attention
- **int4 GPU GenAI:** Paged Attention

**LLM Bench Performance:**

- **fp16 CPU - Optimum:**
  - **1st:** 652.90ms
  - **2nd:** 35.29ms/tok
  - **Throughput:** 28.34 tok/s

- **int8 CPU - Optimum:**
  - **1st:** 325.87ms
  - **2nd:** 22.11ms/tok
  - **Throughput:** 45.23 tok/s

- **int4 CPU - Optimum:**
  - **1st:** 325.51ms
  - **2nd:** 18.41ms/tok
  - **Throughput:** 54.31 tok/s

- **fp16 GPU - Optimum:**
  - **1st:** 839.43ms
  - **2nd:** 43.20ms/tok
  - **Throughput:** 23.15 tok/s

- **int8 GPU - Optimum:**
  - **1st:** 970.09ms
  - **2nd:** 31.66ms/tok
  - **Throughput:** 31.59 tok/s

- **int4 GPU - Optimum:**
  - **1st:** 1028.77ms
  - **2nd:** 31.48ms/tok
  - **Throughput:** 31.77 tok/s

**Validation Warnings:**

- INT4 export with plain --weight-format int4 (group-size 128) previously failed with nncf.InvalidGroupSizeError on rotary_emb MatMul (channel size 1); re-exported here with --group-size-fallback adjust (successful). Informational INT4 precision only.
- INT4 CPU Optimum similarity 0.850767 is below the configured threshold 0.86

## Related model-support PRs

- OpenVINO GenAI: https://github.com/openvinotoolkit/openvino.genai/pull/4360

## Before submitting

- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?
