### PR TITLE
[OpenVINO] Enable MiniCPM-V-4.5 3D-Resampler temporal grouping

### DIFF
--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -16,6 +16,7 @@ import warnings
 from abc import abstractmethod
 from collections import OrderedDict
 from dataclasses import dataclass
+from itertools import chain
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
@@ -2457,6 +2458,8 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
         if input_ids is not None and input_ids.shape[1] == 1:
             return None
         tgt_sizes = kwargs["tgt_sizes"]
+        # MiniCPM-V-4.5's image processor emits temporal groupings for video inputs
+        temporal_ids = kwargs.get("temporal_ids")
         pixel_values_list = pixel_values
         vision_hidden_states = []
         all_pixel_values = []
@@ -2492,28 +2495,88 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
                     pixel_values=all_pixel_values, patch_attention_mask=patch_attn_mask, position_ids=position_ids
                 )[0]
             )
-            vision_embedding = self.resampling(vision_embedding, tgt_sizes)
+            # flatten per-sample groups the same way frames were flattened above, so that
+            # group order follows frame order
+            all_temporal_ids = None
+            if temporal_ids is not None:
+                all_temporal_ids = []
+                for t in temporal_ids:
+                    all_temporal_ids.extend(t)
+            vision_embedding = self.resampling(vision_embedding, tgt_sizes, all_temporal_ids)
 
+            # with grouping the resampler emits one row per group rather than per image, so
+            # each sample's slice width has to be counted in groups
             start = 0
-            for pixel_value in pixel_values_list:
-                img_cnt = len(pixel_value)
-                if img_cnt > 0:
-                    vision_hidden_states.append(vision_embedding[start : start + img_cnt])
-                    start += img_cnt
-                else:
-                    vision_hidden_states.append([])
+            if all_temporal_ids is not None:
+                grp_start = 0
+                for pixel_value in pixel_values_list:
+                    n_img = len(pixel_value)
+                    if n_img == 0:
+                        vision_hidden_states.append([])
+                        continue
+                    n_grp, seen = 0, 0
+                    while seen < n_img:
+                        if grp_start + n_grp >= len(all_temporal_ids):
+                            raise ValueError(
+                                f"temporal_ids ran out after {seen} of this sample's {n_img} images; "
+                                "the flattened groups must cover every image exactly once."
+                            )
+                        seen += len(all_temporal_ids[grp_start + n_grp])
+                        n_grp += 1
+                    if seen != n_img:
+                        raise ValueError(
+                            f"temporal_ids groups span {seen} frames but this sample has {n_img} "
+                            "images; a temporal group must not straddle two samples."
+                        )
+                    vision_hidden_states.append(vision_embedding[start : start + n_grp])
+                    start += n_grp
+                    grp_start += n_grp
+            else:
+                for pixel_value in pixel_values_list:
+                    n_img = len(pixel_value)
+                    if n_img > 0:
+                        vision_hidden_states.append(vision_embedding[start : start + n_img])
+                        start += n_img
+                    else:
+                        vision_hidden_states.append([])
         else:  # no image
             dummy_feature = []
             for _ in range(len(pixel_values_list)):
                 vision_hidden_states.append(dummy_feature)
         return vision_hidden_states
 
-    def resampling(self, x, tgt_sizes):
+    def resampling(self, x, tgt_sizes, temporal_ids=None):
+        """Resample vision features to `query_num` language-space tokens.
+
+        With `temporal_ids`, MiniCPM-V-4.5's 3D-Resampler compresses each temporal GROUP of
+        frames into ONE `query_num`-token vector instead of one per frame. Upstream implements
+        this in `Resampler.batch_attn_forward` via `torch.nn.utils.rnn.pad_sequence`, which the
+        OpenVINO PyTorch frontend cannot convert; the same result is obtained here by folding on
+        the host, so the exported three-input resampler IR is reused unchanged.
+
+        Args:
+            x:            [B_frames, L, D_vis] vision-encoder output.
+            tgt_sizes:    [B_frames, 2] patch grid per frame.
+            temporal_ids: list of groups of temporal ids, e.g. `[[-1], [-1], [2, 6, 9]]`.
+                          Flattened length must equal B_frames. `None` keeps the legacy
+                          per-frame behaviour bit-for-bit.
+
+        Returns:
+            [B_frames, query_num, D] without grouping, or [G, query_num, D] with it.
+        """
         bs = x.shape[0]
-
         patch_len = tgt_sizes[:, 0] * tgt_sizes[:, 1]
-
         self._adjust_pos_cache(tgt_sizes)
+
+        temporal_pos_emb = False
+        temporal_ids_flatten = None
+        if temporal_ids is not None:
+            temporal_ids_flatten = list(chain.from_iterable(temporal_ids))
+            if len(temporal_ids_flatten) != bs:
+                raise ValueError(f"temporal_ids covers {len(temporal_ids_flatten)} frames but {bs} were encoded")
+            # matches the upstream gate; ids of -1 contribute a zero row, so an all -1
+            # grouping stays a no-op
+            temporal_pos_emb = (max(temporal_ids_flatten) + 1) > -1
 
         max_patch_len = torch.max(patch_len)
         key_padding_mask = torch.zeros((bs, max_patch_len), dtype=torch.bool)
@@ -2527,6 +2590,43 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
         pos_embed = torch.nn.utils.rnn.pad_sequence(pos_embed, batch_first=True, padding_value=0.0).permute(
             1, 0, 2
         )  # BLD => L * B * D
+
+        if temporal_pos_emb:
+            # 3D-Resampler: fold frames into temporal groups on the host. The reference
+            # `Resampler.batch_attn_forward` builds, for each group g:
+            #     k_g = concat_{f in g}( x_f + pos2d_f + temporal_f )   (frame-major)
+            #     v_g = concat_{f in g}( x_f )
+            # `kv_proj` and `ln_kv` act per token, so folding the raw features and adding the
+            # temporal vector into the per-token pos_embed is algebraically identical.
+            temporal_per_frame = self._temporal_pos_embed_rows(temporal_ids_flatten, pos_embed.dtype)
+            pos_bld = pos_embed.permute(1, 0, 2) + temporal_per_frame.unsqueeze(1)  # [B, L, D]
+
+            groups = [list(g) for g in temporal_ids]
+            feats, poss, masks = [], [], []
+            start = 0
+            for g in groups:
+                end = start + len(g)
+                # frame-major, matching k[:, start:end, :].permute(1, 0, 2).reshape(-1, D)
+                feats.append(x[start:end].reshape(-1, x.shape[-1]))
+                poss.append(pos_bld[start:end].reshape(-1, pos_bld.shape[-1]))
+                masks.append(key_padding_mask[start:end].reshape(-1))
+                start = end
+
+            n_groups = len(groups)
+            max_len = max(t.shape[0] for t in feats)
+            x_f = x.new_zeros((n_groups, max_len, x.shape[-1]))
+            pos_f = pos_bld.new_zeros((n_groups, max_len, pos_bld.shape[-1]))
+            # True marks padding; those slots pick up a non-zero value from ln_kv(kv_proj(0))
+            # but receive exactly zero attention weight, so the output is unchanged
+            mask_f = torch.ones((n_groups, max_len), dtype=torch.bool)
+            for gi in range(n_groups):
+                ln = feats[gi].shape[0]
+                x_f[gi, :ln] = feats[gi]
+                pos_f[gi, :ln] = poss[gi]
+                mask_f[gi, :ln] = masks[gi]
+
+            x, pos_embed, key_padding_mask = x_f, pos_f.permute(1, 0, 2), mask_f
+
         res = torch.from_numpy(self.resampler(image_feature=x, pos_embed=pos_embed, key_padding_mask=key_padding_mask))
         return res
 
@@ -2540,6 +2640,28 @@ class _OVMiniCPMVForCausalLM(OVModelForVisualCausalLM):
         if max_h > self.max_size[0] or max_w > self.max_size[1]:
             self.max_size = [max(max_h, self.max_size[0]), max(max_w, self.max_size[1])]
             self._set_2d_pos_cache(self.max_size)
+
+    def _temporal_pos_embed_rows(self, temporal_ids_flatten, dtype=torch.float32):
+        """1-D sincos temporal position embeddings, one row per frame.
+
+        Equivalent to the reference implementation's `temporal_pos_embed[id]` lookup, but
+        computes only the rows requested instead of caching `max_temporal_size` (72000) of
+        them, which would reserve roughly 1.2 GB at a hidden size of 4096. An id of -1 means
+        "no temporal information" and yields a zero row, as upstream does.
+        """
+        embed_dim = self.embed_dim
+        omega = np.arange(embed_dim // 2, dtype=np.float32)
+        omega /= embed_dim / 2.0
+        omega = 1.0 / 10000**omega  # (D/2,)
+
+        ids = np.asarray([max(int(t), 0) for t in temporal_ids_flatten], dtype=np.float32)
+        out = np.einsum("m,d->md", ids, omega)  # (M, D/2)
+        rows = torch.from_numpy(np.concatenate([np.sin(out), np.cos(out)], axis=1)).to(dtype)
+
+        for i, t in enumerate(temporal_ids_flatten):
+            if int(t) == -1:
+                rows[i].zero_()
+        return rows
 
     def _get_2d_sincos_pos_embed(self, embed_dim, image_size):
         """

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -77,6 +77,7 @@ from optimum.intel.openvino.modeling_text2speech import (
 from optimum.intel.openvino.modeling_visual_language import (
     MODEL_PARTS_CLS_MAPPING,
     MODEL_TYPE_TO_CLS_MAPPING,
+    _OVMiniCPMVForCausalLM,
     _OVQwen3OmniMoeForCausalLM,
 )
 from optimum.intel.pipelines import pipeline as optimum_pipeline
@@ -1190,6 +1191,74 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
                 device=OPENVINO_DEVICE,
             )
             self.assertIsInstance(ov_restored_model, type(ov_model))
+
+    def test_minicpmv_3d_resampler_temporal_grouping(self):
+        """MiniCPM-V-4.5's 3D-Resampler compresses a temporal GROUP of frames into a single
+        ``query_num``-token vector instead of one per frame.
+
+        Exercises ``resampling()`` directly with a stub resampler so the test needs no model
+        download: it asserts (a) grouping changes the number of emitted vectors, (b) the
+        per-token inputs handed to the resampler are folded frame-major, and (c) passing
+        ``temporal_ids=None`` is bit-identical to the previous per-frame behaviour.
+        """
+        embed_dim, kv_dim, seq_len = 16, 8, 6
+
+        class _Stub:
+            resampling = _OVMiniCPMVForCausalLM.resampling
+            _temporal_pos_embed_rows = _OVMiniCPMVForCausalLM._temporal_pos_embed_rows
+
+            def __init__(self):
+                self.embed_dim = embed_dim
+                self._pos_embeds = torch.arange(8 * 8 * embed_dim, dtype=torch.float32).reshape(8, 8, embed_dim)
+                self.seen = {}
+
+            def _adjust_pos_cache(self, tgt_sizes):
+                pass
+
+            def resampler(self, image_feature, pos_embed, key_padding_mask):
+                self.seen = {
+                    "image_feature": image_feature,
+                    "pos_embed": pos_embed,
+                    "key_padding_mask": key_padding_mask,
+                }
+                # stand in for the exported IR: one vector per batch row
+                return image_feature.sum(dim=1).unsqueeze(1).expand(-1, 2, -1).numpy()
+
+        n_frames = 6
+        tgt_sizes = torch.tensor([[2, 3]] * n_frames, dtype=torch.int32)
+        x = torch.arange(n_frames * seq_len * kv_dim, dtype=torch.float32).reshape(n_frames, seq_len, kv_dim)
+
+        # (a) grouping: 6 frames, 2 groups of 3 -> 2 output vectors, not 6
+        stub = _Stub()
+        out = stub.resampling(x, tgt_sizes, temporal_ids=[[0, 1, 2], [3, 4, 5]])
+        self.assertEqual(out.shape[0], 2)
+        # (b) folded frame-major: group 0 holds frames 0..2 concatenated along the token axis
+        self.assertEqual(tuple(stub.seen["image_feature"].shape), (2, 3 * seq_len, kv_dim))
+        self.assertTrue(torch.equal(stub.seen["image_feature"][0], x[0:3].reshape(-1, kv_dim)))
+        self.assertEqual(tuple(stub.seen["pos_embed"].shape), (3 * seq_len, 2, embed_dim))
+        self.assertEqual(tuple(stub.seen["key_padding_mask"].shape), (2, 3 * seq_len))
+
+        # ragged groups (3 + 2 + 1 frames) are padded to the longest group and masked
+        stub = _Stub()
+        out = stub.resampling(x, tgt_sizes, temporal_ids=[[0, 1, 2], [3, 4], [5]])
+        self.assertEqual(out.shape[0], 3)
+        self.assertEqual(tuple(stub.seen["image_feature"].shape), (3, 3 * seq_len, kv_dim))
+        # the 1-frame group is real for its first seq_len tokens and padding thereafter
+        self.assertFalse(bool(stub.seen["key_padding_mask"][2, :seq_len].any()))
+        self.assertTrue(bool(stub.seen["key_padding_mask"][2, seq_len:].all()))
+
+        # a grouping that does not cover every frame must fail loudly, not silently
+        with self.assertRaises(ValueError):
+            _Stub().resampling(x, tgt_sizes, temporal_ids=[[0, 1, 2], [3, 4]])
+
+        # (c) no regression: temporal_ids=None must reproduce the per-frame path exactly
+        stub_a, stub_b = _Stub(), _Stub()
+        legacy = stub_a.resampling(x, tgt_sizes, temporal_ids=None)
+        self.assertEqual(legacy.shape[0], n_frames)
+        self.assertTrue(torch.equal(stub_a.seen["image_feature"], x))
+        # every frame in its own group is the degenerate case and must agree with it
+        grouped = stub_b.resampling(x, tgt_sizes, temporal_ids=[[i] for i in range(n_frames)])
+        self.assertTrue(np.array_equal(legacy, grouped))
 
 
 @pytest.mark.skipif(is_transformers_version("<", "5.0"), reason="OVModelForMultimodalLM requires transformers >= 5.0")


### PR DESCRIPTION
## What does this PR do?

MiniCPM-V-4.5's 3D-Resampler jointly compresses several consecutive video frames into a single
`query_num`-token group. The OpenVINO path never consumed `temporal_ids`: `resampling()` did not
take them, and the resampler sub-model is driven with three per-frame inputs. So every frame
produced its own 64-token group, MiniCPM-V-2.6 behaviour, even though the checkpoint config
sets `batch_3d_resampler: true`.

Upstream performs the fold inside `Resampler.batch_attn_forward` using
`torch.nn.utils.rnn.pad_sequence`, which the OpenVINO PyTorch frontend cannot convert
(`aten::pad_sequence` has no translator and is listed under "Do not work on these for now" in
openvinotoolkit/openvino#28584).

**This PR does the fold on the host instead, and changes nothing in the graph.** `kv_proj`
(Linear) and `ln_kv` (LayerNorm over the last dim) act per token, so they commute with
regrouping; the per-frame temporal vector is therefore folded into the per-token `pos_embed`
that the existing graph already adds to `k`. Consequently:

* no new resampler IR input,
* no exporter or model-patcher change,
* no `aten::pad_sequence` support required,
* **already-exported resampler IRs run the grouped path unchanged.**

Temporal position embeddings are computed for the ids actually present rather than cached for
`max_temporal_size` (72000) rows, which at `hidden_size = 4096` would reserve ~1.2 GB for a
handful of rows that are ever indexed.

`temporal_ids=None` reproduces the previous per-frame behaviour bit-for-bit, so MiniCPM-V-2.6
and every image-only path are unaffected.

## Verification

Checked against the **unmodified upstream `Resampler`** with `batch_infer=True` (the path the
real checkpoint takes):

| case | result |
|---|---|
| uniform packing=2 (8 frames → 4 groups) | cosine 1.000000 |
| ragged packing=3 (8 frames → 3 groups) | cosine 1.000000 |
| packing=6 (6 frames → 1 group) | cosine 1.000000 |
| ragged `tgt_sizes` within a group | cosine 1.000000 |
| `temporal_ids=None` | **bit-identical** to current behaviour (`max\|diff\| == 0.0`) |

Also verified end to end through an OpenVINO IR: the three-input resampler graph was converted
once with dynamic shapes, then packings 1/2/3/4/6 were each driven through that single compiled
model, matching the reference every time.

The added unit test (`test_minicpmv_3d_resampler_temporal_grouping`) needs no model download —
it drives `resampling()` with a stub resampler and asserts the group count, the frame-major
fold, the ragged padding/mask, the "grouping must cover every frame" guard, and the
`temporal_ids=None` no-regression case.

I kept the test dependency-free deliberately, but `optimum-intel-internal-testing/tiny-random-minicpm-v-4_5`
already exists in the testing org (`version: 4.5`, `batch_3d_resampler: true`, `query_num: 64`)
and is not yet wired into `MODEL_NAMES`. Happy to add an end-to-end export/generate test on top
of it if you would prefer that, either here or as a follow-up.

## End-to-end demonstration

@rkazants  - here is a self-contained script showing exactly the case this fixes. It uses
MiniCPM-V-4.5's **own** `Resampler` as the reference, and downloads a single ~20 kB source file;
no model weights are required.

```python
# Demonstrates the case fixed by this PR, using MiniCPM-V-4.5's OWN Resampler as the
# reference. Downloads a single ~20 kB source file; no model weights required.
import importlib.util, types, torch, numpy as np
from huggingface_hub import hf_hub_download
from optimum.intel.openvino.modeling_visual_language import _OVMiniCPMVForCausalLM

# --- MiniCPM-V-4.5's reference Resampler (the behaviour OpenVINO should reproduce) ---
spec = importlib.util.spec_from_file_location(
    "mcpm_resampler", hf_hub_download("openbmb/MiniCPM-V-4_5", "resampler.py"))
mcpm = importlib.util.module_from_spec(spec); spec.loader.exec_module(mcpm)

EMBED, KV, QUERIES = 128, 64, 64          # query_num=64 as in the 4.5 config
torch.manual_seed(0)
ref = mcpm.Resampler(num_queries=QUERIES, embed_dim=EMBED, num_heads=4, kv_dim=KV,
                     adaptive=False, max_size=(8, 8), max_temporal_size=64,
                     batch_infer=True).eval()          # batch_3d_resampler: true

# --- a 6-frame clip whose processor grouped frames into 2 temporal groups of 3 ---
FRAMES, temporal_ids = 6, [[0, 1, 2], [3, 4, 5]]
tgt_sizes = torch.tensor([[2, 3]] * FRAMES, dtype=torch.int32)
torch.manual_seed(1)
vision_out = torch.randn(FRAMES, 6, KV)               # vision-encoder output

with torch.no_grad():
    expected = ref(vision_out, tgt_sizes=tgt_sizes, temporal_ids=temporal_ids)

# --- drive optimum-intel's resampling() with a stand-in for the exported resampler IR ---
class _Model:
    resampling = _OVMiniCPMVForCausalLM.resampling
    _temporal_pos_embed_rows = _OVMiniCPMVForCausalLM._temporal_pos_embed_rows
    embed_dim, _pos_embeds = EMBED, ref.pos_embed.float()
    def _adjust_pos_cache(self, tgt_sizes): pass
    @torch.no_grad()
    def resampler(self, image_feature, pos_embed, key_padding_mask):   # == OVResamplerModel
        x = ref.ln_kv(ref.kv_proj(image_feature)).permute(1, 0, 2)
        q = ref.ln_q(ref.query).unsqueeze(1).repeat(1, x.shape[1], 1)
        o = ref.attn(q, x + pos_embed, x, key_padding_mask=key_padding_mask)[0]
        return (ref.ln_post(o.permute(1, 0, 2)) @ ref.proj).numpy()

m = _Model()
before = m.resampling(vision_out, tgt_sizes)                              # today
after  = m.resampling(vision_out, tgt_sizes, temporal_ids=temporal_ids)   # with this PR

cos = lambda a, b: float(np.dot(np.ravel(a), np.ravel(b)) /
                         (np.linalg.norm(a) * np.linalg.norm(b)))
print(f"frames={FRAMES}  temporal groups={len(temporal_ids)}  query_num={QUERIES}\n")
print(f"MiniCPM-V-4.5 reference : {tuple(expected.shape)}  -> {expected.shape[0]*QUERIES} vision tokens")
print(f"optimum-intel (before)  : {before.shape}  -> {before.shape[0]*QUERIES} vision tokens   <-- one group PER FRAME")
print(f"optimum-intel (after)   : {after.shape}  -> {after.shape[0]*QUERIES} vision tokens")
print(f"\ncosine(after, reference) = {cos(after, expected.numpy()):.6f}")
print(f"max|after - reference|   = {float(np.abs(np.asarray(after) - expected.numpy()).max()):.2e}")
```

Output:

```
frames=6  temporal groups=2  query_num=64

MiniCPM-V-4.5 reference : (2, 64, 128)  -> 128 vision tokens
optimum-intel (before)  : torch.Size([6, 64, 128])  -> 384 vision tokens   <-- one group PER FRAME
optimum-intel (after)   : torch.Size([2, 64, 128])  -> 128 vision tokens

cosine(after, reference) = 1.000000
max|after - reference|   = 1.67e-06
```

**The case fixed:** a 6-frame clip whose processor grouped the frames into 2 temporal groups.
MiniCPM-V-4.5's reference implementation emits **one 64-token group per temporal group** (2
groups -> 128 vision tokens). Before this PR, optimum-intel emitted **one group per frame** (6
-> 384 tokens) because `resampling()` had no way to receive `temporal_ids`. After it, the output
matches the reference exactly.

Beyond the token count, the mismatch is a correctness problem: the number of resampler rows must
equal the number of image placeholder slots the processor put in the prompt, so a grouped video
input produces a different embedding layout than the model was trained for.

## Rebase status

Rebased and re-verified against `main` @ `2039025` (2026-09-08). No conflicts; the new test and
`black`/`ruff` (pinned `black~=23.1`, `ruff==0.4.4`) all pass on the rebased tree. None of the commits merged since this PR opened touch `resampling()`, `get_vision_embeddings()` or any
temporal handling.

## Relationship to the other open MiniCPM PRs

* **#1941** adds `temporal_ids` to `forward()` / `prepare_inputs_for_generation()` so
  `generate()` stops raising `ValueError("model_kwargs not used: ['temporal_ids']")`. Its test
  notes the runtime should "accept and safely ignore" them — correct for still images (all ids
  are `-1`, contributing a zero embedding), but it means grouped **video** is silently
  discarded. This PR is the other half: #1941 makes the argument arrive, this makes it mean
  something. They compose; happy to rebase if #1941 lands first.
* **#1412** adds MiniCPM-V-4/4.5 decoder plumbing plus a 4-input resampler carrying
  `temporal_embed`, doing one attention call with `bs = n_frames`. That applies the temporal
  *embedding* but not the temporal *fold*, so it still emits one vector per frame where upstream
  emits one per group. Folding into `pos_embed` makes the fourth input unnecessary. Happy to
  rebase onto that branch instead if the maintainers prefer.
* **#1945 / #1906 / #1810** target MiniCPM-V-4.6, which replaced the resampler with a spatial
  `merge_kernel_size` merger and has no temporal path, so they do not cover this.

## Before submitting
- [x] Did you read the [contributor guideline](https://github.com/huggingface/transformers/blob/main/CONTRIBUTING.md#start-contributing-pull-requests)?
- [x] Did you write any new necessary tests?

