### PR TITLE
[OpenVINO] Fix double BOS tokens for Mistral3

### DIFF
--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -2241,8 +2241,18 @@ class _OVMistral3ForCausalLM(OVModelForVisualCausalLM):
         if image is not None:
             conversation[0]["content"].insert(0, {"type": "image"})
 
-        prompt = processor.apply_chat_template(conversation, add_generation_prompt=True)
+        prompt = processor.apply_chat_template(conversation, add_generation_prompt=True, tokenize=False)
+
+        # switch off add_bos_token if chat template already includes it
+        orig_add_bos_token = processor.tokenizer.add_bos_token
+        if "bos_token" in processor.tokenizer.chat_template:
+            processor.tokenizer.add_bos_token = False
+
         inputs = processor(images=image, text=prompt, return_tensors="pt")
+
+        # recover add_bos_token flag in tokenizer
+        processor.tokenizer.add_bos_token = orig_add_bos_token
+
         return inputs
 
 

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -795,9 +795,9 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
 
         image = self.IMAGE.resize((600, 600))
         inputs = ov_model.preprocess_inputs(**preprocessors, text=prompt, image=image)
-        if model_arch in ["gemma3", "gemma3n"]:
+        if model_arch in ["gemma3", "gemma3n", "mistral3"]:
             # validate that preprocessed input ids contain exactly one bos token
-            bos_token = preprocessors["processor"].tokenizer.vocab["<bos>"]
+            bos_token = preprocessors["processor"].tokenizer.bos_token_id
             input_ids = inputs["input_ids"]
             bos_token_counts = (input_ids == bos_token).sum(dim=1)
             self.assertTrue(


### PR DESCRIPTION
# What does this PR do?
- Fix temporarily disable `tokenizer.add_bos_token` before calling the processor to provide one BOS token.
- Before the fix, two leading BOS tokens are present: preprocess_inputs applies the chat template containing a literal BOS and then feeds it through the tokenizer with `add_special_tokens=True`, whose post_processor prepends its own BOS token

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Fixes # (issue)


## Before submitting
- [  ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [  ] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?