### PR TITLE
[OpenVINO] Fix Gemma4-12B vision embedding overflow on GPU by setting activation scale factor

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -125,6 +125,13 @@ def _set_runtime_options(
             or getattr(sub_export_config, "stateful", False)
         ):
             sub_export_config.runtime_options["KV_CACHE_PRECISION"] = "f16"
+        # The gemma4_unified vision embedder produces activations large enough to overflow in
+        # fp16, so scale them down at runtime the same way the language model does.
+        if (
+            model_name == "vision_embeddings_model"
+            and getattr(getattr(sub_export_config, "_orig_config", None), "model_type", None) == "gemma4_unified"
+        ):
+            sub_export_config.runtime_options["ACTIVATIONS_SCALE_FACTOR"] = "8.0"
 
 
 def _save_model(

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -266,6 +266,12 @@ class ExportModelTest(unittest.TestCase):
                     self.assertTrue(
                         ov_model.language_model.model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"])
                     )
+                    if model_type == "gemma4_unified":
+                        vision_model = ov_model.vision_embeddings.model
+                        self.assertTrue(vision_model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"]))
+                        self.assertEqual(
+                            vision_model.get_rt_info()["runtime_options"]["ACTIVATIONS_SCALE_FACTOR"], "8.0"
+                        )
 
                 if library_name == "diffusers":
                     expected_scale_factors = self.EXPECTED_DIFFUSERS_SCALE_FACTORS.get(model_type, {})


### PR DESCRIPTION
# What does this PR do?

Setup:

```sh
pip install -U "optimum-intel @ git+https://github.com/rkazants/optimum-intel.git@gemma4_unified_fix"
pip install transformers==5.10
```

Export cmd-line:

```python
optimum-cli export openvino -m google/gemma-4-12B-it gemma-4-12B-it --weight-format int4
```

Fix Gemma4-12B vision embedding overflow by setting activation scale factor

## Before submitting
- [N/A] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [N/A] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

