### PR TITLE
[EXPERIMENT][WIP][OpenVINO] Add support for BAAI/bge-reranker-v2-m3 (xlm-roberta sequence classification)

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -176,7 +176,7 @@ Here is the list of the supported architectures :
 - Whisper
 - XGLM
 - XLM
-- XLM-RoBERTa
+- XLM-RoBERTa (including sequence-classification / cross-encoder reranker checkpoints, e.g. `BAAI/bge-reranker-v2-m3`)
 - XVERSE
 - Zamba2
 

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -176,7 +176,7 @@ Here is the list of the supported architectures :
 - Whisper
 - XGLM
 - XLM
-- XLM-RoBERTa (including sequence-classification / cross-encoder reranker checkpoints, e.g. `BAAI/bge-reranker-v2-m3`)
+- XLM-RoBERTa (including sequence-classification / cross-encoder reranker checkpoints)
 - XVERSE
 - Zamba2
 

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -782,6 +782,7 @@ class OVModelForSequenceClassificationIntegrationTest(unittest.TestCase):
         "roberta",
         "roformer",
         "squeezebert",
+        "xlm-roberta",
     )
 
     # TODO: add fix for v5 and update MAX_TRANSFORMERS_VERSION accordingly
@@ -796,6 +797,7 @@ class OVModelForSequenceClassificationIntegrationTest(unittest.TestCase):
             model_id, export=True, ov_config=F32_CONFIG, device=OPENVINO_DEVICE
         )
         self.assertIsInstance(ov_model.config, PretrainedConfig)
+        set_seed(SEED)
         transformers_model = AutoModelForSequenceClassification.from_pretrained(model_id)
         tokenizer = AutoTokenizer.from_pretrained(model_id)
         inputs = "This is a sample input"

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -465,6 +465,7 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     "afmoe": {"model": 16},
     "bert": {"model": 68 if is_transformers_version("<", "5") or is_transformers_version(">=", "5.5") else 70},
     "roberta": {"model": 68},
+    "xlm-roberta": {"model": 34},
     "albert": {"model": 84},
     "vit": {"model": 64},
     "blenderbot": {"model": 70 if is_transformers_version("<", "5") or is_transformers_version(">=", "5.5") else 72},


### PR DESCRIPTION
> ⚠️ AUTOMATICALLY GENERATED BY OMEGA AGENT — REQUIRES HUMAN REVIEW ⚠️
> This PR was created by an AI agent as part of automated model enablement.
> A human maintainer must review and approve it before it can be considered for merge.
> Do **NOT** merge without human review and sign-off.

# What does this PR do?

Adds test coverage for `xlm-roberta` in `OVModelForSequenceClassificationIntegrationTest`, enabling verified OpenVINO export/inference support for `BAAI/bge-reranker-v2-m3` (a 24-layer XLM-RoBERTa cross-encoder reranker with a single-logit sequence-classification head).

**No production code change is required or included.** `XLMRobertaOpenVINOConfig(DistilBertOpenVINOConfig)` was already registered for `COMMON_TEXT_TASKS` (including `text-classification`) in `optimum/exporters/openvino/model_configs.py` by the earlier `BAAI/bge-m3` enablement (#1956). This PR only adds the missing test-class entry, mirroring #1956's additive pattern applied to `OVModelForSequenceClassificationIntegrationTest` instead of the feature-extraction test class.

### Changes

1. `tests/openvino/test_modeling.py`
   - Add `"xlm-roberta"` to `OVModelForSequenceClassificationIntegrationTest.SUPPORTED_ARCHITECTURES`.
   - Fix `test_compare_to_transformers` to call `set_seed(SEED)` again immediately before loading the reference `transformers_model`, mirroring the existing pattern in `OVModelForMaskedLMIntegrationTest.test_compare_to_transformers`. This was a latent gap: architectures whose tiny test checkpoint already ships a pretrained classification head (bert, roberta, albert, ...) never exercised it, but `optimum-intel-internal-testing/tiny-random-xlm-roberta` has no classifier/pooler weights, so the head is randomly initialized on load — without re-seeding, the OV-exported model and the reference PyTorch model got two different random inits and the comparison failed non-deterministically. Re-seeding makes both loads deterministic and identical, consistent with the sibling test class.
2. `tests/openvino/utils_tests.py`
   - Add `"xlm-roberta": {"model": 34}` to `_ARCHITECTURES_TO_EXPECTED_INT8` (computed via `get_num_quantized_nodes` against the tiny checkpoint with `load_in_8bit=True`).

### Reuse audit

| New/changed symbol | Existing candidate(s) inspected | Shared behavior | Decision | Remaining model-specific delta |
|---|---|---|---|---|
| `"xlm-roberta"` entry in `SUPPORTED_ARCHITECTURES` (SequenceClassification test) | `"roberta"` entry in same tuple; `"xlm-roberta"` entry already present in `OVModelForMaskedLMIntegrationTest.SUPPORTED_ARCHITECTURES` | Same `test_compare_to_transformers`/`test_pipeline` parametrized test body, same `XLMRobertaOpenVINOConfig(DistilBertOpenVINOConfig): pass` export config (byte-identical shape to `RobertaOpenVINOConfig`) | Reused unchanged — pure data addition, no new test logic | None — `xlm-roberta` and `roberta` share the export config family and encoder architecture; only the tokenizer (sentencepiece) differs, already supported |
| `set_seed(SEED)` before `transformers_model` load | Identical call already present in `OVModelForMaskedLMIntegrationTest.test_compare_to_transformers` (line ~1161) | Deterministic reference-model instantiation across two `from_pretrained` calls when the checkpoint has randomly-initialized head params | Direct reuse of an existing, already-established pattern from the sibling test class | None — copied verbatim; no per-architecture special-casing needed |
| `_ARCHITECTURES_TO_EXPECTED_INT8["xlm-roberta"]` | `_ARCHITECTURES_TO_EXPECTED_INT8["roberta"]`, `["bert"]`, etc. | Same dict shape (`{"model": <int8_node_count>}`), same `get_num_quantized_nodes` helper used to compute the value | Reused unchanged (shared helper, no new code) | Value (34) is architecture/tiny-checkpoint specific, computed directly, not guessed |

No new config class, patcher, or runtime class was written — genuinely nothing to extract or duplicate here.

### Validation performed by the agent (outside the PR diff)

- `optimum-cli export openvino -m BAAI/bge-reranker-v2-m3 --task text-classification` succeeded for `fp16`, `int8`, and `int4` weight formats.
- Inference correctness verified for all three precisions: a clearly relevant query/passage pair scores strongly positive (~1.6-2.1) and a clearly irrelevant pair scores strongly negative (~ -11), matching the expected reranker behavior and PyTorch reference output.
- Added test (`test_compare_to_transformers_9_xlm_roberta` in `OVModelForSequenceClassificationIntegrationTest`) passes locally; full `-k xlm_roberta` run across both `OVModelForSequenceClassificationIntegrationTest` and `OVModelForMaskedLMIntegrationTest` (pre-existing) also passes (3 passed, 1 pre-existing `@slow`-skipped).
- No regression: an existing sibling architecture (`bert`) in the same test class was re-run individually before and after this change with identical outcomes.

### Known pre-existing flakiness (not touched by this PR)

Running the full `OVModelForSequenceClassificationIntegrationTest::test_compare_to_transformers` parametrized suite as one batch intermittently fails several unrelated architectures (`albert`, `convbert`, `distilbert`, `electra`, `ibert`, `roberta`) with `ValueError: The library name could not be automatically inferred`. This reproduces identically on the unmodified `upstream/main` tip (verified via `git stash`), so it is pre-existing local-environment/test-isolation flakiness unrelated to this change and out of scope here. Each architecture, including the new `xlm-roberta` entry, passes reliably when run individually.

## Installation instructions

```bash
pip install git+https://github.com/mlukasze/optimum-intel.git@enable/BAAI-bge-reranker-v2-m3
pip install --pre -U openvino openvino-tokenizers nncf --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
```

## Exporting cmd-line

```bash
optimum-cli export openvino -m BAAI/bge-reranker-v2-m3 --task text-classification ov_model
```

## Inference script

```python
import torch
from optimum.intel import OVModelForSequenceClassification
from transformers import AutoTokenizer

model = OVModelForSequenceClassification.from_pretrained("ov_model")
tokenizer = AutoTokenizer.from_pretrained("ov_model")

pairs = [
    ["what is panda?", "The giant panda is a bear species endemic to China."],
    ["what is panda?", "Paris is the capital of France."],
]
inputs = tokenizer(pairs, padding=True, truncation=True, return_tensors="pt")
with torch.no_grad():
    scores = model(**inputs).logits.view(-1).float()
print(scores)
# tensor([  1.6544, -11.0166])  -- relevant pair scores high, irrelevant pair strongly negative
```

## Before submitting

- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?


## INT4 accuracy note (added after issue #86 investigation)

WWB (`text-reranking`, RerankingSimilarity gate ≥0.9) flagged the **default** INT4
weight-only export for this model:

```bash
optimum-cli export openvino -m BAAI/bge-reranker-v2-m3 --task text-classification \
  --weight-format int4 ov_model
```

as an accuracy regression: **0.845 (CPU) / 0.844 (GPU)**, both well below the 0.9 gate,
while `fp16` (~0.997–1.0) and `int8` (~0.974–0.975) pass comfortably.

**Root cause**: default INT4 weight-only compression (`ratio=1.0`, no calibration data)
is lossier for this architecture than for typical decoder LLMs, because a 24-layer
XLM-RoBERTa cross-encoder collapses to a *single scalar logit* — small per-weight
quantization error accumulates and shifts that one output value more than it would a
multi-class or embedding output. This is not an OpenVINO core/plugin defect (CPU and GPU
scores agree within 0.0008) and not a GenAI pipeline wiring issue.

Tuning attempts:
- `--awq` (data-free): **skipped by NNCF** — "No matching patterns were found for
  applying AWQ algorithm." AWQ's pattern matching targets LLM-style gate/up MLP blocks
  not present in this encoder, so it has no effect here. Data-aware AWQ/scale-estimation
  (which require `--dataset`) are not currently supported for this model class in
  optimum-intel's `OVCalibrationDatasetBuilder` (only `OVModelForCausalLM`,
  `OVModelForVisualCausalLM`, `OVModelForFeatureExtraction`, `OVModelForMaskedLM`,
  `OVModelForSeq2SeqLM`/`SentenceTransformer`, Whisper, zero-shot image, SAM, and
  diffusion pipelines build a calibration dataset — `OVModelForSequenceClassification`
  is not among them).
- `--ratio 0.8 --group-size 128` (mixed int4/int8): 0.887 — improved, still below gate.
- **`--ratio 0.6 --group-size 128`** (mixed int4/int8, 60% int4 / 40% int8 by
  ratio-defining parameter count): **0.9118 (CPU) / 0.9113 (GPU)** — clears the 0.9 gate
  on both devices with margin, verified locally with the same WWB
  `text-reranking`/RerankingSimilarity setup and ground truth used for the original
  regression report. Manual relevant/irrelevant query-passage sanity check also passes
  (relevant score ≈0.9995, irrelevant ≈1.6e-5).

**Recommended INT4 export command for this model:**

```bash
optimum-cli export openvino -m BAAI/bge-reranker-v2-m3 --task text-classification \
  --weight-format int4 --ratio 0.6 --group-size 128 ov_model
```

No production code change is included for this — the `--ratio`/`--group-size` CLI flags
already exist and are already exercised generically by `test_quantization.py`;
this is a per-model export-parameter recommendation rather than a code defect fix.
Flagging here so downstream users/automation exporting this model as INT4 use the tuned
config instead of the (lossy) default.
