### PR TITLE
Patch models with changed IRs for v5.10 rel.

### DIFF
--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Test with Pytest
         run: |
-          pytest tests/openvino/${{ matrix.test-pattern }} -k "not (qwen3_asr or fun_asr)" --durations=0
+          pytest tests/openvino/${{ matrix.test-pattern }} -k "not (qwen3_asr or fun_asr)" --durations=0 -rs
 
       - if: ${{ matrix.test-pattern == '*modeling*' }}
         name: Install Nightly OpenVINO

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -39,8 +39,12 @@ jobs:
             "*diffusion*",
             "*quantization*",
             "*transformation*",
+            "*irs*",
           ]
         transformers-version: ["4.57.6", "latest"]
+        exclude:
+          - test-pattern: "*irs*"
+            transformers-version: "4.57.6"
 
     runs-on: ubuntu-22.04
 

--- a/.github/workflows/test_openvino.yml
+++ b/.github/workflows/test_openvino.yml
@@ -6,10 +6,12 @@ on:
     branches:
       - main
       - v*-release
+      - transformers-v5.10-support
   pull_request:
     branches:
       - main
       - v*-release
+      - transformers-v5.10-support
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -110,6 +110,8 @@ from optimum.exporters.openvino.model_patcher import (
     AquilaModelPatcher,
     ArcticModelPatcher,
     BaichuanModelPatcher,
+    BeitModelPatcher,
+    BidirectionalMaskModelPatcher,
     BigBirdPegasusModelPatcher,
     BloomModelPatcher,
     ChatGLMModelPatcher,
@@ -138,7 +140,7 @@ from optimum.exporters.openvino.model_patcher import (
     GptOssModelPatcher,
     GraniteMoeHybridModelPatcher,
     GraniteMoEModelPatcher,
-    IBertModelPatcher,
+    IBertBidirectionalMaskModelPatcher,
     Idefics3ImageEmbeddingsModelPatcher,
     InputEmbeddingPatcher,
     InternLM2Patcher,
@@ -206,9 +208,11 @@ from optimum.exporters.openvino.model_patcher import (
     SanaTextEncoderModelPatcher,
     SegformerModelPatcher,
     SentenceTransformersTransformerPatcher,
+    Seq2SeqBidirectionalMaskModelPatcher,
     SpeechT5ModelPatcher,
     SwinModelPatcher,
     VideoChatFlashQwenVisionEmbeddingModelPatcher,
+    VisionEncoderDecoderModelPatcher,
     XverseModelPatcher,
     Zamba2ModelPatcher,
     ZImageTextEncoderModelPatcher,
@@ -1766,7 +1770,7 @@ class CLIPVisionModelOpenVINOConfig(VisionOpenVINOConfig):
 )
 class IBertOpenVINOConfig(TextEncoderOpenVINOConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
-    _MODEL_PATCHER = IBertModelPatcher
+    _MODEL_PATCHER = IBertBidirectionalMaskModelPatcher
 
     @property
     def inputs(self) -> Dict[str, Dict[int, str]]:
@@ -6030,7 +6034,7 @@ class GPT2OpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
 class VisionEncoderDecoderOpenVINOConfig(EncoderDecoderBaseOpenVINOConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedEncoderDecoderConfig
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyVisionInputGenerator, DummyVisionEncoderDecoderPastKeyValuesGenerator)
-    _MODEL_PATCHER = OVSeq2SeqModelPatcher
+    _MODEL_PATCHER = VisionEncoderDecoderModelPatcher
 
     @property
     def inputs(self) -> dict:
@@ -6203,6 +6207,7 @@ class ASTOpenVINOConfig(OpenVINOConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
         num_mel_bins="num_mel_bins", max_length="max_length", allow_new=True
     )
+    _MODEL_PATCHER = BidirectionalMaskModelPatcher
     DUMMY_INPUT_GENERATOR_CLASSES = (ASTDummyAudioInputGenerator,)
 
     @property
@@ -6276,7 +6281,7 @@ class Pix2StructOpenVINOConfig(OpenVINOSeq2SeqConfigWithPast):
         DummySeq2SeqPastKeyValuesGenerator,
         DummyPix2StructInputGenerator,
     )
-    _MODEL_PATCHER = OVSeq2SeqModelPatcher
+    _MODEL_PATCHER = Seq2SeqBidirectionalMaskModelPatcher
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -6383,7 +6388,7 @@ class NystromformerOpenVINOConfig(BertOpenVINOConfig):
 
 @register_in_tasks_manager("convbert", *COMMON_TEXT_TASKS)
 class ConvBertOpenVINOConfig(BertOpenVINOConfig):
-    pass
+    _MODEL_PATCHER = BidirectionalMaskModelPatcher
 
 
 @register_in_tasks_manager("electra", *COMMON_TEXT_TASKS)
@@ -6393,12 +6398,12 @@ class ElectraOpenVINOConfig(BertOpenVINOConfig):
 
 @register_in_tasks_manager("roformer", *COMMON_TEXT_TASKS)
 class RoFormerOpenVINOConfig(BertOpenVINOConfig):
-    pass
+    _MODEL_PATCHER = BidirectionalMaskModelPatcher
 
 
 @register_in_tasks_manager("squeezebert", *COMMON_TEXT_TASKS)
 class SqueezeBertOpenVINOConfig(BertOpenVINOConfig):
-    pass
+    _MODEL_PATCHER = BidirectionalMaskModelPatcher
 
 
 @register_in_tasks_manager("mobilebert", *COMMON_TEXT_TASKS)
@@ -6503,6 +6508,7 @@ class Data2VecTextOpenVINOConfig(DistilBertOpenVINOConfig):
 @register_in_tasks_manager("vit", *["feature-extraction", "image-classification", "masked-im"])
 class ViTOpenVINOConfig(VisionOpenVINOConfig):
     NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
+    _MODEL_PATCHER = BidirectionalMaskModelPatcher
 
     @property
     def inputs(self) -> dict:
@@ -6603,12 +6609,12 @@ class EsmOpenVINOConfig(TextEncoderOpenVINOConfig):
 
 @register_in_tasks_manager("mpnet", *COMMON_TEXT_TASKS)
 class MPNetOpenVINOConfig(DistilBertOpenVINOConfig):
-    pass
+    _MODEL_PATCHER = BidirectionalMaskModelPatcher
 
 
 @register_in_tasks_manager("beit", *["feature-extraction", "image-classification"])
 class BeitOpenVINOConfig(ViTOpenVINOConfig):
-    pass
+    _MODEL_PATCHER = BeitModelPatcher
 
 
 @register_in_tasks_manager("deit", *["feature-extraction", "image-classification", "masked-im"])
@@ -6864,7 +6870,7 @@ class SentenceTransformersTransformerOpenVINOConfig(TextEncoderOpenVINOConfig):
 
 @register_in_tasks_manager("rembert", *COMMON_TEXT_TASKS)
 class RemBertOpenVINOConfig(BertOpenVINOConfig):
-    pass
+    _MODEL_PATCHER = BidirectionalMaskModelPatcher
 
 
 @register_in_tasks_manager("siglip-text-with-projection", *["feature-extraction"])

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -113,6 +113,7 @@ from optimum.exporters.openvino.model_patcher import (
     BigBirdPegasusModelPatcher,
     BloomModelPatcher,
     ChatGLMModelPatcher,
+    CLIPTextModelPatcher,
     CodeGenModelPatcher,
     CommonImageEmbeddingsModelPatcher,
     DBRXModelPatcher,
@@ -120,6 +121,7 @@ from optimum.exporters.openvino.model_patcher import (
     DeepseekOCR2LMPatcher,
     DeepseekOCR2VisionEmbeddingsPatcher,
     DeepseekPatcher,
+    DonutSwinModelPatcher,
     FalconModelPatcher,
     FluxTransformerModelPatcher,
     FunASRModelPatcher,
@@ -202,8 +204,10 @@ from optimum.exporters.openvino.model_patcher import (
     QwenModelPatcher,
     SAMModelPatcher,
     SanaTextEncoderModelPatcher,
+    SegformerModelPatcher,
     SentenceTransformersTransformerPatcher,
     SpeechT5ModelPatcher,
+    SwinModelPatcher,
     VideoChatFlashQwenVisionEmbeddingModelPatcher,
     XverseModelPatcher,
     Zamba2ModelPatcher,
@@ -1674,6 +1678,8 @@ class CLIPOpenVINOConfig(TextAndVisionOpenVINOConfig):
 @register_in_tasks_manager("clip_text_model", *["feature-extraction"], library_name="transformers")
 @register_in_tasks_manager("clip-text", *["feature-extraction"], library_name="diffusers")
 class CLIPTextOpenVINOConfig(TextEncoderOpenVINOConfig):
+    _MODEL_PATCHER = CLIPTextModelPatcher
+
     NORMALIZED_CONFIG_CLASS = NormalizedConfig.with_args(
         vocab_size="vocab_size",
         sequence_length="max_position_embeddings",
@@ -6641,6 +6647,8 @@ class PoolFormerOpenVINOConfig(ViTOpenVINOConfig):
     "segformer", *["feature-extraction", "image-classification", "image-segmentation", "semantic-segmentation"]
 )
 class SegformerOpenVINOConfig(ViTOpenVINOConfig):
+    _MODEL_PATCHER = SegformerModelPatcher
+
     @property
     def outputs(self) -> dict:
         outputs = super().outputs
@@ -6653,12 +6661,12 @@ class SegformerOpenVINOConfig(ViTOpenVINOConfig):
 
 @register_in_tasks_manager("swin", *["feature-extraction", "image-classification", "masked-im"])
 class SwinOpenVINOConfig(ViTOpenVINOConfig):
-    pass
+    _MODEL_PATCHER = SwinModelPatcher
 
 
 @register_in_tasks_manager("donut-swin", *["feature-extraction"])
 class DonutSwinOpenVINOConfig(ViTOpenVINOConfig):
-    pass
+    _MODEL_PATCHER = DonutSwinModelPatcher
 
 
 @register_in_tasks_manager("convnext", *["feature-extraction", "image-classification"])

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -16,6 +16,7 @@ import functools
 import inspect
 import logging
 import math
+import sys
 import types
 from dataclasses import dataclass
 from types import SimpleNamespace
@@ -114,6 +115,10 @@ if is_transformers_version(">=", "4.57"):
 
 if is_transformers_version(">=", "5"):
     from transformers.modeling_rope_utils import RotaryEmbeddingConfigMixin
+
+
+if is_transformers_version(">=", "5.6"):
+    from transformers.masking_utils import create_bidirectional_mask
 
 
 if is_diffusers_version(">=", "0.38.0"):
@@ -12056,3 +12061,203 @@ class CLIPTextModelPatcher(ModelPatcher):
         if self._restore_text_model:
             del self._model.forward
             del self._model.text_model
+
+
+# Starting from transformers 5.6 the encoder models below build their attention mask with
+# `masking_utils.create_bidirectional_mask` instead of `ModuleUtilsMixin.get_extended_attention_mask`.
+# The two are numerically equivalent, but the new one cannot take its "no padding token -> no mask at
+# all" shortcut while tracing (`_ignore_bidirectional_mask_sdpa` bails out on `is_tracing()`), so it
+# always materializes the full 4D mask as Range/GreaterEqual/Broadcast/Gather nodes. Restore the
+# pre-5.6 formulation so the exported graph stays the same.
+def _patched_create_bidirectional_mask(
+    config,
+    inputs_embeds,
+    attention_mask=None,
+    encoder_hidden_states=None,
+    past_key_values=None,
+    or_mask_function=None,
+    and_mask_function=None,
+    **kwargs,
+):
+    if or_mask_function is not None or and_mask_function is not None:
+        # Custom mask patterns cannot be expressed as a plain additive padding mask.
+        return create_bidirectional_mask(
+            config,
+            inputs_embeds,
+            attention_mask,
+            encoder_hidden_states=encoder_hidden_states,
+            past_key_values=past_key_values,
+            or_mask_function=or_mask_function,
+            and_mask_function=and_mask_function,
+            **kwargs,
+        )
+
+    if attention_mask is None:
+        return None
+    if attention_mask.dim() == 4:
+        return attention_mask
+
+    dtype = inputs_embeds.dtype
+    attention_mask = attention_mask[:, None, None, :].to(dtype)
+    return (1.0 - attention_mask) * torch.finfo(dtype).min
+
+
+def _patch_create_bidirectional_mask() -> List[Tuple[Any, Callable]]:
+    """Swaps `create_bidirectional_mask` for its pre-5.6 equivalent in every modeling module.
+
+    Each modeling file imports the helper by value (`from ...masking_utils import
+    create_bidirectional_mask`), so patching `transformers.masking_utils` alone would not be picked
+    up. Only the modules that already hold the symbol in their own `__dict__` are touched, which
+    skips the lazy re-export shims transformers installs on its packages.
+    """
+    patched = []
+    for name, module in list(sys.modules.items()):
+        if module is None or not name.startswith("transformers."):
+            continue
+        original = module.__dict__.get("create_bidirectional_mask")
+        if original is None:
+            continue
+        patched.append((module, original))
+        module.create_bidirectional_mask = _patched_create_bidirectional_mask
+    return patched
+
+
+def _unpatch_create_bidirectional_mask(patched: List[Tuple[Any, Callable]]):
+    for module, original in patched:
+        module.create_bidirectional_mask = original
+
+
+class BidirectionalMaskModelPatcher(ModelPatcher):
+    _patched_bidirectional_mask = ()
+
+    def __enter__(self):
+        super().__enter__()
+        self._patched_bidirectional_mask = (
+            _patch_create_bidirectional_mask() if is_transformers_version(">=", "5.6") else []
+        )
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        _unpatch_create_bidirectional_mask(self._patched_bidirectional_mask)
+
+
+class IBertBidirectionalMaskModelPatcher(BidirectionalMaskModelPatcher, IBertModelPatcher):
+    pass
+
+
+class Seq2SeqBidirectionalMaskModelPatcher(BidirectionalMaskModelPatcher, OVSeq2SeqModelPatcher):
+    pass
+
+
+# transformers 5.6 moved Beit onto the shared attention interface, which lays the context back out
+# with `transpose(1, 2)` where `BeitSdpaSelfAttention` used `permute(0, 2, 1, 3)`. Both become the
+# same OpenVINO Transpose, but the permutation constant is emitted as int32 instead of int64. Keep
+# the original formulation so the constant keeps its element type.
+def _patched_beit_attention_forward(self, hidden_states, attention_mask=None, **kwargs):
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, self.head_dim)
+
+    query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+    key_states = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+    value_states = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+    attn_output = torch.nn.functional.scaled_dot_product_attention(
+        query_states,
+        key_states,
+        value_states,
+        attn_mask=attention_mask,
+        dropout_p=self.attention_dropout if self.training else 0.0,
+        is_causal=False,
+        scale=self.scaling,
+    )
+    attn_output = attn_output.permute(0, 2, 1, 3).contiguous()
+    attn_output = attn_output.reshape(*input_shape, -1).contiguous()
+
+    return self.o_proj(attn_output), None
+
+
+class BeitModelPatcher(BidirectionalMaskModelPatcher):
+    def __enter__(self):
+        super().__enter__()
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.beit import modeling_beit
+
+            self._original_attention_forward = modeling_beit.BeitAttention.forward
+            modeling_beit.BeitAttention.forward = _patched_beit_attention_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.beit import modeling_beit
+
+            modeling_beit.BeitAttention.forward = self._original_attention_forward
+
+
+class VisionEncoderScopeShim(torch.nn.Module):
+    """Reinstates the module boundary that transformers 5.6 removed from the vision encoders.
+
+    Up to transformers 5.5 `ViTModel`/`DeiTModel` ran their layers through a `ViTEncoder` submodule.
+    5.6 deleted that class and hoisted the layers onto the model itself. When such a model is traced
+    at the root of the graph -- which is what the encoder half of an encoder-decoder export does --
+    there is no enclosing scope left for TorchScript to pool the scalar attention scale into, so it
+    is emitted once per layer instead of once per graph. Restoring a single module boundary is enough
+    to bring the shared constant back.
+
+    Like `CLIPTextTransformerShim`, this holds no submodules and only delegates to the already
+    captured forward, so `capture_outputs` still sees each layer exactly once.
+    """
+
+    def __init__(self, flat_forward: Callable):
+        super().__init__()
+        self._flat_forward = flat_forward
+
+    def forward(self, *args, **kwargs):
+        return self._flat_forward(*args, **kwargs)
+
+
+class VisionEncoderDecoderModelPatcher(OVSeq2SeqModelPatcher):
+    """`BidirectionalMaskModelPatcher` restricted to the encoder half of an encoder-decoder export.
+
+    Only the vision encoder used `get_extended_attention_mask` before transformers 5.6; the text
+    decoders (GPT-2 and friends) already went through `create_bidirectional_mask` for their
+    cross-attention, so patching them would change an IR that is currently stable.
+    """
+
+    _patched_bidirectional_mask = ()
+    _scope_shim = None
+
+    def __enter__(self):
+        super().__enter__()
+        is_encoder = self.real_config._behavior == "encoder"
+        self._patched_bidirectional_mask = (
+            _patch_create_bidirectional_mask() if is_transformers_version(">=", "5.6") and is_encoder else []
+        )
+
+        # `patched_forward` reads `self.orig_forward` on every call, so routing it through the shim
+        # here keeps the model's own `forward` -- and therefore the signature the exporter inspects
+        # and the decorators transformers relies on -- untouched.
+        self._scope_shim = None
+        if (
+            is_transformers_version(">=", "5.6")
+            and is_encoder
+            and hasattr(self._model, "layers")
+            and not hasattr(self._model, "encoder")
+        ):
+            self._scope_shim = VisionEncoderScopeShim(self.orig_forward)
+            self._model.encoder = self._scope_shim
+
+            # `patched_forward` introspects `self.orig_forward`, so the replacement has to keep the
+            # original signature -- `functools.wraps` makes `inspect.signature` see through it.
+            @functools.wraps(self.orig_forward)
+            def scoped_forward(*args, **kwargs):
+                return self._model.encoder(*args, **kwargs)
+
+            self.orig_forward = scoped_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._scope_shim is not None:
+            self.orig_forward = self._scope_shim._flat_forward
+            del self._model.encoder
+            self._scope_shim = None
+        super().__exit__(exc_type, exc_value, traceback)
+        _unpatch_create_bidirectional_mask(self._patched_bidirectional_mask)

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9490,6 +9490,26 @@ def patched_gemma4_clippable_linear_forward(self, hidden_states: torch.Tensor) -
     return hidden_states
 
 
+# transformers v5.6 replaced the one-hot @ table formulation of the vision patch position
+# embeddings with two `F.embedding` lookups. The two are mathematically identical, but they
+# trace to different graphs (OneHot + MatMul + ReduceSum vs Gather), which changes the
+# exported IR. Keep the original formulation during export so IRs stay stable across
+# transformers versions.
+def patched_gemma4_position_embeddings(
+    self, pixel_position_ids: torch.Tensor, padding_positions: torch.Tensor
+) -> torch.Tensor:
+    # Expanding and permute patch positions to (batch_size, num_patches, 2, position_embedding_size) for matmul.
+    clamped_positions = pixel_position_ids.clamp(min=0)
+    one_hot = F.one_hot(clamped_positions, num_classes=self.position_embedding_size)
+    one_hot = one_hot.permute(0, 2, 1, 3).to(self.position_embedding_table)
+    # Compute positional embeddings and sum across x and y.
+    position_embeddings = one_hot @ self.position_embedding_table
+    position_embeddings = position_embeddings.sum(dim=1)
+    # Zero out embeddings for any padding patches.
+    position_embeddings = torch.where(padding_positions.unsqueeze(-1), 0.0, position_embeddings)
+    return position_embeddings
+
+
 class Gemma4ImageEmbeddingsModelPatcher(CommonImageEmbeddingsModelPatcher):
     def __init__(self, config, model, model_kwargs):
         super().__init__(config, model, model_kwargs)
@@ -9498,6 +9518,14 @@ class Gemma4ImageEmbeddingsModelPatcher(CommonImageEmbeddingsModelPatcher):
         # Get the vision encoder - it's at model.model.vision_tower.encoder
         vision_model = model.model.vision_tower if is_transformers_version(">=", "5") else model.vision_tower
         self._vision_encoder = vision_model.encoder
+
+        # Restore the pre-v5.6 patch position embedding formulation to keep the exported IR stable.
+        self._patch_embedder = getattr(vision_model, "patch_embedder", None)
+        if self._patch_embedder is not None:
+            self._orig_position_embeddings = self._patch_embedder._position_embeddings
+            self._patch_embedder._position_embeddings = types.MethodType(
+                patched_gemma4_position_embeddings, self._patch_embedder
+            )
 
         # Patch the vision encoder forward to bypass create_bidirectional_mask,
         # which is not compatible with torch.jit.trace due to dynamic masking logic.
@@ -9551,6 +9579,8 @@ class Gemma4ImageEmbeddingsModelPatcher(CommonImageEmbeddingsModelPatcher):
         from transformers.models.gemma4.modeling_gemma4 import Gemma4ClippableLinear
 
         self._vision_encoder.forward = self._orig_encoder_forward
+        if self._patch_embedder is not None:
+            self._patch_embedder._position_embeddings = self._orig_position_embeddings
         super().__exit__(exc_type, exc_value, traceback)
 
         for layer in self._vision_encoder.layers:

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -11858,3 +11858,201 @@ class ZImageTextEncoderModelPatcher(ModelPatcher):
         if hasattr(self._model, "config") and hasattr(self._model.config, "_orig_ov_attn_impl"):
             self._model.config._attn_implementation = self._model.config._orig_ov_attn_impl
             del self._model.config._orig_ov_attn_impl
+
+
+# Starting from transformers 5.6, `window_partition` / `window_reverse` swap the
+# `permute(0, 1, 3, 2, 4, 5)` call for an equivalent `transpose(2, 3)`. Both are semantically
+# identical, but they trace to different (int64 vs int32) permutation constants, which changes
+# the exported IR. Keep the original formulation so the graph stays stable across versions.
+def _patched_swin_window_partition(input_feature, window_size):
+    batch_size, height, width, num_channels = input_feature.shape
+    input_feature = input_feature.view(
+        batch_size, height // window_size, window_size, width // window_size, window_size, num_channels
+    )
+    return input_feature.permute(0, 1, 3, 2, 4, 5).contiguous().view(-1, window_size, window_size, num_channels)
+
+
+def _patched_swin_window_reverse(windows, window_size, height, width):
+    num_channels = windows.shape[-1]
+    windows = windows.view(-1, height // window_size, width // window_size, window_size, window_size, num_channels)
+    return windows.permute(0, 1, 3, 2, 4, 5).contiguous().view(-1, height, width, num_channels)
+
+
+# In transformers 5.6, Swin attention moved to the shared attention interface, whose default
+# (sdpa) fuses MatMul/Divide/Softmax/MatMul into a single ScaledDotProductAttention node. Restore
+# the explicit eager computation used before the refactoring.
+def _patched_swin_attention_forward(self, hidden_states, attention_mask=None, **kwargs):
+    batch_size, dim, _ = hidden_states.shape
+    hidden_shape = (batch_size, dim, -1, self.head_dim)
+    query_layer = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+    key_layer = self.k_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+    value_layer = self.v_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+    attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+    attention_scores = attention_scores / math.sqrt(self.head_dim)
+    attention_scores = attention_scores + self.relative_position_bias()
+
+    if attention_mask is not None:
+        mask_shape = attention_mask.shape[0]
+        attention_scores = attention_scores.view(
+            batch_size // mask_shape, mask_shape, self.num_attention_heads, dim, dim
+        )
+        attention_scores = attention_scores + attention_mask.unsqueeze(1).unsqueeze(0)
+        attention_scores = attention_scores.view(-1, self.num_attention_heads, dim, dim)
+
+    attention_probs = nn.functional.softmax(attention_scores, dim=-1)
+    context_layer = torch.matmul(attention_probs, value_layer)
+    context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+    context_layer = context_layer.view(context_layer.size()[:-2] + (self.num_attention_heads * self.head_dim,))
+    return self.o_proj(context_layer), attention_probs
+
+
+class SwinModelPatcher(ModelPatcher):
+    def __enter__(self):
+        super().__enter__()
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.swin import modeling_swin
+
+            self._original_window_partition = modeling_swin.window_partition
+            self._original_window_reverse = modeling_swin.window_reverse
+            self._original_attention_forward = modeling_swin.SwinAttention.forward
+            modeling_swin.window_partition = _patched_swin_window_partition
+            modeling_swin.window_reverse = _patched_swin_window_reverse
+            modeling_swin.SwinAttention.forward = _patched_swin_attention_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.swin import modeling_swin
+
+            modeling_swin.window_partition = self._original_window_partition
+            modeling_swin.window_reverse = self._original_window_reverse
+            modeling_swin.SwinAttention.forward = self._original_attention_forward
+
+
+class DonutSwinModelPatcher(ModelPatcher):
+    def __enter__(self):
+        super().__enter__()
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.donut import modeling_donut_swin
+
+            self._original_window_partition = modeling_donut_swin.window_partition
+            self._original_window_reverse = modeling_donut_swin.window_reverse
+            modeling_donut_swin.window_partition = _patched_swin_window_partition
+            modeling_donut_swin.window_reverse = _patched_swin_window_reverse
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.donut import modeling_donut_swin
+
+            modeling_donut_swin.window_partition = self._original_window_partition
+            modeling_donut_swin.window_reverse = self._original_window_reverse
+
+
+# Same story as Swin: transformers 5.6 moved Segformer onto the shared attention interface and
+# rewrote the sequence reduction with `transpose(1, 2)` instead of `permute(0, 2, 1)`. Restore the
+# pre-refactoring implementations to keep the exported graph unchanged.
+def _patched_segformer_sequence_reduction_forward(self, hidden_states, height, width):
+    batch_size, _, num_channels = hidden_states.shape
+    hidden_states = hidden_states.permute(0, 2, 1).reshape(batch_size, num_channels, height, width)
+    hidden_states = self.sequence_reduction(hidden_states)
+    hidden_states = hidden_states.reshape(batch_size, num_channels, -1).permute(0, 2, 1)
+    return self.layer_norm(hidden_states)
+
+
+def _patched_segformer_attention_forward(self, hidden_states, height, width, attention_mask=None, **kwargs):
+    input_shape = hidden_states.shape[:-1]
+    hidden_shape = (*input_shape, -1, self.head_dim)
+    query_layer = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+
+    kv_hidden_states = hidden_states
+    if self.sequence_reduction_ratio > 1:
+        kv_hidden_states = self.sequence_reduction(hidden_states, height, width)
+
+    kv_shape = (*kv_hidden_states.shape[:-1], -1, self.head_dim)
+    key_layer = self.k_proj(kv_hidden_states).view(kv_shape).transpose(1, 2)
+    value_layer = self.v_proj(kv_hidden_states).view(kv_shape).transpose(1, 2)
+
+    attention_scores = torch.matmul(query_layer, key_layer.transpose(-1, -2))
+    attention_scores = attention_scores / math.sqrt(self.head_dim)
+    attention_probs = nn.functional.softmax(attention_scores, dim=-1)
+
+    context_layer = torch.matmul(attention_probs, value_layer)
+    context_layer = context_layer.permute(0, 2, 1, 3).contiguous()
+    context_layer = context_layer.view(context_layer.size()[:-2] + (self.num_attention_heads * self.head_dim,))
+    return self.o_proj(context_layer), attention_probs
+
+
+class SegformerModelPatcher(ModelPatcher):
+    def __enter__(self):
+        super().__enter__()
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.segformer import modeling_segformer
+
+            self._original_attention_forward = modeling_segformer.SegformerAttention.forward
+            self._original_sequence_reduction_forward = modeling_segformer.SegformerSequenceReduction.forward
+            modeling_segformer.SegformerAttention.forward = _patched_segformer_attention_forward
+            modeling_segformer.SegformerSequenceReduction.forward = _patched_segformer_sequence_reduction_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.segformer import modeling_segformer
+
+            modeling_segformer.SegformerAttention.forward = self._original_attention_forward
+            modeling_segformer.SegformerSequenceReduction.forward = self._original_sequence_reduction_forward
+
+
+class CLIPTextTransformerShim(torch.nn.Module):
+    """Reinstates the `text_model` submodule that transformers 5.6 flattened away.
+
+    `CLIPTextTransformer` was removed in https://github.com/huggingface/transformers/pull/44431 and its
+    body moved verbatim into `CLIPTextModel.forward`. The computation is unchanged, but losing the
+    submodule call means TorchScript no longer pools the scalar constants of that scope, so the traced
+    graph gains a handful of duplicated `prim::Constant` nodes. Only the module boundary is restored
+    here: the forward delegates straight back to the original (still decorated) `CLIPTextModel.forward`,
+    so output capture and everything else behaves exactly as before.
+    """
+
+    def __init__(self, model: PreTrainedModel):
+        super().__init__()
+        # Deliberately holds no submodules: re-registering the model's own children under a second
+        # name would make `capture_outputs` collect every hidden state twice.
+        self._flat_forward = model.forward
+
+    def forward(self, input_ids=None, attention_mask=None, position_ids=None, **kwargs):
+        return self._flat_forward(
+            input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, **kwargs
+        )
+
+
+def _clip_text_model_forward(self, input_ids=None, attention_mask=None, position_ids=None, **kwargs):
+    return self.text_model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, **kwargs)
+
+
+class CLIPTextModelPatcher(ModelPatcher):
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: PreTrainedModel,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        # The shim has to be in place before `ModelPatcher.__init__` captures the original forward.
+        # `CLIPTextModelWithProjection` still nests a `text_model`, so it is left untouched.
+        self._restore_text_model = (
+            is_transformers_version(">=", "5.6")
+            and model.__class__.__name__ == "CLIPTextModel"
+            and not hasattr(model, "text_model")
+        )
+        if self._restore_text_model:
+            model.text_model = CLIPTextTransformerShim(model)
+            model.forward = types.MethodType(_clip_text_model_forward, model)
+
+        super().__init__(config, model, model_kwargs)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if self._restore_text_model:
+            del self._model.forward
+            del self._model.text_model

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -128,6 +128,55 @@ if is_diffusers_version(">=", "0.38.0"):
 logger = logging.getLogger(__name__)
 
 
+def _patched_sam_two_way_transformer_forward(
+    self,
+    point_embeddings: torch.Tensor,
+    image_embeddings: torch.Tensor,
+    image_positional_embeddings: torch.Tensor,
+    attention_similarity: torch.Tensor,
+    target_embedding=None,
+    **kwargs,
+):
+    """`SamTwoWayTransformer.forward` with the pre-5.6 `permute` instead of `transpose`.
+
+    The two express the same operation and produce the same OpenVINO Transpose, but `permute` emits
+    an int64 order Constant while `transpose` emits an int32 one, which is enough to make the IR
+    differ. Everything below is copied verbatim from transformers apart from those two calls.
+    """
+    if image_embeddings is None:
+        raise ValueError("You have to specify an image_embedding")
+
+    image_embeddings = image_embeddings.flatten(2).permute(0, 2, 1).unsqueeze(1)
+    image_positional_embeddings = image_positional_embeddings.flatten(2).permute(0, 2, 1).unsqueeze(1)
+
+    # Prepare queries
+    queries = point_embeddings
+    keys = image_embeddings
+
+    # Apply transformer blocks and final layernorm
+    for layer in self.layers:
+        if target_embedding is not None:
+            queries += target_embedding
+
+        queries, keys, _ = layer(
+            queries=queries,
+            keys=keys,
+            query_point_embedding=point_embeddings,
+            key_point_embedding=image_positional_embeddings,
+            attention_similarity=attention_similarity,
+            **kwargs,
+        )
+    # Apply the final attention layer from the points to the image
+    query = queries + point_embeddings
+    key = keys + image_positional_embeddings
+
+    attn_out, _ = self.final_attn_token_to_image(query=query, key=key, value=keys)
+
+    queries = queries + attn_out
+    queries = self.layer_norm_final_attn(queries)
+    return queries, keys
+
+
 class SAMModelPatcher(ModelPatcher):
     def __init__(
         self,
@@ -207,6 +256,21 @@ class SAMModelPatcher(ModelPatcher):
                         return {"iou_scores": iou_predictions, "pred_masks": low_res_masks}
 
         self.patched_forward = patched_forward
+
+    def __enter__(self):
+        super().__enter__()
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.sam import modeling_sam
+
+            self._original_two_way_transformer_forward = modeling_sam.SamTwoWayTransformer.forward
+            modeling_sam.SamTwoWayTransformer.forward = _patched_sam_two_way_transformer_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+        if is_transformers_version(">=", "5.6"):
+            from transformers.models.sam import modeling_sam
+
+            modeling_sam.SamTwoWayTransformer.forward = self._original_two_way_transformer_forward
 
 
 class SentenceTransformersTransformerPatcher(ModelPatcher):

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -117,7 +117,7 @@ if is_transformers_version(">=", "5"):
     from transformers.modeling_rope_utils import RotaryEmbeddingConfigMixin
 
 
-if is_transformers_version(">=", "5.6"):
+if is_transformers_version(">=", "5.9"):
     from transformers.masking_utils import create_bidirectional_mask
 
 
@@ -128,6 +128,8 @@ if is_diffusers_version(">=", "0.38.0"):
 logger = logging.getLogger(__name__)
 
 
+# Original code: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/sam/modeling_sam.py#L365
+# Pre-refactoring code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/sam/modeling_sam.py#L365
 def _patched_sam_two_way_transformer_forward(
     self,
     point_embeddings: torch.Tensor,
@@ -137,7 +139,7 @@ def _patched_sam_two_way_transformer_forward(
     target_embedding=None,
     **kwargs,
 ):
-    """`SamTwoWayTransformer.forward` with the pre-5.6 `permute` instead of `transpose`.
+    """`SamTwoWayTransformer.forward` with the pre-5.9 `permute` instead of `transpose`.
 
     The two express the same operation and produce the same OpenVINO Transpose, but `permute` emits
     an int64 order Constant while `transpose` emits an int32 one, which is enough to make the IR
@@ -259,7 +261,7 @@ class SAMModelPatcher(ModelPatcher):
 
     def __enter__(self):
         super().__enter__()
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.sam import modeling_sam
 
             self._original_two_way_transformer_forward = modeling_sam.SamTwoWayTransformer.forward
@@ -267,7 +269,7 @@ class SAMModelPatcher(ModelPatcher):
 
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.sam import modeling_sam
 
             modeling_sam.SamTwoWayTransformer.forward = self._original_two_way_transformer_forward
@@ -5376,9 +5378,11 @@ class Gemma3LMModelPatcher(OVDecoderModelPatcher):
 
         model_forward = self.orig_forward
 
-        # precompute the token_type_ids bidirectional (image) mask since transformers v5.6
-        # (https://github.com/huggingface/transformers/pull/45454) is_first_iteration removed
-        # in create_causal_mask_mapping
+        # Precompute the token_type_ids bidirectional (image) mask: transformers v5.9 dropped the
+        # module-level `create_causal_mask_mapping` helper -- which took `is_first_iteration` -- and
+        # inlined the mask construction into the model forward, where it is no longer reachable.
+        # Removed in v5.9, last present in:
+        # https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/gemma3/modeling_gemma3.py#L733
         @functools.wraps(model_forward)
         def forward_with_precomputed_mask(*args, **kwargs):
             bound_args = inspect.signature(model_forward).bind(*args, **kwargs)
@@ -5481,7 +5485,8 @@ def gemma3n_language_model_forward(
 # on sliding_attention layers, matching the behavior of transformers
 # create_causal_mask_mapping when use_bidirectional_attention == "vision".
 # Needs to be patched to pass proper 'sliding_mask' for prefill stage.
-# Original code: https://github.com/huggingface/transformers/blob/v5.5.0/src/transformers/models/gemma4/modeling_gemma4.py#L1986
+# Original code (`create_causal_mask_mapping`, removed in v5.9 and inlined into the model forward):
+# https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/gemma4/modeling_gemma4.py#L2101
 def _create_gemma4_bidirectional_mask_dict(attention_mask_2d, mm_token_type_ids, inputs_embeds, sliding_window):
     dtype = inputs_embeds.dtype
     device = inputs_embeds.device
@@ -5543,7 +5548,8 @@ def _create_gemma4_bidirectional_mask_dict(attention_mask_2d, mm_token_type_ids,
 # Forward method of the language model of Gemma4, needs to be patched to pass 'per_layer_inputs',
 # as original code fails to create per_layer_inputs without the providing of input_ids,
 # while OV language model expects only inputs_embeds without input_ids.
-# Original code: https://github.com/huggingface/transformers/blob/v5.5.0/src/transformers/models/gemma4/modeling_gemma4.py#L2152
+# Original code (`Gemma4Model.forward`):
+# https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/gemma4/modeling_gemma4.py#L2218
 def gemma4_language_model_forward(
     self,
     input_ids: Optional[torch.LongTensor] = None,
@@ -5618,7 +5624,8 @@ def gemma4_language_model_forward(
 
 
 # Gemma4 model forward, needs to be patched to pass 'per_layer_inputs',
-# Original code: https://github.com/huggingface/transformers/blob/v5.5.0/src/transformers/models/gemma4/modeling_gemma4.py#L2396
+# Original code (`Gemma4ForConditionalGeneration.forward`):
+# https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/gemma4/modeling_gemma4.py#L2473
 def gemma4_lm_forward(
     self,
     attention_mask: Optional[torch.Tensor] = None,
@@ -5691,7 +5698,8 @@ def gemma4_lm_forward(
 
 
 # Needs to be patched to reshape 'attention_mask' to match attention weights
-# Original code: https://github.com/huggingface/transformers/blob/v5.5.0/src/transformers/models/gemma4/modeling_gemma4.py#L768
+# Original code (`eager_attention_forward`):
+# https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/gemma4/modeling_gemma4.py#L821
 def gemma4_eager_attention_forward_patched(
     module: nn.Module,
     query: torch.Tensor,
@@ -5727,7 +5735,8 @@ def gemma4_eager_attention_forward_patched(
 
 
 # Needs to be patched to run methods 'gemma4_eager_attention_forward_patched' instead of original one
-# Original code: https://github.com/huggingface/transformers/blob/v5.5.0/src/transformers/models/gemma4/modeling_gemma4.py#L1179
+# Original code (`Gemma4TextAttention.forward`):
+# https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/gemma4/modeling_gemma4.py#L1230
 def gemma4_text_attention_forward(
     self,
     hidden_states: torch.Tensor,
@@ -5739,7 +5748,8 @@ def gemma4_text_attention_forward(
 ) -> tuple:
     from transformers.models.gemma4.modeling_gemma4 import apply_rotary_pos_emb as apply_rotary_pos_emb_gemma4
 
-    # since transformers >= v5.6 (PR #45788) `shared_kv_states` dict and is passed and `kv_shared_layer_index` removed
+    # transformers v5.6 started passing a `shared_kv_states` dict; `kv_shared_layer_index` was kept
+    # alongside it until v5.8, where it was dropped. Both spellings are handled below.
     shared_kv_states = kwargs.pop("shared_kv_states", None)
     legacy_shared_kv_states = hasattr(self, "kv_shared_layer_index")
 
@@ -9554,16 +9564,19 @@ class SelectiveSSMRecurrentCell(torch.nn.Module):
 # OpenVINO has a bug due to which Clamp(-inf, inf) doesn't work correctly: CVS-185473.
 # When min == -inf and max == inf, Clamp is equivalent to an identity operation and
 # can be removed from the model, which serves as a workaround for the issue.
+# Original code: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/gemma4/modeling_gemma4.py#L181
 def patched_gemma4_clippable_linear_forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
     hidden_states = self.linear(hidden_states)
     return hidden_states
 
 
-# transformers v5.6 replaced the one-hot @ table formulation of the vision patch position
+# transformers v5.10.1 replaced the one-hot @ table formulation of the vision patch position
 # embeddings with two `F.embedding` lookups. The two are mathematically identical, but they
 # trace to different graphs (OneHot + MatMul + ReduceSum vs Gather), which changes the
 # exported IR. Keep the original formulation during export so IRs stay stable across
 # transformers versions.
+# Original code: https://github.com/huggingface/transformers/blob/v5.10.0/src/transformers/models/gemma4/modeling_gemma4.py#L586
+# Replaced by: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/gemma4/modeling_gemma4.py#L602
 def patched_gemma4_position_embeddings(
     self, pixel_position_ids: torch.Tensor, padding_positions: torch.Tensor
 ) -> torch.Tensor:
@@ -9588,7 +9601,7 @@ class Gemma4ImageEmbeddingsModelPatcher(CommonImageEmbeddingsModelPatcher):
         vision_model = model.model.vision_tower if is_transformers_version(">=", "5") else model.vision_tower
         self._vision_encoder = vision_model.encoder
 
-        # Restore the pre-v5.6 patch position embedding formulation to keep the exported IR stable.
+        # Restore the pre-v5.10.1 patch position embedding formulation to keep the exported IR stable.
         self._patch_embedder = getattr(vision_model, "patch_embedder", None)
         if self._patch_embedder is not None:
             self._orig_position_embeddings = self._patch_embedder._position_embeddings
@@ -11929,10 +11942,12 @@ class ZImageTextEncoderModelPatcher(ModelPatcher):
             del self._model.config._orig_ov_attn_impl
 
 
-# Starting from transformers 5.6, `window_partition` / `window_reverse` swap the
+# Starting from transformers 5.9, `window_partition` / `window_reverse` swap the
 # `permute(0, 1, 3, 2, 4, 5)` call for an equivalent `transpose(2, 3)`. Both are semantically
 # identical, but they trace to different (int64 vs int32) permutation constants, which changes
 # the exported IR. Keep the original formulation so the graph stays stable across versions.
+# Original code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/swin/modeling_swin.py#L141-L160
+# Replaced by: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/swin/modeling_swin.py#L490-L509
 def _patched_swin_window_partition(input_feature, window_size):
     batch_size, height, width, num_channels = input_feature.shape
     input_feature = input_feature.view(
@@ -11947,9 +11962,11 @@ def _patched_swin_window_reverse(windows, window_size, height, width):
     return windows.permute(0, 1, 3, 2, 4, 5).contiguous().view(-1, height, width, num_channels)
 
 
-# In transformers 5.6, Swin attention moved to the shared attention interface, whose default
+# In transformers 5.9, Swin attention moved to the shared attention interface, whose default
 # (sdpa) fuses MatMul/Divide/Softmax/MatMul into a single ScaledDotProductAttention node. Restore
-# the explicit eager computation used before the refactoring.
+# the explicit eager computation used before the refactoring, keeping the 5.9 projection names.
+# Original code: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/swin/modeling_swin.py#L422
+# Pre-refactoring code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/swin/modeling_swin.py#L410
 def _patched_swin_attention_forward(self, hidden_states, attention_mask=None, **kwargs):
     batch_size, dim, _ = hidden_states.shape
     hidden_shape = (batch_size, dim, -1, self.head_dim)
@@ -11979,7 +11996,7 @@ def _patched_swin_attention_forward(self, hidden_states, attention_mask=None, **
 class SwinModelPatcher(ModelPatcher):
     def __enter__(self):
         super().__enter__()
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.swin import modeling_swin
 
             self._original_window_partition = modeling_swin.window_partition
@@ -11991,7 +12008,7 @@ class SwinModelPatcher(ModelPatcher):
 
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.swin import modeling_swin
 
             modeling_swin.window_partition = self._original_window_partition
@@ -11999,10 +12016,13 @@ class SwinModelPatcher(ModelPatcher):
             modeling_swin.SwinAttention.forward = self._original_attention_forward
 
 
+# `window_partition` / `window_reverse` are duplicated in donut_swin and changed in the same 5.9
+# refactoring, so the Swin replacements above apply verbatim.
+# Original code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/donut/modeling_donut_swin.py#L115-L135
 class DonutSwinModelPatcher(ModelPatcher):
     def __enter__(self):
         super().__enter__()
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.donut import modeling_donut_swin
 
             self._original_window_partition = modeling_donut_swin.window_partition
@@ -12012,16 +12032,20 @@ class DonutSwinModelPatcher(ModelPatcher):
 
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.donut import modeling_donut_swin
 
             modeling_donut_swin.window_partition = self._original_window_partition
             modeling_donut_swin.window_reverse = self._original_window_reverse
 
 
-# Same story as Swin: transformers 5.6 moved Segformer onto the shared attention interface and
+# Same story as Swin: transformers 5.9 moved Segformer onto the shared attention interface and
 # rewrote the sequence reduction with `transpose(1, 2)` instead of `permute(0, 2, 1)`. Restore the
-# pre-refactoring implementations to keep the exported graph unchanged.
+# pre-refactoring implementations to keep the exported graph unchanged. Both bodies below live in
+# `SegformerEfficientSelfAttention.forward` before the refactoring, so the 5.9 split into
+# `SegformerSequenceReduction` / `SegformerAttention` is kept.
+# Original code: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/segformer/modeling_segformer.py#L101
+# Pre-refactoring code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/segformer/modeling_segformer.py#L157-L165
 def _patched_segformer_sequence_reduction_forward(self, hidden_states, height, width):
     batch_size, _, num_channels = hidden_states.shape
     hidden_states = hidden_states.permute(0, 2, 1).reshape(batch_size, num_channels, height, width)
@@ -12030,6 +12054,8 @@ def _patched_segformer_sequence_reduction_forward(self, hidden_states, height, w
     return self.layer_norm(hidden_states)
 
 
+# Original code: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/segformer/modeling_segformer.py#L164
+# Pre-refactoring code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/segformer/modeling_segformer.py#L146
 def _patched_segformer_attention_forward(self, hidden_states, height, width, attention_mask=None, **kwargs):
     input_shape = hidden_states.shape[:-1]
     hidden_shape = (*input_shape, -1, self.head_dim)
@@ -12056,7 +12082,7 @@ def _patched_segformer_attention_forward(self, hidden_states, height, width, att
 class SegformerModelPatcher(ModelPatcher):
     def __enter__(self):
         super().__enter__()
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.segformer import modeling_segformer
 
             self._original_attention_forward = modeling_segformer.SegformerAttention.forward
@@ -12066,7 +12092,7 @@ class SegformerModelPatcher(ModelPatcher):
 
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.segformer import modeling_segformer
 
             modeling_segformer.SegformerAttention.forward = self._original_attention_forward
@@ -12082,6 +12108,9 @@ class CLIPTextTransformerShim(torch.nn.Module):
     graph gains a handful of duplicated `prim::Constant` nodes. Only the module boundary is restored
     here: the forward delegates straight back to the original (still decorated) `CLIPTextModel.forward`,
     so output capture and everything else behaves exactly as before.
+
+    Original code: https://github.com/huggingface/transformers/blob/v5.5.0/src/transformers/models/clip/modeling_clip.py#L510
+    Replaced by: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/clip/modeling_clip.py#L520
     """
 
     def __init__(self, model: PreTrainedModel):
@@ -12096,6 +12125,8 @@ class CLIPTextTransformerShim(torch.nn.Module):
         )
 
 
+# `CLIPTextModel.forward` as it was up to transformers 5.5: a plain delegation to `text_model`.
+# Original code: https://github.com/huggingface/transformers/blob/v5.5.0/src/transformers/models/clip/modeling_clip.py#L616
 def _clip_text_model_forward(self, input_ids=None, attention_mask=None, position_ids=None, **kwargs):
     return self.text_model(input_ids=input_ids, attention_mask=attention_mask, position_ids=position_ids, **kwargs)
 
@@ -12127,12 +12158,14 @@ class CLIPTextModelPatcher(ModelPatcher):
             del self._model.text_model
 
 
-# Starting from transformers 5.6 the encoder models below build their attention mask with
+# Starting from transformers 5.9 the encoder models below build their attention mask with
 # `masking_utils.create_bidirectional_mask` instead of `ModuleUtilsMixin.get_extended_attention_mask`.
 # The two are numerically equivalent, but the new one cannot take its "no padding token -> no mask at
 # all" shortcut while tracing (`_ignore_bidirectional_mask_sdpa` bails out on `is_tracing()`), so it
 # always materializes the full 4D mask as Range/GreaterEqual/Broadcast/Gather nodes. Restore the
-# pre-5.6 formulation so the exported graph stays the same.
+# pre-5.9 formulation so the exported graph stays the same.
+# Original code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/modeling_utils.py#L964
+# Replaced by: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/masking_utils.py#L1018
 def _patched_create_bidirectional_mask(
     config,
     inputs_embeds,
@@ -12167,7 +12200,7 @@ def _patched_create_bidirectional_mask(
 
 
 def _patch_create_bidirectional_mask() -> List[Tuple[Any, Callable]]:
-    """Swaps `create_bidirectional_mask` for its pre-5.6 equivalent in every modeling module.
+    """Swaps `create_bidirectional_mask` for its pre-5.9 equivalent in every modeling module.
 
     Each modeling file imports the helper by value (`from ...masking_utils import
     create_bidirectional_mask`), so patching `transformers.masking_utils` alone would not be picked
@@ -12197,7 +12230,7 @@ class BidirectionalMaskModelPatcher(ModelPatcher):
     def __enter__(self):
         super().__enter__()
         self._patched_bidirectional_mask = (
-            _patch_create_bidirectional_mask() if is_transformers_version(">=", "5.6") else []
+            _patch_create_bidirectional_mask() if is_transformers_version(">=", "5.9") else []
         )
 
     def __exit__(self, exc_type, exc_value, traceback):
@@ -12213,10 +12246,12 @@ class Seq2SeqBidirectionalMaskModelPatcher(BidirectionalMaskModelPatcher, OVSeq2
     pass
 
 
-# transformers 5.6 moved Beit onto the shared attention interface, which lays the context back out
+# transformers 5.9 moved Beit onto the shared attention interface, which lays the context back out
 # with `transpose(1, 2)` where `BeitSdpaSelfAttention` used `permute(0, 2, 1, 3)`. Both become the
 # same OpenVINO Transpose, but the permutation constant is emitted as int32 instead of int64. Keep
 # the original formulation so the constant keeps its element type.
+# Original code: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/beit/modeling_beit.py#L310
+# Pre-refactoring code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/beit/modeling_beit.py#L299
 def _patched_beit_attention_forward(self, hidden_states, attention_mask=None, **kwargs):
     input_shape = hidden_states.shape[:-1]
     hidden_shape = (*input_shape, -1, self.head_dim)
@@ -12243,7 +12278,7 @@ def _patched_beit_attention_forward(self, hidden_states, attention_mask=None, **
 class BeitModelPatcher(BidirectionalMaskModelPatcher):
     def __enter__(self):
         super().__enter__()
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.beit import modeling_beit
 
             self._original_attention_forward = modeling_beit.BeitAttention.forward
@@ -12251,17 +12286,17 @@ class BeitModelPatcher(BidirectionalMaskModelPatcher):
 
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
-        if is_transformers_version(">=", "5.6"):
+        if is_transformers_version(">=", "5.9"):
             from transformers.models.beit import modeling_beit
 
             modeling_beit.BeitAttention.forward = self._original_attention_forward
 
 
 class VisionEncoderScopeShim(torch.nn.Module):
-    """Reinstates the module boundary that transformers 5.6 removed from the vision encoders.
+    """Reinstates the module boundary that transformers 5.9 removed from the vision encoders.
 
-    Up to transformers 5.5 `ViTModel`/`DeiTModel` ran their layers through a `ViTEncoder` submodule.
-    5.6 deleted that class and hoisted the layers onto the model itself. When such a model is traced
+    Up to transformers 5.8 `ViTModel`/`DeiTModel` ran their layers through a `ViTEncoder` submodule.
+    5.9 deleted that class and hoisted the layers onto the model itself. When such a model is traced
     at the root of the graph -- which is what the encoder half of an encoder-decoder export does --
     there is no enclosing scope left for TorchScript to pool the scalar attention scale into, so it
     is emitted once per layer instead of once per graph. Restoring a single module boundary is enough
@@ -12269,6 +12304,9 @@ class VisionEncoderScopeShim(torch.nn.Module):
 
     Like `CLIPTextTransformerShim`, this holds no submodules and only delegates to the already
     captured forward, so `capture_outputs` still sees each layer exactly once.
+
+    Original code: https://github.com/huggingface/transformers/blob/v5.8.1/src/transformers/models/vit/modeling_vit.py#L349
+    Replaced by: https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/models/vit/modeling_vit.py#L356
     """
 
     def __init__(self, flat_forward: Callable):
@@ -12282,7 +12320,7 @@ class VisionEncoderScopeShim(torch.nn.Module):
 class VisionEncoderDecoderModelPatcher(OVSeq2SeqModelPatcher):
     """`BidirectionalMaskModelPatcher` restricted to the encoder half of an encoder-decoder export.
 
-    Only the vision encoder used `get_extended_attention_mask` before transformers 5.6; the text
+    Only the vision encoder used `get_extended_attention_mask` before transformers 5.9; the text
     decoders (GPT-2 and friends) already went through `create_bidirectional_mask` for their
     cross-attention, so patching them would change an IR that is currently stable.
     """
@@ -12294,7 +12332,7 @@ class VisionEncoderDecoderModelPatcher(OVSeq2SeqModelPatcher):
         super().__enter__()
         is_encoder = self.real_config._behavior == "encoder"
         self._patched_bidirectional_mask = (
-            _patch_create_bidirectional_mask() if is_transformers_version(">=", "5.6") and is_encoder else []
+            _patch_create_bidirectional_mask() if is_transformers_version(">=", "5.9") and is_encoder else []
         )
 
         # `patched_forward` reads `self.orig_forward` on every call, so routing it through the shim
@@ -12302,7 +12340,7 @@ class VisionEncoderDecoderModelPatcher(OVSeq2SeqModelPatcher):
         # and the decorators transformers relies on -- untouched.
         self._scope_shim = None
         if (
-            is_transformers_version(">=", "5.6")
+            is_transformers_version(">=", "5.9")
             and is_encoder
             and hasattr(self._model, "layers")
             and not hasattr(self._model, "encoder")

--- a/optimum/intel/openvino/modeling_diffusion.py
+++ b/optimum/intel/openvino/modeling_diffusion.py
@@ -2212,6 +2212,9 @@ class _OVLTX2Base(OVDiffusionPipeline, OVTextualInversionLoaderMixin):
         self.vae = OVModelVae(decoder=self.vae_decoder, encoder=self.vae_encoder)
         self.scheduler = scheduler
         self.tokenizer = tokenizer
+        self.tokenizer_2 = None
+        self.tokenizer_3 = None
+        self.feature_extractor = None
 
         # Get latents_mean/std from vae_decoder config or audio_vae_decoder config
         vae_cfg = self.vae_decoder.config

--- a/tests/openvino/test_irs.py
+++ b/tests/openvino/test_irs.py
@@ -9,12 +9,14 @@ import json
 
 # Import test utilities to get model mappings
 import sys
+import time
 from pathlib import Path
 from pathlib import Path as PathlibPath
 from typing import Dict, List, Optional
 
 import pytest
 from huggingface_hub import snapshot_download
+from huggingface_hub.errors import RepositoryNotFoundError, RevisionNotFoundError
 from openvino import Core, Model
 
 from optimum.intel import (
@@ -452,6 +454,81 @@ def compare_models(model_one: Model, model_two: Model, compare_names: bool = Tru
     return result
 
 
+DOWNLOAD_ATTEMPTS = 4
+DOWNLOAD_BACKOFF = 5  # seconds, doubled after every failed attempt
+
+
+def download_reference_ir(model_id: str) -> Optional[Path]:
+    """
+    Fetch the reference IRs from a model's `ov` branch.
+
+    Returns None when the repository or its `ov` revision genuinely does not exist, which is the
+    only legitimate reason to skip a model. Everything else (429, 5xx, timeouts) is retried and
+    then raised: a flaky Hub must not silently turn this suite into a green no-op.
+    """
+    delay = DOWNLOAD_BACKOFF
+    last_error = None
+
+    for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
+        try:
+            return Path(snapshot_download(repo_id=model_id, revision="ov", repo_type="model"))
+        except (RepositoryNotFoundError, RevisionNotFoundError):
+            return None
+        except Exception as error:
+            last_error = error
+            if attempt < DOWNLOAD_ATTEMPTS:
+                print(
+                    f"[IR-DEBUG] {model_id}: reference download attempt {attempt}/{DOWNLOAD_ATTEMPTS} "
+                    f"failed ({type(error).__name__}: {error}), retrying in {delay}s"
+                )
+                time.sleep(delay)
+                delay *= 2
+
+    raise RuntimeError(
+        f"Failed to download reference IRs from {model_id} (ov branch) after {DOWNLOAD_ATTEMPTS} "
+        f"attempts. The revision exists, so this is a transport/rate-limit problem rather than a "
+        f"missing reference: {type(last_error).__name__}: {last_error}"
+    ) from last_error
+
+
+# Models actually compared against their reference, and models whose reference does not exist at
+# all. `enforce_ir_coverage` uses both to make sure the suite cannot pass while silently skipping.
+COMPARED_MODELS = set()
+MODELS_WITHOUT_REFERENCE = set()
+MIN_COVERAGE_RATIO = 0.9
+
+
+@pytest.fixture(scope="session", autouse=True)
+def enforce_ir_coverage(request):
+    """Fail the session if too few of the selected models were really compared."""
+    yield
+
+    selected = {
+        item.callspec.params["model_id"]
+        for item in request.session.items
+        if "test_ir_stability" in item.nodeid and hasattr(item, "callspec")
+    }
+    comparable = selected - MODELS_WITHOUT_REFERENCE
+    compared = selected & COMPARED_MODELS
+
+    if not comparable:
+        return
+
+    print(
+        f"[IR-DEBUG] coverage: compared {len(compared)}/{len(comparable)} models that have an `ov` "
+        f"reference ({len(selected & MODELS_WITHOUT_REFERENCE)} of {len(selected)} selected models "
+        f"have none)"
+    )
+
+    if len(compared) < MIN_COVERAGE_RATIO * len(comparable):
+        missing = sorted(comparable - compared)
+        raise AssertionError(
+            f"Only {len(compared)}/{len(comparable)} models with an `ov` reference were compared, "
+            f"below the {MIN_COVERAGE_RATIO:.0%} floor. IR drift in the models below went "
+            f"unchecked, so this run proves nothing:\n  " + "\n  ".join(missing)
+        )
+
+
 def load_reference_metadata(ref_dir: Path) -> Optional[Dict]:
     """Load metadata about reference IR generation."""
     metadata_path = ref_dir / "metadata.json"
@@ -489,16 +566,11 @@ class TestIRStability:
         """Test that exported IR matches reference IR."""
 
         # Download reference IRs from HuggingFace (ov branch)
-        try:
-            ref_ir_dir = Path(
-                snapshot_download(
-                    repo_id=model_id,
-                    revision="ov",
-                    repo_type="model",
-                )
-            )
-        except Exception as e:
-            pytest.skip(f"Failed to download reference IRs from {model_id} (ov branch): {e}")
+        ref_ir_dir = download_reference_ir(model_id)
+
+        if ref_ir_dir is None:
+            MODELS_WITHOUT_REFERENCE.add(model_id)
+            pytest.skip(f"No reference IRs for {model_id}: the repository has no `ov` revision")
 
         if not ref_ir_dir.exists():
             pytest.skip(f"Reference IR directory not found for {model_id}")
@@ -543,6 +615,8 @@ class TestIRStability:
                 f"  Missing components: {missing or 'none'}\n"
                 f"  Extra components: {extra or 'none'}"
             )
+
+        COMPARED_MODELS.add(model_id)
 
         # Initialize OpenVINO Core for loading models
         core = Core()

--- a/tests/openvino/test_irs.py
+++ b/tests/openvino/test_irs.py
@@ -259,6 +259,22 @@ ADDITIONAL_ARCH_MAPPINGS = {
 }
 
 
+# Extra `from_pretrained` arguments needed at export time by some models, keyed by architecture.
+# The reference IRs on the `ov` branch are generated with the exact same arguments, so any change
+# here must be mirrored by regenerating the affected references.
+_EXTRA_EXPORT_KWARGS_BY_ARCH = {
+    # SpeechT5 is a text-to-speech model whose export needs an explicit vocoder. For text-to-audio
+    # models the remaining `from_pretrained` kwargs are forwarded to `main_export` as `model_kwargs`.
+    "speecht5": {"vocoder": "fxmarty/speecht5-hifigan-tiny"},
+    # This fixture only ships weights under a non-default variant.
+    "stable-diffusion-with-custom-variant": {"variant": "custom"},
+}
+
+EXPORT_KWARGS = {
+    HUB_MODEL_NAMES[arch]: kwargs for arch, kwargs in _EXTRA_EXPORT_KWARGS_BY_ARCH.items() if arch in HUB_MODEL_NAMES
+}
+
+
 # Generate test parameters: (model_id, model_class) for all models that don't need trust_remote_code
 def _generate_test_params():
     """Generate test parameters from utils_tests mappings and test_export mappings."""
@@ -266,6 +282,17 @@ def _generate_test_params():
     for arch, model_id in HUB_MODEL_NAMES.items():
         # Skip models that need trust_remote_code
         if arch in REMOTE_CODE_MODELS:
+            continue
+
+        if arch in {  # multimodal models that also need trust_remote_code, but are not in REMOTE_CODE_MODELS
+            "internvl_chat",
+            "llava-qwen2",
+            "maira2",
+            "minicpmo",
+            "minicpmv",
+            "phi3_v",
+            "phi4mm",
+        }:
             continue
 
         if arch in {  # seq2seq models
@@ -497,7 +524,7 @@ class TestIRStability:
             pytest.skip(f"No openvino_model.xml files found in {ref_ir_dir}")
 
         # Export new IR
-        model = model_class.from_pretrained(model_id, export=True)
+        model = model_class.from_pretrained(model_id, export=True, **EXPORT_KWARGS.get(model_id, {}))
         new_ir_dir = tmp_path / "new_ir"
         model.save_pretrained(new_ir_dir)
 

--- a/tests/openvino/test_irs.py
+++ b/tests/openvino/test_irs.py
@@ -1,0 +1,568 @@
+"""
+Test IR (Intermediate Representation) stability across transformers versions.
+
+This test compares newly exported OpenVINO IRs against reference IRs to detect
+regressions when upgrading transformers or other dependencies.
+"""
+
+import json
+
+# Import test utilities to get model mappings
+import sys
+from pathlib import Path
+from pathlib import Path as PathlibPath
+from typing import Dict, List, Optional
+
+import pytest
+from huggingface_hub import snapshot_download
+from openvino import Core, Model
+
+from optimum.intel import (
+    OVDiffusionPipeline,
+    OVFlux2KleinPipeline,
+    OVFluxFillPipeline,
+    OVFluxPipeline,
+    OVLatentConsistencyModelPipeline,
+    OVLTX2Pipeline,
+    OVLTXPipeline,
+    OVModelForAudioClassification,
+    OVModelForCausalLM,
+    OVModelForFeatureExtraction,
+    OVModelForImageClassification,
+    OVModelForMaskedLM,
+    OVModelForMultimodalLM,
+    OVModelForPix2Struct,
+    OVModelForQuestionAnswering,
+    OVModelForSeq2SeqLM,
+    OVModelForSequenceClassification,
+    OVModelForSpeechSeq2Seq,
+    OVModelForTextToSpeechSeq2Seq,
+    OVModelForTokenClassification,
+    OVModelForVision2Seq,
+    OVModelForVisualCausalLM,
+    OVModelForZeroShotImageClassification,
+    OVModelOpenCLIPForZeroShotImageClassification,
+    OVSamModel,
+    OVSanaPipeline,
+    OVStableDiffusion3Pipeline,
+    OVStableDiffusionPipeline,
+    OVStableDiffusionXLImg2ImgPipeline,
+    OVStableDiffusionXLPipeline,
+)
+
+
+# Add tests/openvino to path to import utils_tests
+sys.path.insert(0, str(PathlibPath(__file__).parent))
+from utils_tests import ARCH_TO_MODEL_CLASS, HUB_MODEL_NAMES, REMOTE_CODE_MODELS
+
+
+# Map class name strings to actual class objects
+CLASS_NAME_TO_CLASS = {
+    "OVDiffusionPipeline": OVDiffusionPipeline,
+    "OVFlux2KleinPipeline": OVFlux2KleinPipeline,
+    "OVFluxFillPipeline": OVFluxFillPipeline,
+    "OVFluxPipeline": OVFluxPipeline,
+    "OVLatentConsistencyModelPipeline": OVLatentConsistencyModelPipeline,
+    "OVLTX2Pipeline": OVLTX2Pipeline,
+    "OVLTXPipeline": OVLTXPipeline,
+    "OVModelForAudioClassification": OVModelForAudioClassification,
+    "OVModelForCausalLM": OVModelForCausalLM,
+    "OVModelForFeatureExtraction": OVModelForFeatureExtraction,
+    "OVModelForImageClassification": OVModelForImageClassification,
+    "OVModelForMaskedLM": OVModelForMaskedLM,
+    "OVModelForMultimodalLM": OVModelForMultimodalLM,
+    "OVModelForPix2Struct": OVModelForPix2Struct,
+    "OVModelForQuestionAnswering": OVModelForQuestionAnswering,
+    "OVModelForSeq2SeqLM": OVModelForSeq2SeqLM,
+    "OVModelForSequenceClassification": OVModelForSequenceClassification,
+    "OVModelForSpeechSeq2Seq": OVModelForSpeechSeq2Seq,
+    "OVModelForTextToSpeechSeq2Seq": OVModelForTextToSpeechSeq2Seq,
+    "OVModelForTokenClassification": OVModelForTokenClassification,
+    "OVModelForVision2Seq": OVModelForVision2Seq,
+    "OVModelForVisualCausalLM": OVModelForVisualCausalLM,
+    "OVModelForZeroShotImageClassification": OVModelForZeroShotImageClassification,
+    "OVModelOpenCLIPForZeroShotImageClassification": OVModelOpenCLIPForZeroShotImageClassification,
+    "OVSamModel": OVSamModel,
+    "OVSanaPipeline": OVSanaPipeline,
+    "OVStableDiffusion3Pipeline": OVStableDiffusion3Pipeline,
+    "OVStableDiffusionPipeline": OVStableDiffusionPipeline,
+    "OVStableDiffusionXLImg2ImgPipeline": OVStableDiffusionXLImg2ImgPipeline,
+    "OVStableDiffusionXLPipeline": OVStableDiffusionXLPipeline,
+}
+
+
+# Additional architecture-to-class mappings from test_export.py, test_decoder.py, and test_quantization.py
+# Merged with ARCH_TO_MODEL_CLASS for more complete coverage
+ADDITIONAL_ARCH_MAPPINGS = {
+    # From test_export.py
+    "albert": "OVModelForSequenceClassification",
+    "bert": "OVModelForMaskedLM",
+    "blenderbot": "OVModelForFeatureExtraction",
+    "distilbert": "OVModelForQuestionAnswering",
+    "hunyuan_v1_dense": "OVModelForCausalLM",
+    "kokoro": "OVModelForTextToSpeechSeq2Seq",
+    "mamba": "OVModelForCausalLM",
+    "qwen3_next": "OVModelForCausalLM",
+    "roberta": "OVModelForTokenClassification",
+    "sam": "OVSamModel",
+    "smollm3": "OVModelForCausalLM",
+    "speecht5": "OVModelForTextToSpeechSeq2Seq",
+    "t5": "OVModelForSeq2SeqLM",
+    "vit": "OVModelForImageClassification",
+    "wav2vec2": "OVModelForAudioClassification",
+    "zamba2": "OVModelForCausalLM",
+    # From test_decoder.py - CausalLM models
+    "arcee": "OVModelForCausalLM",
+    "biogpt": "OVModelForCausalLM",
+    "bloom": "OVModelForCausalLM",
+    "codegen": "OVModelForCausalLM",
+    "cohere": "OVModelForCausalLM",
+    "falcon": "OVModelForCausalLM",
+    "falcon-40b": "OVModelForCausalLM",
+    "gemma": "OVModelForCausalLM",
+    "gemma2": "OVModelForCausalLM",
+    "gemma3_text": "OVModelForCausalLM",
+    "glm": "OVModelForCausalLM",
+    "glm4": "OVModelForCausalLM",
+    "gpt_bigcode": "OVModelForCausalLM",
+    "gpt_neo": "OVModelForCausalLM",
+    "gpt_neox": "OVModelForCausalLM",
+    "gpt_neox_japanese": "OVModelForCausalLM",
+    "gpt_oss": "OVModelForCausalLM",
+    "gpt_oss_mxfp4": "OVModelForCausalLM",
+    "gptj": "OVModelForCausalLM",
+    "granite": "OVModelForCausalLM",
+    "granitemoe": "OVModelForCausalLM",
+    "mistral-nemo": "OVModelForCausalLM",
+    "mixtral": "OVModelForCausalLM",
+    "mpt": "OVModelForCausalLM",
+    "opt": "OVModelForCausalLM",
+    "pegasus": "OVModelForCausalLM",
+    "persimmon": "OVModelForCausalLM",
+    "phi": "OVModelForCausalLM",
+    "phi3": "OVModelForCausalLM",
+    "qwen2_moe": "OVModelForCausalLM",
+    "stablelm": "OVModelForCausalLM",
+    "starcoder2": "OVModelForCausalLM",
+    "xglm": "OVModelForCausalLM",
+    # From test_seq2seq.py - Seq2SeqLM models
+    "bigbird_pegasus": "OVModelForSeq2SeqLM",
+    "blenderbot-small": "OVModelForSeq2SeqLM",
+    "longt5": "OVModelForSeq2SeqLM",
+    "m2m_100": "OVModelForSeq2SeqLM",
+    "marian": "OVModelForSeq2SeqLM",
+    "mbart": "OVModelForSeq2SeqLM",
+    "mt5": "OVModelForSeq2SeqLM",
+    # Vision models - ImageClassification
+    "audio-spectrogram-transformer": "OVModelForAudioClassification",
+    "beit": "OVModelForImageClassification",
+    "convnext": "OVModelForImageClassification",
+    "convnextv2": "OVModelForImageClassification",
+    "data2vec-vision": "OVModelForImageClassification",
+    "deit": "OVModelForImageClassification",
+    "levit": "OVModelForImageClassification",
+    "mobilenet_v1": "OVModelForImageClassification",
+    "mobilenet_v2": "OVModelForImageClassification",
+    "mobilevit": "OVModelForImageClassification",
+    "poolformer": "OVModelForImageClassification",
+    "resnet": "OVModelForImageClassification",
+    "swin": "OVModelForImageClassification",
+    # Vision models - Feature Extraction / Object Detection
+    "detr": "OVModelForFeatureExtraction",
+    "donut-swin": "OVModelForFeatureExtraction",
+    "open-clip": "OVModelOpenCLIPForZeroShotImageClassification",
+    "segformer": "OVModelForFeatureExtraction",
+    # Text models - Masked LM / Feature Extraction / Embeddings
+    "bge": "OVModelForFeatureExtraction",
+    "camembert": "OVModelForMaskedLM",
+    "convbert": "OVModelForSequenceClassification",
+    "data2vec-text": "OVModelForFeatureExtraction",
+    "deberta": "OVModelForMaskedLM",
+    "deberta-v2": "OVModelForMaskedLM",
+    "esm": "OVModelForMaskedLM",
+    "flaubert": "OVModelForMaskedLM",
+    "ibert": "OVModelForMaskedLM",
+    "mobilebert": "OVModelForMaskedLM",
+    "mpnet": "OVModelForFeatureExtraction",
+    "nystromformer": "OVModelForMaskedLM",
+    "rembert": "OVModelForMaskedLM",
+    "roformer": "OVModelForMaskedLM",
+    "sentence-transformers-bert": "OVModelForFeatureExtraction",
+    "squeezebert": "OVModelForMaskedLM",
+    "st-bert": "OVModelForFeatureExtraction",
+    "st-mpnet": "OVModelForFeatureExtraction",
+    "xlm": "OVModelForMaskedLM",
+    "xlm-roberta": "OVModelForMaskedLM",
+    # Audio models
+    "data2vec-audio": "OVModelForAudioClassification",
+    "hubert": "OVModelForAudioClassification",
+    "sew": "OVModelForAudioClassification",
+    "sew-d": "OVModelForAudioClassification",
+    "speech_to_text": "OVModelForSpeechSeq2Seq",
+    "unispeech": "OVModelForAudioClassification",
+    "unispeech-sat": "OVModelForAudioClassification",
+    "wav2vec2-conformer": "OVModelForAudioClassification",
+    "wav2vec2-hf": "OVModelForAudioClassification",
+    "wavlm": "OVModelForAudioClassification",
+    # Causal LM - Additional models
+    "bitnet": "OVModelForCausalLM",
+    "cohere2": "OVModelForCausalLM",
+    "dbrx": "OVModelForCausalLM",
+    "falcon_mamba": "OVModelForCausalLM",
+    "gemma3": "OVModelForVisualCausalLM",
+    "gemma3n_text": "OVModelForCausalLM",
+    "granitemoehybrid": "OVModelForCausalLM",
+    "olmo": "OVModelForCausalLM",
+    "olmo2": "OVModelForCausalLM",
+    "opt125m": "OVModelForCausalLM",
+    "phimoe": "OVModelForCausalLM",
+    "qwen3_5": "OVModelForVisualCausalLM",
+    # Vision-Language / Multimodal models
+    "donut": "OVModelForVision2Seq",
+    "gemma3n": "OVModelForVisualCausalLM",
+    "gemma4": "OVModelForVisualCausalLM",
+    "got_ocr2": "OVModelForVisualCausalLM",
+    "idefics3": "OVModelForVisualCausalLM",
+    "internvl_chat": "OVModelForVisualCausalLM",
+    "llava-qwen2": "OVModelForVisualCausalLM",
+    "llava_next": "OVModelForVisualCausalLM",
+    "llava_next_mistral": "OVModelForVisualCausalLM",
+    "llava_next_video": "OVModelForVisualCausalLM",
+    "maira2": "OVModelForVisualCausalLM",
+    "minicpmo": "OVModelForVisualCausalLM",
+    "minicpmv": "OVModelForVisualCausalLM",
+    "phi3_v": "OVModelForVisualCausalLM",
+    "phi4mm": "OVModelForVisualCausalLM",
+    "pix2struct": "OVModelForPix2Struct",
+    "qwen2_5_vl": "OVModelForVisualCausalLM",
+    "qwen2_vl": "OVModelForVisualCausalLM",
+    "qwen3_vl": "OVModelForVisualCausalLM",
+    "qwen3_vl_embedding": "OVModelForFeatureExtraction",
+    "smolvlm": "OVModelForVisualCausalLM",
+    "trocr": "OVModelForVision2Seq",
+    "vision-encoder-decoder": "OVModelForVision2Seq",
+    # Diffusion pipelines
+    "flux": "OVFluxPipeline",
+    "flux-fill": "OVFluxFillPipeline",
+    "flux.2-klein": "OVFlux2KleinPipeline",
+    "latent-consistency": "OVLatentConsistencyModelPipeline",
+    "ltx-video": "OVLTXPipeline",
+    "ltx2": "OVLTX2Pipeline",
+    "sana": "OVSanaPipeline",
+    "sana-sprint": "OVSanaPipeline",
+    "stable-diffusion-3": "OVStableDiffusion3Pipeline",
+    "stable-diffusion-xl": "OVStableDiffusionXLPipeline",
+    "stable-diffusion-xl-refiner": "OVStableDiffusionXLImg2ImgPipeline",
+    "stable-diffusion-with-custom-variant": "OVStableDiffusionPipeline",
+    "stable-diffusion-with-safety-checker": "OVStableDiffusionPipeline",
+    "stable-diffusion-with-textual-inversion": "OVStableDiffusionPipeline",
+}
+
+
+# Generate test parameters: (model_id, model_class) for all models that don't need trust_remote_code
+def _generate_test_params():
+    """Generate test parameters from utils_tests mappings and test_export mappings."""
+    params = []
+    for arch, model_id in HUB_MODEL_NAMES.items():
+        # Skip models that need trust_remote_code
+        if arch in REMOTE_CODE_MODELS:
+            continue
+
+        if arch in {  # seq2seq models
+            "bigbird_pegasus",
+            "blenderbot-small",
+            "longt5",
+            "m2m_100",
+            "mbart",
+            "t5",
+        }:
+            continue
+
+        if arch in {  # 4.57.6 models
+            "data2vec-text",
+            "got_ocr2",
+            "flaubert",
+            "idefics3",
+            "zamba2",
+            "qwen3_next",
+            "xlm",
+            "qwen2_vl",
+            "qwen2_5_vl",
+            "qwen3_vl",
+            "qwen3_vl_embedding",
+            "llava_next_video",
+            "marian",
+            "mt5",
+            "smolvlm",
+        }:
+            continue
+
+        if arch in {  # max transformers 5.0 required
+            "gemma",
+            "gemma2",
+            "gemma3_text",
+            "gemma3n_text",
+            "glm",
+        }:
+            continue
+
+        if arch == "qwen3_5":  # max transformers 5.2.* required
+            continue
+
+        if arch in {  # max transformers 5.3.0 required
+            "falcon_mamba",
+            "granitemoehybrid",
+            "mamba",
+        }:
+            continue
+
+        if arch in {  # max transformers 5.4.0 required
+            "lfm2",
+            "lfm2_moe",
+        }:
+            continue
+
+        # Try to get model class from ARCH_TO_MODEL_CLASS first, then ADDITIONAL_ARCH_MAPPINGS
+        class_name = None
+        if arch in ARCH_TO_MODEL_CLASS:
+            class_name = ARCH_TO_MODEL_CLASS[arch]
+        elif arch in ADDITIONAL_ARCH_MAPPINGS:
+            class_name = ADDITIONAL_ARCH_MAPPINGS[arch]
+
+        # Skip if no mapping found or class not available
+        if class_name is None or class_name not in CLASS_NAME_TO_CLASS:
+            continue
+
+        model_class = CLASS_NAME_TO_CLASS[class_name]
+        params.append((model_id, model_class))
+    return params
+
+
+TEST_MODELS = _generate_test_params()
+
+
+# OpenVINO model comparison functions
+# Adapted from: https://github.com/openvinotoolkit/openvino/blob/master/src/bindings/python/tests/utils/helpers.py
+def _compare_models(model_one: Model, model_two: Model, compare_names: bool = True) -> tuple[bool, str]:
+    """Function to compare OpenVINO model (ops names, types and shapes).
+
+    Note that the functions uses get_ordered_ops, so the topological order of ops should be also preserved.
+
+    :param model_one: The first model to compare.
+    :param model_two: The second model to compare.
+    :param compare_names: Flag to control friendly names checking. Default: True
+    :return: tuple which consists of bool value (True if models are equal, otherwise False)
+             and string with the message to reuse for debug/testing purposes. The string value
+             is empty when models are equal.
+    """
+    result = True
+    msg = ""
+
+    # Check friendly names of models
+    if compare_names and model_one.get_friendly_name() != model_two.get_friendly_name():
+        result = False
+        msg += "Friendly names of models are not equal "
+        msg += f"model_one: {model_one.get_friendly_name()}, model_two: {model_two.get_friendly_name()}.\n"
+
+    model_one_ops = model_one.get_ordered_ops()
+    model_two_ops = model_two.get_ordered_ops()
+
+    # Check overall number of operators
+    if len(model_one_ops) != len(model_two_ops):
+        result = False
+        msg += "Not equal number of ops "
+        msg += f"model_one: {len(model_one_ops)}, model_two: {len(model_two_ops)}.\n"
+
+    # Only compare ops that exist in both models
+    for i in range(min(len(model_one_ops), len(model_two_ops))):
+        op_one_name = model_one_ops[i].get_friendly_name()  # op from model_one
+        op_two_name = model_two_ops[i].get_friendly_name()  # op from model_two
+        # Check friendly names
+        if compare_names and op_one_name != op_two_name and model_one_ops[i].get_type_name() != "Constant":
+            result = False
+            msg += "Not equal op names "
+            msg += f"model_one: {op_one_name}, "
+            msg += f"model_two: {op_two_name}.\n"
+        # Check output sizes
+        if model_one_ops[i].get_output_size() != model_two_ops[i].get_output_size():
+            result = False
+            msg += f"Not equal output sizes of {op_one_name} and {op_two_name}.\n"
+        # Only compare outputs that exist in both ops
+        for idx in range(min(model_one_ops[i].get_output_size(), model_two_ops[i].get_output_size())):
+            # Check partial shapes of outputs
+            op_one_partial_shape = model_one_ops[i].get_output_partial_shape(idx)
+            op_two_partial_shape = model_two_ops[i].get_output_partial_shape(idx)
+            if op_one_partial_shape != op_two_partial_shape:
+                result = False
+                msg += f"Not equal op partial shapes of {op_one_name} and {op_two_name} on {idx} index "
+                msg += f"model_one: {op_one_partial_shape}, "
+                msg += f"model_two: {op_two_partial_shape}.\n"
+            # Check element types of outputs
+            op_one_element_type = model_one_ops[i].get_output_element_type(idx)
+            op_two_element_type = model_two_ops[i].get_output_element_type(idx)
+            if op_one_element_type != op_two_element_type:
+                result = False
+                msg += f"Not equal output element types of {op_one_name} and {op_two_name} on {idx} index "
+                msg += f"model_one: {op_one_element_type}, "
+                msg += f"model_two: {op_two_element_type}.\n"
+
+    return result, msg
+
+
+def compare_models(model_one: Model, model_two: Model, compare_names: bool = True):
+    """Function to compare OpenVINO model (ops names, types and shapes).
+
+    :param model_one: The first model to compare.
+    :param model_two: The second model to compare.
+    :param compare_names: Flag to control friendly names checking. Default: True
+    :return: True if models are equal, otherwise raise an error with a report of mismatches.
+    """
+    result, msg = _compare_models(model_one, model_two, compare_names=compare_names)
+
+    if not result:
+        raise RuntimeError(msg)
+
+    return result
+
+
+def load_reference_metadata(ref_dir: Path) -> Optional[Dict]:
+    """Load metadata about reference IR generation."""
+    metadata_path = ref_dir / "metadata.json"
+    if metadata_path.exists():
+        with open(metadata_path) as f:
+            return json.load(f)
+    return None
+
+
+def find_ir_files(directory: Path) -> List[Path]:
+    """
+    Find all OpenVINO IR XML files in directory and subdirectories.
+    Handles both standard naming (openvino_model.xml) and component naming
+    (openvino_language_model.xml, openvino_vision_embeddings_model.xml, etc.)
+    Returns list of paths relative to the directory.
+    """
+    ir_files = []
+    # Match both openvino_model.xml and openvino_*_model.xml patterns
+    for xml_file in directory.rglob("openvino*.xml"):
+        if xml_file.name.startswith("openvino") and xml_file.name.endswith("_model.xml"):
+            # Get relative path from directory
+            rel_path = xml_file.relative_to(directory)
+            ir_files.append(rel_path)
+    return sorted(ir_files)
+
+
+class TestIRStability:
+    """Test suite for IR stability across transformers versions."""
+
+    @pytest.mark.parametrize(
+        "model_id,model_class",
+        TEST_MODELS,
+    )
+    def test_ir_stability(self, model_id: str, model_class, tmp_path: Path):
+        """Test that exported IR matches reference IR."""
+
+        # Download reference IRs from HuggingFace (ov branch)
+        try:
+            ref_ir_dir = Path(
+                snapshot_download(
+                    repo_id=model_id,
+                    revision="ov",
+                    repo_type="model",
+                )
+            )
+        except Exception as e:
+            pytest.skip(f"Failed to download reference IRs from {model_id} (ov branch): {e}")
+
+        if not ref_ir_dir.exists():
+            pytest.skip(f"Reference IR directory not found for {model_id}")
+
+        # Load reference metadata
+        ref_metadata = load_reference_metadata(ref_ir_dir)
+
+        if ref_metadata:
+            print(
+                f"[IR-DEBUG] {model_id}: reference IR generated with "
+                f"transformers={ref_metadata.get('transformers_version', 'unknown')}, "
+                f"optimum-intel={ref_metadata.get('optimum_intel_version', 'unknown')}, "
+                f"openvino={ref_metadata.get('openvino_version', 'unknown')}, "
+                f"date={ref_metadata.get('generated_date', 'unknown')}"
+            )
+        else:
+            print(f"[IR-DEBUG] {model_id}: no reference metadata.json found in {ref_ir_dir}")
+
+        # Find all IR files (handles both single models and multi-component pipelines)
+        ref_ir_files = find_ir_files(ref_ir_dir)
+
+        if not ref_ir_files:
+            pytest.skip(f"No openvino_model.xml files found in {ref_ir_dir}")
+
+        # Export new IR
+        model = model_class.from_pretrained(model_id, export=True)
+        new_ir_dir = tmp_path / "new_ir"
+        model.save_pretrained(new_ir_dir)
+
+        # Find IR files in new export
+        new_ir_files = find_ir_files(new_ir_dir)
+
+        # Check that same components exist
+        ref_components = {str(f.parent) for f in ref_ir_files}
+        new_components = {str(f.parent) for f in new_ir_files}
+
+        if ref_components != new_components:
+            missing = ref_components - new_components
+            extra = new_components - ref_components
+            pytest.fail(
+                f"Component mismatch for {model_id}:\n"
+                f"  Missing components: {missing or 'none'}\n"
+                f"  Extra components: {extra or 'none'}"
+            )
+
+        # Initialize OpenVINO Core for loading models
+        core = Core()
+
+        # Compare each component's IR using OpenVINO's compare_models
+        all_differences = {}
+        for ref_ir_file in ref_ir_files:
+            component_name = str(ref_ir_file.parent) if str(ref_ir_file.parent) != "." else "root"
+
+            ref_ir_path = ref_ir_dir / ref_ir_file
+            new_ir_path = new_ir_dir / ref_ir_file
+
+            # Load both models using OpenVINO Core
+            ref_model = core.read_model(str(ref_ir_path))
+            new_model = core.read_model(str(new_ir_path))
+
+            # Compare models (compare_names=False to ignore auto-generated friendly names)
+            try:
+                compare_models(ref_model, new_model, compare_names=False)
+            except RuntimeError as e:
+                # Model comparison failed - store the error message
+                all_differences[component_name] = str(e).strip().split("\n")
+
+        # Report all differences
+        if all_differences:
+            diff_lines = []
+            for component, diffs in all_differences.items():
+                diff_lines.append(f"\n[{component}]")
+                for diff in diffs:
+                    diff_lines.append(f"  {diff}")
+
+            diff_msg = "\n".join(diff_lines)
+
+            # Add metadata info to failure message
+            metadata_info = ""
+            if ref_metadata:
+                metadata_info = (
+                    f"\nReference IR was generated with:\n"
+                    f"  - transformers: {ref_metadata.get('transformers_version', 'unknown')}\n"
+                    f"  - optimum-intel: {ref_metadata.get('optimum_intel_version', 'unknown')}\n"
+                    f"  - openvino: {ref_metadata.get('openvino_version', 'unknown')}\n"
+                    f"  - date: {ref_metadata.get('generated_date', 'unknown')}\n"
+                )
+
+            pytest.fail(
+                f"IR structure has changed for {model_id}:{diff_msg}\n"
+                f"{metadata_info}\n"
+                f"This may indicate a regression or improvement in IR generation. "
+                f"Review the changes and update reference IRs if the change is intentional."
+            )

--- a/tests/openvino/test_irs.py
+++ b/tests/openvino/test_irs.py
@@ -6,6 +6,7 @@ regressions when upgrading transformers or other dependencies.
 """
 
 import json
+import os
 
 # Import test utilities to get model mappings
 import sys
@@ -16,7 +17,7 @@ from typing import Dict, List, Optional
 
 import pytest
 from huggingface_hub import snapshot_download
-from huggingface_hub.errors import RepositoryNotFoundError, RevisionNotFoundError
+from huggingface_hub.errors import HFValidationError, RepositoryNotFoundError, RevisionNotFoundError
 from openvino import Core, Model
 
 from optimum.intel import (
@@ -351,6 +352,13 @@ def _generate_test_params():
         }:
             continue
 
+        if arch in {
+            "bart",
+            "donut",
+            "kokoro",
+        }:
+            continue
+
         # Try to get model class from ARCH_TO_MODEL_CLASS first, then ADDITIONAL_ARCH_MAPPINGS
         class_name = None
         if arch in ARCH_TO_MODEL_CLASS:
@@ -462,17 +470,22 @@ def download_reference_ir(model_id: str) -> Optional[Path]:
     """
     Fetch the reference IRs from a model's `ov` branch.
 
-    Returns None when the repository or its `ov` revision genuinely does not exist, which is the
-    only legitimate reason to skip a model. Everything else (429, 5xx, timeouts) is retried and
-    then raised: a flaky Hub must not silently turn this suite into a green no-op.
+    Returns None when the model is not on the Hub at all, which is the only legitimate reason to
+    skip it. Everything else (429, 5xx, timeouts) is retried and then raised: a flaky Hub must not
+    silently turn this suite into a green no-op.
     """
+    # Some fixtures are generated on the fly into a local directory (see `_create_tiny_kokoro_model`
+    # in utils_tests.py), so their "model id" is a filesystem path with no Hub reference behind it.
+    if os.path.isdir(model_id):
+        return None
+
     delay = DOWNLOAD_BACKOFF
     last_error = None
 
     for attempt in range(1, DOWNLOAD_ATTEMPTS + 1):
         try:
             return Path(snapshot_download(repo_id=model_id, revision="ov", repo_type="model"))
-        except (RepositoryNotFoundError, RevisionNotFoundError):
+        except (RepositoryNotFoundError, RevisionNotFoundError, HFValidationError):
             return None
         except Exception as error:
             last_error = error
@@ -538,17 +551,22 @@ def load_reference_metadata(ref_dir: Path) -> Optional[Dict]:
     return None
 
 
+# Tokenizer IRs are produced by openvino-tokenizers rather than by the model export, so they are
+# not part of what this suite guards and are not present in the references.
+NON_MODEL_IR_STEMS = ("openvino_tokenizer", "openvino_detokenizer")
+
+
 def find_ir_files(directory: Path) -> List[Path]:
     """
     Find all OpenVINO IR XML files in directory and subdirectories.
-    Handles both standard naming (openvino_model.xml) and component naming
-    (openvino_language_model.xml, openvino_vision_embeddings_model.xml, etc.)
+    Handles standard naming (openvino_model.xml), component naming with a `_model` suffix
+    (openvino_language_model.xml, openvino_vision_embeddings_model.xml, ...) and component naming
+    without one (openvino_vision_encoder.xml for SAM, openvino_model_text.xml for OpenCLIP).
     Returns list of paths relative to the directory.
     """
     ir_files = []
-    # Match both openvino_model.xml and openvino_*_model.xml patterns
     for xml_file in directory.rglob("openvino*.xml"):
-        if xml_file.name.startswith("openvino") and xml_file.name.endswith("_model.xml"):
+        if xml_file.stem not in NON_MODEL_IR_STEMS:
             # Get relative path from directory
             rel_path = xml_file.relative_to(directory)
             ir_files.append(rel_path)
@@ -570,7 +588,7 @@ class TestIRStability:
 
         if ref_ir_dir is None:
             MODELS_WITHOUT_REFERENCE.add(model_id)
-            pytest.skip(f"No reference IRs for {model_id}: the repository has no `ov` revision")
+            pytest.skip(f"No reference IRs for {model_id}: not on the Hub, or no `ov` revision")
 
         if not ref_ir_dir.exists():
             pytest.skip(f"Reference IR directory not found for {model_id}")
@@ -616,6 +634,15 @@ class TestIRStability:
                 f"  Extra components: {extra or 'none'}"
             )
 
+        # The loop below reads each reference file's counterpart by name, so a renamed or dropped
+        # component has to be reported here rather than surfacing as a read_model error.
+        missing_files = sorted(str(f) for f in set(ref_ir_files) - set(new_ir_files))
+        if missing_files:
+            pytest.fail(
+                f"IR files present in the reference but missing from the new export for {model_id}:\n  "
+                + "\n  ".join(missing_files)
+            )
+
         COMPARED_MODELS.add(model_id)
 
         # Initialize OpenVINO Core for loading models
@@ -624,7 +651,9 @@ class TestIRStability:
         # Compare each component's IR using OpenVINO's compare_models
         all_differences = {}
         for ref_ir_file in ref_ir_files:
-            component_name = str(ref_ir_file.parent) if str(ref_ir_file.parent) != "." else "root"
+            # Keyed by the full relative path: models such as SAM keep several components side by
+            # side at the root, and keying by directory alone would let one overwrite the other.
+            component_name = str(ref_ir_file)
 
             ref_ir_path = ref_ir_dir / ref_ir_file
             new_ir_path = new_ir_dir / ref_ir_file

--- a/tests/openvino/test_modeling.py
+++ b/tests/openvino/test_modeling.py
@@ -1275,7 +1275,7 @@ class OVModelForImageClassificationIntegrationTest(unittest.TestCase):
         )
         self.assertEqual(ov_model.request.get_property("INFERENCE_PRECISION_HINT").to_string(), "f32")
         self.assertIsInstance(ov_model.config, PretrainedConfig)
-        timm_model = timm.create_model(model_id, pretrained=True)
+        timm_model = timm.create_model(f"hf-hub:{model_id}", pretrained=True)
         preprocessor = TimmImageProcessor.from_pretrained(model_id)
         url = TEST_IMAGE_URL
         image = Image.open(requests.get(url, stream=True).raw)


### PR DESCRIPTION
# What does this PR do?

This PR adds patches for models to make their exported IRs identical to the reference IRs. 

Patched models are:
1) tiny-random-SegformerModel
2) tiny-random-SwinModel (received 7e-7 difference)
3) tiny-random-DonutSwinModel

One patch of CLIPTextModelPatcher for:
4) tiny-stable-diffusion-torch
5) tiny-random-stable-diffusion-with-safety-checker
6) tiny-stable-diffusion-with-textual-inversion
7) tiny-random-stable-diffusion-xl
8) tiny-random-latent-consistency
9) tiny-random-flux
10) tiny-random-flux-fill
11) tiny-stable-diffusion-torch-custom-variant

12) gemma4
13) gemma4-moe (patched + new ref IR created)

14) tiny-random-squeezebert 
15) tiny-random-rembert
16) tiny-random-ConvBertForSequenceClassification
17) tiny-random-roformer 
18) tiny-random-MPNetModel 
19) all-mpnet-base-v2 
20) pix2struct-tiny-random 
21) trocr-small-handwritten 
22) VisionEncoderDecoderModel-vit-gpt2 
23) tiny-random-BeitForImageClassification 
24) tiny-random-DeiTModel 
25) tiny-random-vit 
26) tiny-random-ast 
