### PR TITLE
Fix error with timm on test_modeling.py

### DIFF
--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1274,7 +1274,7 @@ class OVModelForImageClassificationIntegrationTest(unittest.TestCase):
         )
         self.assertEqual(ov_model.request.get_property("INFERENCE_PRECISION_HINT").to_string(), "f32")
         self.assertIsInstance(ov_model.config, PretrainedConfig)
-        timm_model = timm.create_model(model_id, pretrained=True)
+        timm_model = timm.create_model(f"hf-hub:{model_id}", pretrained=True)
         preprocessor = TimmImageProcessor.from_pretrained(model_id)
         url = TEST_IMAGE_URL
         image = Image.open(requests.get(url, stream=True).raw)


### PR DESCRIPTION
# What does this PR do?

This PR changes the test_compare_to_timm reference-model call to pass the Hub repo id with an explicit hf-hub: prefix, which timm 1.0.29 now requires instead of implicitly treating a bare timm/... name as a Hub id.

