### PR TITLE
Improve OpenVINO export errors for unwritable output filesystems

### DIFF
--- a/docs/source/openvino/export.mdx
+++ b/docs/source/openvino/export.mdx
@@ -236,3 +236,25 @@ Once the model is exported, you can now [load your OpenVINO model](inference) by
 Some models do not work with the latest transformers release. You may see an error message with a maximum supported version. To export these models, install a transformers version that supports the model, for example `pip install transformers==4.53.3`.
 The supported transformers versions compatible with each optimum-intel release are listed on the [Github releases page](https://github.com/huggingface/optimum-intel/releases/).
 
+### `RuntimeError: basic_ios::clear: iostream error`
+
+This error comes from the native OpenVINO serialization and means that the model files could not be written to disk. It is usually caused by:
+
+- not enough free space on the target filesystem (the free space shown by your file manager may not account for the filesystem the model is actually written to, see below);
+- the target directory or filesystem being mounted read-only;
+- a per-file size limit of the target filesystem, for example the 4 GiB limit of FAT32.
+
+Exports that apply an explicit quantization (for example `--weight-format int4`) first write the model to a temporary directory before moving it to the output directory. By default this temporary directory is created next to the output directory, so both must be on a writable filesystem with enough free space. You can override the temporary location with the `OPTIMUM_OPENVINO_TMPDIR` environment variable, for example to use a large local disk:
+
+```bash
+OPTIMUM_OPENVINO_TMPDIR=/path/to/large/disk optimum-cli export openvino --model Qwen/Qwen3-32B --weight-format int4 ov_model/
+```
+
+To diagnose the target filesystem, check its type and mount options:
+
+```bash
+df -hT /path/to/output
+mount | grep /path/to/output
+```
+
+If the filesystem is read-only, remount it read-write. If it is FAT32, use a filesystem without the 4 GiB per-file limit (ext4, NTFS or exFAT) or export to a local disk first. You can also check that the directory is writable with `touch /path/to/output/.write_test && rm /path/to/output/.write_test`.

--- a/optimum/commands/export/openvino.py
+++ b/optimum/commands/export/openvino.py
@@ -343,6 +343,7 @@ class OVExportCommand(BaseOptimumCLICommand):
 
     def run(self):
         from ...exporters.openvino.__main__ import _main_quantize, _merge_move, main_export
+        from ...exporters.openvino.disk_utils import check_output_path, get_export_tmpdir
         from ...intel.openvino.configuration import (
             _DEFAULT_4BIT_WQ_CONFIG,
             OVConfig,
@@ -459,10 +460,18 @@ class OVExportCommand(BaseOptimumCLICommand):
             # in the case when quantization unexpectedly fails, and an intermediate floating point model ends up at the
             # target location.
             original_output = Path(self.args.output)
-            temporary_directory = TemporaryDirectory()
+            check_output_path(original_output)
+            # By default the intermediate model is written next to the final output so that it lives on the same
+            # filesystem: this avoids being constrained by a possibly small '$TMPDIR' (often a size-limited tmpfs)
+            # and a costly cross-device move. It can be overridden with the OPTIMUM_OPENVINO_TMPDIR env variable.
+            tmp_parent = get_export_tmpdir(original_output)
+            Path(tmp_parent).mkdir(parents=True, exist_ok=True)
+            temporary_directory = TemporaryDirectory(dir=tmp_parent)
             output = Path(temporary_directory.name)
+            check_output_path(output)
         else:
             output = Path(self.args.output)
+            check_output_path(output)
 
         try:
             # TODO : add input shapes

--- a/optimum/exporters/openvino/convert.py
+++ b/optimum/exporters/openvino/convert.py
@@ -74,6 +74,7 @@ from optimum.intel.utils.import_utils import (
 from optimum.utils import DEFAULT_DUMMY_SHAPES
 
 from ...intel.utils.modeling_utils import _infer_library_from_model_or_model_class
+from .disk_utils import format_save_error
 from .stateful import (
     ensure_export_task_support_stateful,
     ensure_model_type_support_stateful,
@@ -163,7 +164,13 @@ def _save_model(
     }:
         add_hidden_states_rt_info(source_model, model, config)
 
-    save_model(model, path, compress_to_fp16)
+    try:
+        save_model(model, path, compress_to_fp16)
+    except Exception as e:
+        # OpenVINO serialization is done by a native std::ofstream and only reports an opaque
+        # "basic_ios::clear: iostream error" when the write fails (disk full, read-only mount, FAT32 file size
+        # limit, ...). Re-raise with an actionable message so users know where to look.
+        raise RuntimeError(format_save_error(path, e)) from e
     del model
     gc.collect()
 

--- a/optimum/exporters/openvino/disk_utils.py
+++ b/optimum/exporters/openvino/disk_utils.py
@@ -1,0 +1,202 @@
+#  Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+"""Filesystem helpers used to give actionable errors when exporting models to OpenVINO IR.
+
+These helpers only rely on the standard library so they can be used (and tested) without the full OpenVINO stack.
+The OpenVINO serialization is performed by a native ``std::ofstream`` and, when the write fails, only surfaces an
+opaque ``basic_ios::clear: iostream error``. The utilities below translate that into a message describing the most
+likely causes (disk full, read-only mount, FAT32 per-file size limit, ...).
+"""
+
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+
+# A single file cannot exceed 4 GiB - 1 byte on a FAT32 volume.
+FAT32_MAX_FILE_SIZE = 4 * 1024**3 - 1
+
+# Environment variable letting users override where the CLI stores the temporary export/quantization directory.
+OPTIMUM_OPENVINO_TMPDIR_ENV = "OPTIMUM_OPENVINO_TMPDIR"
+
+
+def get_export_tmpdir(output, env=None) -> str:
+    """Return the parent directory used for the temporary directory of the OpenVINO export CLI.
+
+    By default the temporary directory is created next to the final output so that it lives on the same filesystem
+    (avoiding a size-limited ``/tmp`` and a costly cross-device move). The location can be overridden with the
+    ``OPTIMUM_OPENVINO_TMPDIR`` environment variable.
+    """
+    env = os.environ if env is None else env
+    override = env.get(OPTIMUM_OPENVINO_TMPDIR_ENV)
+    if override:
+        return override
+    output = Path(output)
+    return str(output.parent) if str(output.parent) else "."
+
+
+def human_readable_size(num_bytes: float) -> str:
+    """Format a size in bytes using binary units (KB, MB, GB, ...)."""
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB", "TB", "PB"):
+        if abs(value) < 1024.0 or unit == "PB":
+            return f"{value:.1f} {unit}"
+        value /= 1024.0
+    return f"{value:.1f} PB"
+
+
+def _unescape_mount_field(field: str) -> str:
+    """Decode the octal escapes used by ``/proc/mounts`` (e.g. ``\\040`` for a space)."""
+    return field.replace("\\040", " ").replace("\\011", "\t").replace("\\012", "\n").replace("\\134", "\\")
+
+
+def get_filesystem_info(path) -> dict:
+    """Return information about the filesystem containing ``path``.
+
+    On Linux the mount table is parsed to report the filesystem type and whether it is mounted read-only. On other
+    platforms (or when the information cannot be determined) ``fstype``, ``mount_point`` and ``read_only`` are set to
+    ``None``.
+    """
+    resolved = Path(path).resolve()
+    info = {"path": str(resolved), "fstype": None, "mount_point": None, "read_only": None}
+
+    try:
+        with open("/proc/mounts", "r", encoding="utf-8") as f:
+            mounts = f.read().splitlines()
+    except OSError:
+        return info
+
+    best_mount_point = None
+    best_fstype = None
+    best_read_only = None
+    resolved_str = str(resolved)
+    for line in mounts:
+        fields = line.split()
+        if len(fields) < 4:
+            continue
+        mount_point = _unescape_mount_field(fields[1])
+        fstype = fields[2]
+        options = fields[3].split(",")
+        if resolved_str == mount_point or resolved_str.startswith(mount_point.rstrip("/") + "/"):
+            if best_mount_point is None or len(mount_point) > len(best_mount_point):
+                best_mount_point = mount_point
+                best_fstype = fstype
+                best_read_only = "ro" in options
+
+    if best_mount_point is not None:
+        info["mount_point"] = best_mount_point
+        info["fstype"] = best_fstype
+        info["read_only"] = best_read_only
+    return info
+
+
+def check_output_path(path, required_bytes: Optional[int] = None, purpose: str = "export") -> None:
+    """Validate that ``path`` (a directory) can be used as an export destination.
+
+    The directory (and its parents) is created if needed, then a small probe file is written and removed to detect
+    unwritable or read-only destinations before starting a long export. When ``required_bytes`` is provided it is
+    interpreted as the size of the largest file that will be written and compared against the free space, and checked
+    against the FAT32 per-file size limit.
+
+    Raises:
+        RuntimeError: with an actionable message when the directory cannot be written to.
+    """
+    path = Path(path)
+    try:
+        path.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"The {purpose} directory '{path}' could not be created: {exc}. "
+            "Check that the path is valid and that you have write permissions."
+        ) from exc
+
+    probe = path / f".optimum_write_test_{os.getpid()}"
+    try:
+        probe.write_bytes(b"")
+        probe.unlink()
+    except OSError as exc:
+        raise RuntimeError(
+            f"The {purpose} directory '{path}' is not writable: {exc}. "
+            "Check the permissions and that the filesystem is not mounted read-only."
+        ) from exc
+
+    info = get_filesystem_info(path)
+    if info["read_only"]:
+        raise RuntimeError(
+            f"The {purpose} directory '{path}' is located on '{info['mount_point']}', which is mounted read-only. "
+            "Remount the filesystem read-write or choose another output directory."
+        )
+
+    if required_bytes is not None:
+        if info["fstype"] == "vfat" and required_bytes > FAT32_MAX_FILE_SIZE:
+            raise RuntimeError(
+                f"The {purpose} directory '{path}' is on a FAT32 filesystem, which limits a single file to 4 GiB, "
+                f"but the export may write a file of up to {human_readable_size(required_bytes)}. "
+                "Use a filesystem without this limit (ext4, NTFS, exFAT) or export to a local disk first."
+            )
+        try:
+            free = shutil.disk_usage(path).free
+        except OSError:
+            return
+        if free < required_bytes:
+            raise RuntimeError(
+                f"Not enough free space to {purpose} to '{path}': {human_readable_size(free)} available but "
+                f"{human_readable_size(required_bytes)} required. Free up space or choose another output directory."
+            )
+
+
+def format_save_error(path, error: Exception) -> str:
+    """Build an actionable error message for a failed OpenVINO model serialization.
+
+    ``path`` is the model path that was being written (e.g. ``openvino_model.xml``). The message includes the original
+    error, the free space of the target filesystem and filesystem-specific hints.
+    """
+    path = Path(path)
+    parent = path.parent if str(path.parent) else Path(".")
+    info = get_filesystem_info(parent)
+
+    lines = [
+        f"Failed to save the OpenVINO model to '{path}': {error}",
+        "",
+        "The OpenVINO serialization could not write the model files. The most common causes are:",
+        "  - not enough free disk space on the target filesystem;",
+        "  - the target directory or filesystem being read-only;",
+        "  - a per-file size limit of the target filesystem (e.g. 4 GiB on FAT32).",
+    ]
+
+    try:
+        free = human_readable_size(shutil.disk_usage(parent).free)
+        location = info.get("mount_point") or str(parent)
+        lines.append(f"Free space reported for '{location}': {free}.")
+    except OSError:
+        pass
+
+    if info.get("read_only"):
+        lines.append(
+            f"'{info['mount_point']}' is mounted read-only: remount it read-write or choose another output directory."
+        )
+    if info.get("fstype") == "vfat":
+        lines.append(
+            "The target filesystem is FAT32, which limits a single file to 4 GiB while the OpenVINO '.bin' file can be "
+            "larger. Use ext4, NTFS or exFAT, or export to a local disk first."
+        )
+
+    lines.append(
+        "Note that exports using an explicit quantization (e.g. '--weight-format int4') first write the model to a "
+        "temporary directory (controlled by the 'TMPDIR'/'TEMP' environment variables, default '/tmp'). Make sure that "
+        "temporary location also has enough free space, for example by setting 'TMPDIR' to a directory on a large "
+        "filesystem."
+    )
+    return "\n".join(lines)

--- a/tests/openvino/test_disk_utils.py
+++ b/tests/openvino/test_disk_utils.py
@@ -1,0 +1,136 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _load_disk_utils():
+    """Import the helper module.
+
+    The preferred import goes through the package. When the full OpenVINO stack is not installed we fall back to
+    loading the (dependency-free) module directly from disk so that this unit test can run in isolation.
+    """
+    try:
+        from optimum.exporters.openvino import disk_utils
+    except ImportError:
+        module_path = Path(__file__).resolve().parents[2] / "optimum" / "exporters" / "openvino" / "disk_utils.py"
+        spec = importlib.util.spec_from_file_location("optimum_exporters_openvino_disk_utils", module_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        disk_utils = module
+    return disk_utils
+
+
+disk_utils = _load_disk_utils()
+
+
+class HumanReadableSizeTest(unittest.TestCase):
+    def test_formats_bytes_binary_units(self):
+        self.assertEqual(disk_utils.human_readable_size(0), "0.0 B")
+        self.assertEqual(disk_utils.human_readable_size(1024), "1.0 KB")
+        self.assertEqual(disk_utils.human_readable_size(1536), "1.5 KB")
+        self.assertEqual(disk_utils.human_readable_size(5 * 1024**3), "5.0 GB")
+
+
+class GetFilesystemInfoTest(unittest.TestCase):
+    def test_returns_expected_keys_for_existing_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            info = disk_utils.get_filesystem_info(tmpdir)
+            self.assertEqual(set(info) >= {"path", "fstype", "mount_point", "read_only"}, True)
+            self.assertTrue(Path(info["path"]).exists())
+            self.assertIn(info["read_only"], (True, False, None))
+
+
+class CheckOutputPathTest(unittest.TestCase):
+    def test_creates_missing_directories(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            nested = Path(tmpdir) / "a" / "b"
+            disk_utils.check_output_path(nested)
+            self.assertTrue(nested.is_dir())
+
+    def test_raises_when_parent_is_a_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file_path = Path(tmpdir) / "not_a_dir"
+            file_path.touch()
+            with self.assertRaises(RuntimeError) as ctx:
+                disk_utils.check_output_path(file_path / "sub")
+            self.assertIn(str(file_path / "sub"), str(ctx.exception))
+
+    def test_raises_when_not_enough_free_space(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            free = shutil.disk_usage(tmpdir).free
+            with self.assertRaises(RuntimeError) as ctx:
+                disk_utils.check_output_path(tmpdir, required_bytes=free + 1)
+            self.assertIn("free space", str(ctx.exception).lower())
+
+    def test_no_raise_when_enough_free_space(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            disk_utils.check_output_path(tmpdir, required_bytes=1)
+
+    def test_raises_on_fat32_when_single_file_exceeds_limit(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            info = {"path": str(tmpdir), "fstype": "vfat", "mount_point": "/mnt", "read_only": False}
+            with patch.object(disk_utils, "get_filesystem_info", return_value=info):
+                with self.assertRaises(RuntimeError) as ctx:
+                    disk_utils.check_output_path(tmpdir, required_bytes=disk_utils.FAT32_MAX_FILE_SIZE + 1)
+            self.assertIn("FAT32", str(ctx.exception))
+
+    def test_no_raise_on_fat32_for_small_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            info = {"path": str(tmpdir), "fstype": "vfat", "mount_point": "/mnt", "read_only": False}
+            with patch.object(disk_utils, "get_filesystem_info", return_value=info):
+                disk_utils.check_output_path(tmpdir, required_bytes=1024)
+
+
+class GetExportTmpdirTest(unittest.TestCase):
+    def test_defaults_to_output_parent(self):
+        output = Path("/somewhere/models/qwen-int4")
+        self.assertEqual(disk_utils.get_export_tmpdir(output, env={}), str(output.parent))
+
+    def test_defaults_to_current_dir_without_parent(self):
+        self.assertEqual(disk_utils.get_export_tmpdir("model", env={}), ".")
+
+    def test_env_override_wins(self):
+        env = {disk_utils.OPTIMUM_OPENVINO_TMPDIR_ENV: "/scratch"}
+        self.assertEqual(disk_utils.get_export_tmpdir(Path("/somewhere/models/qwen-int4"), env=env), "/scratch")
+
+
+class FormatSaveErrorTest(unittest.TestCase):
+    def test_includes_path_and_original_error(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "openvino_model.xml"
+            message = disk_utils.format_save_error(target, RuntimeError("basic_ios::clear: iostream error"))
+        self.assertIn(str(target), message)
+        self.assertIn("basic_ios::clear: iostream error", message)
+
+    def test_mentions_read_only_filesystem(self):
+        info = {"path": "/mnt", "fstype": "ext4", "mount_point": "/mnt", "read_only": True}
+        with patch.object(disk_utils, "get_filesystem_info", return_value=info):
+            message = disk_utils.format_save_error(Path("/mnt/openvino_model.xml"), RuntimeError("boom"))
+        self.assertIn("read-only", message)
+
+    def test_mentions_fat32_file_size_limit(self):
+        info = {"path": "/mnt", "fstype": "vfat", "mount_point": "/mnt", "read_only": False}
+        with patch.object(disk_utils, "get_filesystem_info", return_value=info):
+            message = disk_utils.format_save_error(Path("/mnt/openvino_model.xml"), RuntimeError("boom"))
+        self.assertIn("FAT32", message)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/openvino/test_export_errors.py
+++ b/tests/openvino/test_export_errors.py
@@ -1,0 +1,55 @@
+# Copyright 2026 The HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+
+try:
+    import openvino  # noqa: F401
+
+    _OPENVINO_AVAILABLE = True
+except ImportError:
+    _OPENVINO_AVAILABLE = False
+
+
+@unittest.skipUnless(_OPENVINO_AVAILABLE, "OpenVINO is required to import the OpenVINO exporter")
+class SaveModelErrorTest(unittest.TestCase):
+    def test_wraps_save_model_error_with_actionable_message(self):
+        from optimum.exporters.openvino.convert import _save_model
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "openvino_model.xml"
+            native_error = RuntimeError("basic_ios::clear: iostream error")
+            with patch("optimum.exporters.openvino.convert.save_model", side_effect=native_error):
+                with self.assertRaises(RuntimeError) as ctx:
+                    _save_model(
+                        model=MagicMock(),
+                        path=target,
+                        ov_config=None,
+                        library_name="transformers",
+                        config=MagicMock(),
+                    )
+
+            message = str(ctx.exception)
+            self.assertIn(str(target), message)
+            self.assertIn("basic_ios::clear: iostream error", message)
+            # The original exception must be preserved as the cause.
+            self.assertIs(ctx.exception.__cause__, native_error)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Exporting large models (e.g. `optimum-cli export openvino --model ... --weight-format int4 ...`) can fail with the opaque native error:

```
RuntimeError: basic_ios::clear: iostream error
```

This comes from OpenVINO's C++ serialization and only means the model files could not be written to disk (disk full, read-only mount, FAT32 per-file size limit, ...). It reports neither the path nor the cause.

On top of that, exports that apply explicit quantization first write the model to a `TemporaryDirectory()`, which defaults to `$TMPDIR`/`/tmp` (often a size-limited tmpfs). Failures can therefore happen on a filesystem unrelated to the requested output directory, which is why "there is plenty of free space in the output location" does not help.

Related to huggingface/optimum#2487.

## Changes

- Add `optimum/exporters/openvino/disk_utils.py` (stdlib only) with:
  - `check_output_path()`: creates the directory, probes writability, and checks free space, read-only mounts and the FAT32 4 GiB per-file limit.
  - `format_save_error()`: builds an actionable message (path, free space, filesystem type/mount, hints).
  - `get_export_tmpdir()`: default temporary directory selection for the CLI.
- `optimum/exporters/openvino/convert.py`: wrap `save_model(...)` in `_save_model` so failures are re-raised as a `RuntimeError` with the actionable message, chaining the original exception.
- `optimum/commands/export/openvino.py`: run the preflight before exporting, and create the quantization temporary directory next to the output by default (same filesystem, no cross-device move). It can be overridden with the `OPTIMUM_OPENVINO_TMPDIR` environment variable.
- `docs/source/openvino/export.mdx`: troubleshooting section for this error.
- Tests: `tests/openvino/test_disk_utils.py` (14 unit tests) and `tests/openvino/test_export_errors.py` (integration test asserting the wrapped error).

## Testing

```
pytest tests/openvino/test_export_errors.py tests/openvino/test_disk_utils.py -q
# 15 passed
```

Also verified end to end with a tiny model:

```
optimum-cli export openvino --model optimum-intel-internal-testing/tiny-random-LlamaForCausalLM \
  --task text-generation-with-past --weight-format int4 --group-size 16 <out>
```

which exports `openvino_model.xml/.bin` + tokenizer, exercising the preflight, the temp directory next to the output and the merge step.
