### PR TITLE
Don't make optional dependencies hard requirements of Eagle3/DFlash draft-model export

### DIFF
--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -123,7 +123,12 @@ if is_transformers_version(">=", "5"):
 
 
 if is_diffusers_version(">=", "0.38.0"):
-    from diffusers.models.transformers import transformer_ltx2
+    # Imported inside `try` so transformers' remote-code `check_imports` scan does not
+    # make this a hard requirement of every Eagle3/DFlash draft-model export (see #1964).
+    try:
+        from diffusers.models.transformers import transformer_ltx2
+    except ImportError:
+        raise
 
 
 logger = logging.getLogger(__name__)
@@ -887,7 +892,12 @@ SUPPORT_SDPA = is_torch_version(">", "2.1.0")
 
 # TODO: why
 def _qwen_rotate_half(x):
-    from einops import rearrange
+    # Imported inside `try` so transformers' remote-code `check_imports` scan does not
+    # make this a hard requirement of every Eagle3/DFlash draft-model export (see #1964).
+    try:
+        from einops import rearrange
+    except ImportError as exc:
+        raise ImportError("This model patcher requires the `einops` package. Run `pip install einops`.") from exc
 
     x = rearrange(x, "... (j d) -> ... j d", j=2)
     x1, x2 = x.unbind(dim=-2)
@@ -1412,7 +1422,12 @@ def _internlm2_attention_forward(
     **kwargs,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
     # from transformers.models.llama.modeling_llama import apply_rotary_pos_emb, repeat_kv
-    from einops import rearrange
+    # Imported inside `try` so transformers' remote-code `check_imports` scan does not
+    # make this a hard requirement of every Eagle3/DFlash draft-model export (see #1964).
+    try:
+        from einops import rearrange
+    except ImportError as exc:
+        raise ImportError("This model patcher requires the `einops` package. Run `pip install einops`.") from exc
 
     def rotate_half(x):
         """Rotates half the hidden dims of the input."""
@@ -3455,7 +3470,12 @@ class QwenImageTransformerModelPatcher(ModelPatcher):
 class QwenImageVaeModelPatcher(ModelPatcher):
     def __enter__(self):
         super().__enter__()
-        from diffusers.models.autoencoders.autoencoder_kl_qwenimage import QwenImageUpsample
+        # Imported inside `try` so transformers' remote-code `check_imports` scan does not
+        # make this a hard requirement of every Eagle3/DFlash draft-model export (see #1964).
+        try:
+            from diffusers.models.autoencoders.autoencoder_kl_qwenimage import QwenImageUpsample
+        except ImportError:
+            raise
 
         # OpenVINO has no "nearest-exact" upsampling op; "nearest" is identical for the integer
         # scale factor of 2 used here.
@@ -11241,7 +11261,12 @@ def _ltx2_connectors_top_level_forward_patched(
     if self.config.get("per_modality_projections", False):
         import math
 
-        from diffusers.pipelines.ltx2.connectors import per_token_rms_norm
+        # Imported inside `try` so transformers' remote-code `check_imports` scan does not
+        # make this a hard requirement of every Eagle3/DFlash draft-model export (see #1964).
+        try:
+            from diffusers.pipelines.ltx2.connectors import per_token_rms_norm
+        except ImportError:
+            raise
 
         norm_text_encoder_hidden_states = per_token_rms_norm(text_encoder_hidden_states)
         norm_text_encoder_hidden_states = norm_text_encoder_hidden_states.flatten(2, 3)
@@ -12084,7 +12109,12 @@ class ZImageTransformerModelPatcher(ModelPatcher):
     def __enter__(self):
         super().__enter__()
 
-        from diffusers.models.transformers.transformer_z_image import ZSingleStreamAttnProcessor as _ZAttnProc
+        # Imported inside `try` so transformers' remote-code `check_imports` scan does not
+        # make this a hard requirement of every Eagle3/DFlash draft-model export (see #1964).
+        try:
+            from diffusers.models.transformers.transformer_z_image import ZSingleStreamAttnProcessor as _ZAttnProc
+        except ImportError:
+            raise
 
         # 1. Real-valued RoPE in the attention processor (class level — see docstring)
         _ZAttnProc._orig_ov_call = _ZAttnProc.__call__

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import sys
 import unittest
 from pathlib import Path
 
@@ -487,3 +488,45 @@ class CustomExportModelTest(unittest.TestCase):
         ov_outputs = ov_model(**tokens)
         self.assertTrue(torch.allclose(ov_outputs.token_embeddings, model_outputs.token_embeddings, atol=1e-4))
         self.assertTrue(torch.allclose(ov_outputs.sentence_embedding, model_outputs.sentence_embedding, atol=1e-4))
+
+
+class DraftModelAutoMapImportScanTest(unittest.TestCase):
+    """Guards the import surface of the module reached through ``config.auto_map``.
+
+    Exporting an Eagle3 / DFlash draft model points ``config.auto_map`` at
+    ``optimum/exporters/openvino/model_patcher.py``. transformers treats that as a remote-code
+    modeling file and runs ``check_imports`` over it, so every top-level package imported anywhere
+    in it becomes a requirement of the export -- including imports belonging to unrelated model
+    families. ``get_imports`` skips ``try`` bodies, so optional dependencies must be imported
+    inside one.
+
+    Standard-library imports are filtered out rather than listed, so adding one does not fail this
+    test. Third-party imports are allowlisted rather than denylisted, so a new optional dependency
+    fails here instead of quietly becoming a requirement of every draft-model export.
+    """
+
+    # Third-party packages `pip install "optimum-intel[openvino]"` already guarantees, plus torch.
+    ALLOWED_THIRD_PARTY = {
+        "huggingface_hub",
+        "openvino",
+        "optimum",
+        "safetensors",
+        "torch",
+        "transformers",
+    }
+
+    def test_model_patcher_scan_requires_only_guaranteed_dependencies(self):
+        from transformers.dynamic_module_utils import get_imports
+
+        from optimum.exporters.openvino import model_patcher
+
+        required = set(get_imports(model_patcher.__file__))
+        third_party = {name for name in required if name not in sys.stdlib_module_names}
+        unexpected = third_party - self.ALLOWED_THIRD_PARTY
+        self.assertEqual(
+            unexpected,
+            set(),
+            f"{sorted(unexpected)} would become a requirement of every Eagle3/DFlash draft-model "
+            "export. If it is a guaranteed dependency, add it to ALLOWED_THIRD_PARTY; if it is "
+            "optional, import it inside a `try` block so transformers' check_imports scan skips it.",
+        )


### PR DESCRIPTION
# What does this PR do?

Some code for your consideration on item 2 of #1964. Feel free to close it if your team already
has this in flight, or if you would rather it took a different shape.

Exporting an Eagle3 or DFlash draft model fails in a plain `pip install "optimum-intel[openvino]"`
environment. On `main` (`ffc8870`):

```
ImportError: This modeling file requires the following packages that were not found in your environment: diffusers, einops. Run `pip install diffusers einops`
```

`config.auto_map` points at `model_patcher.py`, so `check_imports` makes every top-level package
imported anywhere in that file a requirement of the export, including imports belonging to
unrelated model families. `get_imports` skips `try` bodies — which is why the
`ZSingleStreamAttnProcessor` import in `ZImageTransformerModelPatcher.__exit__` (`:12114`) is
already invisible to the scan while the identical import in `__enter__` is not.

The issue was filed against 2.1.0 and reports `einops` alone, which is right for the release —
`main` has since gained `diffusers` imports to the same file.

## What's in it

Six imports moved inside `try`, each with a comment saying what the wrapper is for.

The two `einops` sites re-raise with a message naming the package: they are unguarded and
function-local, so absence genuinely is the cause. The four `diffusers` sites re-raise unchanged
(`except ImportError: raise`), so behaviour there is identical — reaching any of them already
implies diffusers is installed, whether by the `is_diffusers_version()` guard at `:125` or because
the other three only run while exporting a diffusers pipeline. A `pip install diffusers` hint would
be wrong advice on the only path that can realistically fire.

Plus `DraftModelAutoMapImportScanTest`, which allowlists what the export may require rather than
listing known-bad packages, so a later import fails the test instead of quietly becoming a new
requirement.

## What I ran

Clean venv, `pip install "optimum-intel[openvino]" torch`, `einops` and `diffusers` both absent.
transformers 5.5.4, openvino 2026.3.1, torch 2.14.0, Python 3.14.3, Windows 11.

```
optimum-cli export openvino -m Tengyunw/qwen3_30b_moe_eagle3 --task text-generation-with-past \
  --weight-format fp16 --disable-convert-tokenizer --trust-remote-code <out>
```

| arm | exit | result |
| --- | --- | --- |
| `main` @ `ffc8870` | 1 | the `ImportError` above |
| `main` + this branch | 0 | exports `openvino_model.{xml,bin}` + config/tokenizer files |
| 2.1.0, `einops` absent | 1 | `ImportError: ... einops` |
| 2.1.0, `pip install einops`, no patch | 0 | control — exports normally |

The control arm is there so the result means something: the export succeeds on unmodified code once
the missing package is present, so this removes a spurious requirement rather than skipping work.
It is on 2.1.0 because the equivalent on `main` needs `diffusers` too, and the `diffusers` I get
here (0.40.0) is not import-compatible with transformers 5.5.4 — it fails on
`cannot import name 'Gemma4UnifiedForConditionalGeneration'`.

Scan surface goes from 18 modules to 16, the difference being exactly `diffusers` and `einops`.
The new test passes on this branch and fails on `main` as it stands, run under pytest on Python
3.11.9. The `try`-skip `get_imports` relies on is present at v4.51.0, v4.51.3, v4.55.0, v4.57.6,
v5.0.0, v5.5.4 and `main`, so this holds across `transformers>=4.51,<5.6`. `black --check` and
`ruff check` clean at the pinned versions.

The export arms never reach the wrapped imports — a successful export is precisely one where they
do not fire — so I exercised the `einops` sites directly: with einops importable
`_qwen_rotate_half` returns the same rotate-half result as before, and with the import blocked it
raises the new `ImportError` and nothing else.

**Not verified.** No diffusers-backed model was exported, so the four `diffusers` sites rest on the
scan measurement and the reachability argument above rather than on a run.

## Another shape I tried, which didn't work

Pointing `auto_map` at a small dedicated module would keep the scan surface minimal however
`model_patcher.py` grows. Both versions broke the export: a relative-import shim has an empty scan
surface but dies with `FileNotFoundError` on `transformers_modules\openvino\_ov_ops.py`, because
`get_cached_module_file` copies one level of relative imports while `get_class_in_module` resolves
them recursively; an absolute-import shim cleared the scan and loaded the model, then failed in
`_infer_library_from_model_or_model_class`, which prefix-matches `model.__class__.__module__` and
only accepts the status quo because the copied module is named `transformers_modules…`.

So this branch takes the approach that leaves `auto_map` pointing where it already points. You
will know this codebase far better than I do — if you can see the way around either of those, I
will rework it into the structural fix instead.

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?  — no docs describe this behaviour
- [x] Did you write any new necessary tests?

---

*AI assistance disclosure: this change and the investigation behind it were produced with Claude
Code, which traced the code paths, wrote the patch and the test, and ran the export arms and
version checks above on my machine; the numbers and quoted errors come from those runs. I reviewed
and approved this before opening it. I did not independently validate the code-path analysis.*
