### PR TITLE
[OpenVINO] Add DFlash 2 two-model export

### DIFF
--- a/.github/workflows/test_openvino_remote_code.yml
+++ b/.github/workflows/test_openvino_remote_code.yml
@@ -82,3 +82,4 @@ jobs:
         run: |
           uv pip install transformers==5.2.0
           pytest tests/openvino/test_dflash.py --durations=0
+          pytest tests/openvino/test_exporters_cli.py -k dflash2 --durations=0

--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -224,6 +224,11 @@ Here is the list of the supported architectures :
 - Qwen3.6-*-DFlash
 - Qwen3-Coder-30B-A3B-DFlash
 - gemma-4-31B-it-DFlash
+- Qwen3.8-27B-DFlash2
+
+DFlash v1 export produces `openvino_model.xml` for the draft backbone.
+Dflash v2 export produces in addition `openvino_selector_model.xml` for the candidate selector,
+supplied to OpenVINO GenAI for selector-guided decoding; the backbone remains usable in isolation from selector.
 
 ## [Ouro](https://huggingface.co/ByteDance/Ouro-1.4B)
 - Ouro-1.4B

--- a/optimum/exporters/openvino/__main__.py
+++ b/optimum/exporters/openvino/__main__.py
@@ -29,6 +29,7 @@ from transformers.utils import is_torch_available
 
 from openvino import Core, Type, save_model
 from optimum.exporters.openvino.base import OpenVINOConfig
+from optimum.exporters.openvino.dflash_utils import DFLASH_ARCHITECTURES, parse_and_validate_dflash_config
 from optimum.exporters.tasks import TasksManager
 from optimum.intel.utils.import_utils import (
     DIFFUSERS_IMPORT_ERROR,
@@ -220,6 +221,7 @@ _CUSTOM_DRAFT_MODEL_MAP = {
     "LlamaForCausalLMEagle3": ("LlamaEagle3Model", "LlamaEagle3ForCausalLM"),
     "Eagle3LlamaForCausalLM": ("LlamaEagle3Model", "LlamaEagle3ForCausalLM"),
     "DFlashDraftModel": ("Qwen3DFlashDraftModel", "Qwen3DFlashForCausalLM"),
+    "DFlash2DraftModel": ("Qwen3DFlash2DraftModel", "Qwen3DFlash2ForCausalLM"),
 }
 
 
@@ -402,6 +404,8 @@ def main_export(
 
         # update config to load custom draft models (eagle3 text-only/VLM variants, dflash)
         archs = getattr(config, "architectures", None)
+        if isinstance(archs, list) and archs and archs[0] in DFLASH_ARCHITECTURES:
+            parse_and_validate_dflash_config(config)
         if isinstance(archs, list) and archs:
             draft_classes = _CUSTOM_DRAFT_MODEL_MAP.get(archs[0])
             if draft_classes is not None:

--- a/optimum/exporters/openvino/base.py
+++ b/optimum/exporters/openvino/base.py
@@ -34,6 +34,9 @@ from optimum.utils.doc import add_dynamic_docstring
 
 logger = logging.get_logger(__name__)
 
+ACTIVATIONS_SCALE_FACTOR_RT_OPTION = "ACTIVATIONS_SCALE_FACTOR"
+DEFAULT_ACTIVATIONS_SCALE_FACTOR = 8.0
+
 
 GENERATE_DUMMY_DOCSTRING = r"""
         Generates the dummy inputs necessary for tracing the model. If not explicitly specified, default input shapes are used.
@@ -69,6 +72,7 @@ GENERATE_DUMMY_DOCSTRING = r"""
 class OpenVINOConfig(ExporterConfig, ABC):
     VARIANTS: ClassVar[dict[str, str]] = {"default": "The default OpenVINO variant."}
     DEFAULT_VARIANT = "default"
+    PRESERVE_CHECKPOINT_PRECISION: ClassVar[bool] = False
     PATCHING_SPECS: list[PatchingSpec] | None = None
     _MODEL_PATCHER = ModelPatcher
     MIN_TRANSFORMERS_VERSION = "4.57"
@@ -143,6 +147,9 @@ class OpenVINOConfig(ExporterConfig, ABC):
 
         self.variant = "default"
         self._preprocessors = preprocessors
+        # Export configs may replace generic runtime defaults with
+        # architecture- or component-specific recommendations.
+        self.runtime_options: dict[str, str] = {}
 
     @property
     def variant(self) -> str:

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -29,6 +29,11 @@ from transformers.utils import is_torch_available
 from openvino import Model, save_model
 from openvino.exceptions import OVTypeError
 from openvino.tools.ovc import convert_model
+from optimum.exporters.openvino.base import (
+    ACTIVATIONS_SCALE_FACTOR_RT_OPTION,
+    DEFAULT_ACTIVATIONS_SCALE_FACTOR,
+)
+from optimum.exporters.openvino.dflash_utils import DFLASH_ARCHITECTURES, parse_and_validate_dflash_config
 from optimum.exporters.openvino.utils import (
     MULTI_MODAL_TEXT_GENERATION_MODELS,
     ONNX_SUPPORTED_ARCHITECTURES,
@@ -113,25 +118,19 @@ def _set_runtime_options(
         _, sub_export_config = models_and_export_configs[model_name]
         if not hasattr(sub_export_config, "runtime_options"):
             sub_export_config.runtime_options = {}
-        if (
-            "text-generation" in task
+        submodel_task = getattr(sub_export_config, "task", "") or ""
+        uses_decoder_runtime_options = (
+            "text-generation" in submodel_task
             or ("image-text-to-text" in task and model_name == "language_model")
             or getattr(sub_export_config, "stateful", False)
-        ):
-            sub_export_config.runtime_options["ACTIVATIONS_SCALE_FACTOR"] = "8.0"
-        if not quantized_model and (
-            "text-generation" in task
-            or ("image-text-to-text" in task and model_name == "language_model")
-            or getattr(sub_export_config, "stateful", False)
-        ):
-            sub_export_config.runtime_options["KV_CACHE_PRECISION"] = "f16"
-        # The gemma4_unified vision embedder produces activations large enough to overflow in
-        # fp16, so scale them down at runtime the same way the language model does.
-        if (
-            model_name == "vision_embeddings_model"
-            and getattr(getattr(sub_export_config, "_orig_config", None), "model_type", None) == "gemma4_unified"
-        ):
-            sub_export_config.runtime_options["ACTIVATIONS_SCALE_FACTOR"] = "8.0"
+        )
+        if uses_decoder_runtime_options:
+            sub_export_config.runtime_options.setdefault(
+                ACTIVATIONS_SCALE_FACTOR_RT_OPTION,
+                str(DEFAULT_ACTIVATIONS_SCALE_FACTOR),
+            )
+        if not quantized_model and uses_decoder_runtime_options:
+            sub_export_config.runtime_options.setdefault("KV_CACHE_PRECISION", "f16")
 
 
 def _save_model(
@@ -142,7 +141,11 @@ def _save_model(
     config: "OpenVINOConfig" = None,
     source_model=None,
 ):
-    compress_to_fp16 = ov_config is not None and ov_config.dtype == "fp16"
+    compress_to_fp16 = (
+        ov_config is not None
+        and ov_config.dtype == "fp16"
+        and not getattr(config, "PRESERVE_CHECKPOINT_PRECISION", False)
+    )
     model = _add_version_info_to_model(model, library_name)
 
     runtime_options = config.runtime_options if hasattr(config, "runtime_options") else {}
@@ -150,17 +153,27 @@ def _save_model(
 
     if getattr(config, "eagle3", False):
         model = _add_eagle3_mode_to_rt_info(model)
-    if getattr(config, "dflash", False):
+    is_dflash = getattr(config, "dflash", False)
+    is_dflash_selector = getattr(config, "dflash2_selector", False)
+    if is_dflash:
         model = _add_dflash_mode_to_rt_info(model, config._config)
-    if source_model is not None and getattr(getattr(source_model, "config", None), "model_type", None) in {
-        "qwen3",
-        "qwen3_moe",
-        "qwen3_5",
-        "qwen3_5_moe",
-        "qwen3_5_text",
-        "qwen3_5_moe_text",
-        "gemma4",
-    }:
+    elif is_dflash_selector:
+        model = _add_dflash_selector_mode_to_rt_info(model, config._config)
+    if (
+        source_model is not None
+        and not is_dflash
+        and not is_dflash_selector
+        and getattr(getattr(source_model, "config", None), "model_type", None)
+        in {
+            "qwen3",
+            "qwen3_moe",
+            "qwen3_5",
+            "qwen3_5_moe",
+            "qwen3_5_text",
+            "qwen3_5_moe_text",
+            "gemma4",
+        }
+    ):
         add_hidden_states_rt_info(source_model, model, config)
 
     save_model(model, path, compress_to_fp16)
@@ -375,10 +388,19 @@ def export_pytorch(
                     # patch_everywhere breaks torch.ops namespace
                     del torch.ops._prepare_4d_causal_attention_mask_for_sdpa
                 dynamic_shapes = _get_dynamic_shapes_info(model, config, dummy_inputs)
-                _export_kwargs = {"args": (), "kwargs": _normalize_dummy_inputs(dummy_inputs, _get_model_dtype(model))}
+                normalized_inputs = _normalize_dummy_inputs(dummy_inputs, _get_model_dtype(model))
+                forward_signature = inspect.signature(patcher.orig_forward)
+                ordered_inputs = {
+                    name: normalized_inputs[name] for name in forward_signature.parameters if name in normalized_inputs
+                }
+                ordered_inputs.update(
+                    {name: value for name, value in normalized_inputs.items() if name not in ordered_inputs}
+                )
+                _export_kwargs = {"args": (), "kwargs": ordered_inputs}
                 _export_kwargs["dynamic_shapes"] = dynamic_shapes
 
-                ep = torch.export.export_for_training(model, **_export_kwargs)
+                export_fn = getattr(torch.export, "export_for_training", torch.export.export)
+                ep = export_fn(model, **_export_kwargs)
 
                 ov_model = convert_model(ep)
             else:
@@ -476,31 +498,43 @@ def export_models(
         list of input_names and output_names from OpenVINO configuration
     """
 
-    outputs = []
+    outputs = [None] * len(models_and_export_configs)
 
     if output_names is not None and len(output_names) != len(models_and_export_configs):
         raise ValueError(
             f"Provided custom names {output_names} for the export of {len(models_and_export_configs)} models. Please provide the same number of names as models to export."
         )
 
-    for i, model_name in enumerate(models_and_export_configs.keys()):
+    model_names = list(models_and_export_configs)
+    # The 16-bit traceability patch mutates shared PyTorch modules. Export
+    # opt-out components first so a later component cannot change their
+    # checkpoint precision before conversion.
+    export_order = sorted(
+        model_names,
+        key=lambda name: not getattr(
+            models_and_export_configs[name][1],
+            "PRESERVE_CHECKPOINT_PRECISION",
+            False,
+        ),
+    )
+    for model_name in export_order:
+        i = model_names.index(model_name)
         submodel, sub_export_config = models_and_export_configs[model_name]
         output_name = output_names[i] if output_names is not None else Path(model_name + ".xml")
         output_path = output_dir / output_name
         output_path.parent.mkdir(parents=True, exist_ok=True)
-        outputs.append(
-            export(
-                model=submodel,
-                config=sub_export_config,
-                output=output_path,
-                device=device,
-                input_shapes=input_shapes,
-                model_kwargs=model_kwargs,
-                ov_config=ov_config,
-                stateful=stateful[i] if isinstance(stateful, (list, tuple)) else stateful,
-                patch_16bit_model=patch_16bit_model,
-                library_name=library_name,
-            )
+        outputs[i] = export(
+            model=submodel,
+            config=sub_export_config,
+            output=output_path,
+            device=device,
+            input_shapes=input_shapes,
+            model_kwargs=model_kwargs,
+            ov_config=ov_config,
+            stateful=stateful[i] if isinstance(stateful, (list, tuple)) else stateful,
+            patch_16bit_model=patch_16bit_model
+            and not getattr(sub_export_config, "PRESERVE_CHECKPOINT_PRECISION", False),
+            library_name=library_name,
         )
 
     outputs = list(map(list, zip(*outputs)))
@@ -916,14 +950,9 @@ def export_tokenizer(
 
 
 def _add_runtime_options_to_rt_info(model: Model, options: Dict):
-    """
-    Add runtime optinos
-    """
-    try:
-        for name, value in options.items():
-            model.set_rt_info(value, ["runtime_options", name])
-    except Exception:
-        pass
+    """Add runtime options that must be preserved by the exported IR."""
+    for name, value in options.items():
+        model.set_rt_info(value, ["runtime_options", name])
 
     return model
 
@@ -947,15 +976,33 @@ def _add_dflash_mode_to_rt_info(model: Model, hf_config: "PretrainedConfig") -> 
     Marks model as DFlash draft model and adds DFlash configuration to the model including
     mask token id and target layer ids.
     """
-    try:
-        model.set_rt_info("True", ["dflash_mode"])
-        dflash_config = getattr(hf_config, "dflash_config", {})
-        if "mask_token_id" in dflash_config:
-            model.set_rt_info(str(dflash_config["mask_token_id"]), ["dflash", "mask_token_id"])
-        if "target_layer_ids" in dflash_config:
-            model.set_rt_info(",".join(map(str, dflash_config["target_layer_ids"])), ["dflash", "target_layer_ids"])
-    except Exception:
-        pass
+    dflash = parse_and_validate_dflash_config(hf_config)
+    dflash_config = dflash.values
+    model.set_rt_info("True", ["dflash_mode"])
+    model.set_rt_info(str(dflash_config["mask_token_id"]), ["dflash", "mask_token_id"])
+    model.set_rt_info(",".join(map(str, dflash_config["target_layer_ids"])), ["dflash", "target_layer_ids"])
+    if dflash.version == 2:
+        model.set_rt_info("2", ["dflash", "version"])
+        # GenAI reuses the target embedding and LM head outside the draft IR.
+        # The input scale applies only to embedding rows fed into the draft;
+        # the output transforms apply to unary logits before path selection.
+        for name in ("input_embedding_scale", "output_multiplier", "final_logit_softcapping"):
+            value = dflash_config.get(name)
+            if value is not None:
+                model.set_rt_info(str(value), ["dflash", name])
+
+    return model
+
+
+def _add_dflash_selector_mode_to_rt_info(model: Model, hf_config: "PretrainedConfig") -> Model:
+    """Add DFlash-2 selector contract and structural metadata."""
+    dflash_config = parse_and_validate_dflash_config(hf_config, expected_version=2).values
+    model.set_rt_info("True", ["dflash_selector_mode"])
+    model.set_rt_info("2", ["dflash_selector", "dflash_version"])
+    model.set_rt_info("unary_inclusive", ["dflash_selector", "score_semantics"])
+    model.set_rt_info(str(hf_config.hidden_size), ["dflash_selector", "hidden_size"])
+    model.set_rt_info(str(hf_config.vocab_size), ["dflash_selector", "vocab_size"])
+    model.set_rt_info(str(dflash_config["selector_top_k"]), ["dflash_selector", "top_k"])
 
     return model
 
@@ -1101,6 +1148,24 @@ def _get_submodels_and_export_configs(
         exporter,
     )
     stateful_per_model = [stateful] * len(models_for_export)
+
+    architectures = getattr(model.config, "architectures", None)
+    architecture = architectures[0] if isinstance(architectures, list) and architectures else None
+    is_dflash = architecture in DFLASH_ARCHITECTURES
+    if is_dflash and parse_and_validate_dflash_config(model.config).version == 2:
+        from optimum.exporters.openvino.model_configs import DFlash2SelectorOpenVINOConfig
+        from optimum.exporters.openvino.model_patcher import Qwen3DFlash2SelectorForExport
+
+        selector_model = Qwen3DFlash2SelectorForExport(model.candidate_selector, model.config)
+        selector_config = DFlash2SelectorOpenVINOConfig(
+            model.config,
+            task="feature-extraction",
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        models_for_export["selector_model"] = (selector_model, selector_config)
+        stateful_per_model.append(False)
 
     # VLM Eagle3 models need stateful KV cache despite model_type being "llama"
     # (not in MULTI_MODAL_TEXT_GENERATION_MODELS) and task being "image-text-to-text".

--- a/optimum/exporters/openvino/dflash_utils.py
+++ b/optimum/exporters/openvino/dflash_utils.py
@@ -1,0 +1,186 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from numbers import Real
+from typing import Any, Dict
+
+from transformers import PretrainedConfig
+
+from optimum.intel.utils.import_utils import is_transformers_version
+
+
+DFLASH_ARCHITECTURE_VERSIONS = {
+    "DFlashDraftModel": 1,
+    "DFlash2DraftModel": 2,
+}
+DFLASH_ARCHITECTURES = set(DFLASH_ARCHITECTURE_VERSIONS)
+DFLASH2_RECOMMENDED_ACTIVATIONS_SCALE_FACTOR = 32.0
+DFLASH_COMMON_CONFIG_FIELDS = (
+    "mask_token_id",
+    "target_layer_ids",
+)
+DFLASH2_REQUIRED_CONFIG_FIELDS = (
+    "conv_group_size",
+    "conv_kernel_size",
+    "selector_rank",
+    "selector_top_k",
+)
+# These transforms are applied by the serving runtime because the DFlash export
+# intentionally excludes the target embedding and LM head. `input_embedding_scale`
+# scales only target embedding rows reused as draft inputs before the DFlash-2
+# backbone; it does not alter the target model's own embedding path. When absent,
+# runtimes use the identity scale (1.0). The remaining fields transform selected
+# unary logits before candidate-path scoring.
+DFLASH2_OPTIONAL_CONFIG_FIELDS = (
+    "final_logit_softcapping",
+    "input_embedding_scale",
+    "output_multiplier",
+)
+
+
+@dataclass(frozen=True)
+class DFlashConfig:
+    version: int
+    values: Dict[str, Any]
+
+
+def _detect_dflash_version(config: PretrainedConfig) -> int:
+    architectures = getattr(config, "architectures", None)
+    architecture = architectures[0] if isinstance(architectures, list) and architectures else None
+    if architecture not in DFLASH_ARCHITECTURE_VERSIONS:
+        raise ValueError(
+            "DFlash export requires architectures[0] to be "
+            f"one of {sorted(DFLASH_ARCHITECTURES)}, got {architecture!r}."
+        )
+    if getattr(config, "model_type", None) != "qwen3":
+        raise ValueError(
+            f"DFlash export supports only Qwen3-based draft models, got model_type={config.model_type!r}."
+        )
+    return DFLASH_ARCHITECTURE_VERSIONS[architecture]
+
+
+def _normalize_dflash_config(config: PretrainedConfig, version: int) -> Dict[str, Any]:
+    """Return the canonical nested DFlash config, using flat fields only as fallbacks."""
+    raw_config = getattr(config, "dflash_config", None)
+    if raw_config is None:
+        dflash_config = {}
+    elif isinstance(raw_config, Mapping):
+        dflash_config = dict(raw_config)
+    else:
+        raise ValueError("DFlash dflash_config must be a mapping.")
+
+    config_fields = DFLASH_COMMON_CONFIG_FIELDS
+    if version == 2:
+        config_fields += DFLASH2_REQUIRED_CONFIG_FIELDS + DFLASH2_OPTIONAL_CONFIG_FIELDS
+    for name in config_fields:
+        flat_value = getattr(config, name, None)
+        if name in dflash_config:
+            if flat_value is not None and flat_value != dflash_config[name]:
+                raise ValueError(f"DFlash configuration field {name!r} has conflicting nested and flat values.")
+        elif flat_value is not None:
+            dflash_config[name] = flat_value
+    return dflash_config
+
+
+def _validate_common_dflash_config(config: PretrainedConfig, dflash_config: Dict[str, Any], version: int) -> None:
+    missing = [name for name in DFLASH_COMMON_CONFIG_FIELDS if dflash_config.get(name) is None]
+    if missing:
+        raise ValueError(f"DFlash v{version} export requires configuration fields: {', '.join(missing)}.")
+
+    mask_token_id = dflash_config["mask_token_id"]
+    vocab_size = getattr(config, "vocab_size", None)
+
+    if not _is_positive_int(vocab_size):
+        raise ValueError(f"DFlash v{version} export requires a positive integer vocabulary size.")
+    if not isinstance(mask_token_id, int) or isinstance(mask_token_id, bool) or not 0 <= mask_token_id < vocab_size:
+        raise ValueError(f"DFlash v{version} dflash_config['mask_token_id'] must be an integer in [0, vocab_size).")
+
+    target_layer_ids = dflash_config["target_layer_ids"]
+    if (
+        not isinstance(target_layer_ids, (list, tuple))
+        or not target_layer_ids
+        or any(
+            not isinstance(layer_id, int) or isinstance(layer_id, bool) or layer_id < 0
+            for layer_id in target_layer_ids
+        )
+        or len(set(target_layer_ids)) != len(target_layer_ids)
+    ):
+        raise ValueError(
+            f"DFlash v{version} dflash_config['target_layer_ids'] must be a non-empty sequence "
+            "of unique non-negative integers."
+        )
+
+
+def _validate_dflash2_config(config: PretrainedConfig, dflash_config: Dict[str, Any]) -> None:
+    missing = [name for name in DFLASH2_REQUIRED_CONFIG_FIELDS if dflash_config.get(name) is None]
+    if missing:
+        raise ValueError(f"DFlash v2 export requires configuration fields: {', '.join(missing)}.")
+
+    conv_group_size = dflash_config["conv_group_size"]
+    conv_kernel_size = dflash_config["conv_kernel_size"]
+    selector_rank = dflash_config["selector_rank"]
+    selector_top_k = dflash_config["selector_top_k"]
+    vocab_size = config.vocab_size
+    num_target_layers = getattr(config, "num_target_layers", None)
+
+    if not _is_positive_int(conv_kernel_size):
+        raise ValueError("DFlash v2 dflash_config['conv_kernel_size'] must be a positive integer.")
+    if not _is_positive_int(conv_group_size) or config.hidden_size % conv_group_size:
+        raise ValueError("DFlash v2 dflash_config['conv_group_size'] must be a positive divisor of hidden_size.")
+    if not _is_positive_int(selector_rank):
+        raise ValueError("DFlash v2 dflash_config['selector_rank'] must be a positive integer.")
+    if not _is_positive_int(selector_top_k) or selector_top_k > vocab_size:
+        raise ValueError("DFlash v2 dflash_config['selector_top_k'] must be between 1 and vocab_size.")
+    if not _is_positive_int(num_target_layers):
+        raise ValueError("DFlash v2 export requires a positive integer num_target_layers.")
+    if any(layer_id >= num_target_layers for layer_id in dflash_config["target_layer_ids"]):
+        raise ValueError("DFlash v2 dflash_config['target_layer_ids'] must be smaller than num_target_layers.")
+
+    for name in ("input_embedding_scale", "output_multiplier"):
+        value = dflash_config.get(name)
+        if value is not None and (
+            not isinstance(value, Real) or isinstance(value, bool) or not math.isfinite(value) or value <= 0
+        ):
+            raise ValueError(f"DFlash v2 dflash_config[{name!r}] must be a finite positive number.")
+
+    final_logit_softcapping = dflash_config.get("final_logit_softcapping")
+    if final_logit_softcapping is not None and (
+        not isinstance(final_logit_softcapping, Real)
+        or isinstance(final_logit_softcapping, bool)
+        or not math.isfinite(final_logit_softcapping)
+        or final_logit_softcapping < 0
+    ):
+        raise ValueError("DFlash v2 dflash_config['final_logit_softcapping'] must be a finite non-negative number.")
+
+
+def _is_positive_int(value: Any) -> bool:
+    return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+
+def parse_and_validate_dflash_config(config: PretrainedConfig, expected_version: int | None = None) -> DFlashConfig:
+    """Detect and validate a DFlash draft config, branching by checkpoint version."""
+    version = _detect_dflash_version(config)
+    if expected_version is not None and version != expected_version:
+        raise ValueError(f"Expected a DFlash v{expected_version} checkpoint, got DFlash v{version}.")
+    if version == 2 and not is_transformers_version(">=", "4.57"):
+        raise ValueError("DFlash v2 export requires Transformers >= 4.57.")
+
+    dflash_config = _normalize_dflash_config(config, version)
+    _validate_common_dflash_config(config, dflash_config, version)
+    if version == 2:
+        _validate_dflash2_config(config, dflash_config)
+    return DFlashConfig(version=version, values=dflash_config)

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -17,6 +17,7 @@ from typing import Optional, Tuple
 
 import torch
 
+from optimum.exporters.openvino.dflash_utils import DFLASH_ARCHITECTURES, parse_and_validate_dflash_config
 from optimum.intel.utils.import_utils import is_diffusers_version
 from optimum.utils import (
     DEFAULT_DUMMY_SHAPES,
@@ -236,7 +237,10 @@ class Eagle3DummyGenerator(DummyInputGenerator):
         self.batch_size = batch_size
         self.sequence_length = sequence_length
         self.hidden_size = normalized_config.hidden_size
-        dflash_config = getattr(normalized_config.config, "dflash_config", {}) or {}
+        architectures = getattr(normalized_config.config, "architectures", None)
+        architecture = architectures[0] if isinstance(architectures, list) and architectures else None
+        is_dflash = architecture in DFLASH_ARCHITECTURES
+        dflash_config = parse_and_validate_dflash_config(normalized_config.config).values if is_dflash else {}
         self.num_hidden_state_layers = len(dflash_config.get("target_layer_ids", [])) or 3
 
     def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
@@ -246,6 +250,52 @@ class Eagle3DummyGenerator(DummyInputGenerator):
             self.sequence_length,
             self.hidden_size * self.num_hidden_state_layers,
         )
+        return self.random_float_tensor(shape, framework=framework, dtype=float_dtype)
+
+
+class DFlash2SelectorDummyGenerator(DummyInputGenerator):
+    """Dummy inputs for the DFlash-2 candidate-selector graph."""
+
+    SUPPORTED_INPUT_NAMES = ("candidate_ids", "unary_logits", "draft_hidden_states", "anchor_token_ids")
+
+    def __init__(
+        self,
+        task: str,
+        normalized_config: NormalizedTextConfig,
+        batch_size: int = DEFAULT_DUMMY_SHAPES["batch_size"],
+        sequence_length: int = DEFAULT_DUMMY_SHAPES["sequence_length"],
+        **kwargs,
+    ):
+        self.batch_size = batch_size
+        self.hidden_size = normalized_config.hidden_size
+        config = normalized_config.config
+        dflash_config = parse_and_validate_dflash_config(config, expected_version=2).values
+
+        self.num_draft_tokens = sequence_length
+        self.selector_top_k = dflash_config["selector_top_k"]
+        self.vocab_size = normalized_config.vocab_size
+
+    def generate(self, input_name: str, framework: str = "pt", int_dtype: str = "int64", float_dtype: str = "fp32"):
+        if input_name == "candidate_ids":
+            return self.random_int_tensor(
+                (self.batch_size, self.num_draft_tokens, self.selector_top_k),
+                max_value=self.vocab_size,
+                framework=framework,
+                dtype=int_dtype,
+            )
+        if input_name == "anchor_token_ids":
+            return self.random_int_tensor(
+                (self.batch_size,),
+                max_value=self.vocab_size,
+                framework=framework,
+                dtype=int_dtype,
+            )
+        if input_name == "unary_logits":
+            shape = (self.batch_size, self.num_draft_tokens, self.selector_top_k)
+        elif input_name == "draft_hidden_states":
+            shape = (self.batch_size, self.num_draft_tokens, self.hidden_size)
+        else:
+            raise ValueError(f"Unsupported DFlash-2 selector input: {input_name}")
         return self.random_float_tensor(shape, framework=framework, dtype=float_dtype)
 
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -22,6 +22,8 @@ import torch
 from transformers import AutoConfig, PretrainedConfig, PreTrainedModel
 
 from optimum.exporters.openvino.base import (
+    ACTIVATIONS_SCALE_FACTOR_RT_OPTION,
+    DEFAULT_ACTIVATIONS_SCALE_FACTOR,
     ConfigBehavior,
     OpenVINOConfig,
     OpenVINOConfigWithPast,
@@ -38,10 +40,16 @@ from optimum.exporters.openvino.config import (
     TextSeq2SeqOpenVINOConfig,
     VisionOpenVINOConfig,
 )
+from optimum.exporters.openvino.dflash_utils import (
+    DFLASH2_RECOMMENDED_ACTIVATIONS_SCALE_FACTOR,
+    DFLASH_ARCHITECTURES,
+    parse_and_validate_dflash_config,
+)
 from optimum.exporters.openvino.input_generators import (
     AquilaDummyPastKeyValuesGenerator,
     ChatGLM2DummyPastKeyValuesGenerator,
     DeciDummyPastKeyValuesGenerator,
+    DFlash2SelectorDummyGenerator,
     DummyAudioPhi4MMInputGenerator,
     DummyDeepseekOCR2VisionInputGenerator,
     DummyDeepseekOCR2VisionTilesInputGenerator,
@@ -470,14 +478,16 @@ class Qwen3OpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
             preprocessors=preprocessors,
         )
         archs = getattr(config, "architectures", None)
-        self.dflash = isinstance(archs, list) and len(archs) > 0 and archs[0] == "DFlashDraftModel"
+        architecture = archs[0] if isinstance(archs, list) and archs else None
+        self.dflash = architecture in DFLASH_ARCHITECTURES
+        self.dflash2 = False
         if self.dflash:
-            model_type = getattr(config, "model_type", "")
-            if model_type != "qwen3":
-                raise ValueError(f"DFlash export supports only Qwen3-based draft models, got model_type={model_type}.")
-            dflash_config = getattr(config, "dflash_config", {}) or {}
-            if not dflash_config.get("target_layer_ids", []):
-                raise ValueError("DFlash export requires non-empty dflash_config['target_layer_ids'].")
+            dflash = parse_and_validate_dflash_config(config)
+            self.dflash2 = dflash.version == 2
+            if self.dflash2:
+                self.runtime_options[ACTIVATIONS_SCALE_FACTOR_RT_OPTION] = str(
+                    DFLASH2_RECOMMENDED_ACTIVATIONS_SCALE_FACTOR
+                )
             # DFlash draft checkpoints still advertise model_type="qwen3"; the
             # architecture and dflash_config fields identify the draft variant.
             self.DUMMY_INPUT_GENERATOR_CLASSES = (
@@ -553,6 +563,45 @@ class Qwen3OpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
                 for axis, name in axes.items():
                     if name == "past_sequence_length + sequence_length":
                         axes[axis] = "past_sequence_length + context_length"
+
+
+class DFlash2SelectorOpenVINOConfig(OpenVINOConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DFlash2SelectorDummyGenerator,)
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
+    # The selector is accuracy-sensitive and excluded from draft-backbone
+    # compression until quantized selector quality is characterized.
+    PRESERVE_CHECKPOINT_PRECISION = True
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        task: str = "feature-extraction",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        preprocessors: list[Any] | None = None,
+    ):
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+        )
+        parse_and_validate_dflash_config(config, expected_version=2)
+        self.dflash2_selector = True
+
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        return {
+            "candidate_ids": {0: "batch_size", 1: "draft_sequence_length"},
+            "unary_logits": {0: "batch_size", 1: "draft_sequence_length"},
+            "draft_hidden_states": {0: "batch_size", 1: "draft_sequence_length"},
+            "anchor_token_ids": {0: "batch_size"},
+        }
+
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        return {"edge_scores": {0: "batch_size", 1: "draft_sequence_length"}}
 
 
 @register_in_tasks_manager(
@@ -5503,6 +5552,10 @@ class Gemma4UnifiedOpenVINOConfig(Gemma3OpenVINOConfig):
         )
         self._behavior = behavior
         if self._behavior == VLMConfigBehavior.VISION_EMBEDDINGS:
+            # The encoder-free vision embedder produces values large enough to
+            # overflow in FP16, so retain the upstream scaling recommendation
+            # as component-owned runtime metadata.
+            self.runtime_options[ACTIVATIONS_SCALE_FACTOR_RT_OPTION] = str(DEFAULT_ACTIVATIONS_SCALE_FACTOR)
             self.DUMMY_INPUT_GENERATOR_CLASSES = (DummyGemma4UnifiedVisionInputGenerator,)
             self._config = config.vision_config
             self._normalized_config = self.NORMALIZED_CONFIG_CLASS(self._config)

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -55,6 +55,7 @@ from transformers.utils import ModelOutput
 
 from optimum.exporters.openvino._ov_ops import convert_recurrent_attention_cell, convert_recurrent_selective_ssm_cell
 from optimum.exporters.openvino.base import OpenVINOConfig
+from optimum.exporters.openvino.dflash_utils import parse_and_validate_dflash_config
 from optimum.exporters.openvino.patching_utils import (
     ModelPatcher,
     eager_mask_without_vmap,
@@ -8859,6 +8860,8 @@ class Qwen3DFlashDecoderLayer(nn.Module):
         self.mlp = Qwen3MLP(config)
         self.input_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.post_attention_layernorm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attention_conv = None
+        self.mlp_conv = None
 
     def forward(
         self,
@@ -8875,6 +8878,9 @@ class Qwen3DFlashDecoderLayer(nn.Module):
     ) -> torch.FloatTensor:
         residual = hidden_states
         hidden_states = self.input_layernorm(hidden_states)
+        attention_kernel = None
+        if self.attention_conv is not None:
+            hidden_states, attention_kernel = self.attention_conv.prepare(hidden_states)
         hidden_states = self.self_attn(
             hidden_states=hidden_states,
             target_hidden=target_hidden,
@@ -8887,11 +8893,18 @@ class Qwen3DFlashDecoderLayer(nn.Module):
             position_embeddings=position_embeddings,
             **kwargs,
         )[0]
+        if attention_kernel is not None:
+            hidden_states = self.attention_conv.finish(hidden_states, attention_kernel)
         hidden_states = residual + hidden_states
 
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
+        mlp_kernel = None
+        if self.mlp_conv is not None:
+            hidden_states, mlp_kernel = self.mlp_conv.prepare(hidden_states)
         hidden_states = self.mlp(hidden_states)
+        if mlp_kernel is not None:
+            hidden_states = self.mlp_conv.finish(hidden_states, mlp_kernel)
         hidden_states = residual + hidden_states
         return hidden_states
 
@@ -8899,6 +8912,8 @@ class Qwen3DFlashDecoderLayer(nn.Module):
 # adopted from https://github.com/z-lab/dflash/blob/main/dflash/model.py#L302
 class Qwen3DFlashDraftModel(Qwen3PreTrainedModel):
     config_class = Qwen3Config
+    dflash_version = 1
+    decoder_layer_class = Qwen3DFlashDecoderLayer
     _no_split_modules = ["Qwen3DFlashDecoderLayer"]
 
     def __init__(self, config) -> None:
@@ -8906,17 +8921,21 @@ class Qwen3DFlashDraftModel(Qwen3PreTrainedModel):
         if not hasattr(config, "_orig_attn_implementation"):
             config._orig_attn_implementation = config._attn_implementation
         config._attn_implementation = "sdpa"
+        dflash_config = parse_and_validate_dflash_config(config, expected_version=self.dflash_version).values
         self.layers = nn.ModuleList(
-            [Qwen3DFlashDecoderLayer(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
+            [self.decoder_layer_class(config, layer_idx) for layer_idx in range(config.num_hidden_layers)]
         )
-        dflash_config = getattr(config, "dflash_config", {})
-        self.target_layer_ids = dflash_config.get("target_layer_ids", [])
+        self.target_layer_ids = dflash_config["target_layer_ids"]
         self.norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
         self.rotary_emb = Qwen3RotaryEmbedding(config)
         self.fc = nn.Linear(len(self.target_layer_ids) * config.hidden_size, config.hidden_size, bias=False)
         self.hidden_norm = Qwen3RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
-        self.mask_token_id = dflash_config.get("mask_token_id", None)
+        self.mask_token_id = dflash_config["mask_token_id"]
+        self._init_dflash_variant(config)
         self.post_init()
+
+    def _init_dflash_variant(self, config) -> None:
+        pass
 
     def forward(
         self,
@@ -9011,6 +9030,176 @@ class Qwen3DFlashForCausalLM(Qwen3DFlashDraftModel, GenerationMixin):
             last_hidden_state=last_hidden_state,
             past_key_values=outputs.past_key_values,
         )
+
+
+class GroupedDynamicCausalConv(nn.Module):
+    """Block-local grouped dynamic convolution used around each DFlash-2 sublayer."""
+
+    def __init__(self, config: "Qwen3Config"):
+        super().__init__()
+        dflash_config = parse_and_validate_dflash_config(config, expected_version=2).values
+        self.hidden_size = config.hidden_size
+        self.kernel_size = dflash_config["conv_kernel_size"]
+        self.group_size = dflash_config["conv_group_size"]
+        if self.hidden_size % self.group_size:
+            raise ValueError("DFlash-2 conv_group_size must divide hidden_size.")
+        self.num_groups = self.hidden_size // self.group_size
+
+        # Axis 0 selects the convolution before (0) or after (1) the wrapped sublayer.
+        self.base_kernel = nn.Parameter(torch.zeros(2, self.kernel_size, self.hidden_size))
+        with torch.no_grad():
+            self.base_kernel[:, 0, :].fill_(1.0)
+        self.kernel_projection = nn.Linear(
+            self.hidden_size,
+            2 * self.kernel_size * self.num_groups,
+            bias=False,
+        )
+
+    def _apply_kernel(
+        self,
+        hidden_states: torch.Tensor,
+        dynamic_kernel: torch.Tensor,
+        side: int,
+    ) -> torch.Tensor:
+        batch_size, sequence_length, _ = hidden_states.shape
+        base_kernel = self.base_kernel[side].reshape(
+            self.kernel_size,
+            self.num_groups,
+            self.group_size,
+        )
+        kernel = dynamic_kernel.unsqueeze(-1) + base_kernel[None, None, :, :, :]
+
+        output = torch.zeros_like(hidden_states).reshape(
+            batch_size,
+            sequence_length,
+            self.num_groups,
+            self.group_size,
+        )
+        for tap in range(self.kernel_size):
+            shifted_states = F.pad(hidden_states, (0, 0, tap, 0))[:, :sequence_length, :].reshape(
+                batch_size,
+                sequence_length,
+                self.num_groups,
+                self.group_size,
+            )
+            output = output + shifted_states * kernel[:, :, tap, :, :]
+        return output.reshape(batch_size, sequence_length, self.hidden_size)
+
+    def prepare(self, hidden_states: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        batch_size, sequence_length, _ = hidden_states.shape
+        dynamic_kernel = self.kernel_projection(hidden_states).reshape(
+            batch_size,
+            sequence_length,
+            2,
+            self.kernel_size,
+            self.num_groups,
+        )
+        return self._apply_kernel(hidden_states, dynamic_kernel[:, :, 0, :, :], 0), dynamic_kernel[:, :, 1, :, :]
+
+    def finish(self, hidden_states: torch.Tensor, dynamic_kernel: torch.Tensor) -> torch.Tensor:
+        return self._apply_kernel(hidden_states, dynamic_kernel, 1)
+
+
+class DFlash2CandidateSelector(nn.Module):
+    """Scores the top-K candidate transitions for every DFlash-2 draft position."""
+
+    def __init__(self, config: "Qwen3Config"):
+        super().__init__()
+        dflash_config = parse_and_validate_dflash_config(config, expected_version=2).values
+        self.selector_rank = dflash_config["selector_rank"]
+        self.selector_top_k = dflash_config["selector_top_k"]
+        self.predecessor_codebook = nn.Parameter(torch.empty(config.vocab_size, self.selector_rank))
+        self.successor_codebook = nn.Parameter(torch.empty(config.vocab_size, self.selector_rank))
+        self.hidden_projection = nn.Linear(config.hidden_size, self.selector_rank, bias=False)
+        std = getattr(config, "initializer_range", 0.02)
+        nn.init.normal_(self.predecessor_codebook, mean=0.0, std=std)
+        nn.init.normal_(self.successor_codebook, mean=0.0, std=std)
+
+    def forward(
+        self,
+        candidate_ids: torch.LongTensor,
+        unary_logits: torch.Tensor,
+        draft_hidden_states: torch.Tensor,
+        anchor_token_ids: torch.LongTensor,
+    ) -> torch.Tensor:
+        batch_size = candidate_ids.shape[0]
+        anchor_ids = anchor_token_ids.reshape(batch_size, 1, 1).expand(-1, 1, self.selector_top_k)
+        predecessor_ids = torch.cat([anchor_ids, candidate_ids[:, :-1, :]], dim=1)
+
+        predecessor_codes = F.embedding(predecessor_ids, self.predecessor_codebook).to(torch.float32)
+        successor_codes = F.embedding(candidate_ids, self.successor_codebook).to(torch.float32)
+        projection_input = draft_hidden_states.to(self.hidden_projection.weight.dtype)
+        projected_hidden = self.hidden_projection(projection_input).to(torch.float32)
+        gated_predecessors = predecessor_codes * projected_hidden.unsqueeze(2)
+        transition_scores = torch.matmul(gated_predecessors, successor_codes.transpose(-1, -2))
+        return transition_scores + unary_logits.to(torch.float32).unsqueeze(-2)
+
+
+class Qwen3DFlash2DecoderLayer(Qwen3DFlashDecoderLayer):
+    def __init__(self, config: "Qwen3Config", layer_idx: int):
+        super().__init__(config, layer_idx)
+        self.attention_conv = GroupedDynamicCausalConv(config)
+        self.mlp_conv = GroupedDynamicCausalConv(config)
+
+
+class Qwen3DFlash2DraftModel(Qwen3DFlashDraftModel):
+    dflash_version = 2
+    decoder_layer_class = Qwen3DFlash2DecoderLayer
+    _no_split_modules = ["Qwen3DFlash2DecoderLayer"]
+
+    def _init_dflash_variant(self, config) -> None:
+        self.candidate_selector = DFlash2CandidateSelector(config)
+
+
+class Qwen3DFlash2ForCausalLM(Qwen3DFlash2DraftModel, GenerationMixin):
+    """DFlash-2 backbone exported without the shared target embedding, LM head, or selector."""
+
+    def forward(
+        self,
+        inputs_embeds: torch.FloatTensor,
+        hidden_states: torch.Tensor,
+        position_ids: torch.LongTensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        past_key_values: Optional[Cache] = None,
+        use_cache: Optional[bool] = None,
+        logits_to_keep: Optional[int] = None,
+        **kwargs,
+    ) -> BaseModelOutputWithPast:
+        outputs = super().forward(
+            hidden_states=hidden_states,
+            noise_embedding=inputs_embeds,
+            position_ids=position_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            use_cache=use_cache,
+            **kwargs,
+        )
+        if logits_to_keep is None:
+            last_hidden_state = outputs.last_hidden_state[:, 1:, :]
+        else:
+            last_hidden_state = outputs.last_hidden_state[:, -logits_to_keep:, :]
+        return BaseModelOutputWithPast(
+            last_hidden_state=last_hidden_state,
+            past_key_values=outputs.past_key_values,
+        )
+
+
+class Qwen3DFlash2SelectorForExport(nn.Module):
+    """Export-only wrapper that keeps selector weights in a separate OpenVINO graph."""
+
+    def __init__(self, candidate_selector: DFlash2CandidateSelector, config: "Qwen3Config"):
+        super().__init__()
+        self.candidate_selector = candidate_selector
+        self.config = config
+
+    def forward(
+        self,
+        candidate_ids: torch.LongTensor,
+        unary_logits: torch.Tensor,
+        draft_hidden_states: torch.Tensor,
+        anchor_token_ids: torch.LongTensor,
+    ) -> torch.Tensor:
+        return self.candidate_selector(candidate_ids, unary_logits, draft_hidden_states, anchor_token_ids)
 
 
 # Patched implementation of the gated delta rule in recurrent form.

--- a/tests/openvino/test_dflash.py
+++ b/tests/openvino/test_dflash.py
@@ -14,16 +14,33 @@
 
 
 import json
+import os
 import unittest
+from copy import deepcopy
 from pathlib import Path
+from unittest.mock import patch
 
 import nncf
+import numpy as np
 import openvino as ov
+import torch
 from parameterized import parameterized
 from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
-from utils_tests import MODEL_NAMES
+from transformers.models.qwen3.configuration_qwen3 import Qwen3Config
+from transformers.models.qwen3.modeling_qwen3 import Qwen3ForCausalLM
+from utils_tests import MODEL_NAMES, get_dflash2_model_path
 
 from optimum.exporters.openvino import export_from_model
+from optimum.exporters.openvino.__main__ import main_export
+from optimum.exporters.openvino.convert import _get_submodels_and_export_configs, export_models
+from optimum.exporters.openvino.dflash_utils import parse_and_validate_dflash_config
+from optimum.exporters.openvino.model_configs import DFlash2SelectorOpenVINOConfig, Qwen3OpenVINOConfig
+from optimum.exporters.openvino.model_patcher import (
+    DFlash2CandidateSelector,
+    GroupedDynamicCausalConv,
+    Qwen3DFlash2ForCausalLM,
+    Qwen3DFlashForCausalLM,
+)
 from optimum.intel.openvino.utils import TemporaryDirectory
 from optimum.intel.utils.import_utils import is_transformers_version
 
@@ -116,3 +133,580 @@ class DFlashExportTest(unittest.TestCase):
                     compressed_model = nncf.compress_weights(ov.Core().read_model(xml_path), mode=mode, **kwargs)
                     locators = self._assert_hidden_state_rt_info_is_valid(compressed_model)
                     self.assertEqual(set(locators), layer_ids)
+
+    def test_v1_export_remains_single_ir(self):
+        config = Qwen3Config.from_pretrained(MODEL_NAMES["qwen3"])
+        config.architectures = ["DFlashDraftModel"]
+        config.dflash_config = {
+            "mask_token_id": config.vocab_size - 1,
+            "target_layer_ids": list(range(min(2, config.num_hidden_layers))),
+        }
+        model = Qwen3DFlashForCausalLM(config)
+        _, parts, stateful = _get_submodels_and_export_configs(
+            model,
+            task="text-generation-with-past",
+            monolith=False,
+            custom_export_configs={},
+            custom_architecture=False,
+            _variant="default",
+            library_name="transformers",
+            stateful=True,
+        )
+        self.assertEqual(list(parts), ["model"])
+        with TemporaryDirectory() as tmpdirname:
+            output_dir = Path(tmpdirname)
+            export_models(
+                parts,
+                output_dir,
+                output_names=["openvino_model.xml"],
+                input_shapes={"batch_size": 1, "sequence_length": 3},
+                stateful=stateful,
+                library_name="transformers",
+            )
+            draft_ir = ov.Core().read_model(output_dir / "openvino_model.xml")
+            self.assertTrue(draft_ir.has_rt_info(["dflash_mode"]))
+            self.assertEqual(
+                draft_ir.get_rt_info()["dflash"]["mask_token_id"].value,
+                str(config.dflash_config["mask_token_id"]),
+            )
+            self.assertEqual(
+                draft_ir.get_rt_info()["dflash"]["target_layer_ids"].value,
+                ",".join(map(str, config.dflash_config["target_layer_ids"])),
+            )
+            self.assertFalse(draft_ir.has_rt_info(["dflash", "version"]))
+            self.assertFalse((output_dir / "openvino_selector_model.xml").exists())
+
+
+@unittest.skipUnless(is_transformers_version(">=", "4.57"), "DFlash-2 requires Transformers 4.57 or newer")
+class DFlash2ExportTest(unittest.TestCase):
+    @classmethod
+    def _model_path(cls):
+        return get_dflash2_model_path()
+
+    @classmethod
+    def _config(cls):
+        return Qwen3Config.from_pretrained(cls._model_path())
+
+    @classmethod
+    def _model(cls):
+        return Qwen3DFlash2ForCausalLM.from_pretrained(cls._model_path()).eval()
+
+    @staticmethod
+    def _backbone_inputs(config, num_draft_tokens, context_length=3):
+        block_length = num_draft_tokens + 1
+        return {
+            "inputs_embeds": torch.randn(1, block_length, config.hidden_size),
+            "hidden_states": torch.randn(
+                1,
+                context_length,
+                config.hidden_size * len(config.dflash_config["target_layer_ids"]),
+            ),
+            "position_ids": torch.arange(context_length + block_length).reshape(1, -1),
+            "attention_mask": torch.ones(1, context_length + block_length),
+        }
+
+    @staticmethod
+    def _reference_convolution(hidden_states, dynamic_kernel, base_kernel, group_size):
+        batch_size, sequence_length, hidden_size = hidden_states.shape
+        num_groups = hidden_size // group_size
+        hidden_groups = hidden_states.reshape(batch_size, sequence_length, num_groups, group_size)
+        output = torch.zeros_like(hidden_groups)
+        for position in range(sequence_length):
+            for tap in range(base_kernel.shape[0]):
+                if position < tap:
+                    continue
+                values = hidden_groups[:, position - tap]
+                kernel = base_kernel[tap].reshape(num_groups, group_size)
+                kernel = kernel + dynamic_kernel[:, position, tap].unsqueeze(-1)
+                output[:, position] += values * kernel
+        return output.reshape_as(hidden_states)
+
+    @staticmethod
+    def _constant_count_with_shape(model, shape):
+        return sum(
+            op.get_type_name() == "Constant" and list(op.get_output_shape(0)) == list(shape) for op in model.get_ops()
+        )
+
+    def test_checkpoint_keys(self):
+        config = self._config()
+        model, loading_info = Qwen3DFlash2ForCausalLM.from_pretrained(
+            self._model_path(),
+            output_loading_info=True,
+        )
+        self.assertFalse(loading_info["missing_keys"])
+        self.assertFalse(loading_info["unexpected_keys"])
+
+        parameter_names = set(dict(model.named_parameters()))
+        expected_names = {
+            "candidate_selector.predecessor_codebook",
+            "candidate_selector.successor_codebook",
+            "candidate_selector.hidden_projection.weight",
+        }
+        for layer_idx in range(config.num_hidden_layers):
+            expected_names.update(
+                {
+                    f"layers.{layer_idx}.attention_conv.base_kernel",
+                    f"layers.{layer_idx}.attention_conv.kernel_projection.weight",
+                    f"layers.{layer_idx}.mlp_conv.base_kernel",
+                    f"layers.{layer_idx}.mlp_conv.kernel_projection.weight",
+                }
+            )
+        self.assertTrue(expected_names.issubset(parameter_names))
+
+    def test_config_normalization_and_validation(self):
+        config = self._config()
+        flat_config = deepcopy(config)
+        flat_values = dict(flat_config.dflash_config)
+        flat_config.dflash_config = {}
+        for name, value in flat_values.items():
+            setattr(flat_config, name, value)
+        flat_dflash = parse_and_validate_dflash_config(flat_config)
+        self.assertEqual(flat_dflash.version, 2)
+        self.assertEqual(flat_dflash.values, flat_values)
+
+        zero_softcap_config = deepcopy(config)
+        zero_softcap_config.dflash_config["final_logit_softcapping"] = 0.0
+        self.assertEqual(
+            parse_and_validate_dflash_config(zero_softcap_config).values["final_logit_softcapping"],
+            0.0,
+        )
+
+        negative_softcap_config = deepcopy(config)
+        negative_softcap_config.dflash_config["final_logit_softcapping"] = -1.0
+        with self.assertRaisesRegex(ValueError, "finite non-negative"):
+            parse_and_validate_dflash_config(negative_softcap_config)
+
+        zero_multiplier_config = deepcopy(config)
+        zero_multiplier_config.dflash_config["output_multiplier"] = 0.0
+        with self.assertRaisesRegex(ValueError, "finite positive"):
+            parse_and_validate_dflash_config(zero_multiplier_config)
+
+        missing_config = deepcopy(config)
+        del missing_config.dflash_config["selector_rank"]
+        with self.assertRaisesRegex(ValueError, "selector_rank"):
+            DFlash2SelectorOpenVINOConfig(missing_config)
+
+        invalid_group_config = deepcopy(config)
+        invalid_group_config.dflash_config["conv_group_size"] = 7
+        with self.assertRaisesRegex(ValueError, "positive divisor"):
+            Qwen3OpenVINOConfig(invalid_group_config)
+
+        invalid_target_layer_config = deepcopy(config)
+        invalid_target_layer_config.dflash_config["target_layer_ids"] = [config.num_target_layers]
+        with self.assertRaisesRegex(ValueError, "smaller than num_target_layers"):
+            parse_and_validate_dflash_config(invalid_target_layer_config)
+
+        invalid_mask_config = deepcopy(config)
+        invalid_mask_config.dflash_config["mask_token_id"] = config.vocab_size
+        with self.assertRaisesRegex(ValueError, "mask_token_id"):
+            parse_and_validate_dflash_config(invalid_mask_config)
+
+        duplicate_layers_config = deepcopy(config)
+        duplicate_layers_config.dflash_config["target_layer_ids"] = [0, 0]
+        with self.assertRaisesRegex(ValueError, "unique non-negative"):
+            parse_and_validate_dflash_config(duplicate_layers_config)
+
+        conflicting_config = deepcopy(config)
+        conflicting_config.selector_rank = config.dflash_config["selector_rank"] + 1
+        with self.assertRaisesRegex(ValueError, "conflicting nested and flat"):
+            parse_and_validate_dflash_config(conflicting_config)
+
+        wrong_model_type_config = deepcopy(config)
+        wrong_model_type_config.model_type = "muse_glimmer"
+        with self.assertRaisesRegex(ValueError, "only Qwen3"):
+            parse_and_validate_dflash_config(wrong_model_type_config)
+
+        wrong_architecture_config = deepcopy(config)
+        wrong_architecture_config.architectures = ["Qwen3ForCausalLM", "DFlash2DraftModel"]
+        with self.assertRaisesRegex(ValueError, "architectures"):
+            parse_and_validate_dflash_config(wrong_architecture_config)
+
+        v1_config = deepcopy(config)
+        v1_config.architectures = ["DFlashDraftModel"]
+        v1_config.dflash_config = {
+            "mask_token_id": config.dflash_config["mask_token_id"],
+            "target_layer_ids": list(config.dflash_config["target_layer_ids"]),
+        }
+        v1_dflash = parse_and_validate_dflash_config(v1_config)
+        self.assertEqual(v1_dflash.version, 1)
+        self.assertEqual(v1_dflash.values, v1_config.dflash_config)
+
+        invalid_v1_config = deepcopy(v1_config)
+        invalid_v1_config.dflash_config["target_layer_ids"] = [-1]
+        with self.assertRaisesRegex(ValueError, "unique non-negative"):
+            parse_and_validate_dflash_config(invalid_v1_config)
+
+    def test_target_annotations_cover_dflash2_target_layers(self):
+        draft_config = self._config()
+        target_config = deepcopy(draft_config)
+        target_config.architectures = ["Qwen3ForCausalLM"]
+        target_config.num_hidden_layers = max(draft_config.dflash_config["target_layer_ids"]) + 1
+        target_model = Qwen3ForCausalLM(target_config).eval()
+        with TemporaryDirectory() as tmpdirname:
+            target_dir = Path(tmpdirname) / "target"
+            export_from_model(
+                model=target_model,
+                output=target_dir,
+                task="text-generation",
+                preprocessors=None,
+                stateful=False,
+            )
+            target_ir = ov.Core().read_model(target_dir / "openvino_model.xml")
+            annotation = json.loads(target_ir.get_rt_info()["hidden_states_decoder_layers"].value)
+            for layer_id in draft_config.dflash_config["target_layer_ids"]:
+                locator = annotation["layers"][str(layer_id)]
+                matches = [op for op in target_ir.get_ops() if op.get_friendly_name() == locator["producer"]]
+                self.assertEqual(len(matches), 1)
+                self.assertLess(locator["output_index"], len(matches[0].outputs()))
+
+    def test_grouped_dynamic_convolution_reference_parity(self):
+        config = self._config()
+        convolution = GroupedDynamicCausalConv(config).eval()
+        for sequence_length in (2, 4, 7):
+            with self.subTest(sequence_length=sequence_length):
+                hidden_states = torch.randn(2, sequence_length, config.hidden_size)
+                projected = convolution.kernel_projection(hidden_states).reshape(
+                    2,
+                    sequence_length,
+                    2,
+                    convolution.kernel_size,
+                    convolution.num_groups,
+                )
+                prepared, output_kernel = convolution.prepare(hidden_states)
+                reference_prepared = self._reference_convolution(
+                    hidden_states,
+                    projected[:, :, 0],
+                    convolution.base_kernel[0],
+                    convolution.group_size,
+                )
+                torch.testing.assert_close(prepared, reference_prepared)
+                torch.testing.assert_close(output_kernel, projected[:, :, 1])
+
+                branch_output = torch.randn_like(hidden_states)
+                finished = convolution.finish(branch_output, output_kernel)
+                reference_finished = self._reference_convolution(
+                    branch_output,
+                    projected[:, :, 1],
+                    convolution.base_kernel[1],
+                    convolution.group_size,
+                )
+                torch.testing.assert_close(finished, reference_finished)
+
+    def test_selector_lattice_and_path_reference_parity(self):
+        config = self._config()
+        config.dflash_config["selector_rank"] = 1
+        config.dflash_config["selector_top_k"] = 2
+        selector = DFlash2CandidateSelector(config).eval()
+        with torch.no_grad():
+            selector.predecessor_codebook.zero_()
+            selector.successor_codebook.zero_()
+            selector.hidden_projection.weight.zero_()
+            selector.hidden_projection.weight[0, 0] = 1
+            selector.predecessor_codebook[0, 0] = 1
+            selector.predecessor_codebook[2, 0] = 2
+            selector.successor_codebook[2, 0] = 3
+            selector.successor_codebook[4, 0] = 2
+
+        candidate_ids = torch.tensor([[[1, 2], [3, 4]]])
+        unary_logits = torch.tensor([[[5.0, 4.0], [5.0, 4.0]]])
+        draft_hidden_states = torch.zeros(1, 2, config.hidden_size)
+        draft_hidden_states[..., 0] = 1
+        anchor_token_ids = torch.tensor([0])
+        edge_scores = selector(candidate_ids, unary_logits, draft_hidden_states, anchor_token_ids)
+
+        reference_scores = torch.empty_like(edge_scores)
+        predecessor_ids = torch.tensor([[[0, 0], [1, 2]]])
+        for position in range(2):
+            for predecessor_index in range(2):
+                predecessor = predecessor_ids[0, position, predecessor_index]
+                for candidate_index in range(2):
+                    candidate = candidate_ids[0, position, candidate_index]
+                    correction = (
+                        selector.predecessor_codebook[predecessor, 0]
+                        * draft_hidden_states[0, position, 0]
+                        * selector.successor_codebook[candidate, 0]
+                    )
+                    reference_scores[0, position, predecessor_index, candidate_index] = (
+                        unary_logits[0, position, candidate_index] + correction
+                    )
+        torch.testing.assert_close(edge_scores, reference_scores)
+        self.assertEqual(edge_scores.dtype, torch.float32)
+
+        previous_index = 0
+        path = []
+        selected_rows = []
+        for position in range(candidate_ids.shape[1]):
+            selected_row = edge_scores[:, position, previous_index]
+            selected_rows.append(selected_row)
+            previous_index = selected_row.argmax(dim=-1).item()
+            path.append(candidate_ids[0, position, previous_index].item())
+        self.assertEqual(path, [2, 4])
+        self.assertEqual(unary_logits.argmax(dim=-1).tolist(), [[0, 0]])
+        for selected_row in selected_rows:
+            probabilities = torch.softmax(selected_row, dim=-1)
+            torch.testing.assert_close(probabilities.sum(dim=-1), torch.ones(1))
+
+        selector = selector.to(torch.bfloat16)
+        bf16_scores = selector(
+            candidate_ids,
+            unary_logits,
+            draft_hidden_states.to(torch.bfloat16),
+            anchor_token_ids,
+        )
+        self.assertEqual(bf16_scores.dtype, torch.float32)
+
+    def test_two_ir_export_dynamic_numerical_parity_and_selectorless_backbone(self):
+        torch.manual_seed(1)
+        model = self._model()
+        config = model.config
+        _, parts, stateful = _get_submodels_and_export_configs(
+            model,
+            task="text-generation",
+            monolith=False,
+            custom_export_configs={},
+            custom_architecture=False,
+            _variant="default",
+            library_name="transformers",
+            stateful=False,
+        )
+        self.assertEqual(list(parts), ["model", "selector_model"])
+        self.assertEqual(stateful, [False, False])
+
+        with TemporaryDirectory() as tmpdirname:
+            output_dir = Path(tmpdirname)
+            export_models(
+                parts,
+                output_dir,
+                output_names=["openvino_model.xml", "openvino_selector_model.xml"],
+                input_shapes={"batch_size": 1, "sequence_length": 3},
+                stateful=stateful,
+                library_name="transformers",
+            )
+            core = ov.Core()
+            draft_ir = core.read_model(output_dir / "openvino_model.xml")
+            selector_ir = core.read_model(output_dir / "openvino_selector_model.xml")
+            self.assertEqual({item.any_name for item in draft_ir.outputs}, {"last_hidden_state"})
+            self.assertEqual({item.any_name for item in selector_ir.outputs}, {"edge_scores"})
+            self.assertEqual(
+                {item.any_name for item in selector_ir.inputs},
+                {"candidate_ids", "unary_logits", "draft_hidden_states", "anchor_token_ids"},
+            )
+            self.assertEqual(draft_ir.get_rt_info()["dflash"]["version"].value, "2")
+            for name in ("input_embedding_scale", "output_multiplier", "final_logit_softcapping"):
+                self.assertEqual(
+                    float(draft_ir.get_rt_info()["dflash"][name].value),
+                    config.dflash_config[name],
+                )
+            self.assertEqual(selector_ir.get_rt_info()["dflash_selector"]["score_semantics"].value, "unary_inclusive")
+            self.assertFalse(draft_ir.has_rt_info(["hidden_states_decoder_layers"]))
+            self.assertFalse(selector_ir.has_rt_info(["hidden_states_decoder_layers"]))
+
+            codebook_shape = (config.vocab_size, config.dflash_config["selector_rank"])
+            self.assertEqual(self._constant_count_with_shape(draft_ir, codebook_shape), 0)
+            self.assertGreaterEqual(self._constant_count_with_shape(selector_ir, codebook_shape), 2)
+
+            compiled_draft = core.compile_model(draft_ir, "CPU")
+            compiled_selector = core.compile_model(selector_ir, "CPU")
+            output_head = torch.randn(config.hidden_size, config.vocab_size)
+            for num_draft_tokens in (2, 5):
+                with self.subTest(num_draft_tokens=num_draft_tokens):
+                    backbone_inputs = self._backbone_inputs(config, num_draft_tokens)
+                    with torch.no_grad():
+                        torch_hidden = model(**backbone_inputs, use_cache=False).last_hidden_state
+                    ov_hidden = compiled_draft({name: value.numpy() for name, value in backbone_inputs.items()})[0]
+                    torch.testing.assert_close(
+                        torch.from_numpy(np.array(ov_hidden)),
+                        torch_hidden,
+                        rtol=1e-4,
+                        atol=1e-5,
+                    )
+                    ov_logits = torch.from_numpy(np.array(ov_hidden)) @ output_head
+                    torch_logits = torch_hidden @ output_head
+                    torch.testing.assert_close(ov_logits, torch_logits, rtol=1e-4, atol=1e-5)
+                    self.assertTrue(
+                        torch.equal(
+                            ov_logits.topk(config.dflash_config["selector_top_k"], dim=-1).indices,
+                            torch_logits.topk(config.dflash_config["selector_top_k"], dim=-1).indices,
+                        )
+                    )
+
+                    candidate_ids = torch.randint(
+                        config.vocab_size,
+                        (1, num_draft_tokens, config.dflash_config["selector_top_k"]),
+                    )
+                    unary_logits = torch.randn(1, num_draft_tokens, config.dflash_config["selector_top_k"])
+                    selector_inputs = {
+                        "candidate_ids": candidate_ids,
+                        "unary_logits": unary_logits,
+                        "draft_hidden_states": torch_hidden,
+                        "anchor_token_ids": torch.tensor([1]),
+                    }
+                    with torch.no_grad():
+                        torch_edges = parts["selector_model"][0](**selector_inputs)
+                    ov_edges = compiled_selector({name: value.numpy() for name, value in selector_inputs.items()})[0]
+                    torch.testing.assert_close(torch.from_numpy(np.array(ov_edges)), torch_edges)
+
+            if "GPU" in core.available_devices:
+                gpu_draft = core.compile_model(draft_ir, "GPU")
+                gpu_selector = core.compile_model(selector_ir, "GPU")
+                for num_draft_tokens in (2, 5):
+                    backbone_inputs = self._backbone_inputs(config, num_draft_tokens)
+                    gpu_hidden = np.array(
+                        gpu_draft({name: value.numpy() for name, value in backbone_inputs.items()})[0]
+                    )
+                    self.assertEqual(gpu_hidden.shape, (1, num_draft_tokens, config.hidden_size))
+                    self.assertTrue(np.isfinite(gpu_hidden).all())
+
+                    top_k = config.dflash_config["selector_top_k"]
+                    selector_inputs = {
+                        "candidate_ids": np.random.randint(
+                            config.vocab_size,
+                            size=(1, num_draft_tokens, top_k),
+                            dtype=np.int64,
+                        ),
+                        "unary_logits": np.random.randn(1, num_draft_tokens, top_k).astype(np.float32),
+                        "draft_hidden_states": gpu_hidden,
+                        "anchor_token_ids": np.array([1], dtype=np.int64),
+                    }
+                    gpu_edges = np.array(gpu_selector(selector_inputs)[0])
+                    self.assertEqual(gpu_edges.shape, (1, num_draft_tokens, top_k, top_k))
+                    self.assertTrue(np.isfinite(gpu_edges).all())
+
+            (output_dir / "openvino_selector_model.xml").unlink()
+            (output_dir / "openvino_selector_model.bin").unlink()
+            self.assertFalse((output_dir / "openvino_selector_model.xml").exists())
+            selectorless_draft = core.compile_model(core.read_model(output_dir / "openvino_model.xml"), "CPU")
+            self.assertEqual({item.any_name for item in selectorless_draft.outputs}, {"last_hidden_state"})
+            selectorless_inputs = self._backbone_inputs(config, num_draft_tokens=3)
+            with torch.no_grad():
+                selectorless_reference = model(**selectorless_inputs, use_cache=False).last_hidden_state
+            selectorless_output = selectorless_draft(
+                {name: value.numpy() for name, value in selectorless_inputs.items()}
+            )[0]
+            torch.testing.assert_close(
+                torch.from_numpy(np.array(selectorless_output)),
+                selectorless_reference,
+                rtol=1e-4,
+                atol=1e-5,
+            )
+
+    def test_stateful_draft_compression(self):
+        with TemporaryDirectory() as tmpdirname:
+            stateful_dir = Path(tmpdirname) / "stateful"
+            main_export(
+                self._model_path(),
+                stateful_dir,
+                task="text-generation-with-past",
+                stateful=True,
+                trust_remote_code=True,
+            )
+            core = ov.Core()
+            draft_ir = core.read_model(stateful_dir / "openvino_model.xml")
+            selector_ir = core.read_model(stateful_dir / "openvino_selector_model.xml")
+            self.assertGreater(len(draft_ir.get_variables()), 0)
+            self.assertEqual(len(selector_ir.get_variables()), 0)
+
+            compressed_draft = nncf.compress_weights(draft_ir, mode=nncf.CompressWeightsMode.INT8_ASYM)
+            self.assertTrue(compressed_draft.has_rt_info(["dflash", "version"]))
+            self.assertTrue(selector_ir.has_rt_info(["dflash_selector", "dflash_version"]))
+
+    def test_explicit_cache_export_contract(self):
+        """Explicit cache ports are an exporter contract; the DFlash CB runner uses the stateful form."""
+        with TemporaryDirectory() as tmpdirname:
+            explicit_cache_dir = Path(tmpdirname) / "explicit_cache"
+            main_export(
+                self._model_path(),
+                explicit_cache_dir,
+                task="text-generation-with-past",
+                stateful=False,
+                trust_remote_code=True,
+            )
+            explicit_draft = ov.Core().read_model(explicit_cache_dir / "openvino_model.xml")
+            self.assertTrue(any(item.any_name.startswith("past_key_values") for item in explicit_draft.inputs))
+            self.assertTrue(any(item.any_name.startswith("present") for item in explicit_draft.outputs))
+            self.assertTrue((explicit_cache_dir / "openvino_selector_model.xml").exists())
+
+    def test_dynamo_export_preserves_dflash2_input_contract(self):
+        model = self._model()
+        _, parts, stateful = _get_submodels_and_export_configs(
+            model,
+            task="text-generation",
+            monolith=False,
+            custom_export_configs={},
+            custom_architecture=False,
+            _variant="default",
+            library_name="transformers",
+            stateful=False,
+        )
+        with TemporaryDirectory() as tmpdirname, patch.dict(os.environ, {"OPENVINO_DYNAMO_EXPORT": "true"}):
+            output_dir = Path(tmpdirname)
+            export_models(
+                parts,
+                output_dir,
+                output_names=["openvino_model.xml", "openvino_selector_model.xml"],
+                input_shapes={"batch_size": 2, "sequence_length": 3},
+                stateful=stateful,
+                library_name="transformers",
+            )
+            core = ov.Core()
+            draft_ir = core.read_model(output_dir / "openvino_model.xml")
+            selector_ir = core.read_model(output_dir / "openvino_selector_model.xml")
+            self.assertEqual(
+                [(item.any_name, len(item.partial_shape), item.element_type) for item in draft_ir.inputs],
+                [
+                    ("inputs_embeds", 3, ov.Type.f32),
+                    ("hidden_states", 3, ov.Type.f32),
+                    ("position_ids", 2, ov.Type.i64),
+                    ("attention_mask", 2, ov.Type.i64),
+                ],
+            )
+            self.assertEqual(
+                [item.any_name for item in selector_ir.inputs],
+                ["candidate_ids", "unary_logits", "draft_hidden_states", "anchor_token_ids"],
+            )
+
+    def test_bf16_two_ir_export_keeps_fp32_runtime_contract(self):
+        model = self._model().to(torch.bfloat16)
+        _, parts, stateful = _get_submodels_and_export_configs(
+            model,
+            task="text-generation",
+            monolith=False,
+            custom_export_configs={},
+            custom_architecture=False,
+            _variant="default",
+            library_name="transformers",
+            stateful=False,
+        )
+        with TemporaryDirectory() as tmpdirname:
+            output_dir = Path(tmpdirname)
+            export_models(
+                parts,
+                output_dir,
+                output_names=["openvino_model.xml", "openvino_selector_model.xml"],
+                input_shapes={"batch_size": 1, "sequence_length": 3},
+                stateful=stateful,
+                patch_16bit_model=True,
+                library_name="transformers",
+            )
+            core = ov.Core()
+            draft_ir = core.read_model(output_dir / "openvino_model.xml")
+            selector_ir = core.read_model(output_dir / "openvino_selector_model.xml")
+            self.assertEqual(
+                {item.any_name: item.element_type for item in draft_ir.inputs},
+                {
+                    "inputs_embeds": ov.Type.f32,
+                    "hidden_states": ov.Type.f32,
+                    "position_ids": ov.Type.i64,
+                    "attention_mask": ov.Type.i64,
+                },
+            )
+            self.assertEqual(selector_ir.output("edge_scores").element_type, ov.Type.f32)
+            codebook_shape = [model.config.vocab_size, model.config.dflash_config["selector_rank"]]
+            codebook_types = [
+                op.get_output_element_type(0)
+                for op in selector_ir.get_ops()
+                if op.get_type_name() == "Constant" and list(op.get_output_shape(0)) == codebook_shape
+            ]
+            self.assertEqual(codebook_types, [ov.Type.bf16, ov.Type.bf16])
+            core.compile_model(draft_ir, "CPU")
+            core.compile_model(selector_ir, "CPU")

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -15,6 +15,7 @@
 
 import unittest
 from pathlib import Path
+from types import SimpleNamespace
 
 import torch
 from parameterized import parameterized
@@ -30,6 +31,11 @@ from utils_tests import (
 )
 
 from optimum.exporters.openvino import export_from_model, main_export
+from optimum.exporters.openvino.base import (
+    ACTIVATIONS_SCALE_FACTOR_RT_OPTION,
+    DEFAULT_ACTIVATIONS_SCALE_FACTOR,
+)
+from optimum.exporters.openvino.convert import _set_runtime_options
 from optimum.exporters.openvino.model_configs import BertOpenVINOConfig, Qwen3OmniMoeConfigBehavior
 from optimum.exporters.tasks import TasksManager
 from optimum.intel import (
@@ -71,6 +77,32 @@ from optimum.utils.save_utils import maybe_load_preprocessors
 
 
 logger = logging.get_logger()
+
+
+class RuntimeOptionsTest(unittest.TestCase):
+    def test_generic_defaults_do_not_replace_config_recommendations(self):
+        default_config = SimpleNamespace(task="text-generation", runtime_options={})
+        stateless_config = SimpleNamespace(task=None, runtime_options={})
+        recommended_config = SimpleNamespace(
+            task="text-generation",
+            runtime_options={
+                ACTIVATIONS_SCALE_FACTOR_RT_OPTION: "32.0",
+                "KV_CACHE_PRECISION": "bf16",
+            },
+        )
+
+        _set_runtime_options({"model": (None, default_config)}, "text-generation", "transformers", False)
+        _set_runtime_options({"selector": (None, stateless_config)}, "text-generation", "transformers", False)
+        _set_runtime_options({"model": (None, recommended_config)}, "text-generation", "transformers", False)
+
+        self.assertEqual(
+            default_config.runtime_options[ACTIVATIONS_SCALE_FACTOR_RT_OPTION],
+            str(DEFAULT_ACTIVATIONS_SCALE_FACTOR),
+        )
+        self.assertEqual(default_config.runtime_options["KV_CACHE_PRECISION"], "f16")
+        self.assertEqual(stateless_config.runtime_options, {})
+        self.assertEqual(recommended_config.runtime_options[ACTIVATIONS_SCALE_FACTOR_RT_OPTION], "32.0")
+        self.assertEqual(recommended_config.runtime_options["KV_CACHE_PRECISION"], "bf16")
 
 
 class ExportModelTest(unittest.TestCase):

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -34,6 +34,7 @@ from utils_tests import (
     REMOTE_CODE_MODELS,
     TEST_NAME_TO_MODEL_TYPE,
     check_compression_state_per_model,
+    get_dflash2_model_path,
     get_num_quantized_nodes,
     get_supported_model_for_library,
     is_model_type_transformers_compatible,
@@ -918,6 +919,114 @@ class OVCLIExportTestCase(unittest.TestCase):
                 model_kwargs["trust_remote_code"] = True
 
             self._load_exported_ov_model(model_type, task, tmpdir, model_kwargs)
+
+    @unittest.skipUnless(is_transformers_version(">=", "4.57"), "DFlash-2 requires Transformers 4.57 or newer")
+    def test_exporters_cli_dflash2_two_ir_package(self):
+        model_path = get_dflash2_model_path()
+        with TemporaryDirectory() as tmpdir:
+            subprocess.run(
+                [
+                    "optimum-cli",
+                    "export",
+                    "openvino",
+                    "--model",
+                    model_path,
+                    "--task",
+                    "text-generation-with-past",
+                    "--trust-remote-code",
+                    tmpdir,
+                ],
+                check=True,
+            )
+            draft_path = Path(tmpdir) / "openvino_model.xml"
+            selector_path = Path(tmpdir) / "openvino_selector_model.xml"
+            self.assertTrue(draft_path.exists())
+            self.assertTrue(selector_path.exists())
+
+            import openvino as ov
+
+            core = ov.Core()
+            draft_model = core.read_model(draft_path)
+            self.assertTrue(draft_model.has_rt_info(["dflash", "version"]))
+            self.assertEqual(
+                draft_model.get_rt_info()["runtime_options"]["ACTIVATIONS_SCALE_FACTOR"].value,
+                "32.0",
+            )
+            selector_model = core.read_model(selector_path)
+            self.assertTrue(selector_model.has_rt_info(["dflash_selector", "dflash_version"]))
+            self.assertFalse(selector_model.has_rt_info(["runtime_options", "ACTIVATIONS_SCALE_FACTOR"]))
+            self.assertFalse(selector_model.has_rt_info(["runtime_options", "KV_CACHE_PRECISION"]))
+
+    @unittest.skipUnless(is_transformers_version(">=", "4.57"), "DFlash-2 requires Transformers 4.57 or newer")
+    def test_exporters_cli_dflash2_selector_preserves_checkpoint_precision(self):
+        model_path = get_dflash2_model_path()
+        for weight_format in ("int8", "int4"):
+            with self.subTest(weight_format=weight_format), TemporaryDirectory() as tmpdir:
+                command = [
+                    "optimum-cli",
+                    "export",
+                    "openvino",
+                    "--model",
+                    model_path,
+                    "--task",
+                    "text-generation-with-past",
+                    "--weight-format",
+                    weight_format,
+                    "--trust-remote-code",
+                ]
+                if weight_format == "int4":
+                    command.extend(["--group-size", "-1"])
+                subprocess.run([*command, tmpdir], check=True)
+                import openvino as ov
+
+                core = ov.Core()
+                draft_model = core.read_model(Path(tmpdir) / "openvino_model.xml")
+                selector_model = core.read_model(Path(tmpdir) / "openvino_selector_model.xml")
+                self.assertTrue(draft_model.has_rt_info(["nncf"]))
+                self.assertFalse(selector_model.has_rt_info(["nncf"]))
+                self.assertFalse(selector_model.has_rt_info(["dflash_selector", "quantization_status"]))
+
+    @unittest.skipUnless(is_transformers_version(">=", "4.57"), "DFlash-2 requires Transformers 4.57 or newer")
+    def test_exporters_cli_dflash2_selector_skips_fp16_compression(self):
+        model_path = get_dflash2_model_path()
+        with TemporaryDirectory() as tmpdir:
+            subprocess.run(
+                [
+                    "optimum-cli",
+                    "export",
+                    "openvino",
+                    "--model",
+                    model_path,
+                    "--task",
+                    "text-generation-with-past",
+                    "--weight-format",
+                    "fp16",
+                    "--trust-remote-code",
+                    tmpdir,
+                ],
+                check=True,
+            )
+            import openvino as ov
+            from transformers import AutoConfig
+
+            config = AutoConfig.from_pretrained(model_path)
+            core = ov.Core()
+            draft_model = core.read_model(Path(tmpdir) / "openvino_model.xml")
+            selector_model = core.read_model(Path(tmpdir) / "openvino_selector_model.xml")
+
+            draft_constant_types = {
+                op.get_element_type() for op in draft_model.get_ops() if op.get_type_name() == "Constant"
+            }
+            self.assertIn(ov.Type.f16, draft_constant_types)
+
+            codebook_shape = [config.vocab_size, config.dflash_config["selector_rank"]]
+            selector_codebooks = [
+                op
+                for op in selector_model.get_ops()
+                if op.get_type_name() == "Constant" and list(op.get_output_shape(0)) == codebook_shape
+            ]
+            self.assertGreaterEqual(len(selector_codebooks), 2)
+            self.assertTrue(all(op.get_element_type() == ov.Type.f32 for op in selector_codebooks))
 
     @parameterized.expand(
         arch

--- a/tests/openvino/test_genai.py
+++ b/tests/openvino/test_genai.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import numpy as np
 import openvino as ov
+import openvino_genai as ov_genai
 import pytest
 import requests
 import torch
@@ -52,6 +53,7 @@ from utils_tests import (
     REMOTE_CODE_MODELS,
     TEST_IMAGE_URL,
     TEST_NAME_TO_MODEL_TYPE,
+    get_dflash2_model_pairs,
     get_supported_model_for_library,
 )
 
@@ -671,6 +673,95 @@ class LLMPipelineWithSpeculativeDecodingTestCase(unittest.TestCase):
 
         # compare outputs
         self.assertEqual(genai_speculative_output, genai_output)
+
+    def test_dflash2_text_selector_presence_selectorless_and_sampled(self):
+        if not callable(getattr(ov_genai, "selector_model", None)):
+            self.skipTest("Installed openvino-genai does not expose DFlash-2 selector_model()")
+
+        # Use a tiny text-only target deliberately: this test isolates the
+        # DFlash-2 selector, selectorless, and sampled decoding contracts without
+        # repeating the vision export covered by the parameterized DFlash VLM
+        # tests below.
+        dflash2_model_pairs = get_dflash2_model_pairs()
+        if not dflash2_model_pairs:
+            self.skipTest("DFlash-2 requires Transformers >= 4.57")
+        draft_model_id, target_model_id = dflash2_model_pairs["qwen3_dflash2"]
+        draft_model_path = Path(self.temp_dir) / "dflash2_draft"
+        main_model_path = Path(self.temp_dir) / "dflash2_main"
+        main_export(
+            model_name_or_path=draft_model_id,
+            task="text-generation-with-past",
+            trust_remote_code=True,
+            convert_tokenizer=False,
+            output=draft_model_path,
+        )
+        main_export(
+            model_name_or_path=target_model_id,
+            task="text-generation-with-past",
+            convert_tokenizer=True,
+            output=main_model_path,
+        )
+
+        scheduler = SchedulerConfig()
+        scheduler.enable_prefix_caching = False
+        scheduler.max_num_batched_tokens = 256
+        scheduler.max_num_seqs = 1
+        pipeline_config = {**TEST_CONFIG, "scheduler_config": scheduler}
+        prompt = "Paris is the capital of"
+        generation_kwargs = {
+            **self.GEN_KWARGS,
+            "num_assistant_tokens": 3,
+            "echo": True,
+            "apply_chat_template": False,
+            "ignore_eos": True,
+        }
+
+        baseline = LLMPipeline(main_model_path, OPENVINO_DEVICE, **pipeline_config)
+        baseline_output = str(
+            baseline.generate(
+                prompt,
+                echo=True,
+                apply_chat_template=False,
+                ignore_eos=True,
+                **self.GEN_KWARGS,
+            )
+        )
+
+        selector_enabled = LLMPipeline(
+            main_model_path,
+            OPENVINO_DEVICE,
+            draft_model=draft_model(draft_model_path, "CPU"),
+            selector_model=ov_genai.selector_model(draft_model_path, "CPU"),
+            **pipeline_config,
+        )
+        selector_output = str(selector_enabled.generate(prompt, **generation_kwargs))
+        self.assertEqual(selector_output, baseline_output)
+
+        selectorless = LLMPipeline(
+            main_model_path,
+            OPENVINO_DEVICE,
+            draft_model=draft_model(draft_model_path, "CPU"),
+            **pipeline_config,
+        )
+        selectorless_output = str(selectorless.generate(prompt, **generation_kwargs))
+        self.assertEqual(selectorless_output, baseline_output)
+
+        sampled_kwargs = {
+            "max_new_tokens": 10,
+            "min_new_tokens": 10,
+            "do_sample": True,
+            "temperature": 1.0,
+            "top_p": 1.0,
+            "top_k": 0,
+            "rng_seed": 42,
+            "num_assistant_tokens": 3,
+            "apply_chat_template": False,
+            "ignore_eos": True,
+        }
+        with self.assertRaisesRegex(RuntimeError, "requires the DFlash-2 selector"):
+            selectorless.generate(prompt, **sampled_kwargs)
+        sampled_output = str(selector_enabled.generate(prompt, **sampled_kwargs))
+        self.assertTrue(sampled_output)
 
     @parameterized.expand(SPECULATIVE_DECODING_VLM_MODELS)
     def test_compare_outputs_vlm(

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -17,6 +17,8 @@ import tempfile
 import time
 import unittest
 from contextlib import contextmanager
+from copy import deepcopy
+from functools import lru_cache
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -28,6 +30,83 @@ from huggingface_hub import constants, scan_cache_dir
 import optimum.exporters.openvino  # noqa: F401 (registers OpenVINO export configs in TasksManager)
 from optimum.exporters.tasks import TasksManager
 from optimum.intel.utils.import_utils import is_transformers_version
+
+
+def _save_tiny_qwen3_tokenizer(output_dir: Path) -> None:
+    from transformers import AutoTokenizer
+
+    AutoTokenizer.from_pretrained("optimum-intel-internal-testing/tiny-random-qwen3").save_pretrained(output_dir)
+
+
+@lru_cache(maxsize=1)
+def get_dflash2_model_path():
+    """Create a process-local tiny DFlash-2 checkpoint only when a DFlash-2 test needs it."""
+    output_dir = Path(tempfile.gettempdir()) / f"optimum_intel_tiny_random_qwen3_dflash2_{os.getpid()}"
+    config_file = output_dir / "config.json"
+    weights_file = output_dir / "model.safetensors"
+    tokenizer_file = output_dir / "tokenizer.json"
+    if config_file.exists() and weights_file.exists() and tokenizer_file.exists():
+        return str(output_dir)
+
+    from transformers import AutoConfig
+
+    from optimum.exporters.openvino.model_patcher import Qwen3DFlash2ForCausalLM
+
+    target_config = AutoConfig.from_pretrained("optimum-intel-internal-testing/tiny-random-qwen3")
+    target_num_hidden_layers = target_config.num_hidden_layers
+    config = deepcopy(target_config)
+    config.num_hidden_layers = min(2, target_num_hidden_layers)
+    config.num_target_layers = target_num_hidden_layers
+    if getattr(config, "layer_types", None):
+        config.layer_types = list(config.layer_types[: config.num_hidden_layers])
+    config.architectures = ["DFlash2DraftModel"]
+    config.is_causal = False
+    config.dflash_config = {
+        "conv_group_size": 8 if config.hidden_size % 8 == 0 else 1,
+        "conv_kernel_size": 2,
+        "mask_token_id": config.vocab_size - 1,
+        "selector_rank": 8,
+        "selector_top_k": 4,
+        "target_layer_ids": [0, target_num_hidden_layers - 1],
+        "input_embedding_scale": 1.25,
+        "output_multiplier": 0.75,
+        "final_logit_softcapping": 8.0,
+    }
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with torch.random.fork_rng():
+        torch.manual_seed(0)
+        model = Qwen3DFlash2ForCausalLM(config).eval()
+        model.save_pretrained(output_dir)
+    # save_pretrained records the implementation class; published DFlash-2
+    # checkpoints use this architecture marker to select the custom loader.
+    model.config.architectures = ["DFlash2DraftModel"]
+    model.config.save_pretrained(output_dir)
+    _save_tiny_qwen3_tokenizer(output_dir)
+    return str(output_dir)
+
+
+@lru_cache(maxsize=1)
+def get_dflash2_target_model_path():
+    """Create a matching process-local Qwen3 target checkpoint for DFlash-2 integration tests."""
+    output_dir = Path(tempfile.gettempdir()) / f"optimum_intel_tiny_random_qwen3_target_{os.getpid()}"
+    config_file = output_dir / "config.json"
+    weights_file = output_dir / "model.safetensors"
+    tokenizer_file = output_dir / "tokenizer.json"
+    if config_file.exists() and weights_file.exists() and tokenizer_file.exists():
+        return str(output_dir)
+
+    from transformers import AutoConfig
+    from transformers.models.qwen3.modeling_qwen3 import Qwen3ForCausalLM
+
+    config = AutoConfig.from_pretrained("optimum-intel-internal-testing/tiny-random-qwen3")
+    config.architectures = ["Qwen3ForCausalLM"]
+    output_dir.mkdir(parents=True, exist_ok=True)
+    with torch.random.fork_rng():
+        torch.manual_seed(1)
+        Qwen3ForCausalLM(config).eval().save_pretrained(output_dir)
+    _save_tiny_qwen3_tokenizer(output_dir)
+    return str(output_dir)
 
 
 def _create_tiny_kokoro_model():
@@ -455,6 +534,14 @@ EAGLE3_MODELS = {"qwen3_eagle3": ("qwen3_eagle3", "qwen3_eagle3_target")}
 DFLASH_MODELS = {
     "qwen3_dflash": ("qwen3_dflash", "qwen3"),
 }
+
+
+@lru_cache(maxsize=1)
+def get_dflash2_model_pairs():
+    if not is_transformers_version(">=", "4.57"):
+        return {}
+    return {"qwen3_dflash2": (get_dflash2_model_path(), get_dflash2_target_model_path())}
+
 
 DFLASH_VLM_MODELS = {
     "qwen3_5_dflash": ("qwen3_5_dflash", "qwen3_5"),


### PR DESCRIPTION
## What does this PR do?

This PR adds OpenVINO export support for DFlash 2 while preserving the existing
DFlash v1 flow.

DFlash 2 is exported as a two-model package:

- `openvino_model.xml` contains the draft backbone. It consumes target
  embeddings and selected target hidden states and produces draft hidden
  states. It may be exported with stateful or explicit KV-cache inputs.
- `openvino_selector_model.xml` contains the stateless candidate selector. It
  consumes candidate IDs, unary logits, draft hidden states, and the anchor
  token, and produces transition scores used to select a coherent candidate
  path.

The selector is exported first because OpenVINO's 16-bit traceability patch
mutates shared PyTorch modules. The backbone remains independently usable for
selectorless greedy decoding.

## Implementation details

- Detect and validate DFlash v1 and v2 checkpoint contracts, including
  architecture, required configuration fields, target-layer bounds, grouped
  convolution parameters, selector dimensions, and optional logit transforms.
- Load DFlash 2 checkpoints through dedicated Qwen3 draft classes.
- Implement the grouped dynamic causal convolutions used around DFlash 2
  attention and MLP sublayers.
- Export the candidate selector as a separate stateless IR with explicit
  structural and score-semantics metadata.
- Preserve the existing DFlash v1 single-IR behavior.
- Support TorchScript and Dynamo export, stateful and explicit-cache backbones,
  and selectorless operation.

## Compression policy

The draft backbone follows `--weight-format`.

The selector preserves its checkpoint precision for FP16, INT8, and INT4
backbone exports. Selector quality is sensitive to its codebooks and projection
weights, so selector quantization is intentionally deferred until its accuracy
and performance impact is characterized.

## Runtime metadata and activation scaling

Requested runtime options are treated as part of the exported model contract.
RT-info write failures are propagated instead of silently producing an IR
without correctness-critical activation-scaling or KV-cache hints.

Activation-scale ownership is generalized:

- generic conversion supplies only a non-overwriting default;
- export configurations own architecture- or component-specific
  recommendations;
- DFlash 2 records its validated `ACTIVATIONS_SCALE_FACTOR=32` recommendation
  through `Qwen3OpenVINOConfig`;
- the existing Gemma 4 Unified vision recommendation is moved from
  `convert.py` into `Gemma4UnifiedOpenVINOConfig`;
- explicit recommendations are preserved.

## Runtime dependency

Selector-guided and sampled decoding require the companion OpenVINO GenAI
DFlash 2 runtime implementation, including `selector_model()`, selector
metadata validation, candidate-path selection, and sampled proposal handling.
The companion runtime PR should be linked here when available.

The exported backbone remains usable without that selector API in selectorless
greedy mode.

## Test strategy

The tests cover:

- DFlash v1 single-IR regression;
- DFlash 2 configuration and checkpoint validation;
- grouped-convolution and selector reference parity;
- dynamic two-IR export and CPU/GPU finite-output checks;
- optional DFlash runtime metadata;
- stateful and explicit-cache exports;
- TorchScript and Dynamo input contracts;
- FP16, INT8, and INT4 backbone compression with selector precision
  preservation;
- selector-enabled and selectorless greedy parity;
- sampled decoding requiring a selector;
- MTP regression coverage for shared export code.

The DFlash 2 GenAI selector test deliberately uses a tiny text-only Qwen3 target
to isolate selector-enabled, selectorless, and sampled behavior without
duplicating vision export. Existing parameterized DFlash VLM tests cover the
shared `VLMPipeline`, decomposed-embedding, and multimodal target path.

`utils_tests.py` creates deterministic process-local tiny DFlash 2 draft and
matching Qwen3 target checkpoints lazily. This exercises the real custom loader
and checkpoint contract without checking binary fixtures into the repository
or downloading production-sized models. Per-process caching avoids rebuilding
the fixtures for every test.

Validation performed locally:

```text
black --check .
ruff check .
pytest tests/openvino/test_dflash.py::DFlashExportTest::test_v1_export_remains_single_ir tests/openvino/test_dflash.py::DFlash2ExportTest -q
pytest tests/openvino/test_exporters_cli.py -k dflash2 -q
pytest tests/openvino/test_genai.py::LLMPipelineWithSpeculativeDecodingTestCase::test_dflash2_text_selector_presence_selectorless_and_sampled -q
pytest tests/openvino/test_genai.py -k MTP -q
```

The focused DFlash, CLI, DFlash 2 GenAI, MTP, Black, and Ruff checks pass.

Two unrelated cases in a full local `test_dflash.py` run could not load the
cached `tiny-random-qwen3` fixture because that local Hugging Face snapshot
lacked model weights. They fail before export; the focused DFlash v1/v2 tests
and complete-cache CI path are unaffected.

## Checklist

- [x] Documentation updated.
- [x] New tests added.
- [x] DFlash v1 compatibility covered.
- [x] Selector compression policy covered for FP16, INT8, and INT4.
- [x] Shared MTP export path regression-tested.
