### PR TITLE
[OpemVINO] Qwen3-ASR implement vlm like audio_encoder + text_embedding + language model export

### DIFF
--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -82,7 +82,6 @@ from .stateful import (
 )
 from .utils_annotations import add_hidden_states_rt_info
 
-
 logger = logging.getLogger(__name__)
 
 if is_torch_available():
@@ -660,15 +659,6 @@ def export_from_model(
 
     is_encoder_decoder = getattr(getattr(model, "config", {}), "is_encoder_decoder", False)
 
-    # Qwen3-ASR is structurally encoder-decoder (audio_tower + text LM) but config says is_encoder_decoder=False
-    if model_type == "qwen3_asr" and not is_encoder_decoder:
-        is_encoder_decoder = True
-        model.config.is_encoder_decoder = True
-        if not hasattr(model, "get_encoder"):
-            model.get_encoder = lambda: model.thinker.audio_tower
-        # Set decoder_start_token_id so the saved config enables encoder-decoder generation
-        if model.config.decoder_start_token_id is None:
-            model.config.decoder_start_token_id = 0
     stateful = stateful and (
         ensure_export_task_support_stateful(task) or ensure_model_type_support_stateful(model_type)
     )
@@ -782,6 +772,8 @@ def export_from_model(
         save_config(model.config, output)
         generation_config = getattr(model, "generation_config", None)
         if generation_config is not None:
+            if hasattr(export_config, "prepare_generation_config_for_export"):
+                generation_config = export_config.prepare_generation_config_for_export(generation_config)
             try:
                 generation_config.save_pretrained(output)
             except Exception as exception:

--- a/optimum/exporters/openvino/input_generators.py
+++ b/optimum/exporters/openvino/input_generators.py
@@ -1439,17 +1439,16 @@ class DummyQwen3VLVisionEmbedInputGenerator(DummyQwen2VLVisionEmbedInputGenerato
             )
 
 
-class Qwen3ASRDummySeq2SeqPastKeyValuesGenerator(DummySeq2SeqPastKeyValuesGenerator):
+class Qwen3ASRDummySeq2SeqPastKeyValuesGenerator(DummyPastKeyValuesGenerator):
     """Custom KV cache generator for Qwen3-ASR with GQA (num_key_value_heads != num_attention_heads).
     Qwen3-ASR has no cross-attention, so only self-attention KV cache is generated (2 per layer)."""
 
     def __init__(self, task, normalized_config, **kwargs):
         super().__init__(task, normalized_config, **kwargs)
-        # Override head count and head_dim for GQA
-        self.decoder_num_attention_heads = normalized_config.decoder_num_attention_heads
+        self.decoder_num_attention_heads = normalized_config.num_key_value_heads
         self.decoder_head_dim = getattr(normalized_config, "head_dim", None)
         if self.decoder_head_dim is None:
-            self.decoder_head_dim = self.decoder_hidden_size // normalized_config.num_attention_heads
+            self.decoder_head_dim = self.hidden_size // normalized_config.num_attention_heads
 
     def generate(self, input_name, framework="pt", int_dtype="int64", float_dtype="fp32"):
         if input_name == "past_key_values":
@@ -1465,7 +1464,7 @@ class Qwen3ASRDummySeq2SeqPastKeyValuesGenerator(DummySeq2SeqPastKeyValuesGenera
                     self.random_float_tensor(decoder_shape, framework=framework, dtype=float_dtype),
                     self.random_float_tensor(decoder_shape, framework=framework, dtype=float_dtype),
                 )
-                for _ in range(self.decoder_num_layers)
+                for _ in range(self.num_layers)
             ]
         return super().generate(input_name, framework=framework, int_dtype=int_dtype, float_dtype=float_dtype)
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -192,7 +192,7 @@ from optimum.exporters.openvino.model_patcher import (
     Qwen3_5MTPModelPatcher,
     Qwen3_5MTPModule,
     Qwen3_5VisionEmbMergerPatcher,
-    Qwen3ASRModelPatcher,
+    Qwen3ASRLanguageModelPatcher,
     Qwen3MoeModelPatcher,
     Qwen3NextModelPatcher,
     Qwen3OmniMoeAudioEncoderPatcher,
@@ -255,7 +255,6 @@ from optimum.utils.normalized_config import (
     NormalizedTextConfig,
     NormalizedVisionConfig,
 )
-
 
 COMMON_TEXT_TASKS = [
     "feature-extraction",
@@ -597,6 +596,25 @@ class Qwen3OmniMoeTextOpenVINOConfig(Qwen3VLTextOpenVINOConfig):
     # Qwen3-Omni-MoE support requires Transformers 5.0+ (the fused-experts / router API);
     # override the Qwen3VL parent's 4.57.0 floor so 4.x fails fast with a clear message.
     MIN_TRANSFORMERS_VERSION = "5.0"
+
+
+@register_in_tasks_manager(
+    "qwen3_asr_text",
+    *["text-generation", "text-generation-with-past"],
+    library_name="transformers",
+)
+class Qwen3ASRTextOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen2VLLMInputGenerator, Qwen3ASRDummySeq2SeqPastKeyValuesGenerator)
+    DUMMY_PKV_GENERATOR_CLASS = Qwen3ASRDummySeq2SeqPastKeyValuesGenerator
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(
+        decoder_num_layers="num_hidden_layers",
+        decoder_num_attention_heads="num_key_value_heads",
+        decoder_hidden_size="hidden_size",
+        allow_new=True,
+    )
+    MIN_TRANSFORMERS_VERSION = "4.57.6"
+    MAX_TRANSFORMERS_VERSION = "4.57.6"
+    _MODEL_PATCHER = OVDecoderModelPatcher
 
 
 @register_in_tasks_manager(
@@ -4577,6 +4595,12 @@ class WhisperOpenVINOConfig(AudioToTextOpenVINOConfig):
         return common_outputs
 
 
+class Qwen3ASRConfigBehavior(str, enum.Enum):
+    AUDIO_ENCODER = "audio_encoder"
+    TEXT_EMBEDDINGS = "text_embeddings"
+    LANGUAGE = "language"
+
+
 @register_in_tasks_manager(
     "qwen3_asr",
     *[
@@ -4585,27 +4609,27 @@ class WhisperOpenVINOConfig(AudioToTextOpenVINOConfig):
     ],
     library_name="transformers",
 )
-class Qwen3ASROpenVINOConfig(AudioToTextOpenVINOConfig):
+class Qwen3ASROpenVINOConfig(BaseVLMOpenVINOConfig):
     """OpenVINO export config for Qwen3-ASR model."""
 
-    DUMMY_INPUT_GENERATOR_CLASSES = (
-        DummyAudioInputGenerator,
-        DummySeq2SeqDecoderTextInputGenerator,
-        Qwen3ASRDummySeq2SeqPastKeyValuesGenerator,
-    )
-
-    NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
-        encoder_num_layers="encoder_layers",
-        decoder_num_layers="num_hidden_layers",
-        num_attention_heads="num_attention_heads",
-        # Use num_key_value_heads for KV cache shape generation (GQA)
-        decoder_num_attention_heads="num_key_value_heads",
-        feature_size="num_mel_bins",
-        allow_new=True,
-    )
+    SUPPORTED_BEHAVIORS = [behavior.value for behavior in Qwen3ASRConfigBehavior]
+    DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3OmniMoeAudioInputGenerator,)
+    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
     MIN_TRANSFORMERS_VERSION = "4.57.6"
     MAX_TRANSFORMERS_VERSION = "4.57.6"
-    _MODEL_PATCHER = Qwen3ASRModelPatcher
+
+    @staticmethod
+    def prepare_generation_config_for_export(generation_config):
+        generation_config = copy.deepcopy(generation_config)
+        # https://huggingface.co/Qwen/Qwen3-ASR-0.6B/discussions/13
+        # original generation config has do_sample=False and temperature=1e-6, which is invalid. save_pretrained fails:
+        # ValueError: GenerationConfig is invalid:
+        # - `temperature`: `do_sample` is not set to `True`. However, `temperature` is set to `1e-06` --
+        # this flag is only used in sample-based generation modes. You should set `do_sample=True` or
+        # unset `temperature`.
+        if not generation_config.do_sample:
+            generation_config.temperature = None
+        return generation_config
 
     def __init__(
         self,
@@ -4613,56 +4637,90 @@ class Qwen3ASROpenVINOConfig(AudioToTextOpenVINOConfig):
         task: str = "automatic-speech-recognition",
         int_dtype: str = "int64",
         float_dtype: str = "fp32",
+        behavior: Qwen3ASRConfigBehavior = Qwen3ASRConfigBehavior.AUDIO_ENCODER,
         preprocessors: Optional[List[Any]] = None,
         **kwargs,
     ):
-        # Flatten nested config for NormalizedSeq2SeqConfig
-        thinker = getattr(config, "thinker_config", config)
-        audio_config = getattr(thinker, "audio_config", None)
-        text_config = getattr(thinker, "text_config", None)
-
-        if audio_config is not None:
-            config.encoder_layers = audio_config.encoder_layers
-            config.num_mel_bins = audio_config.num_mel_bins
-            # Use output_dim (post-projection) as d_model since that's the actual encoder output size
-            config.d_model = getattr(audio_config, "output_dim", audio_config.d_model)
-            config.n_window = getattr(audio_config, "n_window", None)
-
-        if text_config is not None:
-            config.num_hidden_layers = text_config.num_hidden_layers
-            config.hidden_size = text_config.hidden_size
-            config.num_attention_heads = text_config.num_attention_heads
-            config.num_key_value_heads = getattr(text_config, "num_key_value_heads", text_config.num_attention_heads)
-            config.head_dim = getattr(
-                text_config, "head_dim", text_config.hidden_size // text_config.num_attention_heads
-            )
-            config.decoder_start_token_id = getattr(text_config, "bos_token_id", None) or 0
-            config.vocab_size = text_config.vocab_size
-
         super().__init__(
             config=config,
             task=task,
             int_dtype=int_dtype,
             float_dtype=float_dtype,
             preprocessors=preprocessors,
-            **kwargs,
+        )
+        self._behavior = behavior
+        self._orig_config = config
+        thinker_config = getattr(config, "thinker_config", config)
+        audio_config = getattr(thinker_config, "audio_config", None)
+        if behavior == Qwen3ASRConfigBehavior.AUDIO_ENCODER and audio_config is not None:
+            self._config = audio_config
+            self._normalized_config = self.NORMALIZED_CONFIG_CLASS(audio_config)
+
+    @staticmethod
+    def get_model_for_behavior(model, behavior: Union[str, Qwen3ASRConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, Qwen3ASRConfigBehavior):
+            behavior = Qwen3ASRConfigBehavior(behavior)
+
+        if behavior == Qwen3ASRConfigBehavior.LANGUAGE:
+            return model
+        if behavior == Qwen3ASRConfigBehavior.TEXT_EMBEDDINGS:
+            text_embeddings = model.thinker.model.get_input_embeddings()
+            text_embeddings.config = model.thinker.config.text_config
+            return text_embeddings
+        if behavior == Qwen3ASRConfigBehavior.AUDIO_ENCODER:
+            audio_encoder = model.thinker.audio_tower
+            audio_encoder.config = model.thinker.config.audio_config
+            return audio_encoder
+        raise ValueError(f"Unsupported Qwen3-ASR behavior: {behavior}")
+
+    def with_behavior(self, behavior: Union[str, Qwen3ASRConfigBehavior]):
+        if isinstance(behavior, str) and not isinstance(behavior, Qwen3ASRConfigBehavior):
+            behavior = Qwen3ASRConfigBehavior(behavior)
+
+        thinker_config = getattr(self._orig_config, "thinker_config", self._orig_config)
+        if behavior == Qwen3ASRConfigBehavior.TEXT_EMBEDDINGS:
+            return get_vlm_text_embeddings_config(
+                "qwen3_asr_text", thinker_config.text_config, self.int_dtype, self.float_dtype
+            )
+        if behavior == Qwen3ASRConfigBehavior.LANGUAGE:
+            return get_vlm_text_generation_config(
+                "qwen3_asr_text",
+                thinker_config.text_config,
+                self.int_dtype,
+                self.float_dtype,
+                model_patcher=Qwen3ASRLanguageModelPatcher,
+                inputs_update={"position_ids": {1: "batch_size", 2: "sequence_length"}},
+            )
+        return self.__class__(
+            self._orig_config,
+            task=self.task,
+            int_dtype=self.int_dtype,
+            float_dtype=self.float_dtype,
+            behavior=behavior,
+            preprocessors=self._preprocessors,
         )
 
-    def add_past_key_values(self, inputs_or_outputs: Dict[str, Dict[int, str]], direction: str):
-        """Override to exclude encoder KV cache since Qwen3-ASR has no cross-attention."""
-        if direction not in ["inputs", "outputs"]:
-            raise ValueError(f'direction must either be "inputs" or "outputs", but {direction} was given')
+    def patch_model_for_export(self, model: PreTrainedModel, model_kwargs: Optional[Dict[str, Any]] = None):
+        if self._behavior == Qwen3ASRConfigBehavior.AUDIO_ENCODER:
+            return Qwen3OmniMoeAudioEncoderPatcher(self, model, model_kwargs or {})
+        return super().patch_model_for_export(model, model_kwargs)
 
-        if direction == "inputs":
-            decoder_sequence_name = "past_decoder_sequence_length"
-            name = "past_key_values"
-        else:
-            decoder_sequence_name = "past_decoder_sequence_length + decoder_sequence_length"
-            name = "present"
+    @property
+    def inputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == Qwen3ASRConfigBehavior.AUDIO_ENCODER:
+            return {
+                "padded_feature": {0: "num_chunks", 2: "audio_sequence_length"},
+                "padded_mask_after_cnn": {0: "num_chunks", 1: "aftercnn_sequence_length"},
+                "aftercnn_lens": {0: "batch_size"},
+                "cu_seqlens": {0: "num_windows + 1"},
+            }
+        raise ValueError(f"Inputs are defined by the config for Qwen3-ASR behavior {self._behavior}")
 
-        for i in range(self._normalized_config.decoder_num_layers):
-            inputs_or_outputs[f"{name}.{i}.decoder.key"] = {0: "batch_size", 2: decoder_sequence_name}
-            inputs_or_outputs[f"{name}.{i}.decoder.value"] = {0: "batch_size", 2: decoder_sequence_name}
+    @property
+    def outputs(self) -> Dict[str, Dict[int, str]]:
+        if self._behavior == Qwen3ASRConfigBehavior.AUDIO_ENCODER:
+            return {"audio_features": {0: "num_chunks", 1: "aftercnn_sequence_length"}}
+        raise ValueError(f"Outputs are defined by the config for Qwen3-ASR behavior {self._behavior}")
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -193,6 +193,7 @@ from optimum.exporters.openvino.model_patcher import (
     Qwen3_5MTPModule,
     Qwen3_5VisionEmbMergerPatcher,
     Qwen3ASRLanguageModelPatcher,
+    Qwen3ASRModelPatcher,
     Qwen3MoeModelPatcher,
     Qwen3NextModelPatcher,
     Qwen3OmniMoeAudioEncoderPatcher,
@@ -4593,6 +4594,86 @@ class WhisperOpenVINOConfig(AudioToTextOpenVINOConfig):
                 output_name = "last_hidden_state"
             common_outputs[output_name] = {0: "batch_size"}  # Remove unnecessary dynamic axis.
         return common_outputs
+
+
+class Qwen3ASREncoderDecoderOpenVINOConfig(AudioToTextOpenVINOConfig):
+    """OpenVINO export config for Qwen3-ASR model."""
+
+    DUMMY_INPUT_GENERATOR_CLASSES = (
+        DummyAudioInputGenerator,
+        DummySeq2SeqDecoderTextInputGenerator,
+        Qwen3ASRDummySeq2SeqPastKeyValuesGenerator,
+    )
+
+    NORMALIZED_CONFIG_CLASS = NormalizedSeq2SeqConfig.with_args(
+        encoder_num_layers="encoder_layers",
+        decoder_num_layers="num_hidden_layers",
+        num_attention_heads="num_attention_heads",
+        # Use num_key_value_heads for KV cache shape generation (GQA)
+        decoder_num_attention_heads="num_key_value_heads",
+        feature_size="num_mel_bins",
+        allow_new=True,
+    )
+    MIN_TRANSFORMERS_VERSION = "4.57.6"
+    MAX_TRANSFORMERS_VERSION = "4.57.6"
+    _MODEL_PATCHER = Qwen3ASRModelPatcher
+
+    def __init__(
+        self,
+        config: "PretrainedConfig",
+        task: str = "automatic-speech-recognition",
+        int_dtype: str = "int64",
+        float_dtype: str = "fp32",
+        preprocessors: Optional[List[Any]] = None,
+        **kwargs,
+    ):
+        # Flatten nested config for NormalizedSeq2SeqConfig
+        thinker = getattr(config, "thinker_config", config)
+        audio_config = getattr(thinker, "audio_config", None)
+        text_config = getattr(thinker, "text_config", None)
+
+        if audio_config is not None:
+            config.encoder_layers = audio_config.encoder_layers
+            config.num_mel_bins = audio_config.num_mel_bins
+            # Use output_dim (post-projection) as d_model since that's the actual encoder output size
+            config.d_model = getattr(audio_config, "output_dim", audio_config.d_model)
+            config.n_window = getattr(audio_config, "n_window", None)
+
+        if text_config is not None:
+            config.num_hidden_layers = text_config.num_hidden_layers
+            config.hidden_size = text_config.hidden_size
+            config.num_attention_heads = text_config.num_attention_heads
+            config.num_key_value_heads = getattr(text_config, "num_key_value_heads", text_config.num_attention_heads)
+            config.head_dim = getattr(
+                text_config, "head_dim", text_config.hidden_size // text_config.num_attention_heads
+            )
+            config.decoder_start_token_id = getattr(text_config, "bos_token_id", None) or 0
+            config.vocab_size = text_config.vocab_size
+
+        super().__init__(
+            config=config,
+            task=task,
+            int_dtype=int_dtype,
+            float_dtype=float_dtype,
+            preprocessors=preprocessors,
+            **kwargs,
+        )
+
+    def add_past_key_values(self, inputs_or_outputs: Dict[str, Dict[int, str]], direction: str):
+        """Override to exclude encoder KV cache since Qwen3-ASR has no cross-attention."""
+        if direction not in ["inputs", "outputs"]:
+            raise ValueError(f'direction must either be "inputs" or "outputs", but {direction} was given')
+
+        if direction == "inputs":
+            decoder_sequence_name = "past_decoder_sequence_length"
+            name = "past_key_values"
+        else:
+            decoder_sequence_name = "past_decoder_sequence_length + decoder_sequence_length"
+            name = "present"
+
+        for i in range(self._normalized_config.decoder_num_layers):
+            inputs_or_outputs[f"{name}.{i}.decoder.key"] = {0: "batch_size", 2: decoder_sequence_name}
+            inputs_or_outputs[f"{name}.{i}.decoder.value"] = {0: "batch_size", 2: decoder_sequence_name}
 
 
 class Qwen3ASRConfigBehavior(str, enum.Enum):

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -607,12 +607,7 @@ class Qwen3OmniMoeTextOpenVINOConfig(Qwen3VLTextOpenVINOConfig):
 class Qwen3ASRTextOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen2VLLMInputGenerator, Qwen3ASRDummySeq2SeqPastKeyValuesGenerator)
     DUMMY_PKV_GENERATOR_CLASS = Qwen3ASRDummySeq2SeqPastKeyValuesGenerator
-    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig.with_args(
-        decoder_num_layers="num_hidden_layers",
-        decoder_num_attention_heads="num_key_value_heads",
-        decoder_hidden_size="hidden_size",
-        allow_new=True,
-    )
+    NORMALIZED_CONFIG_CLASS = NormalizedTextConfig
     MIN_TRANSFORMERS_VERSION = "4.57.6"
     MAX_TRANSFORMERS_VERSION = "4.57.6"
     _MODEL_PATCHER = OVDecoderModelPatcher
@@ -4695,7 +4690,7 @@ class Qwen3ASROpenVINOConfig(BaseVLMOpenVINOConfig):
 
     SUPPORTED_BEHAVIORS = [behavior.value for behavior in Qwen3ASRConfigBehavior]
     DUMMY_INPUT_GENERATOR_CLASSES = (DummyQwen3OmniMoeAudioInputGenerator,)
-    NORMALIZED_CONFIG_CLASS = NormalizedVisionConfig
+    NORMALIZED_CONFIG_CLASS = NormalizedConfig
     MIN_TRANSFORMERS_VERSION = "4.57.6"
     MAX_TRANSFORMERS_VERSION = "4.57.6"
 

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -10766,6 +10766,277 @@ class Qwen3ASRLanguageModelPatcher(OVDecoderModelPatcher):
         del self._model.__orig_forward
 
 
+class Qwen3ASRModelPatcher(OVSeq2SeqModelPatcher):
+    """
+    Model patcher for Qwen3-ASR encoder-decoder export.
+
+    For encoder: patches the audio tower forward to use standard attention (no cu_seqlens/chunking).
+    For decoder: patches forward to accept encoder_outputs/decoder_input_ids and map them to the thinker's interface.
+    """
+
+    def __init__(
+        self,
+        config: "OpenVINOConfig",
+        model: "PreTrainedModel",
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        super().__init__(config, model, model_kwargs)
+
+    def __enter__(self):
+        super().__enter__()
+
+        if self.real_config._behavior == "encoder":
+            self._patch_audio_encoder()
+        elif self.real_config._behavior == "decoder":
+            self._patch_decoder()
+
+    def _patch_audio_encoder(self):
+        """
+        Patch audio encoder forward for OV-compatible tracing.
+        Removes dynamic chunking and cu_seqlens-based attention.
+        Patches attention layers to work with batched 3D inputs.
+        """
+        encoder = self._model
+        # Force eager attention to avoid cu_seqlens dependency
+        encoder.config._attn_implementation = "eager"
+        for layer in encoder.layers:
+            layer.self_attn.config._attn_implementation = "eager"
+
+            # Patch each attention layer to accept 3D batched input (batch, seq, dim)
+            attn = layer.self_attn
+            attn._orig_forward = attn.forward
+
+            def make_patched_attn_forward(attn_module):
+                # Original code: https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L477
+                def patched_attn_forward(hidden_states, cu_seqlens=None, attention_mask=None, **kwargs):
+                    # hidden_states: (batch, seq_len, dim) - standard 3D batched
+                    bsz, seq_length, _ = hidden_states.size()
+
+                    query_states = (
+                        attn_module.q_proj(hidden_states)
+                        .reshape(bsz, seq_length, attn_module.num_heads, -1)
+                        .transpose(1, 2)
+                    )
+                    key_states = (
+                        attn_module.k_proj(hidden_states)
+                        .reshape(bsz, seq_length, attn_module.num_heads, -1)
+                        .transpose(1, 2)
+                    )
+                    value_states = (
+                        attn_module.v_proj(hidden_states)
+                        .reshape(bsz, seq_length, attn_module.num_heads, -1)
+                        .transpose(1, 2)
+                    )
+
+                    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * attn_module.scaling
+                    attn_weights = torch.nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(
+                        query_states.dtype
+                    )
+
+                    attn_output = torch.matmul(attn_weights, value_states)
+                    attn_output = attn_output.transpose(1, 2).contiguous().reshape(bsz, seq_length, -1)
+                    attn_output = attn_module.out_proj(attn_output)
+                    return attn_output
+
+                return patched_attn_forward
+
+            attn.forward = make_patched_attn_forward(attn)
+
+            # Patch each encoder layer to accept 3D input and skip cu_seqlens
+            layer._orig_forward = layer.forward
+
+            def make_patched_layer_forward(enc_layer):
+                # Original code:https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L536
+                def patched_layer_forward(hidden_states, cu_seqlens=None, attention_mask=None, **kwargs):
+                    residual = hidden_states
+                    hidden_states = enc_layer.self_attn_layer_norm(hidden_states)
+                    hidden_states = enc_layer.self_attn(hidden_states=hidden_states, attention_mask=attention_mask)
+                    hidden_states = residual + hidden_states
+                    residual = hidden_states
+                    hidden_states = enc_layer.final_layer_norm(hidden_states)
+                    hidden_states = enc_layer.fc1(hidden_states)
+                    hidden_states = enc_layer.activation_fn(hidden_states)
+                    hidden_states = enc_layer.fc2(hidden_states)
+                    hidden_states = residual + hidden_states
+                    return (hidden_states,)
+
+                return patched_layer_forward
+
+            layer.forward = make_patched_layer_forward(layer)
+
+        # Save original forward
+        encoder._orig_forward = encoder.forward
+
+        # Original code: https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L669
+        def patched_audio_forward(input_features, feature_lens=None, aftercnn_lens=None, **kwargs):
+            """
+            Simplified audio encoder forward for OV export.
+            Processes audio input without dynamic chunking.
+
+            input_features: (batch_size, num_mel_bins, seq_len) or (num_mel_bins, seq_len)
+            """
+            # Ensure input is batched: (batch, num_mel, seq_len)
+            if input_features.dim() == 2:
+                input_features = input_features.unsqueeze(0)
+
+            # Apply convolutions: conv2d expects (batch, 1, num_mel, seq_len)
+            x = input_features.unsqueeze(1)  # (batch, 1, num_mel, seq_len)
+            x = F.gelu(encoder.conv2d1(x))
+            x = F.gelu(encoder.conv2d2(x))
+            x = F.gelu(encoder.conv2d3(x))
+
+            b, c, f, t = x.size()
+            x = encoder.conv_out(x.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
+
+            # Add positional embeddings
+            pos_emb = encoder.positional_embedding.positional_embedding[:t, :].unsqueeze(0).to(x.dtype)
+            hidden_states = x + pos_emb  # (batch, t, hidden_dim)
+
+            # Process through patched encoder layers with standard 3D batched attention
+            for encoder_layer in encoder.layers:
+                layer_outputs = encoder_layer(hidden_states)
+                hidden_states = layer_outputs[0]
+
+            hidden_states = encoder.ln_post(hidden_states)
+            hidden_states = encoder.proj1(hidden_states)
+            hidden_states = encoder.act(hidden_states)
+            hidden_states = encoder.proj2(hidden_states)
+
+            return BaseModelOutput(last_hidden_state=hidden_states)
+
+        encoder.forward = patched_audio_forward
+
+    def _patch_decoder(self):
+        """
+        Patch full model forward for decoder export.
+        Maps seq2seq inputs (encoder_outputs, decoder_input_ids) to the thinker's interface.
+        Returns a flat tuple of tensors (logits + KV cache) for TorchScript tracing compatibility.
+        """
+        model = self._model
+        thinker = model.thinker
+
+        # Force eager attention for text model
+        thinker.config.text_config._attn_implementation = "eager"
+
+        # Save original forward
+        model._orig_forward = model.forward
+
+        # Original code: https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L1159
+        def patched_decoder_forward(
+            encoder_outputs=None,
+            decoder_input_ids=None,
+            attention_mask=None,
+            past_key_values=None,
+            cache_position=None,
+            **kwargs,
+        ):
+            """
+            Decoder forward that accepts seq2seq-style inputs.
+            encoder_outputs: pre-computed audio features from encoder (batch, enc_seq_len, hidden_dim)
+            decoder_input_ids: text token ids (batch, dec_seq_len)
+            Returns a flat tuple: (logits, k0, v0, k1, v1, ...) for TorchScript compatibility.
+            """
+            # Convert past_key_values from legacy list format to DynamicCache
+            if past_key_values is not None and isinstance(past_key_values, (list, tuple)):
+                cache = DynamicCache()
+                for layer_past in past_key_values:
+                    if len(layer_past) >= 2:
+                        cache.update(layer_past[0], layer_past[1], len(cache))
+                past_key_values = cache
+            elif past_key_values is None:
+                # Pre-create DynamicCache so that thinker.model uses it even during
+                # torch.jit.trace (the model skips cache creation when tracing).
+                past_key_values = DynamicCache()
+
+            input_ids = decoder_input_ids
+            inputs_embeds = thinker.get_input_embeddings()(input_ids)
+
+            # Merge audio features from encoder into embeddings at audio placeholder positions
+            if encoder_outputs is not None:
+                if isinstance(encoder_outputs, (tuple, list)):
+                    encoder_hidden_states = encoder_outputs[0]
+                else:
+                    encoder_hidden_states = encoder_outputs
+                # Flatten encoder outputs: (total_audio_tokens, hidden_dim)
+                audio_features = encoder_hidden_states.reshape(-1, encoder_hidden_states.shape[-1])
+                audio_features = audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
+
+                # Use cumsum-based indexing + torch.where for OV-friendly dynamic shapes
+                special_audio_mask = input_ids == thinker.config.audio_token_id  # [batch, seq]
+                # cumsum gives 1-based index of audio tokens; subtract 1 for 0-based
+                audio_cumsum = special_audio_mask.long().cumsum(dim=-1) - 1  # [batch, seq]
+                # Clamp to valid range for gather (non-audio positions will be masked out anyway)
+                audio_cumsum = audio_cumsum.clamp(min=0)
+                # Expand to [batch, seq, hidden] by gathering from audio_features
+                gather_indices = audio_cumsum.unsqueeze(-1).expand(
+                    -1, -1, inputs_embeds.shape[-1]
+                )  # [batch, seq, hidden]
+                # audio_features is [total_audio_tokens, hidden], expand for batch gather
+                audio_features_expanded = audio_features.unsqueeze(0).expand(
+                    inputs_embeds.shape[0], -1, -1
+                )  # [batch, total, hidden]
+                gathered_audio = torch.gather(audio_features_expanded, 1, gather_indices)  # [batch, seq, hidden]
+                # Use where to select: audio feature at audio positions, original embed elsewhere
+                mask_3d = special_audio_mask.unsqueeze(-1)  # [batch, seq, 1]
+                inputs_embeds = torch.where(mask_3d, gathered_audio, inputs_embeds)
+
+            # Compute position_ids
+            position_ids = None
+            if attention_mask is not None:
+                if (
+                    cache_position is None
+                    or (cache_position is not None and cache_position[0] == 0)
+                    or thinker.rope_deltas is None
+                ):
+                    delta0 = (1 - attention_mask).sum(dim=-1).unsqueeze(1)
+                    position_ids, rope_deltas = thinker.get_rope_index(attention_mask)
+                    rope_deltas = rope_deltas - delta0
+                    thinker.rope_deltas = rope_deltas
+                else:
+                    batch_size, seq_length = input_ids.shape
+                    delta = cache_position[0] + thinker.rope_deltas
+                    position_ids = torch.arange(seq_length, device=input_ids.device)
+                    position_ids = position_ids.view(1, -1).expand(batch_size, -1)
+                    position_ids = position_ids.add(delta)
+                    position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+
+            outputs = thinker.model(
+                attention_mask=attention_mask,
+                position_ids=position_ids,
+                past_key_values=past_key_values,
+                inputs_embeds=inputs_embeds,
+                use_cache=True,
+                cache_position=cache_position,
+            )
+
+            logits = thinker.lm_head(outputs[0])
+
+            past_kv = outputs.past_key_values
+            # Convert DynamicCache to flat tuple of tensors for TorchScript tracing
+            # Output format: (logits, k0, v0, k1, v1, ...)
+            flat_output = [logits]
+            if isinstance(past_kv, DynamicCache):
+                for layer in past_kv.layers:
+                    flat_output.append(layer.keys)
+                    flat_output.append(layer.values)
+            elif past_kv is not None:
+                legacy = past_kv if isinstance(past_kv, (list, tuple)) else past_kv.to_legacy_cache()
+                for layer_kv in legacy:
+                    flat_output.append(layer_kv[0])
+                    flat_output.append(layer_kv[1])
+
+            return tuple(flat_output)
+
+        model.forward = patched_decoder_forward
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        super().__exit__(exc_type, exc_value, traceback)
+
+        if hasattr(self._model, "_orig_forward"):
+            self._model.forward = self._model._orig_forward
+            del self._model._orig_forward
+
+
 class FunASRModelPatcher(OVSeq2SeqModelPatcher):
     """
     Model patcher for FunASR (e.g. Fun-ASR-Nano) encoder-decoder export.

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -69,7 +69,6 @@ from optimum.intel.utils.import_utils import (
     is_transformers_version,
 )
 
-
 if is_transformers_version(">=", "4.53"):
     from transformers.masking_utils import (
         ALL_MASK_ATTENTION_FUNCTIONS,
@@ -10722,275 +10721,49 @@ class Qwen3_5MoeMTPModelPatcher(Qwen3_5MTPModelPatcher):
                 sparse_moe_block.forward = sparse_moe_block._orig_forward
 
 
-class Qwen3ASRModelPatcher(OVSeq2SeqModelPatcher):
-    """
-    Model patcher for Qwen3-ASR encoder-decoder export.
-
-    For encoder: patches the audio tower forward to use standard attention (no cu_seqlens/chunking).
-    For decoder: patches forward to accept encoder_outputs/decoder_input_ids and map them to the thinker's interface.
-    """
-
+class Qwen3ASRLanguageModelPatcher(OVDecoderModelPatcher):
     def __init__(
         self,
         config: "OpenVINOConfig",
         model: "PreTrainedModel",
         model_kwargs: Optional[Dict[str, Any]] = None,
     ):
-        super().__init__(config, model, model_kwargs)
-
-    def __enter__(self):
-        super().__enter__()
-
-        if self.real_config._behavior == "encoder":
-            self._patch_audio_encoder()
-        elif self.real_config._behavior == "decoder":
-            self._patch_decoder()
-
-    def _patch_audio_encoder(self):
-        """
-        Patch audio encoder forward for OV-compatible tracing.
-        Removes dynamic chunking and cu_seqlens-based attention.
-        Patches attention layers to work with batched 3D inputs.
-        """
-        encoder = self._model
-        # Force eager attention to avoid cu_seqlens dependency
-        encoder.config._attn_implementation = "eager"
-        for layer in encoder.layers:
-            layer.self_attn.config._attn_implementation = "eager"
-
-            # Patch each attention layer to accept 3D batched input (batch, seq, dim)
-            attn = layer.self_attn
-            attn._orig_forward = attn.forward
-
-            def make_patched_attn_forward(attn_module):
-                # Original code: https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L477
-                def patched_attn_forward(hidden_states, cu_seqlens=None, attention_mask=None, **kwargs):
-                    # hidden_states: (batch, seq_len, dim) - standard 3D batched
-                    bsz, seq_length, _ = hidden_states.size()
-
-                    query_states = (
-                        attn_module.q_proj(hidden_states)
-                        .reshape(bsz, seq_length, attn_module.num_heads, -1)
-                        .transpose(1, 2)
-                    )
-                    key_states = (
-                        attn_module.k_proj(hidden_states)
-                        .reshape(bsz, seq_length, attn_module.num_heads, -1)
-                        .transpose(1, 2)
-                    )
-                    value_states = (
-                        attn_module.v_proj(hidden_states)
-                        .reshape(bsz, seq_length, attn_module.num_heads, -1)
-                        .transpose(1, 2)
-                    )
-
-                    attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) * attn_module.scaling
-                    attn_weights = torch.nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(
-                        query_states.dtype
-                    )
-
-                    attn_output = torch.matmul(attn_weights, value_states)
-                    attn_output = attn_output.transpose(1, 2).contiguous().reshape(bsz, seq_length, -1)
-                    attn_output = attn_module.out_proj(attn_output)
-                    return attn_output
-
-                return patched_attn_forward
-
-            attn.forward = make_patched_attn_forward(attn)
-
-            # Patch each encoder layer to accept 3D input and skip cu_seqlens
-            layer._orig_forward = layer.forward
-
-            def make_patched_layer_forward(enc_layer):
-                # Original code:https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L536
-                def patched_layer_forward(hidden_states, cu_seqlens=None, attention_mask=None, **kwargs):
-                    residual = hidden_states
-                    hidden_states = enc_layer.self_attn_layer_norm(hidden_states)
-                    hidden_states = enc_layer.self_attn(hidden_states=hidden_states, attention_mask=attention_mask)
-                    hidden_states = residual + hidden_states
-                    residual = hidden_states
-                    hidden_states = enc_layer.final_layer_norm(hidden_states)
-                    hidden_states = enc_layer.fc1(hidden_states)
-                    hidden_states = enc_layer.activation_fn(hidden_states)
-                    hidden_states = enc_layer.fc2(hidden_states)
-                    hidden_states = residual + hidden_states
-                    return (hidden_states,)
-
-                return patched_layer_forward
-
-            layer.forward = make_patched_layer_forward(layer)
-
-        # Save original forward
-        encoder._orig_forward = encoder.forward
-
-        # Original code: https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L669
-        def patched_audio_forward(input_features, feature_lens=None, aftercnn_lens=None, **kwargs):
-            """
-            Simplified audio encoder forward for OV export.
-            Processes audio input without dynamic chunking.
-
-            input_features: (batch_size, num_mel_bins, seq_len) or (num_mel_bins, seq_len)
-            """
-            # Ensure input is batched: (batch, num_mel, seq_len)
-            if input_features.dim() == 2:
-                input_features = input_features.unsqueeze(0)
-
-            # Apply convolutions: conv2d expects (batch, 1, num_mel, seq_len)
-            x = input_features.unsqueeze(1)  # (batch, 1, num_mel, seq_len)
-            x = F.gelu(encoder.conv2d1(x))
-            x = F.gelu(encoder.conv2d2(x))
-            x = F.gelu(encoder.conv2d3(x))
-
-            b, c, f, t = x.size()
-            x = encoder.conv_out(x.permute(0, 3, 1, 2).contiguous().view(b, t, c * f))
-
-            # Add positional embeddings
-            pos_emb = encoder.positional_embedding.positional_embedding[:t, :].unsqueeze(0).to(x.dtype)
-            hidden_states = x + pos_emb  # (batch, t, hidden_dim)
-
-            # Process through patched encoder layers with standard 3D batched attention
-            for encoder_layer in encoder.layers:
-                layer_outputs = encoder_layer(hidden_states)
-                hidden_states = layer_outputs[0]
-
-            hidden_states = encoder.ln_post(hidden_states)
-            hidden_states = encoder.proj1(hidden_states)
-            hidden_states = encoder.act(hidden_states)
-            hidden_states = encoder.proj2(hidden_states)
-
-            return BaseModelOutput(last_hidden_state=hidden_states)
-
-        encoder.forward = patched_audio_forward
-
-    def _patch_decoder(self):
-        """
-        Patch full model forward for decoder export.
-        Maps seq2seq inputs (encoder_outputs, decoder_input_ids) to the thinker's interface.
-        Returns a flat tuple of tensors (logits + KV cache) for TorchScript tracing compatibility.
-        """
-        model = self._model
-        thinker = model.thinker
-
-        # Force eager attention for text model
-        thinker.config.text_config._attn_implementation = "eager"
-
-        # Save original forward
-        model._orig_forward = model.forward
-
-        # Original code: https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L1159
-        def patched_decoder_forward(
-            encoder_outputs=None,
-            decoder_input_ids=None,
-            attention_mask=None,
-            past_key_values=None,
+        def language_forward(
+            self,
+            attention_mask,
+            position_ids,
+            past_key_values,
+            inputs_embeds,
+            use_cache=True,
             cache_position=None,
-            **kwargs,
         ):
-            """
-            Decoder forward that accepts seq2seq-style inputs.
-            encoder_outputs: pre-computed audio features from encoder (batch, enc_seq_len, hidden_dim)
-            decoder_input_ids: text token ids (batch, dec_seq_len)
-            Returns a flat tuple: (logits, k0, v0, k1, v1, ...) for TorchScript compatibility.
-            """
-            # Convert past_key_values from legacy list format to DynamicCache
-            if past_key_values is not None and isinstance(past_key_values, (list, tuple)):
+            if isinstance(past_key_values, (list, tuple)):
                 cache = DynamicCache()
-                for layer_past in past_key_values:
-                    if len(layer_past) >= 2:
-                        cache.update(layer_past[0], layer_past[1], len(cache))
+                for layer_idx, layer_past in enumerate(past_key_values):
+                    cache.update(layer_past[0], layer_past[1], layer_idx)
                 past_key_values = cache
             elif past_key_values is None:
-                # Pre-create DynamicCache so that thinker.model uses it even during
-                # torch.jit.trace (the model skips cache creation when tracing).
                 past_key_values = DynamicCache()
 
-            input_ids = decoder_input_ids
-            inputs_embeds = thinker.get_input_embeddings()(input_ids)
-
-            # Merge audio features from encoder into embeddings at audio placeholder positions
-            if encoder_outputs is not None:
-                if isinstance(encoder_outputs, (tuple, list)):
-                    encoder_hidden_states = encoder_outputs[0]
-                else:
-                    encoder_hidden_states = encoder_outputs
-                # Flatten encoder outputs: (total_audio_tokens, hidden_dim)
-                audio_features = encoder_hidden_states.reshape(-1, encoder_hidden_states.shape[-1])
-                audio_features = audio_features.to(inputs_embeds.device, inputs_embeds.dtype)
-
-                # Use cumsum-based indexing + torch.where for OV-friendly dynamic shapes
-                special_audio_mask = input_ids == thinker.config.audio_token_id  # [batch, seq]
-                # cumsum gives 1-based index of audio tokens; subtract 1 for 0-based
-                audio_cumsum = special_audio_mask.long().cumsum(dim=-1) - 1  # [batch, seq]
-                # Clamp to valid range for gather (non-audio positions will be masked out anyway)
-                audio_cumsum = audio_cumsum.clamp(min=0)
-                # Expand to [batch, seq, hidden] by gathering from audio_features
-                gather_indices = audio_cumsum.unsqueeze(-1).expand(
-                    -1, -1, inputs_embeds.shape[-1]
-                )  # [batch, seq, hidden]
-                # audio_features is [total_audio_tokens, hidden], expand for batch gather
-                audio_features_expanded = audio_features.unsqueeze(0).expand(
-                    inputs_embeds.shape[0], -1, -1
-                )  # [batch, total, hidden]
-                gathered_audio = torch.gather(audio_features_expanded, 1, gather_indices)  # [batch, seq, hidden]
-                # Use where to select: audio feature at audio positions, original embed elsewhere
-                mask_3d = special_audio_mask.unsqueeze(-1)  # [batch, seq, 1]
-                inputs_embeds = torch.where(mask_3d, gathered_audio, inputs_embeds)
-
-            # Compute position_ids
-            position_ids = None
-            if attention_mask is not None:
-                if (
-                    cache_position is None
-                    or (cache_position is not None and cache_position[0] == 0)
-                    or thinker.rope_deltas is None
-                ):
-                    delta0 = (1 - attention_mask).sum(dim=-1).unsqueeze(1)
-                    position_ids, rope_deltas = thinker.get_rope_index(attention_mask)
-                    rope_deltas = rope_deltas - delta0
-                    thinker.rope_deltas = rope_deltas
-                else:
-                    batch_size, seq_length = input_ids.shape
-                    delta = cache_position[0] + thinker.rope_deltas
-                    position_ids = torch.arange(seq_length, device=input_ids.device)
-                    position_ids = position_ids.view(1, -1).expand(batch_size, -1)
-                    position_ids = position_ids.add(delta)
-                    position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
-
-            outputs = thinker.model(
+            outputs = self.thinker.model(
+                inputs_embeds=inputs_embeds,
                 attention_mask=attention_mask,
                 position_ids=position_ids,
                 past_key_values=past_key_values,
-                inputs_embeds=inputs_embeds,
-                use_cache=True,
+                use_cache=use_cache,
                 cache_position=cache_position,
             )
+            logits = self.thinker.lm_head(outputs[0])
+            return logits, postprocess_past_key_values(outputs.past_key_values)
 
-            logits = thinker.lm_head(outputs[0])
-
-            past_kv = outputs.past_key_values
-            # Convert DynamicCache to flat tuple of tensors for TorchScript tracing
-            # Output format: (logits, k0, v0, k1, v1, ...)
-            flat_output = [logits]
-            if isinstance(past_kv, DynamicCache):
-                for layer in past_kv.layers:
-                    flat_output.append(layer.keys)
-                    flat_output.append(layer.values)
-            elif past_kv is not None:
-                legacy = past_kv if isinstance(past_kv, (list, tuple)) else past_kv.to_legacy_cache()
-                for layer_kv in legacy:
-                    flat_output.append(layer_kv[0])
-                    flat_output.append(layer_kv[1])
-
-            return tuple(flat_output)
-
-        model.forward = patched_decoder_forward
+        model.__orig_forward = model.forward
+        model.forward = types.MethodType(language_forward, model)
+        super().__init__(config, model, model_kwargs)
 
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
-
-        if hasattr(self._model, "_orig_forward"):
-            self._model.forward = self._model._orig_forward
-            del self._model._orig_forward
+        self._model.forward = self._model.__orig_forward
+        del self._model.__orig_forward
 
 
 class FunASRModelPatcher(OVSeq2SeqModelPatcher):

--- a/optimum/exporters/openvino/utils.py
+++ b/optimum/exporters/openvino/utils.py
@@ -30,7 +30,6 @@ from optimum.intel.utils.import_utils import is_safetensors_available
 from optimum.utils import is_diffusers_available
 from optimum.utils.save_utils import maybe_load_preprocessors, maybe_save_preprocessors
 
-
 if is_torch_available():
     import torch
     import torch.nn as nn
@@ -341,6 +340,7 @@ MULTI_MODAL_TEXT_GENERATION_MODELS = [
     "videochat_flash_qwen",
     "deepseek_ocr2",
     "qwen3_omni_moe",
+    "qwen3_asr",
     "muse_glimmer",
 ]
 

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -1517,16 +1517,10 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
             config.is_encoder_decoder = True
             return _OVModelForFunAsr._from_pretrained(model_id, config, **kwargs)
         if getattr(config, "model_type", None) == "qwen3_asr":
-            split_paths = _OVModelForQwen3ASR._resolve_split_paths(model_id, allow_missing=True, **kwargs)
-            if not split_paths:
+            if not _OVModelForQwen3ASR._is_split_export(model_id, **kwargs):
                 config.is_encoder_decoder = True
                 return super()._from_pretrained(model_id, config, **kwargs)
-            return _OVModelForQwen3ASR._from_pretrained(
-                model_id,
-                config,
-                split_paths=split_paths,
-                **kwargs,
-            )
+            return _OVModelForQwen3ASR._from_pretrained(model_id, config, **kwargs)
         return super()._from_pretrained(model_id, config, **kwargs)
 
 
@@ -1785,7 +1779,7 @@ class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):
         }
 
     @classmethod
-    def _resolve_split_paths(
+    def _is_split_export(
         cls,
         model_id: Union[str, Path],
         token: Optional[Union[bool, str]] = None,
@@ -1794,60 +1788,30 @@ class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
         local_files_only: bool = False,
-        allow_missing: bool = False,
         **kwargs,
-    ) -> Dict[str, Path]:
-        paths = {}
-        for component, file_name in cls._all_ov_model_paths.items():
-            path = cached_file(
-                path_or_repo_id=model_id,
-                token=token,
-                revision=revision,
-                force_download=force_download,
-                cache_dir=cache_dir,
-                filename=file_name,
-                subfolder=subfolder,
-                local_files_only=local_files_only,
-                _raise_exceptions_for_missing_entries=False,
-            )
-            if path is not None and Path(path).is_file():
-                paths[component] = Path(path)
-
-        if not paths and allow_missing:
-            return paths
-        if not paths:
-            raise FileNotFoundError(
-                "Qwen3-ASR split export not found. Re-export the model to create the required "
-                "audio encoder, text embeddings, and language model components."
-            )
-        missing = [file_name for component, file_name in cls._all_ov_model_paths.items() if component not in paths]
-        if missing:
-            raise FileNotFoundError(
-                "Incomplete Qwen3-ASR split export. Missing component files: " + ", ".join(missing)
-            )
-        for component, file_name in cls._all_ov_model_paths.items():
-            path = cls._cached_file(
-                model_path=model_id,
-                file_name=file_name,
-                token=token,
-                revision=revision,
-                force_download=force_download,
-                cache_dir=cache_dir,
-                subfolder=subfolder,
-                local_files_only=local_files_only,
-            )
-            if not Path(path).with_suffix(".bin").is_file():
-                raise FileNotFoundError(
-                    f"Incomplete Qwen3-ASR split export: missing {Path(path).with_suffix('.bin')}."
-                )
-        return paths
+    ) -> bool:
+        """
+        Check if separate language model file exist.
+        That means model was exported with a separate audio_encoder + text_embeddings + language model.
+        """
+        language_model_path = cached_file(
+            path_or_repo_id=model_id,
+            token=token,
+            revision=revision,
+            force_download=force_download,
+            cache_dir=cache_dir,
+            filename=cls._all_ov_model_paths["language_model"],
+            subfolder=subfolder,
+            local_files_only=local_files_only,
+            _raise_exceptions_for_missing_entries=False,
+        )
+        return language_model_path is not None and Path(language_model_path).is_file()
 
     @classmethod
     def _from_pretrained(
         cls,
         model_id: Union[str, Path],
         config: PretrainedConfig,
-        split_paths: Optional[Dict[str, Path]] = None,
         token: Optional[Union[bool, str]] = None,
         revision: Optional[str] = None,
         force_download: bool = False,
@@ -1859,25 +1823,42 @@ class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):
         trust_remote_code: bool = False,
         **kwargs,
     ):
-        split_paths = split_paths or cls._resolve_split_paths(
-            model_id,
-            token=token,
-            revision=revision,
-            force_download=force_download,
-            cache_dir=cache_dir,
-            subfolder=subfolder,
-            local_files_only=local_files_only,
-        )
+        model_file_names = cls._all_ov_model_paths
+        if os.path.isdir(model_id):
+            model_save_dir = Path(model_id) / subfolder
+        else:
+            component_files = {
+                str(Path(subfolder) / component_file)
+                for model_file_name in model_file_names.values()
+                for component_file in (model_file_name, model_file_name.replace(".xml", ".bin"))
+            }
+            model_save_dir = (
+                Path(
+                    snapshot_download(
+                        model_id,
+                        cache_dir=cache_dir,
+                        force_download=force_download,
+                        local_files_only=local_files_only,
+                        revision=revision,
+                        token=token,
+                        user_agent=http_user_agent,
+                        allow_patterns=component_files,
+                    )
+                )
+                / subfolder
+            )
+
+        file_names = {name: model_save_dir / file_name for name, file_name in model_file_names.items()}
+
         compile_only = kwargs.get("compile_only", False)
         device = kwargs.get("device", "CPU")
         ov_config = kwargs.get("ov_config")
-        model_save_dir = split_paths["language_model"].parent
         if compile_only:
             components = {
-                name: cls._compile_model(path, device, ov_config, model_save_dir) for name, path in split_paths.items()
+                name: cls._compile_model(path, device, ov_config, model_save_dir) for name, path in file_names.items()
             }
         else:
-            components = {name: cls.load_model(path) for name, path in split_paths.items()}
+            components = {name: cls.load_model(path) for name, path in file_names.items()}
 
         generation_config = kwargs.pop("generation_config", None)
         if generation_config is None:

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -1623,15 +1623,9 @@ class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):
         return super().to(device)
 
     def reshape(self, batch_size: int, sequence_length: int):
-        if self._compile_only:
-            raise ValueError(
-                "`reshape()` is not supported with `compile_only` mode, please initialize model without this option"
-            )
-        if batch_size != -1 or sequence_length != -1:
-            raise ValueError(
-                "Qwen3-ASR split models only support dynamic shapes (`batch_size=-1`, `sequence_length=-1`)."
-            )
-        return self
+        raise ValueError(
+            "Qwen3-ASR models only support dynamic shapes (`batch_size=-1`, `sequence_length=-1`)."
+        )
 
     def _process_audio_inputs(self, input_features, feature_attention_mask):
         return self.audio_encoder.encode(input_features, feature_attention_mask)

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -14,6 +14,7 @@
 import logging
 import os
 import warnings
+from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -24,6 +25,8 @@ from huggingface_hub import snapshot_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from openvino import CompiledModel, Core
 from openvino._offline_transformations import apply_moc_transformations, compress_model_transformation
+from torch import nn
+from torch.nn import functional as F
 from transformers import (
     AutoConfig,
     AutoModelForImageTextToText,
@@ -38,6 +41,7 @@ from transformers.file_utils import add_start_docstrings, add_start_docstrings_t
 from transformers.generation import GenerationMixin
 from transformers.modeling_outputs import BaseModelOutput, Seq2SeqLMOutput
 from transformers.utils import http_user_agent
+from transformers.utils.hub import cached_file
 
 from ...exporters.openvino import main_export
 from ...exporters.openvino.stateful import model_has_state
@@ -889,6 +893,28 @@ class OVEncoder(OVModelPart):
         super().__init__(model, parent_model, ov_config, model_name)
         self.main_input_name = self.parent_model.main_input_name or "input_ids"
 
+    # Adapted from https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L669
+    def chunked_forward(self, input_features, n_window):
+        feature_lens = input_features.shape[-1]
+        chunk_num = torch.ceil(torch.tensor([feature_lens]) / (n_window * 2)).long()
+
+        chunk_lengths = torch.tensor(
+            [n_window * 2] * chunk_num.sum(),
+            dtype=torch.long,
+        )
+
+        tail_chunk_index = F.pad(chunk_num, (1, 0), value=-1).cumsum(0)[1:]
+        chunk_lengths[tail_chunk_index] = feature_lens % (n_window * 2)
+        chunk_lengths[chunk_lengths == 0] = n_window * 2
+
+        chunk_list = input_features.T.split(chunk_lengths.tolist(), dim=0)
+        padded_feature = nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+        inputs = {}
+        inputs["input_features"] = padded_feature
+        last_hidden_state = torch.from_numpy(self.request(inputs)["last_hidden_state"]).to(self.device)
+
+        return last_hidden_state.view(1, -1, last_hidden_state.shape[-1])
+
     @add_start_docstrings_to_model_forward(ENCODER_INPUTS_DOCSTRING)
     def forward(
         self,
@@ -906,6 +932,16 @@ class OVEncoder(OVModelPart):
             if attention_mask is None:
                 attention_mask = torch.ones_like(inputs[self.main_input_name])
             inputs["attention_mask"] = attention_mask
+
+        # Qwen3-ASR requires input_features chunking before passing to encoder for processing of long audios.
+        if getattr(self.config, "model_type", None) == "qwen3_asr":
+            input_features = inputs["input_features"]
+            audio_features = []
+            for idx, input_feature in enumerate(input_features):
+                audio_feature = self.chunked_forward(input_feature, self.config.n_window)
+                audio_features.append(audio_feature)
+            audio_features = torch.cat(audio_features, dim=0)
+            return BaseModelOutput(last_hidden_state=audio_features)
 
         # Run inference
         last_hidden_state = torch.from_numpy(
@@ -1311,6 +1347,34 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
 
         return super().from_pretrained(model_id, export=export, config=config, **kwargs)
 
+    def _prepare_decoder_input_ids_for_generation(
+        self, batch_size, model_input_name, model_kwargs, decoder_start_token_id, device=None
+    ):
+        """
+        For qwen3_asr: skip prepending decoder_start_token_id since the full prompt
+        (including chat template tokens) is already provided as decoder_input_ids.
+        This matches the PyTorch model behavior where input_ids is used as-is.
+        """
+        if getattr(self.config, "model_type", None) == "qwen3_asr":
+            if model_kwargs is not None and "decoder_input_ids" in model_kwargs:
+                decoder_input_ids = model_kwargs.pop("decoder_input_ids")
+            elif "input_ids" in model_kwargs and model_input_name != "input_ids":
+                decoder_input_ids = model_kwargs.pop("input_ids")
+            else:
+                decoder_input_ids = None
+
+            if decoder_input_ids is None:
+                # Fallback to default behavior if no decoder_input_ids provided
+                return super()._prepare_decoder_input_ids_for_generation(
+                    batch_size, model_input_name, model_kwargs, decoder_start_token_id, device
+                )
+            # Return decoder_input_ids as-is without prepending decoder_start_token_id
+            return decoder_input_ids, model_kwargs
+
+        return super()._prepare_decoder_input_ids_for_generation(
+            batch_size, model_input_name, model_kwargs, decoder_start_token_id, device
+        )
+
     def prepare_inputs_for_generation(
         self,
         decoder_input_ids,
@@ -1361,6 +1425,35 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
         cache_position: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> Seq2SeqLMOutput:
+        # For qwen3_asr: adjust decoder_input_ids to match encoder output audio feature count
+        if (
+            getattr(self.config, "model_type", None) == "qwen3_asr"
+            and decoder_input_ids is not None
+            and past_key_values is None
+        ):
+            # Get encoder outputs (may already be computed by generate())
+            if encoder_outputs is None and input_features is not None:
+                encoder_outputs = self.encoder(input_ids=input_features, attention_mask=attention_mask)
+
+            if encoder_outputs is not None:
+                audio_token_id = getattr(self.config, "audio_token_id", None)
+                if audio_token_id is None:
+                    audio_token_id = getattr(getattr(self.config, "thinker_config", None), "audio_token_id", None)
+                if audio_token_id is not None:
+                    enc_hidden = (
+                        encoder_outputs.last_hidden_state
+                        if hasattr(encoder_outputs, "last_hidden_state")
+                        else encoder_outputs[0]
+                    )
+                    num_encoder_features = enc_hidden.shape[1]
+                    current_audio_count = (decoder_input_ids == audio_token_id).sum(dim=-1).max().item()
+                    if current_audio_count > 0 and current_audio_count != num_encoder_features:
+                        decoder_input_ids = self._adjust_audio_tokens(
+                            decoder_input_ids, audio_token_id, num_encoder_features
+                        )
+                        if decoder_attention_mask is not None:
+                            decoder_attention_mask = torch.ones_like(decoder_input_ids)
+
         return super().forward(
             input_ids=input_features,
             attention_mask=attention_mask,
@@ -1371,6 +1464,44 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
             cache_position=cache_position,
             **kwargs,
         )
+
+    @staticmethod
+    def _adjust_audio_tokens(decoder_input_ids, audio_token_id, target_count):
+        """Adjust the number of audio_pad tokens in decoder_input_ids to match encoder output count."""
+        result_ids = []
+        for batch_idx in range(decoder_input_ids.shape[0]):
+            ids = decoder_input_ids[batch_idx]
+            # Find audio token positions
+            audio_mask = ids == audio_token_id
+            current_count = audio_mask.sum().item()
+            if current_count == target_count:
+                result_ids.append(ids)
+            else:
+                # Split into: before audio tokens, audio tokens, after audio tokens
+                non_audio_before = []
+                non_audio_after = []
+                in_audio = False
+                past_audio = False
+                for tok in ids.tolist():
+                    if tok == audio_token_id:
+                        in_audio = True
+                    else:
+                        if in_audio:
+                            past_audio = True
+                            in_audio = False
+                        if past_audio:
+                            non_audio_after.append(tok)
+                        else:
+                            non_audio_before.append(tok)
+                # Reconstruct with target_count audio tokens
+                new_ids = non_audio_before + [audio_token_id] * target_count + non_audio_after
+                result_ids.append(torch.tensor(new_ids, dtype=ids.dtype, device=ids.device))
+        # Pad to same length
+        max_len = max(t.shape[0] for t in result_ids)
+        padded = torch.zeros(len(result_ids), max_len, dtype=decoder_input_ids.dtype, device=decoder_input_ids.device)
+        for i, t in enumerate(result_ids):
+            padded[i, : t.shape[0]] = t
+        return padded
 
     @classmethod
     def _from_pretrained(
@@ -1387,7 +1518,9 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
             config.is_encoder_decoder = True
             return _OVModelForFunAsr._from_pretrained(model_id, config, **kwargs)
         if getattr(config, "model_type", None) == "qwen3_asr":
-            split_paths = _OVModelForQwen3ASR._resolve_split_paths(model_id, **kwargs)
+            split_paths = _OVModelForQwen3ASR._resolve_split_paths(model_id, allow_missing=True, **kwargs)
+            if not split_paths:
+                return _OVModelForQwen3ASREncoderDecoder._from_pretrained(model_id, config, **kwargs)
             return _OVModelForQwen3ASR._from_pretrained(
                 model_id,
                 config,
@@ -1395,6 +1528,111 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
                 **kwargs,
             )
         return super()._from_pretrained(model_id, config, **kwargs)
+
+
+class _OVModelForQwen3ASREncoderDecoder(OVModelForSpeechSeq2Seq):
+    def __init__(self, encoder, decoder, decoder_with_past=None, config=None, **kwargs):
+        if kwargs.get("compile_only"):
+            raise ValueError("Qwen3-ASR encoder-decoder models require `compile_only=False`.")
+        if kwargs.get("stateful") is False or kwargs.get("use_cache") is False or not model_has_state(decoder):
+            raise ValueError("Qwen3-ASR encoder-decoder inference requires a stateful decoder and `use_cache=True`.")
+        config.is_encoder_decoder = True
+        if not hasattr(config, "n_window"):
+            config.n_window = config.thinker_config.audio_config.n_window
+        super().__init__(encoder, decoder, decoder_with_past, config, **kwargs)
+        logger.warning(
+            "Loading a Qwen3-ASR encoder-decoder export. Only single-recording generation is supported. "
+            "Re-export for split-component inference and PagedAttention compatibility."
+        )
+
+    @classmethod
+    def _from_pretrained(cls, model_id, config, **kwargs):
+        if kwargs.get("compile_only"):
+            raise ValueError("Qwen3-ASR encoder-decoder models require `compile_only=False`.")
+        if kwargs.get("use_cache") is False:
+            raise ValueError("Qwen3-ASR encoder-decoder inference requires `use_cache=True`.")
+        if kwargs.get("from_onnx"):
+            raise ValueError("Qwen3-ASR encoder-decoder compatibility supports OpenVINO IR exports only.")
+        subfolder = kwargs.get("subfolder", "")
+        for argument, default in (
+            ("encoder_file_name", OV_ENCODER_NAME),
+            ("decoder_file_name", OV_DECODER_NAME),
+        ):
+            filename = kwargs.get(argument) or default
+            path = cls._cached_file(
+                model_path=model_id,
+                file_name=filename,
+                subfolder=subfolder,
+                **{
+                    key: kwargs[key]
+                    for key in ("token", "revision", "force_download", "cache_dir", "local_files_only")
+                    if key in kwargs
+                },
+            )
+            for required in (Path(path), Path(path).with_suffix(".bin")):
+                if not required.is_file():
+                    raise FileNotFoundError(f"Incomplete Qwen3-ASR encoder-decoder export: missing {required}.")
+            kwargs[argument] = str(Path(subfolder) / filename)
+        return super(OVModelForSpeechSeq2Seq, cls)._from_pretrained(model_id, config, **kwargs)
+
+    def generate(
+        self,
+        input_features=None,
+        attention_mask=None,
+        decoder_input_ids=None,
+        decoder_attention_mask=None,
+        input_ids=None,
+        feature_attention_mask=None,
+        **kwargs,
+    ):
+        prompt = decoder_input_ids if decoder_input_ids is not None else input_ids
+        if prompt is None or prompt.ndim != 2 or prompt.shape[0] != 1:
+            raise ValueError("Qwen3-ASR encoder-decoder models require a prompt for exactly one recording.")
+        generation_config = kwargs.get("generation_config") or self.generation_config
+        if not kwargs.get("use_cache", generation_config.use_cache):
+            raise ValueError("Qwen3-ASR encoder-decoder inference requires `use_cache=True`.")
+        if (
+            kwargs.get("num_beams", generation_config.num_beams) != 1
+            or kwargs.get("num_return_sequences", generation_config.num_return_sequences) != 1
+        ):
+            raise ValueError("Qwen3-ASR encoder-decoder inference supports one beam and one returned sequence.")
+        if decoder_attention_mask is None and feature_attention_mask is not None:
+            decoder_attention_mask = attention_mask
+        if decoder_attention_mask is not None and not torch.all(decoder_attention_mask == 1):
+            raise ValueError("Qwen3-ASR encoder-decoder inference requires an unpadded text prompt.")
+        encoder_outputs = kwargs.pop("encoder_outputs", None)
+        if encoder_outputs is None:
+            encoder_outputs = self.encoder(input_ids=input_features)
+        if encoder_outputs.last_hidden_state.shape[0] != 1:
+            raise ValueError("Qwen3-ASR encoder-decoder models require exactly one recording per request.")
+        audio_token_id = getattr(self.config, "audio_token_id", None)
+        if audio_token_id is None:
+            audio_token_id = self.config.thinker_config.audio_token_id
+        adjusted_prompt = self._adjust_audio_tokens(prompt, audio_token_id, encoder_outputs.last_hidden_state.shape[1])
+        generation_config = deepcopy(generation_config)
+        prompt_delta = adjusted_prompt.shape[1] - prompt.shape[1]
+        for name in ("max_length", "min_length"):
+            value = kwargs.pop(name, getattr(generation_config, name))
+            if value is not None and value > 0:
+                setattr(generation_config, name, value + prompt_delta)
+        kwargs.pop("generation_config", None)
+        output = GenerationMixin.generate(
+            self,
+            encoder_outputs=encoder_outputs,
+            decoder_input_ids=adjusted_prompt,
+            attention_mask=torch.ones(
+                encoder_outputs.last_hidden_state.shape[:2], dtype=torch.long, device=prompt.device
+            ),
+            decoder_attention_mask=torch.ones_like(adjusted_prompt),
+            generation_config=generation_config,
+            **kwargs,
+        )
+        sequences = output.sequences if hasattr(output, "sequences") else output
+        sequences = torch.cat((prompt.to(sequences.device), sequences[:, adjusted_prompt.shape[1] :]), dim=1)
+        if hasattr(output, "sequences"):
+            output.sequences = sequences
+            return output
+        return sequences
 
 
 class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):
@@ -1661,29 +1899,30 @@ class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):
         cache_dir: str = HUGGINGFACE_HUB_CACHE,
         subfolder: str = "",
         local_files_only: bool = False,
+        allow_missing: bool = False,
         **kwargs,
     ) -> Dict[str, Path]:
         paths = {}
         for component, file_name in cls._all_ov_model_paths.items():
-            try:
-                path = cls._cached_file(
-                    model_path=model_id,
-                    token=token,
-                    revision=revision,
-                    force_download=force_download,
-                    cache_dir=cache_dir,
-                    file_name=file_name,
-                    subfolder=subfolder,
-                    local_files_only=local_files_only,
-                )
-            except OSError:
-                continue
-            if Path(path).is_file():
+            path = cached_file(
+                path_or_repo_id=model_id,
+                token=token,
+                revision=revision,
+                force_download=force_download,
+                cache_dir=cache_dir,
+                filename=file_name,
+                subfolder=subfolder,
+                local_files_only=local_files_only,
+                _raise_exceptions_for_missing_entries=False,
+            )
+            if path is not None and Path(path).is_file():
                 paths[component] = Path(path)
 
+        if not paths and allow_missing:
+            return paths
         if not paths:
             raise FileNotFoundError(
-                "Qwen3-ASR legacy exports are no longer supported. Re-export the model to create the required "
+                "Qwen3-ASR split export not found. Re-export the model to create the required "
                 "audio encoder, text embeddings, and language model components."
             )
         missing = [file_name for component, file_name in cls._all_ov_model_paths.items() if component not in paths]
@@ -1691,6 +1930,21 @@ class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):
             raise FileNotFoundError(
                 "Incomplete Qwen3-ASR split export. Missing component files: " + ", ".join(missing)
             )
+        for component, file_name in cls._all_ov_model_paths.items():
+            path = cls._cached_file(
+                model_path=model_id,
+                file_name=file_name,
+                token=token,
+                revision=revision,
+                force_download=force_download,
+                cache_dir=cache_dir,
+                subfolder=subfolder,
+                local_files_only=local_files_only,
+            )
+            if not Path(path).with_suffix(".bin").is_file():
+                raise FileNotFoundError(
+                    f"Incomplete Qwen3-ASR split export: missing {Path(path).with_suffix('.bin')}."
+                )
         return paths
 
     @classmethod

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -24,8 +24,6 @@ from huggingface_hub import snapshot_download
 from huggingface_hub.constants import HUGGINGFACE_HUB_CACHE
 from openvino import CompiledModel, Core
 from openvino._offline_transformations import apply_moc_transformations, compress_model_transformation
-from torch import nn
-from torch.nn import functional as F
 from transformers import (
     AutoConfig,
     AutoModelForImageTextToText,
@@ -47,13 +45,20 @@ from .. import OVConfig
 from ..utils import is_transformers_version
 from .configuration import OVQuantizationConfigBase, OVWeightQuantizationConfig
 from .modeling_base import OVBaseModel, OVModelPart
+from .modeling_visual_language import (
+    OVModelWithEmbedForCausalLM,
+    OVQwen3AudioEncoder,
+)
 from .utils import (
     ONNX_DECODER_NAME,
     ONNX_DECODER_WITH_PAST_NAME,
     ONNX_ENCODER_NAME,
+    OV_AUDIO_ENCODER_MODEL_NAME,
     OV_DECODER_NAME,
     OV_DECODER_WITH_PAST_NAME,
     OV_ENCODER_NAME,
+    OV_LANGUAGE_MODEL_NAME,
+    OV_TEXT_EMBEDDINGS_MODEL_NAME,
     TemporaryDirectory,
     classproperty,
 )
@@ -884,28 +889,6 @@ class OVEncoder(OVModelPart):
         super().__init__(model, parent_model, ov_config, model_name)
         self.main_input_name = self.parent_model.main_input_name or "input_ids"
 
-    # Adapted from https://github.com/QwenLM/Qwen3-ASR/blob/c17a131fe028b2e428b6e80a33d30bb4fa57b8df/qwen_asr/core/transformers_backend/modeling_qwen3_asr.py#L669
-    def chunked_forward(self, input_features, n_window):
-        feature_lens = input_features.shape[-1]
-        chunk_num = torch.ceil(torch.tensor([feature_lens]) / (n_window * 2)).long()
-
-        chunk_lengths = torch.tensor(
-            [n_window * 2] * chunk_num.sum(),
-            dtype=torch.long,
-        )
-
-        tail_chunk_index = F.pad(chunk_num, (1, 0), value=-1).cumsum(0)[1:]
-        chunk_lengths[tail_chunk_index] = feature_lens % (n_window * 2)
-        chunk_lengths[chunk_lengths == 0] = n_window * 2
-
-        chunk_list = input_features.T.split(chunk_lengths.tolist(), dim=0)
-        padded_feature = nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
-        inputs = {}
-        inputs["input_features"] = padded_feature
-        last_hidden_state = torch.from_numpy(self.request(inputs)["last_hidden_state"]).to(self.device)
-
-        return last_hidden_state.view(1, -1, last_hidden_state.shape[-1])
-
     @add_start_docstrings_to_model_forward(ENCODER_INPUTS_DOCSTRING)
     def forward(
         self,
@@ -923,16 +906,6 @@ class OVEncoder(OVModelPart):
             if attention_mask is None:
                 attention_mask = torch.ones_like(inputs[self.main_input_name])
             inputs["attention_mask"] = attention_mask
-
-        # Qwen3-ASR requires input_features chunking before passing to encoder for processing of long audios.
-        if getattr(self.config, "model_type", None) == "qwen3_asr":
-            input_features = inputs["input_features"]
-            audio_features = []
-            for idx, input_feature in enumerate(input_features):
-                audio_feature = self.chunked_forward(input_feature, self.config.n_window)
-                audio_features.append(audio_feature)
-            audio_features = torch.cat(audio_features, dim=0)
-            return BaseModelOutput(last_hidden_state=audio_features)
 
         # Run inference
         last_hidden_state = torch.from_numpy(
@@ -1338,34 +1311,6 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
 
         return super().from_pretrained(model_id, export=export, config=config, **kwargs)
 
-    def _prepare_decoder_input_ids_for_generation(
-        self, batch_size, model_input_name, model_kwargs, decoder_start_token_id, device=None
-    ):
-        """
-        For qwen3_asr: skip prepending decoder_start_token_id since the full prompt
-        (including chat template tokens) is already provided as decoder_input_ids.
-        This matches the PyTorch model behavior where input_ids is used as-is.
-        """
-        if getattr(self.config, "model_type", None) == "qwen3_asr":
-            if model_kwargs is not None and "decoder_input_ids" in model_kwargs:
-                decoder_input_ids = model_kwargs.pop("decoder_input_ids")
-            elif "input_ids" in model_kwargs and model_input_name != "input_ids":
-                decoder_input_ids = model_kwargs.pop("input_ids")
-            else:
-                decoder_input_ids = None
-
-            if decoder_input_ids is None:
-                # Fallback to default behavior if no decoder_input_ids provided
-                return super()._prepare_decoder_input_ids_for_generation(
-                    batch_size, model_input_name, model_kwargs, decoder_start_token_id, device
-                )
-            # Return decoder_input_ids as-is without prepending decoder_start_token_id
-            return decoder_input_ids, model_kwargs
-
-        return super()._prepare_decoder_input_ids_for_generation(
-            batch_size, model_input_name, model_kwargs, decoder_start_token_id, device
-        )
-
     def prepare_inputs_for_generation(
         self,
         decoder_input_ids,
@@ -1416,35 +1361,6 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
         cache_position: Optional[torch.LongTensor] = None,
         **kwargs,
     ) -> Seq2SeqLMOutput:
-        # For qwen3_asr: adjust decoder_input_ids to match encoder output audio feature count
-        if (
-            getattr(self.config, "model_type", None) == "qwen3_asr"
-            and decoder_input_ids is not None
-            and past_key_values is None
-        ):
-            # Get encoder outputs (may already be computed by generate())
-            if encoder_outputs is None and input_features is not None:
-                encoder_outputs = self.encoder(input_ids=input_features, attention_mask=attention_mask)
-
-            if encoder_outputs is not None:
-                audio_token_id = getattr(self.config, "audio_token_id", None)
-                if audio_token_id is None:
-                    audio_token_id = getattr(getattr(self.config, "thinker_config", None), "audio_token_id", None)
-                if audio_token_id is not None:
-                    enc_hidden = (
-                        encoder_outputs.last_hidden_state
-                        if hasattr(encoder_outputs, "last_hidden_state")
-                        else encoder_outputs[0]
-                    )
-                    num_encoder_features = enc_hidden.shape[1]
-                    current_audio_count = (decoder_input_ids == audio_token_id).sum(dim=-1).max().item()
-                    if current_audio_count > 0 and current_audio_count != num_encoder_features:
-                        decoder_input_ids = self._adjust_audio_tokens(
-                            decoder_input_ids, audio_token_id, num_encoder_features
-                        )
-                        if decoder_attention_mask is not None:
-                            decoder_attention_mask = torch.ones_like(decoder_input_ids)
-
         return super().forward(
             input_ids=input_features,
             attention_mask=attention_mask,
@@ -1455,44 +1371,6 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
             cache_position=cache_position,
             **kwargs,
         )
-
-    @staticmethod
-    def _adjust_audio_tokens(decoder_input_ids, audio_token_id, target_count):
-        """Adjust the number of audio_pad tokens in decoder_input_ids to match encoder output count."""
-        result_ids = []
-        for batch_idx in range(decoder_input_ids.shape[0]):
-            ids = decoder_input_ids[batch_idx]
-            # Find audio token positions
-            audio_mask = ids == audio_token_id
-            current_count = audio_mask.sum().item()
-            if current_count == target_count:
-                result_ids.append(ids)
-            else:
-                # Split into: before audio tokens, audio tokens, after audio tokens
-                non_audio_before = []
-                non_audio_after = []
-                in_audio = False
-                past_audio = False
-                for tok in ids.tolist():
-                    if tok == audio_token_id:
-                        in_audio = True
-                    else:
-                        if in_audio:
-                            past_audio = True
-                            in_audio = False
-                        if past_audio:
-                            non_audio_after.append(tok)
-                        else:
-                            non_audio_before.append(tok)
-                # Reconstruct with target_count audio tokens
-                new_ids = non_audio_before + [audio_token_id] * target_count + non_audio_after
-                result_ids.append(torch.tensor(new_ids, dtype=ids.dtype, device=ids.device))
-        # Pad to same length
-        max_len = max(t.shape[0] for t in result_ids)
-        padded = torch.zeros(len(result_ids), max_len, dtype=decoder_input_ids.dtype, device=decoder_input_ids.device)
-        for i, t in enumerate(result_ids):
-            padded[i, : t.shape[0]] = t
-        return padded
 
     @classmethod
     def _from_pretrained(
@@ -1509,8 +1387,384 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
             config.is_encoder_decoder = True
             return _OVModelForFunAsr._from_pretrained(model_id, config, **kwargs)
         if getattr(config, "model_type", None) == "qwen3_asr":
-            config.is_encoder_decoder = True
+            split_paths = _OVModelForQwen3ASR._resolve_split_paths(model_id, **kwargs)
+            return _OVModelForQwen3ASR._from_pretrained(
+                model_id,
+                config,
+                split_paths=split_paths,
+                **kwargs,
+            )
         return super()._from_pretrained(model_id, config, **kwargs)
+
+
+class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):
+    @classproperty
+    def _all_ov_model_paths(cls) -> Dict[str, str]:
+        return {
+            "audio_encoder": OV_AUDIO_ENCODER_MODEL_NAME,
+            "text_embeddings": OV_TEXT_EMBEDDINGS_MODEL_NAME,
+            "language_model": OV_LANGUAGE_MODEL_NAME,
+        }
+
+    def __init__(
+        self,
+        audio_encoder: openvino.Model,
+        text_embeddings: openvino.Model,
+        language_model: openvino.Model,
+        config: PretrainedConfig = None,
+        device: str = "CPU",
+        dynamic_shapes: bool = True,
+        ov_config: Optional[Dict[str, str]] = None,
+        model_save_dir: Optional[Union[str, Path, TemporaryDirectory]] = None,
+        quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
+        **kwargs,
+    ):
+        if kwargs.get("stateful") is False or kwargs.get("use_cache") is False or not model_has_state(language_model):
+            raise ValueError(
+                "The Qwen3-ASR runtime requires a stateful language model and `use_cache=True`. "
+                "Re-export with `stateful=True` and load with `use_cache=True`. "
+                "Stateless language graphs must be used with an external-cache runtime."
+            )
+        config.is_encoder_decoder = False
+        self.config = config
+        self.name_or_path = getattr(config, "name_or_path", None)
+        self.model_save_dir = model_save_dir
+        self._compile_only = kwargs.get("compile_only", False)
+        self._device = device.upper()
+        self.is_dynamic = dynamic_shapes
+        self.ov_config = {} if ov_config is None else {**ov_config}
+        self.preprocessors = kwargs.get("preprocessors", [])
+        self.generation_config = kwargs.get("generation_config") or GenerationConfig.from_model_config(config)
+        self._openvino_config = None
+        if quantization_config:
+            self._openvino_config = OVConfig(quantization_config=quantization_config)
+        self._set_ov_config_parameters()
+
+        enable_compilation = kwargs.get("compile", True)
+        if self._compile_only and not enable_compilation:
+            raise ValueError("`compile_only=True` requires `compile=True`.")
+
+        self.audio_encoder = OVQwen3AudioEncoder(
+            audio_encoder,
+            self,
+            ov_config=self.ov_config,
+            model_name="audio_encoder",
+        )
+        self.language_model = OVModelWithEmbedForCausalLM(
+            language_model,
+            text_embeddings,
+            config=config,
+            device=device,
+            dynamic_shapes=dynamic_shapes,
+            ov_config=self.ov_config,
+            model_save_dir=model_save_dir,
+            quantization_config=quantization_config,
+            compile=self._compile_only,
+            compile_only=self._compile_only,
+        )
+        self.encoder = self.audio_encoder
+        self.decoder = self.language_model
+        self.decoder_with_past = None
+        self.use_cache = True
+        self.main_input_name = "input_ids"
+
+        if enable_compilation and not self._compile_only:
+            self.compile()
+
+    @property
+    def _component_names(self) -> List[str]:
+        return ["audio_encoder", "language_model"]
+
+    @property
+    def _ov_model_names(self) -> List[str]:
+        return ["audio_encoder", "text_embeddings", "language_model"]
+
+    @property
+    def ov_models(self) -> Dict[str, Union[openvino.Model, CompiledModel]]:
+        return {
+            "audio_encoder": self.audio_encoder.model,
+            "text_embeddings": self.language_model.text_emb_model,
+            "language_model": self.language_model.model,
+        }
+
+    @property
+    def dtype(self) -> Optional[torch.dtype]:
+        return self.audio_encoder.dtype or self.language_model.dtype
+
+    def to(self, device):
+        self.language_model.to(device)
+        return super().to(device)
+
+    def reshape(self, batch_size: int, sequence_length: int):
+        if self._compile_only:
+            raise ValueError(
+                "`reshape()` is not supported with `compile_only` mode, please initialize model without this option"
+            )
+        if batch_size != -1 or sequence_length != -1:
+            raise ValueError(
+                "Qwen3-ASR split models only support dynamic shapes (`batch_size=-1`, `sequence_length=-1`)."
+            )
+        return self
+
+    def _process_audio_inputs(self, input_features, feature_attention_mask):
+        return self.audio_encoder.encode(input_features, feature_attention_mask)
+
+    @staticmethod
+    def _get_prefill_positions(attention_mask):
+        position_ids = attention_mask.long().cumsum(-1) - 1
+        position_ids.masked_fill_(attention_mask == 0, 1)
+        position_ids = position_ids.unsqueeze(0).expand(3, -1, -1)
+        max_position_ids = position_ids.max(0).values.max(-1, keepdim=True).values
+        rope_deltas = max_position_ids + 1 - attention_mask.shape[-1]
+        return position_ids, rope_deltas
+
+    def _merge_audio_embeddings(self, input_ids, text_embeddings, audio_features, audio_feature_lens):
+        audio_token_id = getattr(getattr(self.config, "thinker_config", self.config), "audio_token_id", None)
+        if audio_token_id is None:
+            audio_token_id = getattr(self.config, "audio_token_id", None)
+        if audio_token_id is None:
+            raise ValueError("Qwen3-ASR config does not define `audio_token_id`.")
+
+        merged = text_embeddings.clone()
+        audio_features = torch.as_tensor(audio_features, dtype=merged.dtype, device=merged.device)
+        feature_offset = 0
+        for batch_idx, feature_len in enumerate(audio_feature_lens.tolist()):
+            placeholder_mask = input_ids[batch_idx] == audio_token_id
+            placeholder_count = int(placeholder_mask.sum().item())
+            if placeholder_count != feature_len:
+                raise ValueError(
+                    f"Qwen3-ASR sample {batch_idx} has {placeholder_count} audio placeholders but "
+                    f"the encoder produced {feature_len} valid features."
+                )
+            merged[batch_idx, placeholder_mask] = audio_features[feature_offset : feature_offset + feature_len]
+            feature_offset += feature_len
+        if feature_offset != audio_features.shape[0]:
+            raise ValueError(
+                f"Qwen3-ASR consumed {feature_offset} audio features but the encoder returned {audio_features.shape[0]}."
+            )
+        return merged
+
+    def generate(
+        self,
+        input_features=None,
+        attention_mask=None,
+        decoder_input_ids=None,
+        decoder_attention_mask=None,
+        input_ids=None,
+        feature_attention_mask=None,
+        **kwargs,
+    ):
+        input_ids = decoder_input_ids if decoder_input_ids is not None else input_ids
+        if input_ids is None:
+            raise ValueError("Qwen3-ASR generation requires `decoder_input_ids` or `input_ids`.")
+        if decoder_attention_mask is None and (feature_attention_mask is not None or input_features is None):
+            decoder_attention_mask = attention_mask
+        feature_attention_mask = feature_attention_mask if feature_attention_mask is not None else attention_mask
+        if decoder_attention_mask is None:
+            decoder_attention_mask = torch.ones_like(input_ids)
+
+        inputs_embeds = torch.as_tensor(self.language_model.embed_tokens(input_ids))
+        if input_features is not None:
+            if feature_attention_mask is None:
+                raise ValueError("`attention_mask` or `feature_attention_mask` is required with `input_features`.")
+            audio_features, audio_feature_lens = self._process_audio_inputs(input_features, feature_attention_mask)
+            inputs_embeds = self._merge_audio_embeddings(input_ids, inputs_embeds, audio_features, audio_feature_lens)
+
+        _, rope_deltas = self._get_prefill_positions(decoder_attention_mask)
+        return GenerationMixin.generate(
+            self,
+            input_ids=input_ids,
+            attention_mask=decoder_attention_mask,
+            inputs_embeds=inputs_embeds,
+            rope_deltas=rope_deltas,
+            **kwargs,
+        )
+
+    def forward(
+        self,
+        input_ids=None,
+        attention_mask=None,
+        past_key_values=None,
+        position_ids=None,
+        inputs_embeds=None,
+        cache_position=None,
+        **kwargs,
+    ):
+        """Run the decoder with token IDs or prepared text/audio embeddings."""
+        return self.language_model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            past_key_values=past_key_values,
+            position_ids=position_ids,
+            inputs_embeds=inputs_embeds,
+            cache_position=cache_position,
+            **kwargs,
+        )
+
+    def prepare_inputs_for_generation(
+        self,
+        input_ids,
+        past_key_values=None,
+        attention_mask=None,
+        inputs_embeds=None,
+        cache_position=None,
+        position_ids=None,
+        rope_deltas=None,
+        use_cache=True,
+        **kwargs,
+    ):
+        if past_key_values is None:
+            if position_ids is None:
+                position_ids, computed_rope_deltas = self._get_prefill_positions(attention_mask)
+                rope_deltas = computed_rope_deltas if rope_deltas is None else rope_deltas
+            return {
+                "input_ids": None if inputs_embeds is not None else input_ids,
+                "inputs_embeds": inputs_embeds,
+                "attention_mask": attention_mask,
+                "position_ids": position_ids,
+                "past_key_values": past_key_values,
+                "cache_position": cache_position,
+                "rope_deltas": rope_deltas,
+                "use_cache": use_cache,
+            }
+
+        if rope_deltas is None:
+            raise ValueError("Qwen3-ASR cached decoding requires `rope_deltas` from the prefill step.")
+        if cache_position is not None:
+            input_ids = input_ids[:, -cache_position.shape[0] :]
+            position_start = cache_position[0]
+        else:
+            input_ids = input_ids[:, -1:]
+            position_start = attention_mask.shape[-1] - input_ids.shape[-1]
+        batch_size, sequence_length = input_ids.shape
+        delta = position_start + rope_deltas.to(input_ids.device)
+        position_ids = torch.arange(sequence_length, device=input_ids.device).view(1, -1).expand(batch_size, -1)
+        position_ids = position_ids.add(delta).unsqueeze(0).expand(3, -1, -1)
+        return {
+            "input_ids": input_ids,
+            "inputs_embeds": None,
+            "attention_mask": attention_mask,
+            "position_ids": position_ids,
+            "past_key_values": past_key_values,
+            "cache_position": cache_position,
+            "rope_deltas": rope_deltas,
+            "use_cache": use_cache,
+        }
+
+    @classmethod
+    def _resolve_split_paths(
+        cls,
+        model_id: Union[str, Path],
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        force_download: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        subfolder: str = "",
+        local_files_only: bool = False,
+        **kwargs,
+    ) -> Dict[str, Path]:
+        paths = {}
+        for component, file_name in cls._all_ov_model_paths.items():
+            try:
+                path = cls._cached_file(
+                    model_path=model_id,
+                    token=token,
+                    revision=revision,
+                    force_download=force_download,
+                    cache_dir=cache_dir,
+                    file_name=file_name,
+                    subfolder=subfolder,
+                    local_files_only=local_files_only,
+                )
+            except OSError:
+                continue
+            if Path(path).is_file():
+                paths[component] = Path(path)
+
+        if not paths:
+            raise FileNotFoundError(
+                "Qwen3-ASR legacy exports are no longer supported. Re-export the model to create the required "
+                "audio encoder, text embeddings, and language model components."
+            )
+        missing = [file_name for component, file_name in cls._all_ov_model_paths.items() if component not in paths]
+        if missing:
+            raise FileNotFoundError(
+                "Incomplete Qwen3-ASR split export. Missing component files: " + ", ".join(missing)
+            )
+        return paths
+
+    @classmethod
+    def _from_pretrained(
+        cls,
+        model_id: Union[str, Path],
+        config: PretrainedConfig,
+        split_paths: Optional[Dict[str, Path]] = None,
+        token: Optional[Union[bool, str]] = None,
+        revision: Optional[str] = None,
+        force_download: bool = False,
+        cache_dir: str = HUGGINGFACE_HUB_CACHE,
+        subfolder: str = "",
+        local_files_only: bool = False,
+        load_in_8bit: bool = False,
+        quantization_config: Union[OVWeightQuantizationConfig, Dict] = None,
+        trust_remote_code: bool = False,
+        **kwargs,
+    ):
+        split_paths = split_paths or cls._resolve_split_paths(
+            model_id,
+            token=token,
+            revision=revision,
+            force_download=force_download,
+            cache_dir=cache_dir,
+            subfolder=subfolder,
+            local_files_only=local_files_only,
+        )
+        compile_only = kwargs.get("compile_only", False)
+        device = kwargs.get("device", "CPU")
+        ov_config = kwargs.get("ov_config")
+        model_save_dir = split_paths["language_model"].parent
+        if compile_only:
+            components = {
+                name: cls._compile_model(path, device, ov_config, model_save_dir) for name, path in split_paths.items()
+            }
+        else:
+            components = {name: cls.load_model(path) for name, path in split_paths.items()}
+
+        generation_config = kwargs.pop("generation_config", None)
+        if generation_config is None:
+            try:
+                generation_config = GenerationConfig.from_pretrained(
+                    model_id,
+                    cache_dir=cache_dir,
+                    force_download=force_download,
+                    local_files_only=local_files_only,
+                    token=token,
+                    revision=revision,
+                    subfolder=subfolder,
+                )
+                generation_config.cache_implementation = None
+            except OSError:
+                logger.info(
+                    "Generation config file not found, using a generation config created from the model config."
+                )
+
+        quantization_config = quantization_config or (OVWeightQuantizationConfig(bits=8) if load_in_8bit else None)
+        compile_model = kwargs.pop("compile", True)
+        model = cls(
+            audio_encoder=components["audio_encoder"],
+            text_embeddings=components["text_embeddings"],
+            language_model=components["language_model"],
+            config=config,
+            generation_config=generation_config,
+            model_save_dir=model_save_dir,
+            quantization_config=quantization_config,
+            compile=compile_model and not quantization_config,
+            **kwargs,
+        )
+        if quantization_config:
+            quantization_config = cls._resolve_default_quantization_config(model_id, quantization_config)
+            model._apply_quantization(quantization_config, compile_only, compile_model, model_id, trust_remote_code)
+        return model
 
 
 class _OVModelForWhisper(OVModelForSpeechSeq2Seq, WhisperForConditionalGeneration):

--- a/optimum/intel/openvino/modeling_seq2seq.py
+++ b/optimum/intel/openvino/modeling_seq2seq.py
@@ -14,7 +14,6 @@
 import logging
 import os
 import warnings
-from copy import deepcopy
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -1520,7 +1519,8 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
         if getattr(config, "model_type", None) == "qwen3_asr":
             split_paths = _OVModelForQwen3ASR._resolve_split_paths(model_id, allow_missing=True, **kwargs)
             if not split_paths:
-                return _OVModelForQwen3ASREncoderDecoder._from_pretrained(model_id, config, **kwargs)
+                config.is_encoder_decoder = True
+                return super()._from_pretrained(model_id, config, **kwargs)
             return _OVModelForQwen3ASR._from_pretrained(
                 model_id,
                 config,
@@ -1528,111 +1528,6 @@ class OVModelForSpeechSeq2Seq(OVModelForSeq2SeqLM):
                 **kwargs,
             )
         return super()._from_pretrained(model_id, config, **kwargs)
-
-
-class _OVModelForQwen3ASREncoderDecoder(OVModelForSpeechSeq2Seq):
-    def __init__(self, encoder, decoder, decoder_with_past=None, config=None, **kwargs):
-        if kwargs.get("compile_only"):
-            raise ValueError("Qwen3-ASR encoder-decoder models require `compile_only=False`.")
-        if kwargs.get("stateful") is False or kwargs.get("use_cache") is False or not model_has_state(decoder):
-            raise ValueError("Qwen3-ASR encoder-decoder inference requires a stateful decoder and `use_cache=True`.")
-        config.is_encoder_decoder = True
-        if not hasattr(config, "n_window"):
-            config.n_window = config.thinker_config.audio_config.n_window
-        super().__init__(encoder, decoder, decoder_with_past, config, **kwargs)
-        logger.warning(
-            "Loading a Qwen3-ASR encoder-decoder export. Only single-recording generation is supported. "
-            "Re-export for split-component inference and PagedAttention compatibility."
-        )
-
-    @classmethod
-    def _from_pretrained(cls, model_id, config, **kwargs):
-        if kwargs.get("compile_only"):
-            raise ValueError("Qwen3-ASR encoder-decoder models require `compile_only=False`.")
-        if kwargs.get("use_cache") is False:
-            raise ValueError("Qwen3-ASR encoder-decoder inference requires `use_cache=True`.")
-        if kwargs.get("from_onnx"):
-            raise ValueError("Qwen3-ASR encoder-decoder compatibility supports OpenVINO IR exports only.")
-        subfolder = kwargs.get("subfolder", "")
-        for argument, default in (
-            ("encoder_file_name", OV_ENCODER_NAME),
-            ("decoder_file_name", OV_DECODER_NAME),
-        ):
-            filename = kwargs.get(argument) or default
-            path = cls._cached_file(
-                model_path=model_id,
-                file_name=filename,
-                subfolder=subfolder,
-                **{
-                    key: kwargs[key]
-                    for key in ("token", "revision", "force_download", "cache_dir", "local_files_only")
-                    if key in kwargs
-                },
-            )
-            for required in (Path(path), Path(path).with_suffix(".bin")):
-                if not required.is_file():
-                    raise FileNotFoundError(f"Incomplete Qwen3-ASR encoder-decoder export: missing {required}.")
-            kwargs[argument] = str(Path(subfolder) / filename)
-        return super(OVModelForSpeechSeq2Seq, cls)._from_pretrained(model_id, config, **kwargs)
-
-    def generate(
-        self,
-        input_features=None,
-        attention_mask=None,
-        decoder_input_ids=None,
-        decoder_attention_mask=None,
-        input_ids=None,
-        feature_attention_mask=None,
-        **kwargs,
-    ):
-        prompt = decoder_input_ids if decoder_input_ids is not None else input_ids
-        if prompt is None or prompt.ndim != 2 or prompt.shape[0] != 1:
-            raise ValueError("Qwen3-ASR encoder-decoder models require a prompt for exactly one recording.")
-        generation_config = kwargs.get("generation_config") or self.generation_config
-        if not kwargs.get("use_cache", generation_config.use_cache):
-            raise ValueError("Qwen3-ASR encoder-decoder inference requires `use_cache=True`.")
-        if (
-            kwargs.get("num_beams", generation_config.num_beams) != 1
-            or kwargs.get("num_return_sequences", generation_config.num_return_sequences) != 1
-        ):
-            raise ValueError("Qwen3-ASR encoder-decoder inference supports one beam and one returned sequence.")
-        if decoder_attention_mask is None and feature_attention_mask is not None:
-            decoder_attention_mask = attention_mask
-        if decoder_attention_mask is not None and not torch.all(decoder_attention_mask == 1):
-            raise ValueError("Qwen3-ASR encoder-decoder inference requires an unpadded text prompt.")
-        encoder_outputs = kwargs.pop("encoder_outputs", None)
-        if encoder_outputs is None:
-            encoder_outputs = self.encoder(input_ids=input_features)
-        if encoder_outputs.last_hidden_state.shape[0] != 1:
-            raise ValueError("Qwen3-ASR encoder-decoder models require exactly one recording per request.")
-        audio_token_id = getattr(self.config, "audio_token_id", None)
-        if audio_token_id is None:
-            audio_token_id = self.config.thinker_config.audio_token_id
-        adjusted_prompt = self._adjust_audio_tokens(prompt, audio_token_id, encoder_outputs.last_hidden_state.shape[1])
-        generation_config = deepcopy(generation_config)
-        prompt_delta = adjusted_prompt.shape[1] - prompt.shape[1]
-        for name in ("max_length", "min_length"):
-            value = kwargs.pop(name, getattr(generation_config, name))
-            if value is not None and value > 0:
-                setattr(generation_config, name, value + prompt_delta)
-        kwargs.pop("generation_config", None)
-        output = GenerationMixin.generate(
-            self,
-            encoder_outputs=encoder_outputs,
-            decoder_input_ids=adjusted_prompt,
-            attention_mask=torch.ones(
-                encoder_outputs.last_hidden_state.shape[:2], dtype=torch.long, device=prompt.device
-            ),
-            decoder_attention_mask=torch.ones_like(adjusted_prompt),
-            generation_config=generation_config,
-            **kwargs,
-        )
-        sequences = output.sequences if hasattr(output, "sequences") else output
-        sequences = torch.cat((prompt.to(sequences.device), sequences[:, adjusted_prompt.shape[1] :]), dim=1)
-        if hasattr(output, "sequences"):
-            output.sequences = sequences
-            return output
-        return sequences
 
 
 class _OVModelForQwen3ASR(OVModelForSpeechSeq2Seq):

--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -57,7 +57,6 @@ from optimum.intel.openvino.utils import (
 )
 from optimum.intel.utils.import_utils import is_transformers_version
 
-
 if is_transformers_version(">=", "4.57"):
     from transformers.models.qwen3_omni_moe.processing_qwen3_omni_moe import _get_feat_extract_output_lengths
     from transformers.models.qwen3_vl.modeling_qwen3_vl import (
@@ -222,7 +221,9 @@ class OVModelWithEmbedForCausalLM(OVModelForCausalLM):
 
             if self.config.model_type in ["qwen3_5", "qwen3_5_moe"] and position_ids.ndim != 3:
                 position_ids = np.repeat(np.expand_dims(position_ids, 0), 4, axis=0)
-            elif (self.config.model_type in ["qwen2_vl", "qwen2_5_vl", "qwen3_vl"]) and position_ids.ndim == 2:
+            elif (
+                self.config.model_type in ["qwen2_vl", "qwen2_5_vl", "qwen3_vl", "qwen3_asr"]
+            ) and position_ids.ndim == 2:
                 # Qwen2-VL and Qwen3-VL use 3D mrope (3 spatial dimensions)
                 position_ids = np.repeat(np.expand_dims(position_ids, 0), 3, axis=0)
             elif self.config.model_type == "qwen3_omni_moe" and position_ids.ndim == 2:
@@ -428,6 +429,67 @@ class OVAudioEncoder(OVModelPart):
         else:
             inputs = {k: v for k, v in kwargs.items() if k in self.input_names}
         return self.request(inputs)[0]
+
+
+class OVQwen3AudioEncoder(OVAudioEncoder):
+    def encode(self, input_features, feature_attention_mask):
+        encoder_inputs, feature_lens, chunk_lens = self._prepare_inputs(input_features, feature_attention_mask)
+        output = super().forward(**encoder_inputs)
+        return self._compact_features(output, chunk_lens), feature_lens
+
+    def _prepare_inputs(self, input_features, feature_attention_mask):
+        thinker_config = getattr(self.config, "thinker_config", self.config)
+        audio_config = getattr(thinker_config, "audio_config", None)
+        n_window = getattr(audio_config, "n_window", 100) if audio_config else 100
+        n_window_infer = getattr(audio_config, "n_window_infer", 400) if audio_config else 400
+
+        feature_lens = feature_attention_mask.sum(-1).to(torch.int64)
+        if torch.any(feature_lens == 0):
+            raise ValueError("Each sample must contain at least one valid audio frame.")
+        audio_flat = input_features.permute(0, 2, 1)[feature_attention_mask.bool()].permute(1, 0)
+
+        aftercnn_lens = _get_feat_extract_output_lengths(feature_lens)
+        chunk_num = torch.ceil(feature_lens / (n_window * 2)).long()
+        chunk_lengths = torch.tensor([n_window * 2] * chunk_num.sum(), dtype=torch.long)
+        tail_chunk_index = torch.nn.functional.pad(chunk_num, (1, 0), value=-1).cumsum(0)[1:]
+        chunk_lengths[tail_chunk_index] = feature_lens % (n_window * 2)
+        chunk_lengths[chunk_lengths == 0] = n_window * 2
+
+        chunk_list = audio_flat.T.split(chunk_lengths.tolist(), dim=0)
+        padded_feature = torch.nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
+        chunk_output_lens = _get_feat_extract_output_lengths(chunk_lengths)
+        padded_mask_after_cnn = torch.nn.utils.rnn.pad_sequence(
+            [torch.ones(length, dtype=torch.bool) for length in chunk_output_lens],
+            batch_first=True,
+        )
+
+        window_aftercnn = padded_mask_after_cnn.shape[-1] * (n_window_infer // (n_window * 2))
+        cu_chunk_lens = [0]
+        for cnn_len in aftercnn_lens:
+            cnn_len_val = cnn_len.item()
+            cu_chunk_lens += [window_aftercnn] * (cnn_len_val // window_aftercnn)
+            remainder = cnn_len_val % window_aftercnn
+            if remainder != 0:
+                cu_chunk_lens += [remainder]
+        cu_seqlens = torch.tensor(cu_chunk_lens, device=aftercnn_lens.device).cumsum(-1, dtype=torch.int32)
+
+        encoder_inputs = {
+            "padded_feature": padded_feature,
+            "padded_mask_after_cnn": padded_mask_after_cnn,
+            "aftercnn_lens": aftercnn_lens,
+            "cu_seqlens": cu_seqlens,
+        }
+        return encoder_inputs, aftercnn_lens, chunk_output_lens
+
+    @staticmethod
+    def _compact_features(audio_output, chunk_output_lens):
+        audio_output = torch.from_numpy(audio_output) if not isinstance(audio_output, torch.Tensor) else audio_output
+        if audio_output.ndim != 3:
+            return audio_output
+        return torch.cat(
+            [audio_output[chunk_idx, : length.item()] for chunk_idx, length in enumerate(chunk_output_lens)],
+            dim=0,
+        )
 
 
 class OVTalkerDecoder(OVModelPart):
@@ -4277,6 +4339,8 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
         )
         # OVQwen3OmniMoeVisionEmbeddings merges deepstack into the vision graph; swap in for the default wrapper.
         self.vision_embeddings = OVQwen3OmniMoeVisionEmbeddings(self.vision_embeddings.model, self)
+        if self.audio_encoder is not None:
+            self.audio_encoder = OVQwen3AudioEncoder(self.audio_encoder.model, self, model_name="audio_encoder")
 
         self._apply_component_device_overrides()
         if enable_compilation and not self._compile_only:
@@ -4631,60 +4695,9 @@ class _OVQwen3OmniMoeForCausalLM(OVModelForVisualCausalLM):
             cached_features, cached_lens = cached
             return cached_features.clone(), cached_lens.clone()
 
-        thinker_config = getattr(self.config, "thinker_config", self.config)
-        audio_config = getattr(thinker_config, "audio_config", None)
-        n_window = getattr(audio_config, "n_window", 100) if audio_config else 100
-        n_window_infer = getattr(audio_config, "n_window_infer", 400) if audio_config else 400
-
-        feature_lens = feature_attention_mask.sum(-1).to(torch.int64)
-        if feature_lens.sum() == 0:
-            raise ValueError("feature_attention_mask is all-zero; no valid audio frames to process.")
-        audio_flat = input_features.permute(0, 2, 1)[feature_attention_mask.bool()].permute(1, 0)
-
-        aftercnn_lens = _get_feat_extract_output_lengths(feature_lens)
-        chunk_num = torch.ceil(feature_lens / (n_window * 2)).long()
-        chunk_lengths = torch.tensor([n_window * 2] * chunk_num.sum(), dtype=torch.long)
-        tail_chunk_index = torch.nn.functional.pad(chunk_num, (1, 0), value=-1).cumsum(0)[1:]
-        chunk_lengths[tail_chunk_index] = feature_lens % (n_window * 2)
-        chunk_lengths[chunk_lengths == 0] = n_window * 2
-
-        chunk_list = audio_flat.T.split(chunk_lengths.tolist(), dim=0)
-        padded_feature = torch.nn.utils.rnn.pad_sequence(chunk_list, batch_first=True).transpose(1, 2)
-        feature_lens_after_cnn = _get_feat_extract_output_lengths(chunk_lengths)
-        padded_mask_after_cnn = torch.nn.utils.rnn.pad_sequence(
-            [torch.ones(length, dtype=torch.bool) for length in feature_lens_after_cnn],
-            batch_first=True,
-        )
-
-        # cu_seqlens are required by the audio encoder's windowed attention kernels.
-        window_aftercnn = padded_mask_after_cnn.shape[-1] * (n_window_infer // (n_window * 2))
-        cu_chunk_lens = [0]
-        for cnn_len in aftercnn_lens:
-            cnn_len_val = cnn_len.item()
-            cu_chunk_lens += [window_aftercnn] * (cnn_len_val // window_aftercnn)
-            remainder = cnn_len_val % window_aftercnn
-            if remainder != 0:
-                cu_chunk_lens += [remainder]
-        cu_seqlens = torch.tensor(cu_chunk_lens, device=aftercnn_lens.device).cumsum(-1, dtype=torch.int32)
-
         if self.audio_encoder is None:
             raise ValueError("Audio encoder model not loaded. Cannot process audio inputs.")
-        audio_out = self.audio_encoder(
-            padded_feature=padded_feature,
-            padded_mask_after_cnn=padded_mask_after_cnn,
-            aftercnn_lens=aftercnn_lens,
-            cu_seqlens=cu_seqlens,
-        )
-        audio_out = torch.from_numpy(audio_out) if not isinstance(audio_out, torch.Tensor) else audio_out
-
-        # Encoder returns padded [N_chunks, aftercnn_time, dim]; drop pad frames per chunk before concatenation.
-        if audio_out.ndim == 3:
-            valid_tokens = []
-            for i, length in enumerate(feature_lens_after_cnn):
-                valid_tokens.append(audio_out[i, : length.item()])
-            audio_features = torch.cat(valid_tokens, dim=0)
-        else:
-            audio_features = audio_out
+        audio_features, aftercnn_lens = self.audio_encoder.encode(input_features, feature_attention_mask)
         self._lru_put(
             self._audio_cache,
             cache_key,

--- a/optimum/intel/openvino/utils.py
+++ b/optimum/intel/openvino/utils.py
@@ -35,13 +35,13 @@ from transformers import AutoTokenizer, CLIPTokenizer, PreTrainedTokenizer, PreT
 
 from optimum.intel.utils.import_utils import is_torch_version
 
-
 logger = logging.getLogger(__name__)
 
 OV_XML_FILE_NAME = "openvino_model.xml"
 OV_ENCODER_NAME = "openvino_encoder_model.xml"
 OV_DECODER_NAME = "openvino_decoder_model.xml"
 OV_DECODER_WITH_PAST_NAME = "openvino_decoder_with_past_model.xml"
+OV_AUDIO_ENCODER_MODEL_NAME = "openvino_audio_encoder_model.xml"
 OV_TEXT_EMBEDDINGS_MODEL_NAME = "openvino_text_embeddings_model.xml"
 OV_LANGUAGE_MODEL_NAME = "openvino_language_model.xml"
 OV_VISION_EMBEDDINGS_MODEL_NAME = "openvino_vision_embeddings_model.xml"

--- a/tests/openvino/test_asr.py
+++ b/tests/openvino/test_asr.py
@@ -14,6 +14,9 @@
 
 import gc
 import unittest
+from copy import deepcopy
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 import numpy as np
 import pytest
@@ -22,6 +25,8 @@ from parameterized import parameterized
 from transformers import AutoProcessor, set_seed
 from utils_tests import F32_CONFIG, MODEL_NAMES, OPENVINO_DEVICE, SEED
 
+from optimum.exporters.openvino.convert import export_models
+from optimum.exporters.openvino.model_configs import Qwen3ASREncoderDecoderOpenVINOConfig
 from optimum.intel import OVModelForSpeechSeq2Seq
 from optimum.intel.utils.import_utils import is_transformers_version
 
@@ -42,20 +47,47 @@ class OVASRTest(unittest.TestCase):
         audio_data = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
         return audio_data, sample_rate
 
-    @parameterized.expand(SUPPORTED_ARCHITECTURES)
+    @parameterized.expand([("qwen3_asr", "split"), ("qwen3_asr", "encoder_decoder"), ("fun_asr", "default")])
     @pytest.mark.skipif(
         is_transformers_version("<", "4.57") or is_transformers_version(">=", "4.58"),
         reason="Currently, we support Qwen3-ASR and FunASR only for transformers==4.57 since they are trust-remote-code models.",
     )
-    def test_compare_to_transformers(self, model_arch):
+    def test_compare_to_transformers(self, model_arch, export_format):
         model_id = MODEL_NAMES[model_arch]
         set_seed(SEED)
 
         ref = self._get_pt_reference(model_arch)
 
-        ov_model = OVModelForSpeechSeq2Seq.from_pretrained(
-            model_id, export=True, trust_remote_code=True, ov_config=F32_CONFIG, device=OPENVINO_DEVICE
-        )
+        if export_format == "encoder_decoder":
+            directory = TemporaryDirectory()
+            self.addCleanup(directory.cleanup)
+            output_dir = Path(directory.name)
+            source = ref["pt_model"]
+            config = deepcopy(source.config)
+            config.is_encoder_decoder = True
+            export_config = Qwen3ASREncoderDecoderOpenVINOConfig(config)
+            export_models(
+                models_and_export_configs={
+                    "encoder": (source.thinker.audio_tower, export_config.with_behavior("encoder")),
+                    "decoder": (
+                        source,
+                        export_config.with_behavior("decoder", use_past=True, use_past_in_inputs=True),
+                    ),
+                },
+                output_dir=output_dir,
+                output_names=["openvino_encoder_model.xml", "openvino_decoder_model.xml"],
+                stateful=[False, True],
+            )
+            config.save_pretrained(output_dir)
+            ov_model = OVModelForSpeechSeq2Seq.from_pretrained(
+                directory.name, ov_config=F32_CONFIG, device=OPENVINO_DEVICE
+            )
+            self.assertEqual(ov_model._ov_model_names, ["encoder", "decoder"])
+            self.assertIn("encoder_hidden_states", ov_model.decoder.input_names)
+        else:
+            ov_model = OVModelForSpeechSeq2Seq.from_pretrained(
+                model_id, export=True, trust_remote_code=True, ov_config=F32_CONFIG, device=OPENVINO_DEVICE
+            )
 
         # For models with standalone preprocess_input, verify it reproduces the reference inputs.
         if ref.get("preprocess_check") is not None:

--- a/tests/openvino/test_asr.py
+++ b/tests/openvino/test_asr.py
@@ -37,7 +37,7 @@ class OVASRTest(unittest.TestCase):
     Compares OpenVINO model output to original PyTorch model output.
     """
 
-    SUPPORTED_ARCHITECTURES = ("qwen3_asr", "fun_asr")
+    SUPPORTED_ARCHITECTURES = [("qwen3_asr", "default"), ("qwen3_asr", "encoder_decoder"), ("fun_asr", "default")]
 
     def _generate_audio_data(self):
         np.random.seed(SEED)
@@ -47,7 +47,7 @@ class OVASRTest(unittest.TestCase):
         audio_data = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
         return audio_data, sample_rate
 
-    @parameterized.expand([("qwen3_asr", "split"), ("qwen3_asr", "encoder_decoder"), ("fun_asr", "default")])
+    @parameterized.expand(SUPPORTED_ARCHITECTURES)
     @pytest.mark.skipif(
         is_transformers_version("<", "4.57") or is_transformers_version(">=", "4.58"),
         reason="Currently, we support Qwen3-ASR and FunASR only for transformers==4.57 since they are trust-remote-code models.",

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -736,9 +736,9 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
     },
     "ouro": {"model": 34},
     "qwen3_asr": {
-        "encoder": 36,
-        "decoder": 30,
-        "decoder_with_past": 30,
+        "audio_encoder": 36,
+        "text_embeddings": 2,
+        "language_model": 30,
     },
     "fun_asr": {
         "encoder": 46,


### PR DESCRIPTION
# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

### Split Qwen3-ASR export into audio, embeddings, and language components

Refactor Qwen3-ASR export to produce openvino_audio_encoder_model.xml, openvino_text_embeddings_model.xml, and openvino_language_model.xml. Separating the language graph enables SDPA-to-PagedAttention transformation.

Reuse the Qwen3-Omni audio preprocessing and patcher, shared text-embedding export, and embedding-based language runtime.

Validated with Transformers 4.57.6, qwen-asr==0.0.6, and OpenVINO 2026.5.0 development build.

### Exported models

The export produces three model pairs, each consisting of an XML graph and BIN weights:

- `openvino_audio_encoder_model.xml`: encodes chunked mel features into audio embeddings.
- `openvino_text_embeddings_model.xml`: maps text token IDs to embeddings.
- `openvino_language_model.xml`: processes merged text/audio embeddings and produces vocabulary logits.

#### Audio encoder

| Direction | Name | Type | Shape | Description |
| --- | --- | --- | --- | --- |
| Input | `padded_feature` | float32 | `[num_chunks, 128, padded_chunk_frames]` | Mel features split into chunks of at most `2 * n_window` frames and padded across the batch. |
| Input | `padded_mask_after_cnn` | bool | `[num_chunks, padded_encoded_positions]` | Valid encoded positions in each chunk; `False` marks padding. |
| Input | `aftercnn_lens` | int64 | `[batch_size]` | Number of valid encoded positions per original recording. |
| Input | `cu_seqlens` | int32 | `[num_windows + 1]` | Cumulative attention-window boundaries in the compacted encoded sequence, starting at zero. |
| Output | `audio_features` | float32 | `[num_chunks, padded_encoded_positions, 1024]` | Padded audio embeddings projected into the language model's embedding space. |

The runtime prepares these inputs from processor outputs and removes padded output positions before replacing audio-placeholder embeddings in the text prompt. `num_chunks` counts chunks across all recordings in the batch.

The current audio patcher accepts `aftercnn_lens` and `cu_seqlens` but does not use them to control computation. Attention operates independently within each convolution chunk; larger attention-window grouping remains outside this PR.

#### Text embeddings

| Direction | Name | Type | Shape | Description |
| --- | --- | --- | --- | --- |
| Input | `input` | int64 | `[batch_size, current_tokens]` | Text token IDs; the exported port is named `input`. |
| Output | `inputs_embeds` | float32 | `[batch_size, current_tokens, 1024]` | Token embeddings before audio-placeholder positions are replaced with audio embeddings. |

#### Language model

| Direction | Name | Type | Shape | Description |
| --- | --- | --- | --- | --- |
| Input | `inputs_embeds` | float32 | `[batch_size, current_tokens, 1024]` | Merged text/audio embeddings during prefill; new token embeddings during decoding. |
| Input | `attention_mask` | int64 | `[batch_size, cached_tokens + current_tokens]` | Valid-token mask covering cached and current tokens. |
| Input | `position_ids` | int64 | `[3, batch_size, current_tokens]` | Three-axis rotary position IDs. The runtime supplies three axes, although the inspected IR declares all dimensions dynamic. |
| Input | `beam_idx` | int32 | `[batch_size]` | Cache-row indices for beam reordering; identity mapping for ordinary greedy decoding. |
| Output | `logits` | float32 | `[batch_size, current_tokens, 151936]` | Vocabulary scores for the tokens processed in the current call. |

### Usage

```sh
optimum-cli export openvino --model Qwen/Qwen3-ASR-0.6B \
  --task automatic-speech-recognition ./qwen3-asr-openvino
```

Batched inference uses AutoProcessor followed by generate, rather than the generic ASR pipeline. Audio is downloaded entirely in memory:

```python
import io
import librosa
import qwen_asr
import requests
import soundfile as sf
from transformers import AutoProcessor
from optimum.intel import OVModelForSpeechSeq2Seq

model_id = "Qwen/Qwen3-ASR-0.6B"
model = OVModelForSpeechSeq2Seq.from_pretrained(model_id, device="CPU")
processor = AutoProcessor.from_pretrained(model_id, fix_mistral_regex=True)
audio_urls = [
    "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav",
    "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_zh.wav",
]
sampling_rate = processor.feature_extractor.sampling_rate
audios = []
for url in audio_urls:
    response = requests.get(url, timeout=60)
    response.raise_for_status()
    audio, source_rate = sf.read(io.BytesIO(response.content), dtype="float32", always_2d=True)
    audios.append(librosa.resample(
        audio.mean(axis=1), orig_sr=source_rate, target_sr=sampling_rate
    ))

prompt = processor.apply_chat_template(
    [{"role": "system", "content": ""},
     {"role": "user", "content": [{"type": "audio"}]}],
    add_generation_prompt=True, tokenize=False,
)
inputs = processor(
    text=[prompt] * len(audios), audio=audios,
    sampling_rate=sampling_rate, padding=True, return_tensors="pt",
)
generated_ids = model.generate(
    **inputs, max_new_tokens=256, do_sample=False, eos_token_id=[151643, 151645]
)
print(processor.batch_decode(
    generated_ids[:, inputs.input_ids.shape[1]:], skip_special_tokens=True
))
```

### Accuracy for Qwen/Qwen3-ASR-0.6B

| Export | Similarity | WER | Word errors |
| --- | --- | --- | --- |
| Split (optimum) | 0.970588 | 2.94% | 14 / 476 |
| Legacy (optimum-main) | 0.962185 | 3.78% | 18 / 476 |


### LLM Bench results for Qwen/Qwen3-ASR-0.6B

| Export | 2nd tokens throughput (tokens/sec) | 
| --- | --- |
| Split (optimum) | 22.00  |
| Legacy (optimum-main) | 21.98  |





## Before submitting
- [NA] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [NA] Did you make sure to update the documentation with your changes?
- [X] Did you write any new necessary tests?

