### PR TITLE
Add OpenVINO GenAI AIPC test workflow and report

### DIFF
--- a/.github/workflows/generate_genai_report.py
+++ b/.github/workflows/generate_genai_report.py
@@ -1,0 +1,758 @@
+"""
+Generate a markdown report summarizing the latest workflow run for test_openvino_genai_aipc.yml.
+
+Fetches job data and logs from the GitHub Actions API, parses pytest results per model,
+and produces a markdown table with models in rows, MTL/LNL columns with CPU/GPU/NPU subcolumns.
+
+Requirements:
+    pip install requests
+    pip install openpyxl  # only needed for --xlsx
+
+Usage:
+    # Set GITHUB_TOKEN environment variable (needs repo/actions read access)
+    # Or have `gh` CLI authenticated (token will be auto-detected)
+    set GITHUB_TOKEN=ghp_...
+    python generate_genai_report.py
+
+    # Optionally specify a run ID:
+    python generate_genai_report.py --run-id 29916107736
+
+    # Save to file (markdown):
+    python generate_genai_report.py --output optimum-genai-test-report.md
+
+    # Generate HTML report:
+    python generate_genai_report.py --html --output optimum-genai-test-report.html
+
+    # Generate Excel report (single sheet, transformers version as column):
+    python generate_genai_report.py --xlsx --output optimum-genai-test-report.xlsx
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from collections import defaultdict
+
+import requests
+
+
+OWNER = os.environ.get("GITHUB_REPOSITORY_OWNER", "huggingface")
+REPO_NAME = os.environ.get("GITHUB_REPOSITORY", "huggingface/optimum-intel").split("/")[-1]
+WORKFLOW_FILE = "test_openvino_genai_aipc.yml"
+API_BASE = f"https://api.github.com/repos/{OWNER}/{REPO_NAME}"
+
+
+def get_headers():
+    token = os.environ.get("GITHUB_TOKEN")
+    if not token:
+        # Try to get token from gh CLI
+        try:
+            result = subprocess.run(["gh", "auth", "token"], capture_output=True, text=True, check=True)
+            token = result.stdout.strip()
+        except (subprocess.CalledProcessError, FileNotFoundError):
+            pass
+    if not token:
+        print(
+            "ERROR: GITHUB_TOKEN environment variable is required (or authenticate via `gh auth login`).",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    return {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+
+
+def get_latest_run(run_id=None):
+    """Get the latest completed workflow run, or a specific run by ID."""
+    headers = get_headers()
+    if run_id:
+        url = f"{API_BASE}/actions/runs/{run_id}"
+        resp = requests.get(url, headers=headers)
+        resp.raise_for_status()
+        return resp.json()
+    else:
+        url = f"{API_BASE}/actions/workflows/{WORKFLOW_FILE}/runs"
+        params = {"per_page": 10, "status": "completed"}
+        resp = requests.get(url, headers=headers, params=params)
+        resp.raise_for_status()
+        runs = resp.json()["workflow_runs"]
+        if not runs:
+            print("No completed workflow runs found.", file=sys.stderr)
+            sys.exit(1)
+        return runs[0]
+
+
+def get_jobs(run_id):
+    """Get all jobs for a workflow run."""
+    headers = get_headers()
+    jobs = []
+    page = 1
+    while True:
+        url = f"{API_BASE}/actions/runs/{run_id}/jobs"
+        resp = requests.get(url, headers=headers, params={"per_page": 100, "page": page})
+        resp.raise_for_status()
+        data = resp.json()
+        jobs.extend(data["jobs"])
+        if len(jobs) >= data["total_count"]:
+            break
+        page += 1
+    return jobs
+
+
+def download_job_log(job_id):
+    """Download log for a single job. Returns the log text or None on failure."""
+    headers = get_headers()
+    url = f"{API_BASE}/actions/jobs/{job_id}/logs"
+    resp = requests.get(url, headers=headers, allow_redirects=True)
+    if resp.status_code == 200:
+        return resp.text
+    return None
+
+
+def parse_job_name(job_name):
+    """Parse job name like 'test (4.57.6, GPU, MTL)' into (version, device, runner)."""
+    match = re.match(r"test\s*\(([^,]+),\s*([^,]+),\s*([^)]+)\)", job_name)
+    if match:
+        return match.group(1).strip(), match.group(2).strip(), match.group(3).strip()
+    return None, None, None
+
+
+def parse_versions_from_log(log_text):
+    """Extract package versions from the 'Verify imports' step output.
+
+    Looks for lines like:
+        openvino_genai 2026.3.0.0-3272-e9c0cf80d50
+        openvino 2026.3.0-22446-ce03a15d415-releases/2026/3
+        transformers 4.57.6
+        torch 2.13.0+cpu
+
+    Returns dict of {package_name: version_string}.
+    """
+    versions = {}
+    timestamp_re = re.compile(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s?")
+    for line in log_text.split("\n"):
+        stripped = timestamp_re.sub("", line).strip()
+        for pkg in ("openvino_genai", "openvino", "transformers", "torch"):
+            if stripped.startswith(f"{pkg} "):
+                versions[pkg] = stripped[len(pkg) + 1 :].strip()
+                break
+    return versions
+
+
+def parse_test_results_from_log(log_text):
+    """Parse pytest output from a GitHub Actions job log to extract per-test results.
+
+    The log format is:
+        2026-07-22T11:35:00.6366112Z tests/openvino/test_genai.py::ClassName::method_name
+        ... (optional log lines) ...
+        2026-07-22T11:35:06.8379394Z PASSED                                   [ xx%]
+
+    Or inline (for some tests):
+        2026-07-22T... tests/openvino/test_genai.py::Class::method SKIPPED [xx%]
+
+    Under pytest-xdist the result is reported by the controller instead:
+        2026-07-22T... [gw0] [ xx%] PASSED tests/openvino/test_genai.py::Class::method
+
+    A test whose worker died from a native crash (access violation) is reported as:
+        2026-07-22T... worker 'gw0' crashed while running 'tests/openvino/test_genai.py::Class::method'
+
+    Tests that were collected but never reported a status (the run was aborted before reaching
+    them) are returned as 'not_run' so they are not confused with passing tests.
+
+    Returns dict of {(class_name, test_method): status} where status is 'passed', 'failed',
+    'skipped', 'error', or 'not_run'.
+    """
+    results = {}
+    collected = set()
+    crashed = set()
+    lines = log_text.split("\n")
+
+    # Strip timestamp prefix from lines: "2026-07-22T11:35:00.6366112Z "
+    timestamp_re = re.compile(r"^\d{4}-\d{2}-\d{2}T[\d:.]+Z\s?")
+
+    current_test = None  # (class_name, method_name)
+
+    for line in lines:
+        stripped = timestamp_re.sub("", line).strip()
+
+        # A crashed worker takes the whole process down, so the status is recorded separately
+        # and applied last: xdist also reports the test as a plain failure.
+        crash_match = re.search(
+            r"worker '\w+' crashed while running '(?:tests/openvino/)?test_genai\.py::(\w+)::(\w+)'",
+            stripped,
+        )
+        if crash_match:
+            crashed.add((crash_match.group(1), crash_match.group(2)))
+            continue
+
+        # Check for a status-first result line, emitted both by pytest-xdist progress
+        # ("[gw0] [ xx%] PASSED test_genai.py::Class::method") and by the short test
+        # summary that -r produces ("FAILED test_genai.py::Class::method").
+        status_first_match = re.match(
+            r"(?:\[gw\d+\]\s*)?(?:\[\s*\d+%\]\s*)?(PASSED|FAILED|SKIPPED|ERROR)\s+"
+            r"(?:tests/openvino/)?test_genai\.py::(\w+)::(\w+)",
+            stripped,
+        )
+        if status_first_match:
+            status = status_first_match.group(1).lower()
+            results[(status_first_match.group(2), status_first_match.group(3))] = status
+            current_test = None
+            continue
+
+        # Check for inline result: "test_genai.py::Class::method PASSED/FAILED/SKIPPED [xx%]"
+        inline_match = re.match(
+            r"(?:tests/openvino/)?test_genai\.py::(\w+)::(\w+)\s+(PASSED|FAILED|SKIPPED)",
+            stripped,
+        )
+        if inline_match:
+            class_name = inline_match.group(1)
+            method = inline_match.group(2)
+            status = inline_match.group(3).lower()
+            results[(class_name, method)] = status
+            current_test = None
+            continue
+
+        # Check for test name line: "tests/openvino/test_genai.py::ClassName::method_name"
+        test_match = re.match(
+            r"(?:tests/openvino/)?test_genai\.py::(\w+)::(\w+)\s*$",
+            stripped,
+        )
+        if test_match:
+            current_test = (test_match.group(1), test_match.group(2))
+            collected.add(current_test)
+            continue
+
+        # Check for standalone result line: "PASSED  [ xx%]" or "FAILED  [ xx%]" or "SKIPPED (reason)  [ xx%]"
+        # These always end with a percentage indicator like "[ xx%]"
+        result_match = re.match(r"(PASSED|FAILED|SKIPPED)\b", stripped)
+        if result_match and current_test and re.search(r"\[\s*\d+%\]", stripped):
+            status = result_match.group(1).lower()
+            results[current_test] = status
+            current_test = None
+            continue
+
+        # Check for crash/access violation (indicates current test errored)
+        if current_test and "fatal exception" in stripped.lower():
+            results[current_test] = "error"
+            current_test = None
+            continue
+
+    for test in crashed:
+        results[test] = "error"
+
+    for test in collected:
+        results.setdefault(test, "not_run")
+
+    return results
+
+
+def extract_model_from_test_name(test_method):
+    """Extract model architecture name from test method like 'test_compare_outputs_00_gpt2'.
+
+    parameterized adds a numeric prefix: test_compare_outputs_00_gpt_bigcode, test_compare_outputs_01_bloom, etc.
+    Returns None if the test method doesn't match the expected pattern.
+    """
+    match = re.match(r"test_compare_outputs_(?:vlm_)?\d+_(.+)", test_method)
+    if match:
+        return match.group(1)
+    return None
+
+
+def extract_test_category(class_name):
+    """Map test class name to a category."""
+    mapping = {
+        "LLMPipelineTestCase": "LLM",
+        "VLMPipelineTestCase": "VLM",
+        "Speech2TextPipelineTestCase": "Speech2Text",
+        "Text2SpeechPipelineTestCase": "Text2Speech",
+        "LLMPipelineWithEagle3TestCase": "Eagle3",
+        "VLMPipelineWithEagle3TestCase": "Eagle3-VLM",
+    }
+    return mapping.get(class_name, class_name)
+
+
+def build_report(run_info, jobs, job_logs):
+    """Build the markdown report from jobs and their logs.
+
+    Args:
+        run_info: Workflow run metadata from API
+        jobs: List of job objects from API
+        job_logs: Dict of {job_id: log_text}
+    """
+    # Structure: results[version][(category, model_name)] = {(runner, device): status}
+    results = defaultdict(lambda: defaultdict(dict))
+    job_conclusions = {}
+    # Track versions per transformers version (from any job with that version)
+    version_info = {}  # {transformers_version: {pkg: version_str}}
+
+    for job in jobs:
+        job_name = job["name"]
+        version, device, runner = parse_job_name(job_name)
+        if not version:
+            continue
+
+        conclusion = job.get("conclusion", "unknown")
+        job_conclusions[(version, device, runner)] = conclusion
+
+        log_content = job_logs.get(job["id"])
+        if log_content:
+            # Extract package versions (once per transformers version is enough)
+            if version not in version_info:
+                versions = parse_versions_from_log(log_content)
+                if versions:
+                    version_info[version] = versions
+
+            test_results = parse_test_results_from_log(log_content)
+            for (class_name, test_method), status in test_results.items():
+                category = extract_test_category(class_name)
+                model_name = extract_model_from_test_name(test_method)
+                if model_name is None:
+                    continue  # Skip unparseable test names
+                model_key = (category, model_name)
+                results[version][model_key][(runner, device)] = status
+
+    # If no per-test results found, fall back to job-level conclusions
+    if not any(results.values()):
+        print(
+            "WARNING: Could not parse per-test results from logs. Using job-level conclusions only.", file=sys.stderr
+        )
+        for job in jobs:
+            job_name = job["name"]
+            version, device, runner = parse_job_name(job_name)
+            if not version:
+                continue
+            conclusion = job.get("conclusion", "unknown")
+            results[version][("Job", "all_tests")][(runner, device)] = conclusion
+
+    # Generate markdown
+    lines = []
+    run_url = run_info.get("html_url", "")
+    run_number = run_info.get("run_number", "")
+    run_status = run_info.get("conclusion", run_info.get("status", "unknown"))
+    head_branch = run_info.get("head_branch", "")
+    created_at = run_info.get("created_at", "")
+
+    lines.append("# OpenVINO GenAI AIPC Test Report")
+    lines.append("")
+    lines.append(f"**Workflow Run:** [#{run_number}]({run_url})")
+    lines.append(f"**Branch:** `{head_branch}`")
+    lines.append(f"**Status:** {run_status}")
+    lines.append(f"**Date:** {created_at}")
+    lines.append("")
+
+    # Package versions table
+    if version_info:
+        lines.append("### Package Versions")
+        lines.append("")
+        lines.append("| Transformers | OpenVINO | OpenVINO GenAI | PyTorch |")
+        lines.append("|:---:|:---:|:---:|:---:|")
+        for tv in sorted(version_info.keys()):
+            vi = version_info[tv]
+            ov = vi.get("openvino", "-")
+            ov_genai = vi.get("openvino_genai", "-")
+            torch_ver = vi.get("torch", "-")
+            tf_ver = vi.get("transformers", tv)
+            lines.append(f"| {tf_ver} | {ov} | {ov_genai} | {torch_ver} |")
+        lines.append("")
+
+    # Status emoji mapping
+    status_symbols = {
+        "passed": "\u2705",
+        "success": "\u2705",
+        "failed": "\u274c",
+        "failure": "\u274c",
+        "skipped": "\u23ed\ufe0f",
+        "error": "\u26a0\ufe0f",
+        "not_run": "\u2b1c",
+        "cancelled": "\u23f9\ufe0f",
+        "unknown": "\u2753",
+    }
+
+    runners = ["MTL", "LNL"]
+    devices = ["CPU", "GPU", "NPU"]
+
+    for version in sorted(results.keys()):
+        lines.append(f"## Transformers {version}")
+        lines.append("")
+
+        # Table header with sub-columns
+        header = "| Category | Model |"
+        separator = "|----------|-------|"
+        for runner in runners:
+            for device in devices:
+                header += f" {runner}/{device} |"
+                separator += ":---:|"
+
+        lines.append(header)
+        lines.append(separator)
+
+        # Group by category, sorted
+        model_keys = sorted(results[version].keys(), key=lambda x: (x[0], x[1]))
+
+        for category, model_name in model_keys:
+            row = f"| {category} | {model_name} |"
+            for runner in runners:
+                for device in devices:
+                    status = results[version][(category, model_name)].get((runner, device), "-")
+                    symbol = status_symbols.get(status, status)
+                    row += f" {symbol} |"
+            lines.append(row)
+
+        lines.append("")
+
+    # Legend
+    lines.append("## Legend")
+    lines.append("")
+    lines.append("| Symbol | Meaning |")
+    lines.append("|--------|---------|")
+    lines.append("| \u2705 | Passed |")
+    lines.append("| \u274c | Failed |")
+    lines.append("| \u23ed\ufe0f | Skipped |")
+    lines.append("| \u26a0\ufe0f | Error (crash/access violation) |")
+    lines.append("| \u2b1c | Not run (collected, but the run ended first) |")
+    lines.append("| \u23f9\ufe0f | Cancelled |")
+    lines.append("| - | Not run / No data |")
+    lines.append("")
+
+    # Job-level summary
+    lines.append("## Job-Level Summary")
+    lines.append("")
+    header = "| Version |"
+    separator = "|---------|"
+    for runner in runners:
+        for device in devices:
+            header += f" {runner}/{device} |"
+            separator += ":---:|"
+    lines.append(header)
+    lines.append(separator)
+
+    for version in sorted({v for v, _, _ in job_conclusions.keys()}):
+        row = f"| {version} |"
+        for runner in runners:
+            for device in devices:
+                conclusion = job_conclusions.get((version, device, runner), "-")
+                symbol = status_symbols.get(conclusion, conclusion)
+                row += f" {symbol} |"
+        lines.append(row)
+    lines.append("")
+
+    # Direct links to jobs
+    lines.append("<details><summary>Job Links</summary>")
+    lines.append("")
+    lines.append("| Job | Conclusion |")
+    lines.append("|-----|-----------|")
+    for job in sorted(jobs, key=lambda j: j["name"]):
+        job_name = job["name"]
+        conclusion = job.get("conclusion", "unknown")
+        symbol = status_symbols.get(conclusion, conclusion)
+        job_url = job.get("html_url", "")
+        lines.append(f"| [{job_name}]({job_url}) | {symbol} {conclusion} |")
+    lines.append("")
+    lines.append("</details>")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def build_xlsx_report(run_info, jobs, job_logs, output_path):
+    """Build an Excel report with a single sheet combining all transformers versions.
+
+    Columns: Transformers Version | Category | Model | MTL/CPU | MTL/GPU | MTL/NPU | LNL/CPU | LNL/GPU | LNL/NPU
+    """
+    try:
+        from openpyxl import Workbook
+        from openpyxl.styles import Alignment, Font, PatternFill
+    except ImportError:
+        print("ERROR: openpyxl is required for --xlsx. Install with: pip install openpyxl", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse results (same logic as build_report)
+    results = defaultdict(lambda: defaultdict(dict))
+    # Map (version, runner, device) -> job URL for hyperlinks
+    job_urls = {}
+
+    for job in jobs:
+        job_name = job["name"]
+        version, device, runner = parse_job_name(job_name)
+        if not version:
+            continue
+
+        job_url = job.get("html_url", "")
+        if job_url:
+            job_urls[(version, runner, device)] = job_url
+
+        log_content = job_logs.get(job["id"])
+        if log_content:
+            test_results = parse_test_results_from_log(log_content)
+            for (class_name, test_method), status in test_results.items():
+                category = extract_test_category(class_name)
+                model_name = extract_model_from_test_name(test_method)
+                if model_name is None:
+                    continue
+                model_key = (category, model_name)
+                results[version][model_key][(runner, device)] = status
+
+    runners = ["MTL", "LNL"]
+    devices = ["CPU", "GPU", "NPU"]
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "GenAI Test Results"
+
+    # Header row
+    headers = ["Transformers Version", "Category", "Model"]
+    for runner in runners:
+        for device in devices:
+            headers.append(f"{runner}/{device}")
+    ws.append(headers)
+
+    # Style header
+    header_font = Font(bold=True)
+    header_fill = PatternFill(start_color="F6F8FA", end_color="F6F8FA", fill_type="solid")
+    for col_idx, cell in enumerate(ws[1], 1):
+        cell.font = header_font
+        cell.fill = header_fill
+        cell.alignment = Alignment(horizontal="center")
+
+    # Status fill colors
+    status_fills = {
+        "passed": PatternFill(start_color="DCFCE7", end_color="DCFCE7", fill_type="solid"),
+        "failed": PatternFill(start_color="FEE2E2", end_color="FEE2E2", fill_type="solid"),
+        "skipped": PatternFill(start_color="FEF9C3", end_color="FEF9C3", fill_type="solid"),
+        "error": PatternFill(start_color="FFEDD5", end_color="FFEDD5", fill_type="solid"),
+        "not_run": PatternFill(start_color="E5E7EB", end_color="E5E7EB", fill_type="solid"),
+    }
+
+    # Build column order for status columns: [(runner, device), ...]
+    col_order = [(runner, device) for runner in runners for device in devices]
+
+    # Data rows - sorted by version, then category, then model
+    row_versions = []  # track version per data row for hyperlink lookup
+    for version in sorted(results.keys()):
+        model_keys = sorted(results[version].keys(), key=lambda x: (x[0], x[1]))
+        for category, model_name in model_keys:
+            row = [version, category, model_name]
+            for runner, device in col_order:
+                status = results[version][(category, model_name)].get((runner, device), "")
+                row.append(status)
+            ws.append(row)
+            row_versions.append(version)
+
+    # Apply status fills, center alignment, and hyperlinks to data cells
+    link_font = Font(underline="single", color="0563C1")
+    for row_idx in range(2, ws.max_row + 1):
+        version = row_versions[row_idx - 2]
+        # Left-align text columns
+        for col_idx in range(1, 4):
+            ws.cell(row=row_idx, column=col_idx).alignment = Alignment(horizontal="left")
+        # Center, color, and hyperlink status columns
+        for col_offset, (runner, device) in enumerate(col_order):
+            col_idx = 4 + col_offset
+            cell = ws.cell(row=row_idx, column=col_idx)
+            cell.alignment = Alignment(horizontal="center")
+            fill = status_fills.get(cell.value)
+            if fill:
+                cell.fill = fill
+            # Add hyperlink to the job run
+            url = job_urls.get((version, runner, device))
+            if url and cell.value:
+                cell.hyperlink = url
+                cell.font = link_font
+
+    # Auto-fit column widths
+    for col in ws.columns:
+        max_length = 0
+        col_letter = col[0].column_letter
+        for cell in col:
+            if cell.value:
+                max_length = max(max_length, len(str(cell.value)))
+        ws.column_dimensions[col_letter].width = min(max_length + 2, 30)
+
+    # Add metadata in a freeze pane note: freeze the header row
+    ws.freeze_panes = "A2"
+
+    wb.save(output_path)
+
+
+def markdown_to_html(md_text):
+    """Convert markdown report to a self-contained HTML page.
+
+    Handles: headings, bold, inline code, tables, links, <details> blocks, and paragraphs.
+    Uses GitHub-like styling with no external dependencies.
+    """
+    html_lines = []
+
+    html_lines.append(
+        """<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenVINO GenAI AIPC Test Report</title>
+<style>
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif; max-width: 1400px; margin: 0 auto; padding: 20px; color: #24292f; background: #fff; }
+h1 { border-bottom: 1px solid #d0d7de; padding-bottom: 8px; }
+h2 { border-bottom: 1px solid #d0d7de; padding-bottom: 6px; margin-top: 24px; }
+h3 { margin-top: 20px; }
+table { border-collapse: collapse; margin: 12px 0; width: auto; }
+th, td { border: 1px solid #d0d7de; padding: 6px 12px; text-align: center; }
+th { background: #f6f8fa; font-weight: 600; }
+td:first-child, td:nth-child(2) { text-align: left; }
+a { color: #0969da; text-decoration: none; }
+a:hover { text-decoration: underline; }
+code { background: #f6f8fa; padding: 2px 6px; border-radius: 3px; font-size: 90%; }
+details { margin: 12px 0; }
+summary { cursor: pointer; font-weight: 600; }
+p { margin: 4px 0; }
+</style>
+</head>
+<body>
+"""
+    )
+
+    in_table = False
+    lines = md_text.split("\n")
+
+    for line in lines:
+        # Details blocks (pass through)
+        if line.strip().startswith("<details"):
+            html_lines.append(line)
+            continue
+        if line.strip() == "</details>":
+            html_lines.append(line)
+            continue
+        if line.strip().startswith("<summary"):
+            html_lines.append(line)
+            continue
+
+        # Table
+        if line.strip().startswith("|"):
+            cells = [c.strip() for c in line.strip().strip("|").split("|")]
+            # Skip separator rows
+            if all(re.match(r"^[-:]+$", c) for c in cells):
+                continue
+            if not in_table:
+                html_lines.append("<table>")
+                # First row is header
+                html_lines.append("<tr>" + "".join(f"<th>{_inline_md(c)}</th>" for c in cells) + "</tr>")
+                in_table = True
+            else:
+                html_lines.append("<tr>" + "".join(f"<td>{_inline_md(c)}</td>" for c in cells) + "</tr>")
+            continue
+        else:
+            if in_table:
+                html_lines.append("</table>")
+                in_table = False
+
+        # Headings
+        heading_match = re.match(r"^(#{1,6})\s+(.+)", line)
+        if heading_match:
+            level = len(heading_match.group(1))
+            text = _inline_md(heading_match.group(2))
+            html_lines.append(f"<h{level}>{text}</h{level}>")
+            continue
+
+        # Empty line
+        if not line.strip():
+            continue
+
+        # Paragraph/text line
+        html_lines.append(f"<p>{_inline_md(line)}</p>")
+
+    if in_table:
+        html_lines.append("</table>")
+
+    html_lines.append("</body>\n</html>")
+    return "\n".join(html_lines)
+
+
+def _inline_md(text):
+    """Convert inline markdown (bold, code, links) to HTML."""
+    # Links: [text](url)
+    text = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r'<a href="\2">\1</a>', text)
+    # Bold: **text**
+    text = re.sub(r"\*\*([^*]+)\*\*", r"<strong>\1</strong>", text)
+    # Inline code: `text`
+    text = re.sub(r"`([^`]+)`", r"<code>\1</code>", text)
+    return text
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate markdown report for GenAI AIPC workflow run")
+    parser.add_argument("--run-id", type=int, help="Specific workflow run ID (default: latest completed)")
+    parser.add_argument("--output", "-o", type=str, help="Output file path (default: stdout)")
+    parser.add_argument("--html", action="store_true", help="Also generate an HTML version of the report")
+    parser.add_argument(
+        "--xlsx",
+        action="store_true",
+        help="Generate an Excel (.xlsx) report with a single sheet and transformers version as column",
+    )
+    parser.add_argument(
+        "--no-logs", action="store_true", help="Skip downloading logs (only show job-level conclusions)"
+    )
+    args = parser.parse_args()
+
+    print("Fetching workflow run info...", file=sys.stderr)
+    run_info = get_latest_run(args.run_id)
+    run_id = run_info["id"]
+    print(
+        f"  Run #{run_info['run_number']} (ID: {run_id}), "
+        f"status: {run_info.get('conclusion', run_info['status'])}",
+        file=sys.stderr,
+    )
+
+    print("Fetching jobs...", file=sys.stderr)
+    jobs = get_jobs(run_id)
+    print(f"  Found {len(jobs)} jobs", file=sys.stderr)
+
+    job_logs = {}
+    if not args.no_logs:
+        print("Downloading job logs...", file=sys.stderr)
+        for i, job in enumerate(jobs):
+            job_name = job["name"]
+            version, device, runner = parse_job_name(job_name)
+            if not version:
+                continue
+            print(f"  [{i+1}/{len(jobs)}] {job_name}...", end="", file=sys.stderr)
+            log = download_job_log(job["id"])
+            if log:
+                job_logs[job["id"]] = log
+                print(" OK", file=sys.stderr)
+            else:
+                print(" no logs", file=sys.stderr)
+
+    print("Generating report...", file=sys.stderr)
+    report = build_report(run_info, jobs, job_logs)
+
+    if args.output:
+        with open(args.output, "w", encoding="utf-8") as f:
+            f.write(report)
+        print(f"Report saved to {args.output}", file=sys.stderr)
+    else:
+        print(report)
+
+    if args.html:
+        html_content = markdown_to_html(report)
+        if args.output:
+            base, _ = os.path.splitext(args.output)
+            html_path = base + ".html"
+        else:
+            html_path = "report.html"
+        with open(html_path, "w", encoding="utf-8") as f:
+            f.write(html_content)
+        print(f"HTML report saved to {html_path}", file=sys.stderr)
+
+    if args.xlsx:
+        if args.output:
+            base, _ = os.path.splitext(args.output)
+            xlsx_path = base + ".xlsx"
+        else:
+            xlsx_path = "report.xlsx"
+        build_xlsx_report(run_info, jobs, job_logs, xlsx_path)
+        print(f"Excel report saved to {xlsx_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/test_openvino_genai_aipc.yml
+++ b/.github/workflows/test_openvino_genai_aipc.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install dependencies
         shell: cmd
         run: |
-          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install "optimum-intel[tests] @ git+https://github.com/huggingface/optimum-intel.git" "transformers==${{ matrix.transformers-version }}"
+          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install ".[tests]" "transformers==${{ matrix.transformers-version }}"
           %RUNNER_TEMP%\venv\Scripts\python -m uv pip install pytest-xdist
 
       # Workaround for internlm tokenizer issue with sentencepiece>=0.3
@@ -76,7 +76,7 @@ jobs:
         if: inputs.openvino_version == '2026.4-release-candidate'
         shell: cmd
         run: |
-          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install --pre --upgrade "openvino-genai>=2026.4.0.0,<2026.5.0.0" --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
+          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install --pre --upgrade "openvino-genai>=2026.4.0.0rc1,<2026.5.0.0" --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
 
       - name: Pip freeze
         shell: cmd
@@ -94,7 +94,7 @@ jobs:
       # pytest-xdist with -n 1 runs the tests serially in a worker process: a native crash (access violation) is
       # reported as a single test failure and the remaining tests continue in a fresh worker.
       # The restart budget is deliberately low so a systematically crashing environment aborts
-      # the run instead of restarting its way through the whole suite. This is useful or Windows.
+      # the run instead of restarting its way through the whole suite. This is useful on Windows.
       - name: Test with Pytest
         shell: cmd
         env:

--- a/.github/workflows/test_openvino_genai_aipc.yml
+++ b/.github/workflows/test_openvino_genai_aipc.yml
@@ -1,0 +1,143 @@
+name: OpenVINO GenAI - CPU, GPU, NPU (Self-Hosted)
+
+on:
+  workflow_dispatch:
+    inputs:
+      openvino_version:
+        description: "OpenVINO version to test"
+        required: true
+        default: "release"
+        type: choice
+        options:
+          - release
+          - nightly
+          # The latest Release Candidate cannot easily be resolved dynamically; pin the 2026.4 line for now.
+          - 2026.4-release-candidate
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  UV_TORCH_BACKEND: cpu
+  TRANSFORMERS_IS_CI: true
+  PYTHONUNBUFFERED: "1"
+  HF_TOKEN: ${{ secrets.HF_HUB_READ_TOKEN }}
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        transformers-version: ["4.57.6", "5.0.0", "5.5.*"]
+        device: ["GPU", "NPU", "CPU"]
+        runner: ["MTL", "LNL"]
+    runs-on: [self-hosted, "${{ matrix.runner }}"]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Create virtual environment
+        shell: cmd
+        run: |
+          python -m venv %RUNNER_TEMP%\venv
+          %RUNNER_TEMP%\venv\Scripts\python -m pip install --upgrade pip uv
+
+      - name: Install dependencies
+        shell: cmd
+        run: |
+          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install "optimum-intel[tests] @ git+https://github.com/huggingface/optimum-intel.git" "transformers==${{ matrix.transformers-version }}"
+          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install pytest-xdist
+
+      # Workaround for internlm tokenizer issue with sentencepiece>=0.3
+      - name: Pin sentencepiece for transformers 4.57.6
+        if: matrix.transformers-version == '4.57.6'
+        shell: cmd
+        run: |
+          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install "sentencepiece==0.2.1"
+
+      - name: Install OpenVINO GenAI nightly
+        if: inputs.openvino_version == 'nightly'
+        shell: cmd
+        run: |
+          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install --pre --upgrade openvino-genai --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
+
+      - name: Install OpenVINO GenAI Release Candidate
+        # Install the latest OpenVINO release between version limits. If there is a Release Candidate matching the lower bound version, it will be installed.
+        if: inputs.openvino_version == '2026.4-release-candidate'
+        shell: cmd
+        run: |
+          %RUNNER_TEMP%\venv\Scripts\python -m uv pip install --pre --upgrade "openvino-genai>=2026.4.0.0,<2026.5.0.0" --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
+
+      - name: Pip freeze
+        shell: cmd
+        run: |
+          %RUNNER_TEMP%\venv\Scripts\python -m uv pip freeze
+
+      - name: Verify imports
+        shell: cmd
+        run: |
+          %RUNNER_TEMP%\venv\Scripts\python -c "import openvino_genai; print('openvino_genai', openvino_genai.__version__)"
+          %RUNNER_TEMP%\venv\Scripts\python -c "import openvino; print('openvino', openvino.__version__)"
+          %RUNNER_TEMP%\venv\Scripts\python -c "import transformers; print('transformers', transformers.__version__)"
+          %RUNNER_TEMP%\venv\Scripts\python -c "import torch; print('torch', torch.__version__)"
+
+      # pytest-xdist with -n 1 runs the tests serially in a worker process: a native crash (access violation) is
+      # reported as a single test failure and the remaining tests continue in a fresh worker.
+      # The restart budget is deliberately low so a systematically crashing environment aborts
+      # the run instead of restarting its way through the whole suite. This is useful or Windows.
+      - name: Test with Pytest
+        shell: cmd
+        env:
+          OPENVINO_TEST_DEVICE: ${{ matrix.device }}
+        run: |
+          echo Running tests on device: %OPENVINO_TEST_DEVICE%
+          %RUNNER_TEMP%\venv\Scripts\python -m pytest tests/openvino/test_genai.py -rpFs --durations=0 --log-cli-level info -n 1 --max-worker-restart 10
+
+  report:
+    if: always()
+    needs: test
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install requests openpyxl
+
+      - name: Generate report
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python .github/workflows/generate_genai_report.py \
+            --run-id ${{ github.run_id }} \
+            --html \
+            --xlsx \
+            --output optimum-genai-test-report.md
+
+      - name: Upload report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: optimum-genai-test-report
+          path: |
+            optimum-genai-test-report.md
+            optimum-genai-test-report.html
+            optimum-genai-test-report.xlsx

--- a/tests/openvino/conftest.py
+++ b/tests/openvino/conftest.py
@@ -6,12 +6,13 @@ import pytest
 def pytest_report_header(config):
     # Must live in conftest: pytest-xdist does not forward worker logs, so this only
     # reaches the terminal from the controller process.
+    import openvino as ov
+    import transformers
+
     device = os.getenv("OPENVINO_TEST_DEVICE", "CPU")
-    header = f"OpenVINO test device: {device}"
+    header = f"OpenVINO {ov.__version__} Transformers {transformers.__version__} Device: {device}"
     if device == "NPU":
         try:
-            import openvino as ov
-
             header += f", NPU driver version: {ov.Core().get_property('NPU', 'NPU_DRIVER_VERSION')}"
         except Exception as exception:
             header += f", NPU driver version unavailable: {exception}"

--- a/tests/openvino/conftest.py
+++ b/tests/openvino/conftest.py
@@ -1,4 +1,21 @@
+import os
+
 import pytest
+
+
+def pytest_report_header(config):
+    # Must live in conftest: pytest-xdist does not forward worker logs, so this only
+    # reaches the terminal from the controller process.
+    device = os.getenv("OPENVINO_TEST_DEVICE", "CPU")
+    header = f"OpenVINO test device: {device}"
+    if device == "NPU":
+        try:
+            import openvino as ov
+
+            header += f", NPU driver version: {ov.Core().get_property('NPU', 'NPU_DRIVER_VERSION')}"
+        except Exception as exception:
+            header += f", NPU driver version unavailable: {exception}"
+    return header
 
 
 @pytest.hookimpl(tryfirst=True)

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -377,8 +377,6 @@ class VLMPipelineTestCase(unittest.TestCase):
         if TEST_NAME_TO_MODEL_TYPE.get(arch, arch) in get_supported_model_for_library("transformers")
     )
 
-    REMOTE_CODE_MODELS = _test_seq2seq.OVModelForVisualCausalLMIntegrationTest.REMOTE_CODE_MODELS
-
     GEN_KWARGS = {
         "max_new_tokens": 10,
         "min_new_tokens": 10,
@@ -420,7 +418,7 @@ class VLMPipelineTestCase(unittest.TestCase):
             from transformers import Qwen2VLForConditionalGeneration
 
             return Qwen2VLForConditionalGeneration
-        elif model_arch in self.REMOTE_CODE_MODELS:
+        elif model_arch in REMOTE_CODE_MODELS:
             from transformers import AutoModel
 
             return AutoModel
@@ -431,7 +429,7 @@ class VLMPipelineTestCase(unittest.TestCase):
     def test_compare_outputs(self, model_arch):
         logger.info("Testing %s on device=%s", model_arch, OPENVINO_DEVICE)
         model_id = MODEL_NAMES[model_arch]
-        trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
+        trust_remote_code = model_arch in REMOTE_CODE_MODELS
 
         set_seed(42)
         transformers_class = self._get_model_class(model_arch)

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -1,16 +1,19 @@
 """
 Test OpenVINO GenAI inference on models exported with optimum-intel
 
-- OpenVINO device can be set by environment variable OPENVINO_TEST_DEVICE
-  - For NPU, Text2Speech test is not supported; for LLM and VLM only a limited list of models is currently supported. This will be expanded. Only the latest supported transformers/OpenVINO/optimum-intel versions are tested.
-  - For GPU, there are known failed tests on some GPUs. This is under investigation.
+- OpenVINO device can be set by setting environment variable OPENVINO_TEST_DEVICE to CPU, GPU or NPU
+  - For NPU, Text2Speech test is not supported; for LLM and VLM only a limited list of models is currently supported.
+    This will be expanded.
 """
 
 # ruff: noqa: I001  # Avoid black/ruff conflict: ruff isort wants 2 blank lines after imports, black collapses to 1
 
 import gc
+import logging
 import os
+import psutil
 import shutil
+import sys
 import tempfile
 import traceback as traceback_mod
 import unittest
@@ -40,6 +43,8 @@ from transformers import (
     AutoTokenizer,
     set_seed,
 )
+import test_decoder as _test_decoder
+import test_seq2seq as _test_seq2seq
 from utils_tests import (
     DFLASH_MODELS,
     DFLASH_VLM_MODELS,
@@ -56,6 +61,7 @@ from utils_tests import (
 )
 
 from optimum.exporters.openvino import main_export
+from optimum.intel import OVConfig
 from optimum.intel.openvino import (
     OVModelForCausalLM,
     OVModelForSpeechSeq2Seq,
@@ -66,10 +72,66 @@ from optimum.intel.openvino.modeling_visual_language import MODEL_TYPE_TO_CLS_MA
 from optimum.intel.utils.import_utils import is_openvino_version
 from optimum.utils import is_transformers_version
 
-# NPU does not support f32 inference
-TEST_CONFIG = {"CACHE_DIR": ""} if OPENVINO_DEVICE == "NPU" else {**F32_CONFIG, "CACHE_DIR": ""}
+logger = logging.getLogger(__name__)
+
+if OPENVINO_DEVICE == "NPU":
+    TEST_CONFIG = {"CACHE_DIR": ""}
+else:
+    TEST_CONFIG = {**F32_CONFIG, "CACHE_DIR": ""}
+if OPENVINO_DEVICE == "CPU":
+    TEST_CONFIG["INFERENCE_NUM_THREADS"] = 1  # TODO, workaround for crashes
 
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+
+TOP_K_TOLERANCE = 3  # Accept divergences where the alternative token is in the top-K of the reference logits
+
+
+def _assert_tokens_match(test_case, ref_ids, ref_top_k, test_ids, ref_label, test_label):
+    """Assert that test_ids match ref_ids, tolerating near-tied logit divergences.
+
+    When tokens differ at a position, checks whether the test token ranks within
+    TOP_K_TOLERANCE of the reference logit distribution at that step. If it does,
+    it means the model was ambivalent (near-tied logits) and the divergence is
+    acceptable. Only fails if a test token is far from the reference top-K.
+
+    After the first divergence, subsequent tokens are not compared (since the
+    autoregressive cascade makes them meaningless).
+
+    Args:
+        test_case: unittest.TestCase instance (for assertions)
+        ref_ids: list of token IDs from the reference backend
+        ref_top_k: list of top-K token ID lists (one per generated position) from the reference;
+                   can be None if scores unavailable (falls back to strict equality)
+        test_ids: list of token IDs from the backend under test
+        ref_label: name of reference backend (e.g. "Transformers")
+        test_label: name of test backend (e.g. "OpenVINO GenAI")
+    """
+    if ref_ids == test_ids:
+        return
+
+    if ref_top_k is None:
+        test_case.assertEqual(ref_ids, test_ids, f"{ref_label} ids and {test_label} ids are not the same")
+        return
+
+    for pos, (ref_tok, test_tok) in enumerate(zip(ref_ids, test_ids)):
+        if ref_tok == test_tok:
+            continue
+
+        top_k_tokens = ref_top_k[pos]
+
+        test_case.assertIn(
+            test_tok,
+            top_k_tokens,
+            f"{ref_label} vs {test_label}: token mismatch at position {pos}. "
+            f"{ref_label} chose {ref_tok}, {test_label} chose {test_tok}, "
+            f"but {test_tok} is not in {ref_label}'s top-{TOP_K_TOLERANCE} "
+            f"(top-{TOP_K_TOLERANCE}: {top_k_tokens}). "
+            f"This indicates a real inference divergence, not a near-tied logit flip.",
+        )
+        # After first divergence, the autoregressive cascade makes further comparisons meaningless
+        break
+
 
 _temp_dirs = []  # Collect temp dirs for batch cleanup after all tests finish
 
@@ -123,71 +185,56 @@ def temp_dir_fixture(request):
     tmp_path = tempfile.mkdtemp()
     request.instance.temp_dir = tmp_path
     yield
+    gc.collect()
     try:
         shutil.rmtree(tmp_path)
     except (PermissionError, OSError):
         _temp_dirs.append(tmp_path)
 
 
+_GENAI_LLM_UNSUPPORTED_ARCHITECTURES = (
+    # seq2seq models — not supported by LLMPipeline
+    "bart",
+    "bigbird_pegasus",
+    "blenderbot",
+    "blenderbot-small",
+    "marian",
+    "mbart",
+    "pegasus",
+    # SSM / hybrid models
+    "mamba",
+    "falcon_mamba",
+    "granitemoehybrid",
+    "zamba2",
+    # not supported by GenAI
+    "afmoe",
+    "biogpt",
+    "gemma3n_text",
+    # tiny test model issues
+    "gpt_neo",  # missing generation_config.json
+    "mpt",  # output mismatch with GenAI
+    # quantized variant tested via gpt_oss
+    "gpt_oss_mxfp4",
+)
+
+
 class LLMPipelineTestCase(unittest.TestCase):
-    ALL_SUPPORTED_ARCHITECTURES = (
-        "gpt_bigcode",
-        "bloom",
-        "codegen",
-        "gpt2",
-        "gptj",
-        "gpt_neox",
-        "llama",
-        "mistral",
-        "mixtral",
-        "phi",
-        "falcon",
-        "persimmon",
-        "xglm",
-        "gemma",
-        "olmo",
-        "stablelm",
-        "starcoder2",
-        "cohere",
-        "qwen2",
-        "qwen2_moe",
-        "gemma2",
-        "granite",
-        "granitemoe",
-        "glm",
-        "mistral-nemo",
-        "opt",
-        "cohere2",
-        "gemma3_text",
-        "qwen3",
-        "qwen3_moe",
-        "glm4",
-        "arcee",
-        "gpt_oss",
-        "smollm3",
-        "phi3",
-        "phimoe",
-        "exaone4",
-        "exaone",
-        "decilm",
-        "internlm2",
-        "orion",
-        "aquila2",
-        "jais",
-        "aquila",
-        "internlm",
-        "dbrx",
+    ALL_SUPPORTED_ARCHITECTURES = tuple(
+        arch
+        for arch in _test_decoder.OVModelForCausalLMIntegrationTest.SUPPORTED_ARCHITECTURES
+        if arch not in _GENAI_LLM_UNSUPPORTED_ARCHITECTURES
     )
 
     # remote modeling incompatible with v5 but not filtered as CodeGenOpenVINOConfig is compatible (codegen)
     if is_transformers_version("<", "5"):
         ALL_SUPPORTED_ARCHITECTURES += ("codegen2",)
 
-    # to be expanded, other architectures work on NPU too
-    # qwen2, phi and phi3 tests are flaky on NPU, not including for now
-    NPU_SUPPORTED_ARCHITECTURES = ("gpt2", "glm", "opt", "qwen3_moe", "gpt_oss")
+    # To be expanded, other architectures work on NPU too.
+    # lfm2 and qwen3 are kept here on purpose although their tiny models currently crash on NPU:
+    # the crash is what we want to keep track of. phi3 is left out because its tiny model crashes
+    # with transformers 5.5 only (no issue with 5.0).
+    NPU_SUPPORTED_ARCHITECTURES = ("glm", "gptj", "qwen3_moe", "gpt_oss", "gemma2", "lfm2", "qwen3")
 
-    # for now we do not test NPU with old transformers versions
     SUPPORTED_ARCHITECTURES = NPU_SUPPORTED_ARCHITECTURES if OPENVINO_DEVICE == "NPU" else ALL_SUPPORTED_ARCHITECTURES
     # filter architectures depending on min/max transformers supported versions
     SUPPORTED_ARCHITECTURES = tuple(
@@ -196,33 +243,18 @@ class LLMPipelineTestCase(unittest.TestCase):
         if TEST_NAME_TO_MODEL_TYPE.get(arch, arch) in get_supported_model_for_library("transformers")
     )
 
-    REMOTE_CODE_MODELS = (
-        "minicpm",
-        "jais",
-        "qwen",
-        "internlm2",
-        "orion",
-        "aquila",
-        "aquila2",
-        "internlm",
-        "codegen2",
-        "arctic",
-        "chatglm4",
-        "exaone",
-        "exaone4",
-        "decilm",
-        "minicpm3",
-        "deepseek",
-    )
     NO_CACHE_MODELS = (  # mostly remote that are broken with past key values
         "aquila",
         "aquila2",
+        "baichuan2",
+        "baichuan2-13b",
         "decilm",
         "internlm",
         "internlm2",
         "orion",
         "jais",
         "qwen",
+        "xverse",
     )
 
     GEN_KWARGS = {
@@ -232,87 +264,110 @@ class LLMPipelineTestCase(unittest.TestCase):
         "num_beams": 1,
     }
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
     def test_compare_outputs(self, model_arch):
-        if model_arch in (
-            "xglm",
-            "persimmon",
-        ) and is_openvino_version(">=", "2026.1.0"):
-            self.skipTest("CVS-185350: OpenVINO 2026.1.0 inference results mismatch")
-        if (
-            model_arch in ("mixtral", "qwen2_moe", "qwen3_moe", "gpt_oss")
-            and is_openvino_version(">=", "2026.1.0")
-            and is_transformers_version(">=", "5.0.0")
-        ):
-            self.skipTest("CVS-185350: OpenVINO 2026.1.0 inference results mismatch")
-
+        logger.info("Testing %s on device=%s", model_arch, OPENVINO_DEVICE)
         model_id = MODEL_NAMES[model_arch]
         use_cache = model_arch not in self.NO_CACHE_MODELS
-        trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
-
-        set_seed(42)
-        transformers_model = AutoModelForCausalLM.from_pretrained(model_id, trust_remote_code=trust_remote_code).eval()
-
-        set_seed(42)
-        main_export(
-            model_name_or_path=model_id,
-            task="text-generation-with-past",
-            trust_remote_code=trust_remote_code,
-            convert_tokenizer=True,
-            output=self.temp_dir,
-        )
-        genai_model = LLMPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
-
+        trust_remote_code = model_arch in REMOTE_CODE_MODELS
         prompt = "Paris is the capital of"
-        tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
-        inputs = tokenizer(prompt, return_tensors="pt")
-        input_len = inputs["input_ids"].shape[-1]
 
-        with torch.no_grad():
-            transformers_ids = transformers_model.generate(**inputs, use_cache=use_cache, **self.GEN_KWARGS)
-            transformers_ids = transformers_ids.squeeze()[input_len:]
+        # BitNet uses torch.compile for custom ternary weight ops, which requires a C++ compiler (cl.exe on Windows)
+        if model_arch == "bitnet":
+            torch._dynamo.config.disable = True
 
-        if OPENVINO_DEVICE != "NPU":
-            optimum_model = OVModelForCausalLM.from_pretrained(
-                self.temp_dir, trust_remote_code=trust_remote_code, device=OPENVINO_DEVICE, ov_config=TEST_CONFIG
+        transformers_model = optimum_model = genai_model = None
+        try:
+            set_seed(42)
+            transformers_model = AutoModelForCausalLM.from_pretrained(
+                model_id, trust_remote_code=trust_remote_code
+            ).eval()
+
+            # fixed in https://github.com/huggingface/transformers/pull/43445, still needed for v5.0
+            if model_arch == "phimoe" and is_transformers_version("==", "5.0"):
+                transformers_model.model.rotary_emb.short_mscale = transformers_model.config.rope_parameters[
+                    "short_mscale"
+                ]
+                transformers_model.model.rotary_emb.long_mscale = transformers_model.config.rope_parameters[
+                    "long_mscale"
+                ]
+
+            set_seed(42)
+            # For NPU, convert to fp16 explicitly
+            export_ov_config = OVConfig(dtype="fp16") if OPENVINO_DEVICE == "NPU" else None
+            main_export(
+                model_name_or_path=model_id,
+                task="text-generation-with-past",
+                trust_remote_code=trust_remote_code,
+                convert_tokenizer=True,
+                output=self.temp_dir,
+                ov_config=export_ov_config,
             )
-            optimum_ids = optimum_model.generate(**inputs, use_cache=use_cache, **self.GEN_KWARGS)
-            optimum_ids = optimum_ids.squeeze()[input_len:]
-            self.assertEqual(
-                transformers_ids.squeeze().tolist(),
-                optimum_ids.squeeze().tolist(),
-                "Transformers ids and Optimum ids are not the same",
-            )
+            genai_model = LLMPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
 
-        genai_ids = genai_model(
-            ov.Tensor(inputs["input_ids"].numpy()), apply_chat_template=False, **self.GEN_KWARGS
-        ).tokens[0]
+            tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+            inputs = tokenizer(prompt, return_tensors="pt")
+            input_len = inputs["input_ids"].shape[-1]
 
-        del genai_model
-        del transformers_model
-        if OPENVINO_DEVICE != "NPU":
-            del optimum_model
-        gc.collect()
+            with torch.no_grad():
+                output = transformers_model.generate(
+                    **inputs, use_cache=use_cache, output_scores=True, return_dict_in_generate=True, **self.GEN_KWARGS
+                )
+                transformers_ids = output.sequences.squeeze()[input_len:].tolist()
+                transformers_top_k = [s.squeeze(0).topk(TOP_K_TOLERANCE).indices.tolist() for s in output.scores]
+            transformers_model = None
 
-        self.assertEqual(
-            transformers_ids.tolist(), genai_ids, "Transformers ids and OpenVINO GenAI ids are not the same"
-        )
+            if OPENVINO_DEVICE != "NPU":
+                optimum_model = OVModelForCausalLM.from_pretrained(
+                    self.temp_dir, trust_remote_code=trust_remote_code, device=OPENVINO_DEVICE, ov_config=TEST_CONFIG
+                )
+                optimum_ids = optimum_model.generate(**inputs, use_cache=use_cache, **self.GEN_KWARGS)
+                optimum_ids = optimum_ids.squeeze()[input_len:].tolist()
+                optimum_model = None
+                _assert_tokens_match(
+                    self, transformers_ids, transformers_top_k, optimum_ids, "Transformers", "Optimum"
+                )
+
+            mem = psutil.virtual_memory()
+            logger.info(f"Memory before GenAI call: {mem.percent}% used, {mem.available // (1024**2)} MB available")
+            genai_ids = genai_model(
+                ov.Tensor(inputs["input_ids"].numpy()), apply_chat_template=False, **self.GEN_KWARGS
+            ).tokens[0]
+        finally:
+            # Release on failure too: a failing test's traceback keeps its frame locals alive for the
+            # rest of the session, which would leave OpenVINO objects (and their file handles) around.
+            transformers_model = optimum_model = genai_model = None
+            gc.collect()
+
+        _assert_tokens_match(self, transformers_ids, transformers_top_k, genai_ids, "Transformers", "OpenVINO GenAI")
+
+
+_GENAI_VLM_UNSUPPORTED_ARCHITECTURES = (
+    "gemma3n",  # Supported from 2026.3.0 but known issue
+    "idefics3",
+    "got_ocr2",
+    "internvl_chat",  # AssertionError in model's remote code during inference
+    "llama4",
+    "maira2",
+    "minicpmv",  # transformers output is empty with tiny model on transformers 4.57
+    "smolvlm",
+    "videochat_flash_qwen",  # GenAI requires video input; image-only not supported
+    "qwen3_omni_moe",
+    "mistral3",
+)
 
 
 class VLMPipelineTestCase(unittest.TestCase):
-    ALL_SUPPORTED_ARCHITECTURES = (
-        "llava_next",
-        # "minicpmv", # output is truncated for some reason
-        "qwen2_vl",
-        "llava_next_mistral",
-        "qwen2_5_vl",
-        "gemma3",
-        "llava",
-        "llava_next_video",
+    GENAI_UNSUPPORTED_ARCHITECTURES = _GENAI_VLM_UNSUPPORTED_ARCHITECTURES
+
+    ALL_SUPPORTED_ARCHITECTURES = tuple(
+        arch
+        for arch in _test_seq2seq.OVModelForVisualCausalLMIntegrationTest.SUPPORTED_ARCHITECTURES
+        if arch not in _GENAI_VLM_UNSUPPORTED_ARCHITECTURES
     )
 
     # for now we do not test NPU with old transformers versions
-    NPU_SUPPORTED_ARCHITECTURES = ("qwen2_vl", "qwen2_5_vl")
+    NPU_SUPPORTED_ARCHITECTURES = ("qwen2_vl", "qwen2_5_vl", "gemma3", "gemma4")
 
     SUPPORTED_ARCHITECTURES = NPU_SUPPORTED_ARCHITECTURES if OPENVINO_DEVICE == "NPU" else ALL_SUPPORTED_ARCHITECTURES
     # filter architectures depending on min/max transformers supported versions
@@ -322,13 +377,7 @@ class VLMPipelineTestCase(unittest.TestCase):
         if TEST_NAME_TO_MODEL_TYPE.get(arch, arch) in get_supported_model_for_library("transformers")
     )
 
-    REMOTE_CODE_MODELS = (
-        "minicpmv",
-        "minicpmo",
-        "llava-qwen2",
-        "phi3_v",
-        "phi4mm",
-    )
+    REMOTE_CODE_MODELS = _test_seq2seq.OVModelForVisualCausalLMIntegrationTest.REMOTE_CODE_MODELS
 
     GEN_KWARGS = {
         "max_new_tokens": 10,
@@ -347,7 +396,10 @@ class VLMPipelineTestCase(unittest.TestCase):
             "mistral3",
             "qwen2_vl",
             "qwen2_5_vl",
+            "qwen3_vl",
             "gemma3",
+            "gemma3n",
+            "llama4",
         }:
             from transformers import AutoModelForImageTextToText
 
@@ -368,80 +420,107 @@ class VLMPipelineTestCase(unittest.TestCase):
             from transformers import Qwen2VLForConditionalGeneration
 
             return Qwen2VLForConditionalGeneration
+        elif model_arch in self.REMOTE_CODE_MODELS:
+            from transformers import AutoModel
+
+            return AutoModel
         else:
             return AutoModelForCausalLM
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
     def test_compare_outputs(self, model_arch):
+        logger.info("Testing %s on device=%s", model_arch, OPENVINO_DEVICE)
         model_id = MODEL_NAMES[model_arch]
         trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
 
         set_seed(42)
         transformers_class = self._get_model_class(model_arch)
-        transformers_model = transformers_class.from_pretrained(model_id, trust_remote_code=trust_remote_code).eval()
 
-        set_seed(42)
-        main_export(
-            model_name_or_path=model_id,
-            trust_remote_code=trust_remote_code,
-            task="image-text-to-text",
-            convert_tokenizer=True,
-            output=self.temp_dir,
-        )
-        genai_model = VLMPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
+        transformers_model = optimum_model = genai_model = None
+        try:
+            transformers_model = transformers_class.from_pretrained(
+                model_id, trust_remote_code=trust_remote_code
+            ).eval()
 
-        image = self.IMAGE
-        prompt = "A photo of a cat sitting on a"
-        config = AutoConfig.from_pretrained(model_id, trust_remote_code=trust_remote_code)
-        tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
-        processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trust_remote_code)
-        # On NPU, the optimum models cannot be loaded, so we use the preprocess_inputs method from the model class directly
-        model_cls = MODEL_TYPE_TO_CLS_MAPPING[config.model_type]
-        inputs = model_cls.preprocess_inputs(
-            text=prompt, image=image, tokenizer=tokenizer, processor=processor, config=config
-        )
-        full_prompt = tokenizer.decode(inputs["input_ids"][0], skip_special_tokens=True)
-
-        with torch.no_grad():
-            transformers_ids = transformers_model.generate(**inputs, **self.GEN_KWARGS)
-        transformers_output = tokenizer.decode(transformers_ids[0], skip_special_tokens=True)
-        transformers_output = transformers_output[len(full_prompt) :].strip()
-
-        if OPENVINO_DEVICE != "NPU":
-            optimum_model = OVModelForVisualCausalLM.from_pretrained(
-                self.temp_dir, device=OPENVINO_DEVICE, ov_config=TEST_CONFIG, trust_remote_code=trust_remote_code
+            set_seed(42)
+            # For NPU, convert to fp16 explicitly
+            export_ov_config = OVConfig(dtype="fp16") if OPENVINO_DEVICE == "NPU" else None
+            main_export(
+                model_name_or_path=model_id,
+                trust_remote_code=trust_remote_code,
+                task="image-text-to-text",
+                convert_tokenizer=True,
+                output=self.temp_dir,
+                ov_config=export_ov_config,
             )
-            optimum_ids = optimum_model.generate(**inputs, **self.GEN_KWARGS)
-            optimum_output = tokenizer.decode(optimum_ids[0], skip_special_tokens=True)
-            optimum_output = optimum_output[len(full_prompt) :].strip()
-            self.assertTrue(optimum_output)
-            self.assertEqual(transformers_output, optimum_output, "Transformers and Optimum outputs are not the same")
+            genai_model = VLMPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
 
-        # apply_chat_template is set to True because it is also set in preprocess_inputs()
-        genai_output = genai_model.generate(
-            prompt, images=[ov.Tensor(np.array(image))], ignore_eos=True, apply_chat_template=True, **self.GEN_KWARGS
-        ).texts[0]
+            image = self.IMAGE
+            prompt = "A photo of a cat sitting on a"
+            config = AutoConfig.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+            # For remote code models, transformers sets _name_or_path to the local snapshot path which may
+            # be incomplete (missing auxiliary .py files). Reset to the hub ID so the model can download them.
+            if trust_remote_code:
+                config._name_or_path = model_id
+            tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+            processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=trust_remote_code)
+            # On NPU, the optimum models cannot be loaded, so we use the preprocess_inputs method
+            # from the model class directly
+            model_cls = MODEL_TYPE_TO_CLS_MAPPING[config.model_type]
+            inputs = model_cls.preprocess_inputs(
+                text=prompt, image=image, tokenizer=tokenizer, processor=processor, config=config
+            )
+            input_len = inputs["input_ids"].shape[-1]
+            with torch.no_grad():
+                output = transformers_model.generate(
+                    **inputs, output_scores=True, return_dict_in_generate=True, **self.GEN_KWARGS
+                )
+                transformers_ids = output.sequences.squeeze()[input_len:].tolist()
+                transformers_top_k = [s.squeeze(0).topk(TOP_K_TOLERANCE).indices.tolist() for s in output.scores]
+            transformers_output = tokenizer.decode(transformers_ids, skip_special_tokens=True).strip()
+            transformers_model = None
 
-        del genai_model
-        del transformers_model
-        if OPENVINO_DEVICE != "NPU":
-            del optimum_model
-        gc.collect()
+            if OPENVINO_DEVICE != "NPU":
+                optimum_model = OVModelForVisualCausalLM.from_pretrained(
+                    self.temp_dir, device=OPENVINO_DEVICE, ov_config=TEST_CONFIG, trust_remote_code=trust_remote_code
+                )
+                optimum_ids = optimum_model.generate(**inputs, **self.GEN_KWARGS)
+                optimum_ids = optimum_ids.squeeze()[input_len:].tolist()
+                optimum_model = None
+                self.assertTrue(optimum_ids)
+                _assert_tokens_match(
+                    self, transformers_ids, transformers_top_k, optimum_ids, "Transformers", "Optimum"
+                )
+
+            # apply_chat_template is set to True because it is also set in preprocess_inputs()
+            genai_output = genai_model.generate(
+                prompt,
+                images=[ov.Tensor(np.array(image))],
+                ignore_eos=True,
+                apply_chat_template=True,
+                **self.GEN_KWARGS,
+            ).texts[0]
+        finally:
+            # Release on failure too: a failing test's traceback keeps its frame locals alive for the
+            # rest of the session, which would leave OpenVINO objects (and their file handles) around.
+            transformers_model = optimum_model = genai_model = None
+            gc.collect()
 
         # assert they are not empty
         self.assertTrue(transformers_output)
         self.assertTrue(genai_output)
 
-        # compare outputs
-        self.assertEqual(transformers_output, genai_output, "Transformers and OpenVINO GenAI outputs are not the same")
+        # GenAI VLM only returns text; compare decoded outputs
+        if transformers_output != genai_output:
+            # Tokenize both to find divergence point and check against top-K
+            genai_ids = tokenizer.encode(genai_output, add_special_tokens=False)
+            _assert_tokens_match(
+                self, transformers_ids, transformers_top_k, genai_ids, "Transformers", "OpenVINO GenAI"
+            )
 
 
-@pytest.mark.skipif(
-    OPENVINO_DEVICE == "NPU" and is_transformers_version(">=", "5.0"),
-    reason="Speech2Text test on NPU is only supported with transformers < 5.0",
-)
 class Speech2TextPipelineTestCase(unittest.TestCase):
-    SUPPORTED_ARCHITECTURES = ("whisper",)
+    SUPPORTED_ARCHITECTURES = _test_seq2seq.OVModelForSpeechSeq2SeqIntegrationTest.SUPPORTED_ARCHITECTURES
 
     GEN_KWARGS = {
         "max_new_tokens": 10,
@@ -456,54 +535,63 @@ class Speech2TextPipelineTestCase(unittest.TestCase):
         audio = 0.5 * np.sin(2 * np.pi * 220 * t)
         return audio
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
     def test_compare_outputs(self, model_arch):
+        logger.info("Testing %s on device=%s", model_arch, OPENVINO_DEVICE)
         model_id = MODEL_NAMES[model_arch]
 
-        set_seed(42)
-        transformers_model = AutoModelForSpeechSeq2Seq.from_pretrained(model_id).eval()
+        transformers_model = optimum_model = genai_model = None
+        try:
+            set_seed(42)
+            transformers_model = AutoModelForSpeechSeq2Seq.from_pretrained(model_id).eval()
 
-        set_seed(42)
-        main_export(
-            model_name_or_path=model_id,
-            task="automatic-speech-recognition-with-past",
-            convert_tokenizer=True,
-            output=self.temp_dir,
-        )
-
-        genai_model = WhisperPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
-
-        audio = self._get_audio()
-        processor = AutoProcessor.from_pretrained(model_id)
-        tokenizer = AutoTokenizer.from_pretrained(model_id)
-        inputs = processor(audio, sampling_rate=16000, return_tensors="pt")
-
-        with torch.no_grad():
-            transformers_ids = transformers_model.generate(**inputs, **self.GEN_KWARGS)
-            transformers_output = tokenizer.decode(transformers_ids[0], skip_special_tokens=True)
-
-        if OPENVINO_DEVICE != "NPU":
-            optimum_model = OVModelForSpeechSeq2Seq.from_pretrained(
-                self.temp_dir, device=OPENVINO_DEVICE, ov_config=TEST_CONFIG
+            set_seed(42)
+            # For NPU, convert to fp16 explicitly
+            export_ov_config = OVConfig(dtype="fp16") if OPENVINO_DEVICE == "NPU" else None
+            main_export(
+                model_name_or_path=model_id,
+                task="automatic-speech-recognition-with-past",
+                convert_tokenizer=True,
+                output=self.temp_dir,
+                ov_config=export_ov_config,
             )
-            optimum_ids = optimum_model.generate(**inputs, **self.GEN_KWARGS)
-            optimum_output = tokenizer.decode(optimum_ids[0], skip_special_tokens=True)
-            self.assertEqual(transformers_output, optimum_output)
 
-        genai_output = genai_model.generate(inputs["input_features"].flatten().tolist(), **self.GEN_KWARGS).texts[0]
+            genai_model = WhisperPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
 
-        del genai_model
-        del transformers_model
-        if OPENVINO_DEVICE != "NPU":
-            del optimum_model
-        gc.collect()
+            audio = self._get_audio()
+            processor = AutoProcessor.from_pretrained(model_id)
+            tokenizer = AutoTokenizer.from_pretrained(model_id)
+            inputs = processor(audio, sampling_rate=16000, return_tensors="pt")
+
+            with torch.no_grad():
+                transformers_ids = transformers_model.generate(**inputs, **self.GEN_KWARGS)
+                transformers_output = tokenizer.decode(transformers_ids[0], skip_special_tokens=True)
+            transformers_model = None
+
+            if OPENVINO_DEVICE != "NPU":
+                optimum_model = OVModelForSpeechSeq2Seq.from_pretrained(
+                    self.temp_dir, device=OPENVINO_DEVICE, ov_config=TEST_CONFIG
+                )
+                optimum_ids = optimum_model.generate(**inputs, **self.GEN_KWARGS)
+                optimum_output = tokenizer.decode(optimum_ids[0], skip_special_tokens=True)
+                optimum_model = None
+                self.assertEqual(transformers_output, optimum_output)
+
+            genai_output = genai_model.generate(inputs["input_features"].flatten().tolist(), **self.GEN_KWARGS).texts[
+                0
+            ]
+        finally:
+            # Release on failure too: a failing test's traceback keeps its frame locals alive for the
+            # rest of the session, which would leave OpenVINO objects (and their file handles) around.
+            transformers_model = optimum_model = genai_model = None
+            gc.collect()
 
         self.assertEqual(transformers_output, genai_output)
 
 
 @pytest.mark.skipif(OPENVINO_DEVICE == "NPU", reason="Text2Speech test is not yet supported on NPU")
 class Text2SpeechPipelineTestCase(unittest.TestCase):
-    SUPPORTED_ARCHITECTURES = ("speecht5",)
+    SUPPORTED_ARCHITECTURES = _test_seq2seq.OVModelForTextToSpeechSeq2SeqIntegrationTest.SUPPORTED_ARCHITECTURES
     VOCODER = "fxmarty/speecht5-hifigan-tiny"
 
     GEN_KWARGS = {
@@ -527,55 +615,60 @@ class Text2SpeechPipelineTestCase(unittest.TestCase):
         speaker_embedding = np.random.randn(1, 512).astype(np.float32)
         return torch.tensor(speaker_embedding)
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    @parameterized.expand(SUPPORTED_ARCHITECTURES, skip_on_empty=True)
     def test_compare_outputs(self, model_arch):
-        if model_arch in ("speecht5",) and is_openvino_version(">=", "2026.1.0"):
-            self.skipTest("CVS-185350: OpenVINO 2026.1.0 inference results mismatch")
+        logger.info("Testing %s on device=%s", model_arch, OPENVINO_DEVICE)
         model_id = MODEL_NAMES[model_arch]
 
-        set_seed(42)
-        transformers_model = AutoModelForTextToSpectrogram.from_pretrained(model_id).eval()
+        transformers_model = optimum_model = genai_model = None
+        try:
+            set_seed(42)
+            transformers_model = AutoModelForTextToSpectrogram.from_pretrained(model_id).eval()
 
-        set_seed(42)
-        main_export(
-            model_name_or_path=model_id,
-            task="text-to-audio-with-past",
-            model_kwargs={"vocoder": self.VOCODER},
-            convert_tokenizer=True,
-            output=self.temp_dir,
-        )
-        optimum_model = OVModelForTextToSpeechSeq2Seq.from_pretrained(
-            self.temp_dir, device=OPENVINO_DEVICE, ov_config=TEST_CONFIG
-        )
-        genai_model = Text2SpeechPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
+            set_seed(42)
+            # For NPU, convert to fp16 explicitly
+            export_ov_config = OVConfig(dtype="fp16") if OPENVINO_DEVICE == "NPU" else None
+            main_export(
+                model_name_or_path=model_id,
+                task="text-to-audio-with-past",
+                model_kwargs={"vocoder": self.VOCODER},
+                convert_tokenizer=True,
+                output=self.temp_dir,
+                ov_config=export_ov_config,
+            )
+            optimum_model = OVModelForTextToSpeechSeq2Seq.from_pretrained(
+                self.temp_dir, device=OPENVINO_DEVICE, ov_config=TEST_CONFIG
+            )
+            genai_model = Text2SpeechPipeline(self.temp_dir, device=OPENVINO_DEVICE, **TEST_CONFIG)
 
-        text = "Hello, how are you?"
-        processor = AutoProcessor.from_pretrained(model_id)
-        speaker_embeddings = self._generate_speaker_embedding()
-        vocoder = self._get_vocoder(self.VOCODER, model_arch).eval()
-        inputs = processor(text=text, return_tensors="pt")
-        inputs["speaker_embeddings"] = speaker_embeddings
+            text = "Hello, how are you?"
+            processor = AutoProcessor.from_pretrained(model_id)
+            speaker_embeddings = self._generate_speaker_embedding()
+            vocoder = self._get_vocoder(self.VOCODER, model_arch).eval()
+            inputs = processor(text=text, return_tensors="pt")
+            inputs["speaker_embeddings"] = speaker_embeddings
 
-        with torch.no_grad():
-            transformers_output = transformers_model.generate(**inputs, **self.GEN_KWARGS, vocoder=vocoder)
-            transformers_output = transformers_output.squeeze(0)  # collapse batch dimension (if any)
+            with torch.no_grad():
+                transformers_output = transformers_model.generate(**inputs, **self.GEN_KWARGS, vocoder=vocoder)
+                transformers_output = transformers_output.squeeze(0)  # collapse batch dimension (if any)
 
-        optimum_output = optimum_model.generate(**inputs, **self.GEN_KWARGS)
-        optimum_output = optimum_output.squeeze(0)  # collapse batch dimension (if any)
+            optimum_output = optimum_model.generate(**inputs, **self.GEN_KWARGS)
+            optimum_output = optimum_output.squeeze(0)  # collapse batch dimension (if any)
 
-        genai_output = genai_model.generate(text, **self.GEN_KWARGS).speeches[0]
-        genai_output = torch.from_numpy(genai_output.data).squeeze(0)  # collapse batch dimension (if any)
-
-        del genai_model
-        del optimum_model
-        del transformers_model
-        gc.collect()
+            genai_output = genai_model.generate(text, **self.GEN_KWARGS).speeches[0]
+            genai_output = torch.from_numpy(genai_output.data).squeeze(0)  # collapse batch dimension (if any)
+        finally:
+            # Release on failure too: a failing test's traceback keeps its frame locals alive for the
+            # rest of the session, which would leave OpenVINO objects (and their file handles) around.
+            transformers_model = optimum_model = genai_model = None
+            gc.collect()
 
         torch.testing.assert_close(transformers_output, optimum_output, rtol=1e-2, atol=1e-3)
         torch.testing.assert_close(transformers_output, genai_output, rtol=1e-2, atol=1e-3)
 
 
 # NOTE: DFlash has been merged to 2026.4 release
+@pytest.mark.skipif(sys.platform == "win32", reason="Access violation on Windows")
 @pytest.mark.skipif(OPENVINO_DEVICE == "NPU", reason="Speculative decoding tests are not yet supported on NPU")
 class LLMPipelineWithSpeculativeDecodingTestCase(unittest.TestCase):
     GEN_KWARGS = {
@@ -626,6 +719,7 @@ class LLMPipelineWithSpeculativeDecodingTestCase(unittest.TestCase):
         trust_remote_code = model_arch in REMOTE_CODE_MODELS
 
         # export main and draft models and initialize OV LLM pipelines w/o speculative decoding
+        export_ov_config = OVConfig(dtype="fp16") if OPENVINO_DEVICE == "NPU" else None
         draft_model_path = Path(self.temp_dir) / "draft_model"
         main_model_path = Path(self.temp_dir) / "main_model"
         main_export(
@@ -634,12 +728,14 @@ class LLMPipelineWithSpeculativeDecodingTestCase(unittest.TestCase):
             trust_remote_code=trust_remote_code,
             convert_tokenizer=False,
             output=draft_model_path,
+            ov_config=export_ov_config,
         )
         main_export(
             model_name_or_path=target_model_id,
             task="text-generation-with-past",
             convert_tokenizer=True,
             output=main_model_path,
+            ov_config=export_ov_config,
         )
 
         prompt = "Paris is the capital of"
@@ -695,6 +791,7 @@ class LLMPipelineWithSpeculativeDecodingTestCase(unittest.TestCase):
         min_openvino_version,
         draft_task,
     ):
+        logger.info("Testing %s VLM %s on device=%s", speculative_decoding_type, model_arch, OPENVINO_DEVICE)
         if is_openvino_version("<", min_openvino_version):
             self.skipTest(f"{speculative_decoding_type} VLM requires openvino-genai >= {min_openvino_version}")
 
@@ -703,6 +800,8 @@ class LLMPipelineWithSpeculativeDecodingTestCase(unittest.TestCase):
         trust_remote_code = model_arch in REMOTE_CODE_MODELS
 
         # export main (VLM) and speculative draft models
+        # For NPU (not yet supported), convert to fp16 explicitly
+        export_ov_config = OVConfig(dtype="fp16") if OPENVINO_DEVICE == "NPU" else None
         draft_model_path = Path(self.temp_dir) / "draft_model"
         main_model_path = Path(self.temp_dir) / "main_model"
         main_export(
@@ -711,12 +810,14 @@ class LLMPipelineWithSpeculativeDecodingTestCase(unittest.TestCase):
             trust_remote_code=trust_remote_code,
             convert_tokenizer=False,
             output=draft_model_path,
+            ov_config=export_ov_config,
         )
         main_export(
             model_name_or_path=target_model_id,
             task="image-text-to-text",
             convert_tokenizer=True,
             output=main_model_path,
+            ov_config=export_ov_config,
         )
 
         rng = np.random.default_rng(42)

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -49,6 +49,7 @@ from utils_tests import (
     F32_CONFIG,
     MODEL_NAMES,
     OPENVINO_DEVICE,
+    REMOTE_CODE_MODELS,
     SEED,
     TEST_IMAGE_URL,
     TEST_NAME_TO_MODEL_TYPE,
@@ -635,17 +636,6 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         if TEST_NAME_TO_MODEL_TYPE.get(arch, arch) in get_supported_model_for_library("transformers")
     ]
 
-    REMOTE_CODE_MODELS = [
-        "internvl_chat",
-        "minicpmv",
-        "minicpmo",
-        "llava-qwen2",
-        "phi3_v",
-        "maira2",
-        "phi4mm",
-        "videochat_flash_qwen",
-        "gemma3n",
-    ]
     IMAGE = Image.open(
         requests.get(
             TEST_IMAGE_URL,
@@ -764,7 +754,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         set_seed(SEED)
         loading_kwargs = {}
 
-        trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
+        trust_remote_code = model_arch in REMOTE_CODE_MODELS
         if "llama4" in model_arch:
             loading_kwargs = {"_attn_implementation": "sdpa"}
         if model_arch == "muse_glimmer":
@@ -870,9 +860,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         with torch.no_grad():
             if model_arch in ["minicpmo"]:
                 # `generate` method for minicpmo requires tokenizer
-                tokenizer = AutoTokenizer.from_pretrained(
-                    model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
-                )
+                tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=model_arch in REMOTE_CODE_MODELS)
                 additional_inputs["tokenizer"] = tokenizer
             transformers_outputs = transformers_model.generate(
                 **transformers_inputs, generation_config=gen_config, **additional_inputs
@@ -931,13 +919,13 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
     def test_llava_with_new_preprocessing(self, model_arch):
         prompt = "<image>\n What is shown in this image?"
         model_id = MODEL_NAMES[model_arch]
-        trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
+        trust_remote_code = model_arch in REMOTE_CODE_MODELS
         config = AutoConfig.from_pretrained(model_id, trust_remote_code=trust_remote_code)
         processor = AutoProcessor.from_pretrained(
             model_id,
             patch_size=config.vision_config.patch_size,
             vision_feature_select_strategy=config.vision_feature_select_strategy,
-            trust_remote_code=model_arch in self.REMOTE_CODE_MODELS,
+            trust_remote_code=model_arch in REMOTE_CODE_MODELS,
             num_additional_image_tokens=1,
         )
         transformers_model = self.get_transformer_model_class(model_arch).from_pretrained(model_id)
@@ -988,7 +976,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         if model_arch == "gemma4":
             self.skipTest("gemma4 is causing segfault CVS-193103")
         model_id = MODEL_NAMES[model_arch]
-        trust_remote_code = model_arch in self.REMOTE_CODE_MODELS
+        trust_remote_code = model_arch in REMOTE_CODE_MODELS
         model = self.OVMODEL_CLASS.from_pretrained(
             model_id, export=True, trust_remote_code=trust_remote_code, device=OPENVINO_DEVICE
         )
@@ -1156,25 +1144,19 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
 
     def get_preprocessors(self, model_arch):
         model_id = MODEL_NAMES[model_arch]
-        config = AutoConfig.from_pretrained(model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS)
+        config = AutoConfig.from_pretrained(model_id, trust_remote_code=model_arch in REMOTE_CODE_MODELS)
 
         if model_arch == "llava-qwen2":
             processor = AutoProcessor.from_pretrained(
-                config.mm_vision_tower, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
+                config.mm_vision_tower, trust_remote_code=model_arch in REMOTE_CODE_MODELS
             )
-            tokenizer = AutoTokenizer.from_pretrained(
-                model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
-            )
+            tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=model_arch in REMOTE_CODE_MODELS)
             preprocessors = {"processor": processor, "tokenizer": tokenizer, "config": config}
         elif model_arch in ["internvl_chat", "videochat_flash_qwen"]:
-            tokenizer = AutoTokenizer.from_pretrained(
-                model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
-            )
+            tokenizer = AutoTokenizer.from_pretrained(model_id, trust_remote_code=model_arch in REMOTE_CODE_MODELS)
             preprocessors = {"processor": None, "tokenizer": tokenizer, "config": config}
         else:
-            processor = AutoProcessor.from_pretrained(
-                model_id, trust_remote_code=model_arch in self.REMOTE_CODE_MODELS
-            )
+            processor = AutoProcessor.from_pretrained(model_id, trust_remote_code=model_arch in REMOTE_CODE_MODELS)
             preprocessors = {"processor": processor, "tokenizer": None, "config": config}
 
         return preprocessors
@@ -1186,14 +1168,14 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
             ov_model = self.OVMODEL_CLASS.from_pretrained(
                 model_id,
                 compile=False,
-                trust_remote_code=model_arch in self.REMOTE_CODE_MODELS,
+                trust_remote_code=model_arch in REMOTE_CODE_MODELS,
                 device=OPENVINO_DEVICE,
             )
             ov_model.save_pretrained(save_dir)
             ov_restored_model = self.OVMODEL_CLASS.from_pretrained(
                 save_dir,
                 compile=False,
-                trust_remote_code=model_arch in self.REMOTE_CODE_MODELS,
+                trust_remote_code=model_arch in REMOTE_CODE_MODELS,
                 device=OPENVINO_DEVICE,
             )
             self.assertIsInstance(ov_restored_model, type(ov_model))

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -438,11 +438,24 @@ def _resolve_cached_model_paths(model_names: dict) -> dict:
         if not os.path.exists(constants.HF_HUB_CACHE):
             return model_names
 
-        repo_id_to_local_paths = {
-            repo.repo_id: str(next(iter(repo.revisions)).snapshot_path)
-            for repo in scan_cache_dir().repos
-            if repo.revisions
-        }
+        repo_id_to_local_paths = {}
+        for repo in scan_cache_dir().repos:
+            if not repo.revisions:
+                continue
+            best = None
+            for rev in sorted(repo.revisions, key=lambda r: r.last_modified, reverse=True):
+                file_names = {f.file_name for f in rev.files}
+                if "config.json" not in file_names:
+                    continue
+                # Skip repos with custom Python code — their Hub repos can add new .py
+                # files that a stale local snapshot won't have, causing FileNotFoundError
+                if any(f.endswith(".py") for f in file_names):
+                    break
+                if all(os.path.exists(f.file_path) for f in rev.files):
+                    best = rev
+                    break
+            if best is not None:
+                repo_id_to_local_paths[repo.repo_id] = str(best.snapshot_path)
         return {k: repo_id_to_local_paths.get(v, v) for k, v in model_names.items()}
     except Exception:
         return model_names

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -792,6 +792,14 @@ REMOTE_CODE_MODELS = (
     "qwen3_asr",
     "fun_asr",
     "videochat_flash_qwen",
+    "internvl_chat",
+    "minicpmv",
+    "minicpmo",
+    "llava-qwen2",
+    "phi3_v",
+    "maira2",
+    "phi4mm",
+    "gemma3n",
 )
 
 if is_transformers_version("<", "5"):


### PR DESCRIPTION
Adds a manually triggered self-hosted AIPC test workflow for OpenVINO GenAI across CPU, GPU, and NPU, OpenVINO release/nightly builds, and supported Transformers versions.

- Adds workflow for running test_genai.py on self-hosted AI PC runners
- Adds a generated markdown, HTML, and XLSX report with per-model results for every device/runner combination.
- Adds NPU model filtering
- Makes NPU runs more diagnosable by reporting the selected device and NPU driver version.
- Runs Github Actions tests through a single `pytest-xdist` worker so an isolated Windows native access violation is recorded as a failed test and the remaining tests can continue (especially important on NPU).
- Avoids stale or incomplete locally cached model snapshots when resolving test model paths.
- Adds TOP_K_TOLERANCE to test_genai.py to allow small deviations caused by for example FP16 vs FP32 inference precision.

Example command to run the test:

```
uv pip install pytest-xdist
set OPENVINO_TEST_DEVICE=CPU
python -m pytest test_genai.py -rpfs --log-cli-level info -n 1 --max-worker-restart 10
```

Note:
- test_genai.py may fail on NPU/GPU. This is outside the scope of this PR. CPU should pass.
- currently Release Candidate version and transformers versions are hardcoded in the workflow file. Not ideal but pragmatically the best option for now
- lists of supported models for NPU, and excluded models for OpenVINO GenAI are not finalized, will be updated. 