### PR TITLE
[EXPERIMENT][WIP][OpenVINO] Add support for BAAI/bge-m3

### DIFF
--- a/docs/source/openvino/inference.mdx
+++ b/docs/source/openvino/inference.mdx
@@ -49,6 +49,22 @@ As shown in the table below, each task is associated with a class enabling to au
 | `OVModelForImageTextToText`          | `image-to-text`                      |
 | `OVModelForTextToSpeechSeq2Seq`      | `text-to-audio`                      |
 
+`OVModelForFeatureExtraction` also supports multilingual text-embedding models built on
+encoder-only backbones registered under `feature-extraction`, such as the
+[XLM-RoBERTa](https://huggingface.co/docs/transformers/model_doc/xlm-roberta)-based
+[`BAAI/bge-m3`](https://huggingface.co/BAAI/bge-m3):
+
+```python
+from optimum.intel import OVModelForFeatureExtraction
+from transformers import AutoTokenizer
+
+model_id = "BAAI/bge-m3"
+model = OVModelForFeatureExtraction.from_pretrained(model_id, export=True)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+inputs = tokenizer("Hello, this is a multilingual embedding example.", return_tensors="pt")
+embeddings = model(**inputs).last_hidden_state
+```
+
 ### Diffusers models
 
 Make sure you have 🤗 Diffusers installed. To install `diffusers`:

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -413,6 +413,18 @@ class OVCLIExportTestCase(unittest.TestCase):
             },
         ),
         (
+            "feature-extraction",
+            "xlm-roberta",
+            "int8",
+            "--dataset c4 --num-samples 1",
+            {
+                "model": 12,
+            },
+            {
+                "model": {"int8": 15},
+            },
+        ),
+        (
             "fill-mask",
             "roberta",
             "int8",

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1040,6 +1040,7 @@ class OVModelForFeatureExtractionIntegrationTest(unittest.TestCase):
         "roberta",
         "sentence-transformers-bert",
         "qwen3",
+        "xlm-roberta",
     )
     if is_transformers_version("<", "5.4") or is_transformers_version(">=", "5.6"):
         SUPPORTED_ARCHITECTURES += ("qwen3_vl_embedding",)

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -330,6 +330,21 @@ class OVQuantizerTest(unittest.TestCase):
             },
         ),
         (
+            OVModelForFeatureExtraction,
+            "xlm-roberta",
+            OVQuantizationConfig(
+                dtype="int8",
+                dataset="c4",
+                num_samples=1,
+            ),
+            {
+                "model": 12,
+            },
+            {
+                "model": {"int8": 15},
+            },
+        ),
+        (
             OVModelForZeroShotImageClassification,
             "clip",
             OVQuantizationConfig(

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -403,7 +403,7 @@ HUB_MODEL_NAMES = {
     "wav2vec2-conformer": "optimum-intel-internal-testing/tiny-random-wav2vec2-conformer",
     "whisper": "optimum-intel-internal-testing/tiny-random-whisper",
     "xlm": "optimum-intel-internal-testing/tiny-random-xlm",
-    "xlm-roberta": "optimum-intel-internal-testing/tiny-random-xlm-roberta",
+    "xlm-roberta": "optimum-intel-internal-testing/tiny-random-xlm-roberta",  # used by fill-mask and feature-extraction (e.g. BAAI/bge-m3) tests
     "xglm": "optimum-intel-internal-testing/tiny-random-XGLMForCausalLM",
     "xverse": "optimum-intel-internal-testing/tiny-random-xverse",
     "glm4": "optimum-intel-internal-testing/tiny-random-glm4",


### PR DESCRIPTION
⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
This PR was created by an AI agent as part of automated model enablement.
A human maintainer must review and approve it before it can be considered for merge.
Do **NOT** merge without human review and sign-off.

# What does this PR do?

## Summary

Validates OpenVINO export/inference for [`BAAI/bge-m3`](https://huggingface.co/BAAI/bge-m3), a multilingual (100+ languages) text-embedding model built on an `XLMRobertaModel` backbone (`model_type=xlm-roberta`, 24 layers, ~568M params).

**No new architecture, config class, or patcher is required.** `xlm-roberta` is already fully registered for `feature-extraction` via `COMMON_TEXT_TASKS`, and `OVModelForFeatureExtraction` already supports it end-to-end. `optimum-cli export openvino --task feature-extraction --model BAAI/bge-m3` works cleanly out of the box (FP16 baseline, INT8 and INT4 weight-only quantization all export without warnings or errors).

The one genuine, narrow gap found: the `feature-extraction` task for the `xlm-roberta` architecture was **untested** — it was previously only exercised via `fill-mask` (`OVModelForMaskedLM`). Since `feature-extraction` is BGE-M3's actual real-world usage (and the existing `optimum-intel-internal-testing/tiny-random-xlm-roberta` fixture already exists), this PR closes that test-coverage gap:

- `tests/openvino/test_modeling.py` — added `xlm-roberta` to `OVModelForFeatureExtractionIntegrationTest.SUPPORTED_ARCHITECTURES`
- `tests/openvino/test_quantization.py` — added an `OVModelForFeatureExtraction` + `xlm-roberta` INT8 static-quantization case to `SUPPORTED_ARCHITECTURES_OV_MODEL_WITH_AUTO_DATASET`
- `tests/openvino/test_exporters_cli.py` — added a `feature-extraction` + `xlm-roberta` case to `SUPPORTED_QUANTIZATION_ARCHITECTURES`
- `tests/openvino/utils_tests.py` — annotated the existing `xlm-roberta` fixture entry to note it is now also used by feature-extraction tests
- `docs/source/openvino/inference.mdx` — added a short usage example under the `OVModelForFeatureExtraction` table showing `BAAI/bge-m3` as a validated multilingual embedding model

## Validation performed (this ticket)

Exported `BAAI/bge-m3` with `optimum-cli export openvino --task feature-extraction` at FP16 (baseline), INT8, and INT4 weight compression. Verified inference (short input + a 1622-token long-context input, exceeding BGE-M3's 1024-token multi-granularity requirement) on both **CPU** and **GPU**. Compared OpenVINO embeddings (mean-pooled, L2-normalized `last_hidden_state`) against the original HF PyTorch model:

| Precision | Device | Cosine similarity (avg, 3 test sentences) | Model size | Status |
|-----------|--------|---------------------------------------------|------------|--------|
| FP16 | CPU | 1.0000 | 2.2 GB | ✅ PASS |
| INT8 | CPU | 0.9991 | 570 MB | ✅ PASS |
| INT4 (asym, group_size=128) | CPU | 0.9743 | 433 MB | ✅ PASS (expected weight-compression loss) |
| FP16 | GPU | inference OK (shape/latency verified) | — | ✅ PASS |

> INT4 similarity of 0.974 reflects expected 4-bit weight-compression loss on a 24-layer, 1024-hidden-size encoder and is not caused by any change in this PR.

Long-context validation: a 1622-token input (tokenized from a repeated-sentence stress text) produced the expected `[1, 1622, 1024]` output shape with no truncation or errors on CPU, confirming BGE-M3's up-to-8192-token multi-granularity support is preserved through the OpenVINO export.

**Known, explicitly out-of-scope limitation:** BGE-M3's sparse-lexical (`sparse_linear.pt`) and multi-vector ColBERT-style (`colbert_linear.pt`) retrieval heads are implemented by the separate `FlagEmbedding` package's `BGEM3FlagModel` wrapper, not by `transformers.AutoModel`/`config.json`'s declared architecture (`XLMRobertaModel`). There is no optimum-intel precedent for these extra heads; this PR intentionally covers only the standard dense-embedding path (backbone `last_hidden_state` + pooling → single dense vector), identical to any other `feature-extraction` model.

## Reuse audit (Check 6)

| Changed/added item | Existing candidate(s) inspected | Shared behavior | Decision | Remaining model-specific delta |
|---|---|---|---|---|
| `xlm-roberta` in `OVModelForFeatureExtractionIntegrationTest.SUPPORTED_ARCHITECTURES` (test_modeling.py) | `bert`, `roberta`, `distilbert` entries in same tuple; `xlm-roberta` already present in `OVModelForMaskedLMIntegrationTest` | Reuses the exact same parametrized test body (`test_compare_to_transformers`, `test_pipeline`, `test_sentence_transformers_pipeline`) and the pre-existing tiny model fixture | Reused unchanged — no new test logic, only a new architecture entry in an existing list | None; `xlm-roberta` behaves identically to `roberta`/`bert` for this task |
| `OVModelForFeatureExtraction` + `xlm-roberta` case in `test_quantization.py` `SUPPORTED_ARCHITECTURES_OV_MODEL_WITH_AUTO_DATASET` | `OVModelForFeatureExtraction` + `blenderbot` case (same list); `OVModelForMaskedLM` + `xlm-roberta` case (same file) | Reuses `test_ov_model_static_quantization_with_auto_dataset` unchanged; node counts (12 fake, 15 int8) measured empirically with the existing tiny fixture | Reused unchanged — data-only addition | None |
| `feature-extraction` + `xlm-roberta` case in `test_exporters_cli.py` `SUPPORTED_QUANTIZATION_ARCHITECTURES` | `feature-extraction` + `sentence-transformers-bert` case (same list); `fill-mask` + `xlm-roberta` case (same file) | Reuses `test_exporters_cli_full_quantization` unchanged | Reused unchanged — data-only addition | None |
| `utils_tests.py` comment annotation | n/a (comment only) | n/a | Genuinely new (documentation only) | Clarifies the fixture is now dual-purpose |
| `inference.mdx` usage example | n/a (new doc content) | n/a | Genuinely new (documentation only) | New example, no code |

No production code (`model_configs.py`, `model_patcher.py`, `modeling.py`, `convert.py`, etc.) was touched — this PR is test-coverage and documentation only, since the existing implementation already handles this architecture/task combination correctly.

## Regression check

No shared production files were modified, so the shared-code regression check does not apply. As an extra precaution the pre-existing `xlm-roberta` fill-mask tests (`test_compare_to_transformers_16_xlm_roberta`, `test_pipeline_16_xlm_roberta`) were re-run alongside the new feature-extraction tests and both continue to pass (see test log).

## Installation instructions

```bash
pip install git+https://github.com/mlukasze/optimum-intel.git@enable/BAAI-bge-m3
pip install --pre -U openvino openvino-tokenizers nncf --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
```

## Exporting cmd-line

```bash
optimum-cli export openvino -m BAAI/bge-m3 --task feature-extraction bge-m3-ov
# INT8: add --weight-format int8
# INT4: add --weight-format int4
```

## Inference script

```python
from optimum.intel import OVModelForFeatureExtraction
from transformers import AutoTokenizer
import torch

model_id = "bge-m3-ov"  # or "BAAI/bge-m3" with export=True
tokenizer = AutoTokenizer.from_pretrained(model_id)
model = OVModelForFeatureExtraction.from_pretrained(model_id, device="CPU")  # or device="GPU"

texts = ["Hello, this is a multilingual embedding example."]
inputs = tokenizer(texts, padding=True, return_tensors="pt")
outputs = model(**inputs).last_hidden_state

# mean pooling + L2 normalization to get a single dense embedding per input
mask = inputs["attention_mask"].unsqueeze(-1).expand(outputs.size()).float()
embeddings = torch.sum(outputs * mask, 1) / torch.clamp(mask.sum(1), min=1e-9)
embeddings = torch.nn.functional.normalize(embeddings, dim=-1)
print(embeddings.shape)  # torch.Size([1, 1024])
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?
