### PR TITLE
Update Gemma 4 12B Config

### DIFF
--- a/optimum/intel/openvino/configuration.py
+++ b/optimum/intel/openvino/configuration.py
@@ -449,10 +449,15 @@ _DEFAULT_4BIT_WQ_CONFIGS = {
         "scale_estimation": True,
     },
     "google/gemma-4-12B-it": {
-        "bits": 4,
-        "sym": False,
-        "group_size": 64,
-        "quant_method": OVQuantizationMethod.AWQ,
+        "quantization_configs": {
+            "lm_model": {
+                "bits": 4,
+                "sym": False,
+                "group_size": 64,
+                "quant_method": OVQuantizationMethod.AWQ,
+            },
+            "text_embeddings_model": {"bits": 8, "sym": True, "weight_only": True},
+        },
     },
     "google/gemma-4-26B-A4B-it": {
         "bits": 4,


### PR DESCRIPTION
# What does this PR do?

Update Gemma 4 12B Config to not compress the vision embeddings model. This is done to resolve accuracy issues with compressed inference of vision embedding model on the GPU.


Fixes # (issue)

191056

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

