### PR TITLE
Add ministral3 (Ministral-3-3B-Reasoning-2512) OpenVINO export support

### DIFF
--- a/docs/source/openvino/models.mdx
+++ b/docs/source/openvino/models.mdx
@@ -111,6 +111,7 @@ Here is the list of the supported architectures :
 - MiniCPM3
 - MiniCPM-o
 - MiniCPM-V
+- Ministral 3
 - Mistral
 - Mistral 3
 - Mixtral

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1387,6 +1387,22 @@ class MistralOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
 
 
 @register_in_tasks_manager(
+    "ministral3",
+    *[
+        "feature-extraction",
+        "feature-extraction-with-past",
+        "text-generation",
+        "text-generation-with-past",
+        "text-classification",
+    ],
+    library_name="transformers",
+)
+class Ministral3OpenVINOConfig(MistralOpenVINOConfig):
+    # ministral3 is the text-decoder config used inside Mistral3ForConditionalGeneration (Mistral3 VLM family).
+    pass
+
+
+@register_in_tasks_manager(
     "gpt_neox",
     *[
         "feature-extraction",
@@ -2241,6 +2257,16 @@ class Mistral3OpenVINOConfig(BaseVLMOpenVINOConfig):
                 if hasattr(model, "multi_modal_projector")
                 else model.model.multi_modal_projector
             )
+
+        if behavior == Mistral3ConfigBehavior.TEXT_EMBEDDINGS:
+            # newer transformers versions nest the decoder under `model.model.language_model`
+            language_model = getattr(model, "language_model", None) or getattr(
+                model.model, "language_model", None
+            )
+            text_embedding = model.get_input_embeddings()
+            if language_model is not None:
+                text_embedding.config = language_model.config
+            return text_embedding
 
         return super().get_model_for_behavior(model, behavior)
 

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -1399,7 +1399,7 @@ class MistralOpenVINOConfig(TextDecoderWithPositionIdsOpenVINOConfig):
 )
 class Ministral3OpenVINOConfig(MistralOpenVINOConfig):
     # ministral3 is the text-decoder config used inside Mistral3ForConditionalGeneration (Mistral3 VLM family).
-    pass
+    MIN_TRANSFORMERS_VERSION = "5.0.0"
 
 
 @register_in_tasks_manager(

--- a/optimum/exporters/openvino/model_configs.py
+++ b/optimum/exporters/openvino/model_configs.py
@@ -2260,9 +2260,7 @@ class Mistral3OpenVINOConfig(BaseVLMOpenVINOConfig):
 
         if behavior == Mistral3ConfigBehavior.TEXT_EMBEDDINGS:
             # newer transformers versions nest the decoder under `model.model.language_model`
-            language_model = getattr(model, "language_model", None) or getattr(
-                model.model, "language_model", None
-            )
+            language_model = getattr(model, "language_model", None) or getattr(model.model, "language_model", None)
             text_embedding = model.get_input_embeddings()
             if language_model is not None:
                 text_embedding.config = language_model.config

--- a/optimum/exporters/openvino/model_patcher.py
+++ b/optimum/exporters/openvino/model_patcher.py
@@ -875,9 +875,9 @@ class MistralModelPatcher(OVDecoderModelPatcher):
     def __exit__(self, exc_type, exc_value, traceback):
         super().__exit__(exc_type, exc_value, traceback)
 
-        if hasattr(self._model.model, "model") and hasattr(self._model.model.model, "layers"):
+        if hasattr(self._model, "model") and hasattr(self._model.model, "layers"):
             for layer in self._model.model.layers:
-                if hasattr(layer.self_attn, "rotary_emb"):
+                if hasattr(layer.self_attn, "rotary_emb") and hasattr(layer.self_attn.rotary_emb, "_orig_forward"):
                     layer.self_attn.rotary_emb.forward = layer.self_attn.rotary_emb._orig_forward
                     del layer.self_attn.rotary_emb._orig_forward
 

--- a/optimum/intel/openvino/modeling_base.py
+++ b/optimum/intel/openvino/modeling_base.py
@@ -1020,6 +1020,16 @@ class OVBaseModel(OptimizedModel, OVModelHostMixin):
         """
         return isinstance(self, GenerationMixin)
 
+    def get_experts_implementation(self):
+        # transformers>=5.15 `generate` queries the experts implementation to decide
+        # on a decode-time MoE kernel swap; that swap is a no-op for OpenVINO models,
+        # since any MoE kernel is baked into the exported graph.
+        return "openvino_impl"
+
+    def set_experts_implementation(self, experts_implementation):
+        # No-op: the MoE kernel (if any) is baked into the exported OpenVINO graph.
+        return
+
     def _inference(self, inputs):
         try:
             outputs = self.request(inputs)

--- a/tests/openvino/test_decoder.py
+++ b/tests/openvino/test_decoder.py
@@ -287,6 +287,8 @@ class OVModelForCausalLMIntegrationTest(unittest.TestCase):
         supported_architectures -= to_remove
         # llama4_text is the text sub-model of llama4 (VLM), tested in the VLM group
         supported_architectures.discard("llama4_text")
+        # ministral3 is the text sub-model of the Mistral3 VLM, tested in the seq2seq group
+        supported_architectures.discard("ministral3")
         # *_text variants below are sub-models of VLM architectures tested in the seq2seq group
         supported_architectures -= {
             "qwen3_vl_text",

--- a/tests/openvino/test_export.py
+++ b/tests/openvino/test_export.py
@@ -127,6 +127,7 @@ class ExportModelTest(unittest.TestCase):
         "gemma4_unified": OVModelForVisualCausalLM,
         "gemma3n": OVModelForVisualCausalLM,
         "mistral3": OVModelForVisualCausalLM,
+        "ministral3": OVModelForVisualCausalLM,
         "flux.2-klein": OVFlux2KleinPipeline,
         "z-image": OVZImagePipeline,
         "qwen3_omni_moe": OVModelForMultimodalLM,

--- a/tests/openvino/test_exporters_cli.py
+++ b/tests/openvino/test_exporters_cli.py
@@ -139,6 +139,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         ("text-generation-with-past", "falcon_mamba"),
         ("text-to-image", "flux.2-klein"),
         ("image-text-to-text", "mistral3"),
+        ("image-text-to-text", "ministral3"),
         ("text-to-image", "z-image"),
         ("image-text-to-text", "muse_glimmer"),
     ]
@@ -183,6 +184,7 @@ class OVCLIExportTestCase(unittest.TestCase):
         "lfm2_moe": 2,
         "llava": 2,
         "mistral3": 2,
+        "ministral3": 2,
         "sana": 2,
         "ltx-video": 2,
         "ltx2": 2,

--- a/tests/openvino/test_quantization.py
+++ b/tests/openvino/test_quantization.py
@@ -1185,6 +1185,7 @@ class OVWeightCompressionTest(unittest.TestCase):
         (OVModelForVisualCausalLM, "gemma4_moe", False),
         (OVModelForVisualCausalLM, "deepseek_ocr2", False),
         (OVModelForVisualCausalLM, "mistral3", False),
+        (OVModelForVisualCausalLM, "ministral3", False),
     ]
 
     # gemma3n openvino>=2026.2.0 because it needs erfinv operation,

--- a/tests/openvino/test_seq2seq.py
+++ b/tests/openvino/test_seq2seq.py
@@ -600,6 +600,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
         "qwen3_5_moe_mtp",
         "qwen3_omni_moe",
         "mistral3",
+        "ministral3",
         "muse_glimmer",
         "deepseek_ocr2",
     ]
@@ -663,6 +664,7 @@ class OVModelForVisualCausalLMIntegrationTest(OVSeq2SeqTestMixin):
             "llava_next",
             "llava_next_mistral",
             "mistral3",
+            "ministral3",
             "qwen2_vl",
             "qwen2_5_vl",
             "got_ocr2",

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -194,69 +194,6 @@ def _create_tiny_mistral3_model():
     return str(output_dir)
 
 
-def _create_tiny_ministral3_model():
-    """Mistral3 VLM wrapper around a `ministral3` text decoder (YaRN rope) + pixtral vision tower.
-
-    Unlike `_create_tiny_mistral3_model()` (text_config.model_type == "mistral"), this fixture's
-    text_config.model_type is "ministral3", exercising the dedicated Ministral3OpenVINOConfig
-    registration and the preserved YaRN rope_scaling path.
-    """
-    output_dir = Path(tempfile.gettempdir()) / "optimum_intel_tiny_random_ministral3"
-    config_file = output_dir / "config.json"
-    weights_file = output_dir / "model.safetensors"
-
-    if config_file.exists() and weights_file.exists():
-        return str(output_dir)
-
-    from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
-
-    model_id = "mistralai/Ministral-3-3B-Reasoning-2512"
-
-    torch.manual_seed(SEED)
-
-    config = AutoConfig.from_pretrained(model_id)
-
-    config.tie_word_embeddings = False
-    config.text_config.tie_word_embeddings = False
-
-    config.text_config.num_hidden_layers = 2
-    config.text_config.hidden_size = 64
-    config.text_config.intermediate_size = 128
-    config.text_config.num_attention_heads = 4
-    config.text_config.num_key_value_heads = 2
-    config.text_config.head_dim = 16
-    config.text_config.max_position_embeddings = 512
-
-    # Preserve the YaRN rope path: keep rope_type == "yarn" and all yarn fields, only rescale
-    # original_max_position_embeddings so factor * original == max_position_embeddings.
-    rope_scaling = dict(config.text_config.rope_scaling)
-    assert rope_scaling["rope_type"] == "yarn"
-    rope_scaling["original_max_position_embeddings"] = 32
-    config.text_config.rope_scaling = rope_scaling
-
-    config.vision_config.num_hidden_layers = 2
-    config.vision_config.hidden_size = 64
-    config.vision_config.intermediate_size = 128
-    config.vision_config.num_attention_heads = 4
-    config.vision_config.head_dim = 16
-    config.vision_config.image_size = 56
-
-    for subconfig in (config, config.text_config, config.vision_config):
-        subconfig.dtype = "float32"
-        subconfig.torch_dtype = "float32"
-
-    model = AutoModelForImageTextToText.from_config(config).float().eval()
-    processor = AutoProcessor.from_pretrained(model_id)
-    processor.image_processor.size = {"longest_edge": 56}
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-
-    model.save_pretrained(output_dir, safe_serialization=True)
-    processor.save_pretrained(output_dir)
-
-    return str(output_dir)
-
-
 SEED = 42
 
 F32_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
@@ -381,7 +318,7 @@ HUB_MODEL_NAMES = {
     "mistral": "optimum-intel-internal-testing/tiny-random-mistral",
     "mistral-nemo": "optimum-intel-internal-testing/tiny-random-mistral-nemo",
     "mistral3": _create_tiny_mistral3_model(),
-    "ministral3": _create_tiny_ministral3_model(),
+    "ministral3": "optimum-intel-internal-testing/tiny-random-ministral3",
     "mixtral": "optimum-intel-internal-testing/tiny-mixtral",
     "mixtral_awq": "optimum-intel-internal-testing/tiny-mixtral-AWQ-4bit",
     "mobilebert": "optimum-intel-internal-testing/tiny-random-MobileBertModel",
@@ -1019,7 +956,6 @@ TEST_NAME_TO_MODEL_TYPE = {
     "gpt_oss_mxfp4": "gpt_oss",
     "llama_awq": "llama",
     "llava_next_mistral": "llava_next",
-    "ministral3": "mistral3",
     "mistral-nemo": "mistral",
     "mixtral_awq": "mixtral",
     "nanollava_vision_tower": "siglip",

--- a/tests/openvino/utils_tests.py
+++ b/tests/openvino/utils_tests.py
@@ -194,6 +194,69 @@ def _create_tiny_mistral3_model():
     return str(output_dir)
 
 
+def _create_tiny_ministral3_model():
+    """Mistral3 VLM wrapper around a `ministral3` text decoder (YaRN rope) + pixtral vision tower.
+
+    Unlike `_create_tiny_mistral3_model()` (text_config.model_type == "mistral"), this fixture's
+    text_config.model_type is "ministral3", exercising the dedicated Ministral3OpenVINOConfig
+    registration and the preserved YaRN rope_scaling path.
+    """
+    output_dir = Path(tempfile.gettempdir()) / "optimum_intel_tiny_random_ministral3"
+    config_file = output_dir / "config.json"
+    weights_file = output_dir / "model.safetensors"
+
+    if config_file.exists() and weights_file.exists():
+        return str(output_dir)
+
+    from transformers import AutoConfig, AutoModelForImageTextToText, AutoProcessor
+
+    model_id = "mistralai/Ministral-3-3B-Reasoning-2512"
+
+    torch.manual_seed(SEED)
+
+    config = AutoConfig.from_pretrained(model_id)
+
+    config.tie_word_embeddings = False
+    config.text_config.tie_word_embeddings = False
+
+    config.text_config.num_hidden_layers = 2
+    config.text_config.hidden_size = 64
+    config.text_config.intermediate_size = 128
+    config.text_config.num_attention_heads = 4
+    config.text_config.num_key_value_heads = 2
+    config.text_config.head_dim = 16
+    config.text_config.max_position_embeddings = 512
+
+    # Preserve the YaRN rope path: keep rope_type == "yarn" and all yarn fields, only rescale
+    # original_max_position_embeddings so factor * original == max_position_embeddings.
+    rope_scaling = dict(config.text_config.rope_scaling)
+    assert rope_scaling["rope_type"] == "yarn"
+    rope_scaling["original_max_position_embeddings"] = 32
+    config.text_config.rope_scaling = rope_scaling
+
+    config.vision_config.num_hidden_layers = 2
+    config.vision_config.hidden_size = 64
+    config.vision_config.intermediate_size = 128
+    config.vision_config.num_attention_heads = 4
+    config.vision_config.head_dim = 16
+    config.vision_config.image_size = 56
+
+    for subconfig in (config, config.text_config, config.vision_config):
+        subconfig.dtype = "float32"
+        subconfig.torch_dtype = "float32"
+
+    model = AutoModelForImageTextToText.from_config(config).float().eval()
+    processor = AutoProcessor.from_pretrained(model_id)
+    processor.image_processor.size = {"longest_edge": 56}
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    model.save_pretrained(output_dir, safe_serialization=True)
+    processor.save_pretrained(output_dir)
+
+    return str(output_dir)
+
+
 SEED = 42
 
 F32_CONFIG = {"INFERENCE_PRECISION_HINT": "f32"}
@@ -318,6 +381,7 @@ HUB_MODEL_NAMES = {
     "mistral": "optimum-intel-internal-testing/tiny-random-mistral",
     "mistral-nemo": "optimum-intel-internal-testing/tiny-random-mistral-nemo",
     "mistral3": _create_tiny_mistral3_model(),
+    "ministral3": _create_tiny_ministral3_model(),
     "mixtral": "optimum-intel-internal-testing/tiny-mixtral",
     "mixtral_awq": "optimum-intel-internal-testing/tiny-mixtral-AWQ-4bit",
     "mobilebert": "optimum-intel-internal-testing/tiny-random-MobileBertModel",
@@ -583,6 +647,12 @@ _ARCHITECTURES_TO_EXPECTED_INT8 = {
         "vision_embeddings_model": 15,
     },
     "mistral3": {
+        "lm_model": 30,
+        "text_embeddings_model": 1,
+        "vision_embeddings_model": 16,
+        "multi_modal_projector_model": 3,
+    },
+    "ministral3": {
         "lm_model": 30,
         "text_embeddings_model": 1,
         "vision_embeddings_model": 16,
@@ -949,6 +1019,7 @@ TEST_NAME_TO_MODEL_TYPE = {
     "gpt_oss_mxfp4": "gpt_oss",
     "llama_awq": "llama",
     "llava_next_mistral": "llava_next",
+    "ministral3": "mistral3",
     "mistral-nemo": "mistral",
     "mixtral_awq": "mixtral",
     "nanollava_vision_tower": "siglip",


### PR DESCRIPTION
# What does this PR do?

OpenVINO export:
```
optimum-cli export openvino -m mistralai/Ministral-3-3B-Reasoning-2512 ./Ministral-3-3B-Reasoning-2512-ov --task image-text-to-text
```

Inference Script:
```python
from transformers import AutoProcessor
from optimum.intel.openvino import OVModelForVisualCausalLM

MODEL_ID = "./Ministral-3-3B-Reasoning-2512-ov"

# Load model
processor = AutoProcessor.from_pretrained(MODEL_ID)
model = OVModelForVisualCausalLM.from_pretrained(MODEL_ID)

# Prompt - add image before text
messages = [
    {
        "role": "user", "content": [
            {"type": "image", "url": "http://images.cocodataset.org/val2017/000000039769.jpg"},
            {"type": "text", "text": "What is shown in this image?"}
        ]
    }
]

# Process input
inputs = processor.apply_chat_template(
    messages,
    tokenize=True,
    return_dict=True,
    return_tensors="pt",
    add_generation_prompt=True,
)
input_len = inputs["input_ids"].shape[-1]

# Generate output
outputs = model.generate(**inputs, max_new_tokens=512, do_sample=False)
response = processor.decode(outputs[0][input_len:], skip_special_tokens=False)
print("Response:", response)
```

Fixes # CVS-181878

## Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Did you make sure to update the documentation with your changes?
- [x] Did you write any new necessary tests?

