### PR TITLE
Support Muse-Glimmer Dflash method

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -224,6 +224,7 @@ Here is the list of the supported architectures :
 - Qwen3.6-*-DFlash
 - Qwen3-Coder-30B-A3B-DFlash
 - gemma-4-31B-it-DFlash
+- Muse-Glimmer-30B-assistant
 
 ## [Ouro](https://huggingface.co/ByteDance/Ouro-1.4B)
 - Ouro-1.4B

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -222,6 +222,20 @@ _CUSTOM_DRAFT_MODEL_MAP = {
     "DFlashDraftModel": ("Qwen3DFlashDraftModel", "Qwen3DFlashForCausalLM"),
 }
 
+# Maps config.architectures[0] to a loader for draft models whose architecture is native to
+# transformers. Unlike `_CUSTOM_DRAFT_MODEL_MAP` these need no remote-code re-implementation
+# (and so no `auto_map` indirection); only their KV-cache handling is restructured for export.
+_NATIVE_DRAFT_MODEL_LOADERS = {
+    "MuseGlimmerAssistantModel": "load_muse_glimmer_assistant_draft_model",
+}
+
+
+def load_native_draft_model(architecture: str, model_name_or_path: str, **kwargs):
+    from optimum.exporters.openvino import model_patcher
+
+    loader = getattr(model_patcher, _NATIVE_DRAFT_MODEL_LOADERS[architecture])
+    return loader(model_name_or_path, **kwargs)
+
 
 def update_config_for_custom_draft_model(config, auto_model, auto_model_for_causal_lm):
     moduler_name = "optimum.exporters.openvino.model_patcher"
@@ -584,6 +598,21 @@ def main_export(
             from optimum.intel.openvino.modeling_funasr import _FunASRForSpeechSeq2Seq
 
             model = _FunASRForSpeechSeq2Seq.from_pretrained(model_name_or_path, cache_dir=cache_dir, token=token)
+        elif (
+            library_name == "transformers"
+            and (getattr(config, "architectures", None) or [None])[0] in _NATIVE_DRAFT_MODEL_LOADERS
+        ):
+            model = load_native_draft_model(
+                config.architectures[0],
+                model_name_or_path,
+                subfolder=subfolder,
+                revision=revision,
+                cache_dir=cache_dir,
+                token=token,
+                local_files_only=local_files_only,
+                force_download=force_download,
+                **loading_kwargs,
+            )
         else:
             # remote code models like phi3_v internvl2, minicpmv, internvl2, nanollava, maira2 should be loaded using AutoModelForCausalLM and not AutoModelForImageTextToText
             # TODO: use config.auto_map to load remote code models instead (for other models we can directly use config.architectures)

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -160,6 +160,8 @@ def _save_model(
         "qwen3_5_text",
         "qwen3_5_moe_text",
         "gemma4",
+        "muse_glimmer",
+        "muse_glimmer_text",
     }:
         add_hidden_states_rt_info(source_model, model, config)
 
@@ -945,15 +947,30 @@ def _add_dflash_mode_to_rt_info(model: Model, hf_config: "PretrainedConfig") -> 
     Add DFlash metadata to DFlash draft model.
 
     Marks model as DFlash draft model and adds DFlash configuration to the model including
-    mask token id and target layer ids.
+    mask token id, block size and target layer ids.
+
+    Draft checkpoints carry these fields either in a nested ``dflash_config`` block (the
+    Qwen3-based ``DFlashDraftModel`` variants) or flat on the config itself (the native
+    ``muse_glimmer_assistant`` architecture), so both layouts are read here.
     """
     try:
         model.set_rt_info("True", ["dflash_mode"])
-        dflash_config = getattr(hf_config, "dflash_config", {})
-        if "mask_token_id" in dflash_config:
-            model.set_rt_info(str(dflash_config["mask_token_id"]), ["dflash", "mask_token_id"])
-        if "target_layer_ids" in dflash_config:
-            model.set_rt_info(",".join(map(str, dflash_config["target_layer_ids"])), ["dflash", "target_layer_ids"])
+        dflash_config = getattr(hf_config, "dflash_config", {}) or {}
+
+        def _dflash_field(name):
+            if name in dflash_config:
+                return dflash_config[name]
+            return getattr(hf_config, name, None)
+
+        mask_token_id = _dflash_field("mask_token_id")
+        if mask_token_id is not None:
+            model.set_rt_info(str(mask_token_id), ["dflash", "mask_token_id"])
+        target_layer_ids = _dflash_field("target_layer_ids")
+        if target_layer_ids:
+            model.set_rt_info(",".join(map(str, target_layer_ids)), ["dflash", "target_layer_ids"])
+        block_size = _dflash_field("block_size")
+        if block_size is not None:
+            model.set_rt_info(str(block_size), ["dflash", "block_size"])
     except Exception:
         pass
 

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -236,8 +236,13 @@ class Eagle3DummyGenerator(DummyInputGenerator):
         self.batch_size = batch_size
         self.sequence_length = sequence_length
         self.hidden_size = normalized_config.hidden_size
+        # Draft checkpoints keep `target_layer_ids` either nested under `dflash_config`
+        # (Qwen3-based DFlash) or flat on the config (native muse_glimmer_assistant).
         dflash_config = getattr(normalized_config.config, "dflash_config", {}) or {}
-        self.num_hidden_state_layers = len(dflash_config.get("target_layer_ids", [])) or 3
+        target_layer_ids = dflash_config.get("target_layer_ids") or getattr(
+            normalized_config.config, "target_layer_ids", None
+        )
+        self.num_hidden_state_layers = len(target_layer_ids or []) or 3
 
     def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
         # hidden_states is provided as a concatenation of hidden-layer outputs from the main model

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2397,6 +2397,108 @@ class MuseGlimmerTextOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
     _MODEL_PATCHER = MuseGlimmerLanguageModelPatcher
 
 
+@register_in_tasks_manager(
+    "muse_glimmer_assistant",
+    *["text-generation", "text-generation-with-past"],
+    library_name="transformers",
+)
+class MuseGlimmerAssistantOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
+    """Export config for the MuseGlimmer DFlash drafter (``Muse-Glimmer-30B-assistant``).
+
+    Follows the same I/O contract as the Qwen3 DFlash draft export: ``inputs_embeds``
+    carries the diffusion window (the anchor token plus ``block_size - 1`` mask tokens)
+    embedded with the target's raw lookup table, ``hidden_states`` carries the target's
+    hidden states at ``target_layer_ids`` concatenated on the last axis, and the model
+    emits ``last_hidden_state`` for the drafted positions only. Neither the embedding
+    table nor the lm_head is part of the export - the drafter borrows the target's.
+
+    Unlike the Qwen3 drafters this is a native transformers architecture, so no
+    re-implementation is needed; only the KV-cache handling is restructured for export
+    (see ``MuseGlimmerAssistantDFlashForCausalLM``).
+    """
+
+    DEFAULT_ONNX_OPSET = 14
+    MIN_TRANSFORMERS_VERSION = "5.15.0"
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        DummyTextInputGenerator,
+        Eagle3VLMDummyGenerator,
+        Eagle3DummyGenerator,
+        MistralDummyPastKeyValuesGenerator,
+    )
+    DUMMY_PKV_GENERATOR_CLASS = MistralDummyPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+    _MODEL_PATCHER = OVDecoderModelPatcher
+    PAD_ATTENTION_MASK_TO_PAST = False
+    # Tells `convert.py` to stamp the DFlash RT-info block onto the exported graph.
+    dflash = True
+
+    def __init__(self, config: PretrainedConfig, *args, **kwargs):
+        # The drafter has neither an embedding table nor an lm_head, so its config carries
+        # no `vocab_size`. `DummyTextInputGenerator` requires one at construction even
+        # though `input_ids` is dropped from the exported inputs, so supply a value that
+        # is guaranteed to cover the drafter's own mask token.
+        if getattr(config, "vocab_size", None) is None:
+            config.vocab_size = int(getattr(config, "mask_token_id", 0)) + 1
+        super().__init__(config, *args, **kwargs)
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        common_inputs = super().inputs
+        common_inputs.pop("input_ids", None)
+        common_inputs["inputs_embeds"] = {0: "batch_size", 1: "block_size"}
+        common_inputs["hidden_states"] = {0: "batch_size", 1: "context_length"}
+        common_inputs["position_ids"] = {0: "batch_size", 1: "context_length + block_size"}
+        if self.use_past_in_inputs:
+            mask_length = "past_sequence_length + context_length + block_size"
+        else:
+            mask_length = "context_length + block_size"
+        common_inputs["attention_mask"] = {0: "batch_size", 1: mask_length}
+        return common_inputs
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        common_outputs = super().outputs
+        common_outputs.pop("logits", None)
+        return {
+            "last_hidden_state": {0: "batch_size", 1: "draft_sequence_length"},
+            **common_outputs,
+        }
+
+    def overwrite_shape_and_generate_input(
+        self, dummy_input_gen: DummyInputGenerator, input_name: str, framework: str, input_shapes: dict
+    ):
+        if input_name in {"inputs_embeds", "hidden_states", "position_ids", "attention_mask"}:
+            sequence_length = dummy_input_gen.sequence_length
+            block_length = sequence_length + 1
+            if input_name == "inputs_embeds":
+                dummy_input_gen.sequence_length = block_length
+            elif input_name == "hidden_states":
+                dummy_input_gen.sequence_length = sequence_length
+            elif input_name == "position_ids":
+                dummy_input_gen.sequence_length = sequence_length + block_length
+            else:
+                if self.use_past_in_inputs:
+                    dummy_input_gen.sequence_length = sequence_length * 2 + block_length
+                else:
+                    dummy_input_gen.sequence_length = sequence_length + block_length
+            dummy_input = dummy_input_gen.generate(
+                input_name, framework=framework, int_dtype=self.int_dtype, float_dtype=self.float_dtype
+            )
+            dummy_input_gen.sequence_length = sequence_length
+            return dummy_input
+        return super().overwrite_shape_and_generate_input(dummy_input_gen, input_name, framework, input_shapes)
+
+    def add_past_key_values(self, inputs_or_outputs: Dict[str, Dict[int, str]], direction: str):
+        super().add_past_key_values(inputs_or_outputs, direction)
+        if direction == "outputs":
+            # Only the target context is written to the cache; the diffusion window's
+            # K/V is local to the forward, so the cache grows by `context_length`.
+            for axes in inputs_or_outputs.values():
+                for axis, name in axes.items():
+                    if name == "past_sequence_length + sequence_length":
+                        axes[axis] = "past_sequence_length + context_length"
+
+
 @register_in_tasks_manager("muse_glimmer", *["image-text-to-text"], library_name="transformers")
 class MuseGlimmerOpenVINOConfig(BaseVLMOpenVINOConfig):
     """Multi-part OpenVINO export config for the native MuseGlimmer VLM.

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -9001,6 +9001,204 @@ class Qwen3DFlashForCausalLM(Qwen3DFlashDraftModel, GenerationMixin):
         )
 
 
+def _muse_glimmer_assistant_attention_mask(
+    query_states: torch.Tensor,
+    key_states: torch.Tensor,
+    sliding_window: Optional[int],
+    attention_mask: Optional[torch.Tensor],
+) -> Optional[torch.Tensor]:
+    """Bidirectional (optionally windowed) additive mask for the MuseGlimmer drafter.
+
+    The drafter's queries are the diffusion window; they attend bidirectionally to each
+    other and to every cached target-context key. Transformers builds this with
+    ``create_bidirectional_sliding_window_mask``, whose window test is
+    ``abs(q_idx - kv_idx) <= sliding_window`` - note the inclusive bound, which differs
+    from the exclusive one the Qwen3 DFlash reference uses.
+
+    ``key_states`` may already have been trimmed to the last ``sliding_window`` context
+    entries. Distances survive a uniform shift of both position frames, so a 0-based
+    frame over the kept keys gives the same mask as absolute positions would.
+    """
+    q_len = query_states.shape[-2]
+    kv_len = key_states.shape[-2]
+    if attention_mask is not None:
+        # Keep the columns matching the (possibly trimmed) key set.
+        attention_mask = attention_mask[:, :, :, -kv_len:]
+    if sliding_window is None:
+        return attention_mask
+
+    dtype = query_states.dtype
+    device = query_states.device
+    query_positions = torch.arange(kv_len - q_len, kv_len, device=device)
+    key_positions = torch.arange(kv_len, device=device)
+    outside_window = (query_positions.reshape(-1, 1) - key_positions.reshape(1, -1)).abs() > sliding_window
+    window_mask = torch.zeros((q_len, kv_len), dtype=dtype, device=device)
+    window_mask = window_mask.masked_fill(outside_window, torch.finfo(dtype).min)
+    window_mask = window_mask[None, None, :, :].expand(query_states.shape[0], 1, -1, -1)
+
+    if attention_mask is None:
+        return window_mask
+    return attention_mask + window_mask
+
+
+def _muse_glimmer_assistant_attention_forward(
+    self,
+    hidden_states: torch.Tensor,
+    context_hidden_states: torch.Tensor,
+    position_embeddings: Tuple[torch.Tensor, torch.Tensor],
+    attention_mask: Optional[torch.Tensor] = None,
+    past_key_values: Optional[Cache] = None,
+    **kwargs,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor]]:
+    """MuseGlimmer drafter attention that keeps only the target context in the KV cache.
+
+    The stock implementation appends the diffusion window to the cache alongside the
+    context and relies on ``DFlashCache.crop`` to evict it again on the next step. A
+    stateful OpenVINO model cannot roll its state back, so the window's K/V is instead
+    concatenated locally, after the cache update. The cache then only ever grows by the
+    accepted-token context, which is exactly the DFlash contract and needs no rollback.
+    """
+    from transformers.modeling_utils import ALL_ATTENTION_FUNCTIONS
+    from transformers.models.muse_glimmer_assistant.modeling_muse_glimmer_assistant import (
+        eager_attention_forward as muse_glimmer_assistant_eager_attention_forward,
+    )
+
+    bsz, q_len = hidden_states.shape[:-1]
+    ctx_len = context_hidden_states.shape[1]
+    hidden_shape = (bsz, q_len, -1, self.head_dim)
+    kv_hidden_shape = (bsz, ctx_len + q_len, -1, self.head_dim)
+
+    kv_hidden_states = torch.cat([context_hidden_states, hidden_states], dim=1)
+    query_states = self.q_proj(hidden_states).view(hidden_shape).transpose(1, 2)
+    key_states = self.k_proj(kv_hidden_states).view(kv_hidden_shape).transpose(1, 2)
+    value_states = self.v_proj(kv_hidden_states).view(kv_hidden_shape).transpose(1, 2)
+    query_states = self.q_norm(query_states)
+    key_states = self.k_norm(key_states)
+
+    # `cos`/`sin` span the context plus the diffusion window; the queries are the window,
+    # so they take the trailing positions while the keys take all of them.
+    cos, sin = position_embeddings
+    query_states, key_states = _dflash_apply_rotary_pos_emb(query_states, key_states, cos, sin)
+
+    context_key_states, block_key_states = key_states.split([ctx_len, q_len], dim=2)
+    context_value_states, block_value_states = value_states.split([ctx_len, q_len], dim=2)
+    if past_key_values is not None:
+        context_key_states, context_value_states = past_key_values.update(
+            context_key_states, context_value_states, self.layer_idx
+        )
+
+    sliding_window = self.sliding_window if self.is_sliding else None
+    if sliding_window is not None:
+        # A window query attends back at most `sliding_window` positions, so older
+        # context can never be reached. Trimming keeps the concat and SDPA O(window).
+        context_key_states = context_key_states[:, :, -sliding_window:, :]
+        context_value_states = context_value_states[:, :, -sliding_window:, :]
+
+    key_states = torch.cat([context_key_states, block_key_states], dim=2)
+    value_states = torch.cat([context_value_states, block_value_states], dim=2)
+    attention_mask = _muse_glimmer_assistant_attention_mask(query_states, key_states, sliding_window, attention_mask)
+
+    attention_interface = muse_glimmer_assistant_eager_attention_forward
+    attention_module = self
+    if self.config._attn_implementation != "eager":
+        attention_interface = ALL_ATTENTION_FUNCTIONS[self.config._attn_implementation]
+        if self.config._attn_implementation == "sdpa" and self.num_key_value_groups > 1:
+            # Same reasoning as the Qwen3 DFlash path: re-pin the KV head count with a
+            # literal-dim Reshape so the GPU plugin still dispatches native-GQA SDPA.
+            key_states = key_states.reshape(bsz, self.num_key_value_heads, -1, self.head_dim)
+            value_states = value_states.reshape(bsz, self.num_key_value_heads, -1, self.head_dim)
+            key_states = _dflash_repeat_kv(key_states, self.num_key_value_groups)
+            value_states = _dflash_repeat_kv(value_states, self.num_key_value_groups)
+            attention_module = SimpleNamespace(is_causal=False)
+
+    attn_output, attn_weights = attention_interface(
+        attention_module,
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        dropout=0.0,
+        scaling=self.scaling,
+        sliding_window=None,
+        **kwargs,
+    )
+    attn_output = attn_output.reshape(bsz, q_len, -1).contiguous()
+    attn_output = self.o_proj(attn_output)
+    return attn_output, attn_weights
+
+
+@functools.lru_cache(maxsize=1)
+def get_muse_glimmer_assistant_draft_model_class():
+    """Build the MuseGlimmer DFlash drafter export class.
+
+    Defined lazily because ``muse_glimmer_assistant`` only exists in transformers >= 5.15,
+    while this module is imported eagerly.
+
+    The class exposes the same I/O contract as the Qwen3 DFlash export: the token
+    embedding and lm_head are intentionally absent, because the drafter borrows the
+    target's at runtime. ``inputs_embeds`` is the diffusion window (anchor token +
+    ``block_size - 1`` mask tokens) embedded with the target's *raw* lookup table, and
+    ``hidden_states`` is the target's hidden states at ``config.target_layer_ids``
+    concatenated on the last axis. The returned ``last_hidden_state`` drops the anchor
+    position so it aligns 1:1 with the drafted tokens the grafted lm_head will score.
+    """
+    from transformers.models.muse_glimmer_assistant.modeling_muse_glimmer_assistant import MuseGlimmerAssistantModel
+
+    class MuseGlimmerAssistantDFlashForCausalLM(MuseGlimmerAssistantModel):
+        def __init__(self, config):
+            super().__init__(config)
+            for layer in self.layers:
+                layer.self_attn.forward = types.MethodType(_muse_glimmer_assistant_attention_forward, layer.self_attn)
+
+        def forward(
+            self,
+            inputs_embeds: torch.FloatTensor,
+            hidden_states: torch.Tensor,
+            position_ids: torch.LongTensor,
+            attention_mask: Optional[torch.Tensor] = None,
+            past_key_values: Optional[Cache] = None,
+            use_cache: Optional[bool] = True,
+            **kwargs,
+        ) -> BaseModelOutputWithPast:
+            noise_states = inputs_embeds
+            context_hidden_states = self.encoder(hidden_states.to(noise_states.dtype))
+
+            if is_transformers_version("<", "5"):
+                past_key_values = DynamicCache.from_legacy_cache(past_key_values)
+            else:
+                past_key_values = DynamicCache(past_key_values)
+
+            if attention_mask is not None and attention_mask.dim() == 2:
+                attention_mask = (1.0 - attention_mask[:, None, None, :].to(dtype=noise_states.dtype)) * torch.finfo(
+                    noise_states.dtype
+                ).min
+
+            position_embeddings = self.rotary_emb(noise_states, position_ids)
+            for layer in self.layers:
+                noise_states = layer(
+                    hidden_states=noise_states,
+                    context_hidden_states=context_hidden_states,
+                    position_embeddings=position_embeddings,
+                    attention_mask=attention_mask,
+                    past_key_values=past_key_values,
+                    **kwargs,
+                )
+
+            # Drop the anchor position so the emitted states align with the drafted tokens.
+            last_hidden_state = self.norm(noise_states)[:, 1:, :]
+            return BaseModelOutputWithPast(
+                last_hidden_state=last_hidden_state,
+                past_key_values=postprocess_past_key_values(past_key_values),
+            )
+
+    return MuseGlimmerAssistantDFlashForCausalLM
+
+
+def load_muse_glimmer_assistant_draft_model(model_name_or_path: str, **kwargs):
+    """Load a ``Muse-Glimmer-*-assistant`` checkpoint as its OpenVINO export class."""
+    return get_muse_glimmer_assistant_draft_model_class().from_pretrained(model_name_or_path, **kwargs)
+
+
 # Patched implementation of the gated delta rule in recurrent form.
 # Adapted from:
 # https://github.com/huggingface/transformers/blob/v4.57-release/src/transformers/models/qwen3_next/modeling_qwen3_next.py#L522

--- a/optimum/intel/__init__.py
+++ b/optimum/intel/__init__.py
@@ -75,6 +75,7 @@ _import_structure = {
         "OVModelForTextToSpeechSeq2Seq",
         "OVModelForVision2Seq",
         "OVModelForVisualCausalLM",
+        "OVAssistantForCausalLM",
         "OVModelForSequenceClassification",
         "OVModelForTokenClassification",
         "OVConfig",
@@ -202,6 +203,7 @@ else:
 
 if TYPE_CHECKING:
     from .openvino import (
+        OVAssistantForCausalLM,
         OVConfig,
         OVModelForAudioClassification,
         OVModelForAudioFrameClassification,

--- a/optimum/intel/openvino/__init__.py
+++ b/optimum/intel/openvino/__init__.py
@@ -81,6 +81,7 @@ from .modeling import (
     OVModelForZeroShotImageClassification,
 )
 from .modeling_decoder import OVModelForCausalLM
+from .modeling_dflash import OVAssistantForCausalLM
 from .modeling_open_clip import (
     OVModelOpenCLIPForZeroShotImageClassification,
     OVModelOpenCLIPText,

--- a/optimum/intel/openvino/modeling_dflash.py
+++ b/optimum/intel/openvino/modeling_dflash.py
@@ -1,0 +1,588 @@
+#  Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+"""OpenVINO runtime for DFlash speculative decoding.
+
+DFlash pairs a large target model with a small block-diffusion "drafter": the drafter
+reads the target's hidden states at a handful of layers plus the last decoded token, and
+denoises a whole block of `block_size` masked tokens in one forward pass. The target then
+verifies the block in a single forward, so several tokens can be committed per target
+call. Greedy DFlash is lossless - the accepted prefix plus the bonus token always
+reproduces the target's own greedy continuation.
+
+The drafter ships without a token embedding and without an lm_head: it borrows the
+target's. With an OpenVINO export those two live inside other IR files - the embedding
+inside `openvino_text_embeddings_model.xml` (behind the embedding norm) and the lm_head
+fused into `openvino_language_model.xml`. This module extracts each as a small standalone
+`ov.Model` rather than requiring a different export or duplicating weights in float.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+import numpy as np
+import openvino as ov
+import torch
+from openvino import opset13
+from transformers import AutoModel, GenerationConfig, PretrainedConfig
+from transformers.generation.candidate_generator import CandidateGenerator
+from transformers.modeling_outputs import BaseModelOutputWithPast
+
+from .modeling_base import OVBaseModel
+
+
+if TYPE_CHECKING:
+    from transformers.generation.logits_process import LogitsProcessorList
+
+
+HIDDEN_STATES_RT_INFO_KEY = "hidden_states_decoder_layers"
+DFLASH_HIDDEN_STATE_PREFIX = "dflash_hidden_states"
+
+
+def is_dflash_draft_model(ov_model: ov.Model) -> bool:
+    """Whether an IR was exported as a DFlash drafter."""
+    return ov_model.has_rt_info(["dflash_mode"]) and ov_model.get_rt_info(["dflash_mode"]).value == "True"
+
+
+def read_dflash_rt_info(ov_model: ov.Model) -> Dict[str, Any]:
+    """Read the `dflash` RT-info block stamped onto a drafter export."""
+    info = {}
+    if ov_model.has_rt_info(["dflash", "mask_token_id"]):
+        info["mask_token_id"] = int(ov_model.get_rt_info(["dflash", "mask_token_id"]).value)
+    if ov_model.has_rt_info(["dflash", "block_size"]):
+        info["block_size"] = int(ov_model.get_rt_info(["dflash", "block_size"]).value)
+    if ov_model.has_rt_info(["dflash", "target_layer_ids"]):
+        raw = ov_model.get_rt_info(["dflash", "target_layer_ids"]).value
+        info["target_layer_ids"] = [int(part) for part in raw.split(",") if part != ""]
+    return info
+
+
+# --------------------------------------------------------------------------------------
+# Subgraph extraction
+# --------------------------------------------------------------------------------------
+
+
+def _hidden_state_locators(ov_model: ov.Model) -> Dict[int, ov.Output]:
+    """Resolve the `hidden_states_decoder_layers` RT-info annotation to graph outputs.
+
+    The annotation is written at export time by `utils_annotations.add_hidden_states_rt_info`
+    and survives weight compression, because it records friendly names rather than
+    positions.
+    """
+    import json
+
+    if not ov_model.has_rt_info([HIDDEN_STATES_RT_INFO_KEY]):
+        raise ValueError(
+            "The language model was exported without the `hidden_states_decoder_layers` annotation, "
+            "which DFlash needs to tap the target's intermediate hidden states. Re-export the target "
+            "with a recent optimum-intel."
+        )
+    annotation = json.loads(ov_model.get_rt_info([HIDDEN_STATES_RT_INFO_KEY]).value)
+    by_name = {}
+    for op in ov_model.get_ordered_ops():
+        by_name.setdefault(op.get_friendly_name(), op)
+
+    locators = {}
+    for layer_id, locator in annotation["layers"].items():
+        producer = by_name.get(locator["producer"])
+        if producer is None:
+            raise ValueError(f"Hidden-state producer {locator['producer']!r} is missing from the graph.")
+        locators[int(layer_id)] = producer.output(int(locator["output_index"]))
+    return locators
+
+
+def add_hidden_state_outputs(ov_model: ov.Model, layer_ids: List[int]) -> List[str]:
+    """Expose the target's hidden states at `layer_ids` as extra model outputs.
+
+    Returns the tensor names of the added outputs, ordered like `layer_ids`. Adding
+    outputs does not change the graph's computation, only what it hands back.
+    """
+    locators = _hidden_state_locators(ov_model)
+    missing = [layer_id for layer_id in layer_ids if layer_id not in locators]
+    if missing:
+        raise ValueError(
+            f"The target model exposes hidden states for layers {sorted(locators)}, "
+            f"but the drafter asks for {missing}."
+        )
+
+    names = []
+    for layer_id in layer_ids:
+        name = f"{DFLASH_HIDDEN_STATE_PREFIX}.{layer_id}"
+        names.append(name)
+        if name in {n for out in ov_model.outputs for n in out.get_names()}:
+            continue
+        added = ov_model.add_outputs([locators[layer_id]])[0]
+        # `add_outputs` keeps the producer's existing tensor names; add a stable one so the
+        # output can be looked up by name regardless of how the graph was serialized.
+        added.get_tensor().set_names(added.get_names() | {name})
+    return names
+
+
+def extract_raw_embedding_model(text_embeddings_model: ov.Model) -> ov.Model:
+    """Build a lookup-only embedding model from an exported text-embeddings IR.
+
+    Some architectures (MuseGlimmer among them) normalize or scale the embedding right
+    after the lookup, and the exported IR includes that. A DFlash drafter needs the *raw*
+    table - transformers spells this `F.embedding(ids, embed_tokens.weight)` - so the
+    graph is cut at the Gather and everything downstream is dropped.
+    """
+    gathers = [op for op in text_embeddings_model.get_ordered_ops() if op.get_type_name() == "Gather"]
+    if len(gathers) != 1:
+        raise ValueError(f"Expected exactly one Gather in the text-embeddings model, found {len(gathers)}.")
+    output = gathers[0].output(0)
+    output.get_tensor().set_names(output.get_names() | {"inputs_embeds"})
+    return ov.Model([output], text_embeddings_model.get_parameters(), "raw_text_embeddings")
+
+
+def extract_lm_head_model(language_model: ov.Model, hidden_size: int) -> ov.Model:
+    """Build a standalone lm_head model from an exported language model IR.
+
+    The final entry of the `hidden_states_decoder_layers` annotation is, by construction,
+    the hidden-width value consumed by the lm_head. Re-rooting the graph there and keeping
+    only the `logits` result prunes everything else away, leaving the projection (plus any
+    logit softcapping the architecture applies, which is monotonic and so does not disturb
+    greedy verification).
+
+    The graph is re-rooted on a clone, so the caller's `language_model` is left intact.
+    """
+    language_model = language_model.clone()
+    locators = _hidden_state_locators(language_model)
+    source = locators[max(locators)]
+
+    results = [result for result in language_model.get_results() if "logits" in result.get_output_tensor(0).names]
+    if len(results) != 1:
+        raise ValueError("Expected exactly one `logits` result in the language model.")
+
+    parameter = opset13.parameter(
+        ov.PartialShape([-1, -1, hidden_size]), source.get_element_type(), name="hidden_states"
+    )
+    parameter.get_output_tensor(0).set_names({"hidden_states"})
+    for consumer in list(source.get_target_inputs()):
+        consumer.replace_source_output(parameter.output(0))
+    return ov.Model(results, [parameter], "lm_head")
+
+
+# --------------------------------------------------------------------------------------
+# Stateful KV-cache proxy
+# --------------------------------------------------------------------------------------
+
+
+class OVStatefulCacheProxy:
+    """Gives a stateful OpenVINO model the `crop()` API assisted decoding relies on.
+
+    Speculative decoding feeds `candidate_length + 1` tokens in one target forward and
+    then keeps only the accepted prefix, so the rejected tail has to leave the KV cache.
+    A stateful OpenVINO model holds that cache in `VariableState`s rather than in tensors
+    the caller passes around, but those states can be read back and written, so the tail
+    can be trimmed in place.
+    """
+
+    def __init__(self, model_part):
+        self._model_part = model_part
+
+    def crop(self, max_length: int) -> None:
+        """Trim the cache. Negative `max_length` drops that many trailing positions."""
+        request = self._model_part.request
+        if request is None:
+            return
+        past_length = self._model_part._past_length
+        keep = past_length + max_length if max_length < 0 else min(max_length, past_length)
+        if keep >= past_length:
+            return
+        if keep < 0:
+            raise ValueError(f"Cannot crop {-max_length} positions from a cache of length {past_length}.")
+
+        # Drop a fixed *count* from the tail rather than truncating to an absolute length:
+        # a sliding-window layer's state is capped at its window, so it can be shorter than
+        # the logical past length while still needing the same number of entries removed.
+        dropped = past_length - keep
+        for state in request.query_state():
+            data = state.state.data
+            # KV states are laid out [batch, heads, sequence, head_dim].
+            if data.ndim != 4:
+                continue
+            state.state = ov.Tensor(np.ascontiguousarray(data[:, :, : max(data.shape[2] - dropped, 0), :]))
+        self._model_part._past_length = keep
+
+    def activate_past_recording(self) -> None:
+        # Transformers asks a Cache to start recording so that `crop` can roll it back.
+        # An OpenVINO variable state is always readable and writable, so nothing to arm.
+        return
+
+    def get_seq_length(self, layer_idx: int = 0) -> int:
+        return self._model_part._past_length
+
+    def __len__(self) -> int:
+        return self._model_part._past_length
+
+    def __bool__(self) -> bool:
+        # Truthiness decides "has a cache", which is true from the first forward onwards.
+        return True
+
+
+# --------------------------------------------------------------------------------------
+# Drafter runtime
+# --------------------------------------------------------------------------------------
+
+
+class OVAssistantForCausalLM(OVBaseModel):
+    """OpenVINO runtime for a DFlash draft ("assistant") model.
+
+    Pass an instance as `assistant_model=` to a compatible OpenVINO target model's
+    `generate()` to run speculative decoding:
+
+    ```python
+    from optimum.intel.openvino import OVAssistantForCausalLM, OVModelForVisualCausalLM
+
+    model = OVModelForVisualCausalLM.from_pretrained("Muse-Glimmer-30B-ov")
+    assistant = OVAssistantForCausalLM.from_pretrained("Muse-Glimmer-30B-assistant-ov")
+    model.generate(**inputs, max_new_tokens=64, assistant_model=assistant)
+    ```
+
+    The exported IR takes the diffusion window's embeddings (`inputs_embeds`) and the
+    target's concatenated hidden states (`hidden_states`) and returns `last_hidden_state`
+    for the drafted positions. Its KV cache holds only the target context, so - unlike the
+    target's - it never needs to be rolled back after a rejected block.
+    """
+
+    export_feature = "text-generation-with-past"
+    auto_model_class = AutoModel
+
+    def __init__(
+        self,
+        model: ov.Model,
+        config: PretrainedConfig = None,
+        device: str = "CPU",
+        dynamic_shapes: bool = None,
+        ov_config: Optional[Dict[str, str]] = None,
+        model_save_dir: Optional[Union[str, Path]] = None,
+        quantization_config: Optional[Dict] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            model,
+            config=config,
+            device=device,
+            dynamic_shapes=dynamic_shapes,
+            ov_config=ov_config,
+            model_save_dir=model_save_dir,
+            quantization_config=quantization_config,
+            **kwargs,
+        )
+        rt_info = {}
+        if not self._compile_only:
+            if not is_dflash_draft_model(self.model):
+                raise ValueError(
+                    f"{model_save_dir} is not a DFlash draft model. Export one with "
+                    "`optimum-cli export openvino --task text-generation-with-past`, from a "
+                    "checkpoint whose architecture optimum-intel exports as a drafter."
+                )
+            rt_info = read_dflash_rt_info(self.model)
+
+        # The RT-info block is authoritative (it travels with the IR), the config is the
+        # fallback for drafters exported before it was stamped.
+        self.block_size = rt_info.get("block_size") or getattr(config, "block_size", None)
+        self.mask_token_id = rt_info.get("mask_token_id")
+        if self.mask_token_id is None:
+            self.mask_token_id = getattr(config, "mask_token_id", None)
+        self.target_layer_ids = rt_info.get("target_layer_ids") or getattr(config, "target_layer_ids", None)
+        if not self.block_size or self.mask_token_id is None or not self.target_layer_ids:
+            raise ValueError(
+                "Could not determine the DFlash parameters (block_size, mask_token_id, target_layer_ids) "
+                f"of {model_save_dir}. Re-export the drafter with a recent optimum-intel."
+            )
+        self.request = None if not self._compile_only else self.model.create_infer_request()
+
+    def can_generate(self) -> bool:
+        # A drafter emits hidden states, not logits; it is never driven by `generate()`
+        # directly, only through a target model's candidate generator.
+        return False
+
+    def _reshape(self, model: ov.Model, batch_size: int, sequence_length: int, height=None, width=None):
+        # Every axis of the drafter is dynamic by construction, and the context, the
+        # diffusion window and the attention mask all have different lengths, so there is
+        # no single `sequence_length` to pin. Only the batch axis is set here; `beam_idx`
+        # is rank-1 and has no sequence axis at all.
+        shapes = {}
+        for model_input in model.inputs:
+            shape = model_input.get_partial_shape()
+            shape[0] = batch_size
+            shapes[model_input] = shape
+        model.reshape(shapes)
+        return model
+
+    def compile(self):
+        if self.request is None:
+            super().compile()
+            self.request = self.request.create_infer_request()
+
+    def clear_requests(self):
+        if not self._compile_only:
+            self.request = None
+
+    def reset_state(self):
+        if self.request is not None:
+            self.request.reset_state()
+
+    def forward(
+        self,
+        inputs_embeds: torch.Tensor,
+        hidden_states: torch.Tensor,
+        position_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        **kwargs,
+    ) -> BaseModelOutputWithPast:
+        self.compile()
+        inputs = {
+            "inputs_embeds": np.ascontiguousarray(inputs_embeds.numpy()),
+            "hidden_states": np.ascontiguousarray(hidden_states.numpy()),
+            "position_ids": np.ascontiguousarray(position_ids.numpy()),
+            "attention_mask": np.ascontiguousarray(attention_mask.numpy()),
+        }
+        if "beam_idx" in self.input_names:
+            inputs["beam_idx"] = np.arange(inputs_embeds.shape[0], dtype=np.int32)
+        self.request.start_async(inputs, share_inputs=True)
+        self.request.wait()
+        last_hidden_state = torch.from_numpy(self.request.get_tensor("last_hidden_state").data).clone()
+        return BaseModelOutputWithPast(last_hidden_state=last_hidden_state)
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
+
+# --------------------------------------------------------------------------------------
+# Candidate generator
+# --------------------------------------------------------------------------------------
+
+
+class OVDFlashCandidateGenerator(CandidateGenerator):
+    """DFlash candidate generator driving OpenVINO models.
+
+    Adapted from `transformers.generation.candidate_generator.DFlashTokenCandidateGenerator`.
+    The drafting logic is identical; what differs is where the two borrowed pieces of the
+    target come from. Transformers reaches into the target's `nn.Module`s - `F.embedding`
+    against the embedding weight, and a call to the lm_head - which an OpenVINO target does
+    not have, because those weights live compressed inside its IR files. Here they are
+    small `ov.Model`s extracted from the target's own exports (see
+    `extract_raw_embedding_model` / `extract_lm_head_model`), so nothing is materialized in
+    float and no second export is needed.
+
+    The drafter's own KV cache lives inside its stateful IR, so there is no `DFlashCache`
+    to crop here; the export persists only the target context, never the diffusion window.
+    """
+
+    requires_model_outputs: bool = True
+    # The target must hand back the hidden states the drafter conditions on.
+    model_kwargs_overrides: Dict[str, Any] = {}
+
+    def __init__(
+        self,
+        assistant_model: OVAssistantForCausalLM,
+        raw_embedding: "ov.CompiledModel",
+        lm_head: "ov.CompiledModel",
+        generation_config: GenerationConfig,
+        logits_processor: Optional["LogitsProcessorList"] = None,
+    ):
+        self.assistant_model = assistant_model
+        self.raw_embedding = raw_embedding
+        self.lm_head = lm_head
+        self.main_model_max_length = generation_config.max_length
+
+        self.target_layer_ids = assistant_model.target_layer_ids
+        self.block_size = assistant_model.block_size
+        self.mask_token_id = assistant_model.mask_token_id
+        self.noise_ids_mask = torch.tensor([self.mask_token_id] * (self.block_size - 1))[None, ...]
+
+        self.do_sample = generation_config.do_sample
+        self.logits_processor = logits_processor
+        self.is_main_model_prefill = True
+        assistant_model.reset_state()
+
+    def get_candidates(
+        self,
+        input_ids: torch.LongTensor,
+        model_kwargs: Dict[str, Any],
+        model_outputs,
+        is_first_iteration: bool,
+        n_last_matches: int,
+        **kwargs,
+    ):
+        # The first loop of `_assisted_decoding` runs the target so that its hidden states
+        # exist for the drafter to condition on; nothing is drafted yet.
+        if is_first_iteration:
+            return input_ids, None
+
+        max_new_tokens = min(int(self.block_size), self.main_model_max_length - input_ids.shape[1] - 1)
+        if max_new_tokens <= 0:
+            return input_ids, None
+
+        hidden_states = getattr(model_outputs, "dflash_hidden_states", None)
+        if hidden_states is None:
+            raise ValueError("The target model did not return the hidden states DFlash needs.")
+
+        # The target's last forward covered all candidates; keep only the accepted ones.
+        num_last_main_model_tokens = n_last_matches + 1 if not self.is_main_model_prefill else input_ids.shape[1] - 1
+        context_hidden_states = torch.cat(
+            [hidden_states[layer_id][:, :num_last_main_model_tokens] for layer_id in self.target_layer_ids],
+            dim=-1,
+        )
+
+        # `position_ids`/`attention_mask` cover the full sequence including the bonus token
+        # the target just produced; the drafter sees the tokens the target processed plus
+        # the diffusion window that follows them.
+        position_ids = model_kwargs["position_ids"][:, -num_last_main_model_tokens - 1 : -1]
+        attention_mask = model_kwargs["attention_mask"][:, :-1]
+
+        # The window is the last decoded token ("anchor") followed by mask tokens.
+        noise_ids = torch.cat([input_ids[:, -1:], self.noise_ids_mask.to(input_ids.device)], dim=-1)
+        noise_embeds = torch.from_numpy(self.raw_embedding(np.ascontiguousarray(noise_ids.numpy()))[0]).clone()
+
+        noise_position_ids = torch.arange(self.block_size, device=position_ids.device) + position_ids[..., -1:] + 1
+        position_ids = torch.cat([position_ids, noise_position_ids], dim=-1)
+        noise_attention_mask = torch.ones(
+            attention_mask.shape[0], self.block_size, device=attention_mask.device, dtype=attention_mask.dtype
+        )
+        attention_mask = torch.cat([attention_mask, noise_attention_mask], dim=-1)
+
+        outputs = self.assistant_model(
+            inputs_embeds=noise_embeds,
+            hidden_states=context_hidden_states,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+        )
+        self.is_main_model_prefill = False
+
+        # The export already dropped the anchor position, so these states line up 1:1 with
+        # the drafted tokens.
+        candidate_logits = torch.from_numpy(
+            self.lm_head(np.ascontiguousarray(outputs.last_hidden_state.numpy()))[0]
+        ).clone()
+
+        if self.logits_processor is not None and len(self.logits_processor) > 0:
+            candidate_ids = input_ids
+            for i in range(candidate_logits.shape[1]):
+                next_token_logits = self.logits_processor(candidate_ids, candidate_logits[:, i, :].float())
+                if self.do_sample:
+                    probs = torch.nn.functional.softmax(next_token_logits, dim=-1, dtype=torch.float32)
+                    next_token = torch.multinomial(probs, num_samples=1)
+                else:
+                    next_token = torch.argmax(next_token_logits, dim=-1, keepdim=True)
+                candidate_ids = torch.cat([candidate_ids, next_token], dim=-1)
+        else:
+            if self.do_sample:
+                probs = torch.nn.functional.softmax(candidate_logits, dim=-1, dtype=torch.float32)
+                # Assisted decoding is batch-size 1, and multinomial needs a 2D input.
+                candidate_ids = torch.multinomial(probs.squeeze(0), num_samples=1)
+            else:
+                candidate_ids = candidate_logits.argmax(dim=-1)
+            candidate_ids = torch.cat([input_ids, candidate_ids], dim=-1)
+
+        return candidate_ids, candidate_logits
+
+    def update_candidate_strategy(self, input_ids: torch.LongTensor, scores: torch.FloatTensor, num_matches: int):
+        return
+
+
+# --------------------------------------------------------------------------------------
+# Target-side wiring
+# --------------------------------------------------------------------------------------
+
+
+class OVDFlashTargetMixin:
+    """Adds DFlash speculative decoding to an OpenVINO target model.
+
+    Mixed into models whose language part is an `OVModelWithEmbedForCausalLM`. Setup is
+    lazy: nothing changes until `generate()` is actually called with an
+    `OVAssistantForCausalLM`, so ordinary generation is untouched.
+    """
+
+    def _setup_dflash(self, assistant_model: OVAssistantForCausalLM) -> None:
+        language_model = self.language_model
+        layer_ids = list(assistant_model.target_layer_ids)
+        if getattr(language_model, "_dflash_layer_ids", None) == layer_ids:
+            return
+        if language_model._compile_only:
+            raise ValueError(
+                "DFlash speculative decoding needs to add hidden-state outputs to the language model, "
+                "which `compile_only=True` does not allow. Load the target without `compile_only`."
+            )
+
+        hidden_size = self.config.get_text_config().hidden_size
+        language_model._dflash_hidden_state_names = add_hidden_state_outputs(language_model.model, layer_ids)
+        language_model._dflash_layer_ids = layer_ids
+        # The graph gained outputs, so the compiled model is stale.
+        language_model.clear_requests()
+        language_model.compile()
+
+        core = ov.Core()
+        ov_config = getattr(language_model, "ov_config", None) or {}
+        self._dflash_lm_head = core.compile_model(
+            extract_lm_head_model(language_model.model, hidden_size), language_model._device, ov_config
+        )
+        self._dflash_raw_embedding = core.compile_model(
+            extract_raw_embedding_model(language_model.text_emb_model), language_model._device, ov_config
+        )
+
+    def generate(self, *args, **kwargs):
+        # `speculation_type="dflash"` is what tells transformers' assisted decoding that
+        # the drafter is a block-diffusion model rather than a small copy of the target
+        # (and so that they need not share a tokenizer). It is implied by passing an
+        # `OVAssistantForCausalLM`, so callers do not have to spell it out.
+        assistant_model = kwargs.get("assistant_model")
+        if isinstance(assistant_model, OVAssistantForCausalLM):
+            kwargs.setdefault("speculation_type", "dflash")
+            self._setup_dflash(assistant_model)
+
+            # Assisted decoding insists on a Cache object it can roll back, and refuses to
+            # start without one. The OpenVINO target keeps its KV cache in variable states
+            # instead, so seed the proxy that exposes them; transformers leaves a
+            # caller-provided cache alone. Seeding it also means the target's forward will
+            # not see `past_key_values=None`, so reset the state here as that branch would.
+            language_model = self.language_model
+            language_model.compile()
+            language_model.request.reset_state()
+            language_model._past_length = 0
+            language_model.next_beam_idx = np.arange(1, dtype=int)
+            kwargs.setdefault("past_key_values", OVStatefulCacheProxy(language_model))
+            assistant_model.reset_state()
+        return super().generate(*args, **kwargs)
+
+    def _get_candidate_generator(
+        self,
+        generation_config,
+        input_ids,
+        inputs_tensor,
+        logits_processor,
+        model_kwargs,
+        assistant_model=None,
+        **kwargs,
+    ):
+        if not isinstance(assistant_model, OVAssistantForCausalLM):
+            return super()._get_candidate_generator(
+                generation_config,
+                input_ids,
+                inputs_tensor,
+                logits_processor,
+                model_kwargs,
+                assistant_model=assistant_model,
+                **kwargs,
+            )
+        self._setup_dflash(assistant_model)
+        return OVDFlashCandidateGenerator(
+            assistant_model=assistant_model,
+            raw_embedding=self._dflash_raw_embedding,
+            lm_head=self._dflash_lm_head,
+            generation_config=generation_config,
+            logits_processor=logits_processor,
+        )

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -48,6 +48,7 @@ from optimum.exporters.openvino.utils import save_config
 from optimum.intel.openvino.configuration import OVConfig, OVQuantizationConfigBase, OVWeightQuantizationConfig
 from optimum.intel.openvino.modeling_base import OVBaseModel, OVModelPart
 from optimum.intel.openvino.modeling_decoder import CausalLMOutputWithPast, OVModelForCausalLM
+from optimum.intel.openvino.modeling_dflash import OVDFlashTargetMixin, OVStatefulCacheProxy
 from optimum.intel.openvino.utils import (
     OV_LANGUAGE_MODEL_NAME,
     OV_TEXT_EMBEDDINGS_MODEL_NAME,
@@ -301,6 +302,17 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
         past_key_values = ((),)
         self._past_length += inputs["inputs_embeds"].shape[1]
 
+        # DFlash speculative decoding needs two things a plain forward does not provide:
+        # the target's hidden states at the drafter's `target_layer_ids`, and a cache the
+        # verifier can roll back after a rejected block.
+        dflash_hidden_states = None
+        if getattr(self, "_dflash_hidden_state_names", None):
+            dflash_hidden_states = {
+                layer_id: torch.from_numpy(self.request.get_tensor(name).data).clone().to(self.device)
+                for layer_id, name in zip(self._dflash_layer_ids, self._dflash_hidden_state_names)
+            }
+            past_key_values = OVStatefulCacheProxy(self)
+
         collecting = getattr(self, "_collecting_hidden_states", False)
         hidden_states_out = None
         if collecting and "hidden_states" in self.output_names:
@@ -314,6 +326,7 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
         result = CausalLMOutputWithPast(logits=logits, past_key_values=past_key_values)
         result.last_hidden_state = hidden_states_out
         result.intermediate_hidden_state = intermediate_hidden
+        result.dflash_hidden_states = dflash_hidden_states
         return result
 
 
@@ -767,7 +780,7 @@ MODEL_PARTS_CLS_MAPPING = {
 }
 
 
-class OVModelForVisualCausalLM(OVBaseModel, GenerationMixin):
+class OVModelForVisualCausalLM(OVBaseModel, OVDFlashTargetMixin, GenerationMixin):
     export_feature = "image-text-to-text"
     additional_parts = []
     auto_model_class = AutoModelForImageTextToText
@@ -7809,7 +7822,10 @@ class _OVMuseGlimmerForCausalLM(OVModelForVisualCausalLM):
     ):
         inputs_embeds = self.get_text_embeddings(input_ids)
         inputs_embeds = torch.from_numpy(inputs_embeds) if isinstance(inputs_embeds, np.ndarray) else inputs_embeds
-        is_prefill = input_ids is not None and input_ids.shape[1] != 1
+        # An empty KV cache identifies the prefill. The token count does not: under
+        # speculative decoding a continuation step verifies a whole block at once.
+        past_key_values = kwargs.get("past_key_values")
+        is_prefill = past_key_values is None or self.language_model._get_past_length(past_key_values) == 0
         # Images and videos share the same vision graph (video_grid_thw plays the role
         # of image_grid_thw); each modality is scattered into its own placeholder token.
         if is_prefill and pixel_values is not None:

--- a/optimum/intel/utils/modeling_utils.py
+++ b/optimum/intel/utils/modeling_utils.py
@@ -203,7 +203,7 @@ def _infer_library_from_model_or_model_class(
         library_name = "kokoro"
     elif model.__module__.startswith("funasr") or getattr(model, "_funasr_model", False):
         library_name = "funasr"
-    elif model.__module__.startswith("optimum"):
+    elif model.__module__.startswith("optimum") and hasattr(model, "model"):
         # for wrapped models like timm in optimum.intel.openvino.modeling_timm
         library_name = TasksManager._infer_library_from_model_or_model_class(model=model.model)
     else:

--- a/tests/openvino/test_dflash.py
+++ b/tests/openvino/test_dflash.py
@@ -18,12 +18,16 @@ import unittest
 from pathlib import Path
 
 import nncf
+import numpy as np
 import openvino as ov
+import torch
 from parameterized import parameterized
-from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
+from PIL import Image
+from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoProcessor
 from utils_tests import MODEL_NAMES
 
-from optimum.exporters.openvino import export_from_model
+from optimum.exporters.openvino import export_from_model, main_export
+from optimum.intel.openvino import OVAssistantForCausalLM, OVConfig, OVModelForVisualCausalLM
 from optimum.intel.openvino.utils import TemporaryDirectory
 from optimum.intel.utils.import_utils import is_transformers_version
 
@@ -93,6 +97,83 @@ class DFlashExportTest(unittest.TestCase):
         self._export_and_assert_hidden_state_locators(
             model_type, AutoModelForImageTextToText, "image-text-to-text", "openvino_language_model.xml"
         )
+
+    def test_export_muse_glimmer_assistant_draft_contract(self):
+        if not is_transformers_version(">=", "5.15.0"):
+            self.skipTest("MuseGlimmer requires Transformers >= 5.15.0")
+
+        with TemporaryDirectory() as tmpdirname:
+            tmpdirname = Path(tmpdirname)
+            main_export(
+                model_name_or_path=MODEL_NAMES["muse_glimmer_assistant"],
+                output=tmpdirname,
+                task="text-generation-with-past",
+            )
+            model = ov.Core().read_model(tmpdirname / "openvino_model.xml")
+
+            # The drafter borrows the target's embedding and lm_head, so it takes
+            # embeddings in and emits hidden states out - never token ids or logits.
+            input_names = {inp.get_any_name() for inp in model.inputs}
+            self.assertEqual(
+                input_names, {"inputs_embeds", "hidden_states", "position_ids", "attention_mask", "beam_idx"}
+            )
+            self.assertEqual({out.get_any_name() for out in model.outputs}, {"last_hidden_state"})
+
+            self.assertTrue(model.has_rt_info(["dflash_mode"]))
+            self.assertTrue(model.has_rt_info(["dflash", "block_size"]))
+            self.assertTrue(model.has_rt_info(["dflash", "mask_token_id"]))
+            target_layer_ids = model.get_rt_info(["dflash", "target_layer_ids"]).value.split(",")
+            self.assertEqual(len(target_layer_ids), 2)
+
+            # `hidden_states` is the target's states at every target layer, concatenated.
+            hidden_size = model.input("inputs_embeds").get_partial_shape()[2].get_length()
+            context_width = model.input("hidden_states").get_partial_shape()[2].get_length()
+            self.assertEqual(context_width, hidden_size * len(target_layer_ids))
+
+    def test_muse_glimmer_dflash_speculative_decoding_is_lossless(self):
+        if not is_transformers_version(">=", "5.15.0"):
+            self.skipTest("MuseGlimmer requires Transformers >= 5.15.0")
+
+        with TemporaryDirectory() as tmpdirname:
+            tmpdirname = Path(tmpdirname)
+            target_dir, draft_dir = tmpdirname / "target", tmpdirname / "draft"
+            # Export uncompressed. The fixture is randomly initialized, so its logits sit
+            # within ~1e-3 of each other; weight compression then lets the (unavoidable)
+            # numeric difference between verifying a block and decoding token by token
+            # flip an argmax tie, which would fail this check for reasons that have
+            # nothing to do with speculation. Real weights are not this degenerate.
+            fp32 = OVConfig(dtype="fp32")
+            main_export(
+                model_name_or_path=MODEL_NAMES["muse_glimmer"],
+                output=target_dir,
+                task="image-text-to-text",
+                ov_config=fp32,
+            )
+            main_export(
+                model_name_or_path=MODEL_NAMES["muse_glimmer_assistant"],
+                output=draft_dir,
+                task="text-generation-with-past",
+                ov_config=fp32,
+            )
+
+            model = OVModelForVisualCausalLM.from_pretrained(target_dir)
+            assistant = OVAssistantForCausalLM.from_pretrained(draft_dir)
+            processor = AutoProcessor.from_pretrained(MODEL_NAMES["muse_glimmer"], padding_side="left")
+
+            image = Image.fromarray(np.random.default_rng(0).integers(0, 255, (224, 224, 3), dtype=np.uint8))
+            messages = [
+                {"role": "user", "content": [{"type": "image"}, {"type": "text", "text": "What is in this image?"}]}
+            ]
+            text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+            inputs = processor(text=[text], images=[image], return_tensors="pt")
+
+            baseline = model.generate(**inputs, max_new_tokens=24, do_sample=False)
+            speculative = model.generate(**inputs, max_new_tokens=24, do_sample=False, assistant_model=assistant)
+
+            # Greedy DFlash is lossless: the accepted prefix plus the bonus token always
+            # reproduces the target's own greedy continuation.
+            self.assertEqual(baseline.shape, speculative.shape)
+            self.assertTrue(torch.equal(baseline, speculative))
 
     def test_hidden_state_locators_survive_weight_compression(self):
         with TemporaryDirectory() as tmpdirname:

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -327,6 +327,7 @@ HUB_MODEL_NAMES = {
     "mpt": "optimum-intel-internal-testing/tiny-random-MptForCausalLM",
     "mpnet": "optimum-intel-internal-testing/tiny-random-MPNetModel",
     "muse_glimmer": "optimum-intel-internal-testing/tiny-random-muse-glimmer",
+    "muse_glimmer_assistant": "optimum-intel-internal-testing/tiny-random-muse-glimmer-assistant",
     "mt5": "optimum-intel-internal-testing/mt5-tiny-random",
     "llava-qwen2": "optimum-intel-internal-testing/tiny-random-nanollava",
     "nanollava_vision_tower": "optimum-intel-internal-testing/tiny-random-siglip",


### PR DESCRIPTION
# What does this PR do?

```python
import time

import torch
from transformers import AutoProcessor
from transformers.image_utils import load_image

from optimum.intel.openvino import OVAssistantForCausalLM, OVModelForVisualCausalLM

model_id = "./ov_muse_glimmer_int4"
#assistant_model_id = "./ov_muse_glimmer_assistant"
assistant_model_id = "./ov_muse_glimmer_assistant_int4"

model = OVModelForVisualCausalLM.from_pretrained(model_id)
assistant_model = OVAssistantForCausalLM.from_pretrained(assistant_model_id)
processor = AutoProcessor.from_pretrained("meta-models/Muse-Glimmer-30B", padding_side="left")

url = "https://media.istockphoto.com/id/1192867753/photo/cow-in-berchida-beach-siniscola.jpg?s=612x612&w=0&k=20&c=v0hjjniwsMNfJSuKWZuIn8pssmD5h5bSN1peBd1CmH4="
question = "What is shown in this image?"

# OnyxProcessor expects the rendered text and a *flat* list of PIL images, so render the
# prompt (without tokenizing) and load the image ourselves rather than letting
# apply_chat_template(tokenize=True) hand the processor a nested per-conversation image
# list it does not unwrap.
messages = [
    {
        "role": "system",
        "content": [
            {"type": "text", "text": "You are a helpful assistant."}
        ]
    },
    {
        "role": "user", "content": [
            {"type": "image", "url": url},
            {"type": "text", "text": question},
        ]
    },
]
text = processor.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
inputs = processor(text=[text], images=[load_image(url)], return_tensors="pt")
prompt_len = inputs.input_ids.shape[1]

# Count target forwards: the first one is the prefill, the rest are verification steps.
num_forwards = [0]
orig_lm_forward = model.language_model.forward


def counting_forward(*args, **kwargs):
    num_forwards[0] += 1
    return orig_lm_forward(*args, **kwargs)


model.language_model.forward = counting_forward

start = time.perf_counter()
output = model.generate(**inputs, max_new_tokens=64, do_sample=False, assistant_model=assistant_model)
spec_time = time.perf_counter() - start
spec_forwards = num_forwards[0]
num_new_tokens = output.shape[1] - prompt_len

# Greedy speculative decoding is lossless, so the same prompt without the assistant must
# produce exactly the same tokens.
num_forwards[0] = 0
start = time.perf_counter()
reference = model.generate(**inputs, max_new_tokens=64, do_sample=False)
base_time = time.perf_counter() - start
base_forwards = num_forwards[0]

print("--- with the DFlash assistant ---")
print(f"new tokens        : {num_new_tokens}")
print(f"wall time         : {spec_time:.2f} s ({num_new_tokens / spec_time:.2f} tok/s)")
print(f"target forwards   : {spec_forwards} (1 prefill + {spec_forwards - 1} verify)")
print(f"tokens per verify : {num_new_tokens / (spec_forwards - 1):.2f}")

print("--- without the assistant ---")
print(f"wall time         : {base_time:.2f} s ({num_new_tokens / base_time:.2f} tok/s)")
print(f"target forwards   : {base_forwards} (1 prefill + {base_forwards - 1} decode)")
print(f"speedup           : {base_time / spec_time:.2f}x")

print("--- generated text ---")
print(processor.batch_decode(output[:, prompt_len:], skip_special_tokens=True)[0])

if reference.shape == output.shape and torch.equal(reference, output):
    print("lossless: identical to the output without the assistant")
else:
    print("MISMATCH: differs from the output without the assistant")
    print(processor.batch_decode(reference[:, prompt_len:], skip_special_tokens=True)[0])
```

Fixes # (issue)


## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [ ] Did you make sure to update the documentation with your changes?
- [ ] Did you write any new necessary tests?

