### PR TITLE
Make modeling_visual_language importable on newer transformers (VLLM 0.29 support)

### DIFF
--- a/optimum/intel/openvino/modeling_visual_language.py
+++ b/optimum/intel/openvino/modeling_visual_language.py
@@ -39,7 +39,20 @@ from transformers import (
 )
 from transformers.modeling_outputs import BaseModelOutputWithPooling
 from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLModel
-from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLModel, VisionRotaryEmbedding
+from transformers.models.qwen2_vl.modeling_qwen2_vl import Qwen2VLModel
+
+try:
+    from transformers.models.qwen2_vl.modeling_qwen2_vl import VisionRotaryEmbedding
+except ImportError:
+    # Newer transformers renamed the Qwen2-VL vision RoPE class and changed
+    # its interface. Qwen2-VL vision support on such versions needs a dedicated
+    # port, so fail loudly at first use instead of at import time.
+    class VisionRotaryEmbedding:
+        def __init__(self, *args, **kwargs):
+            raise ImportError(
+                "Qwen2-VL vision RoPE (VisionRotaryEmbedding) is not available "
+                "in the installed transformers version."
+            )
 from transformers.utils import ModelOutput
 
 from optimum.exporters.openvino import main_export
@@ -4230,7 +4243,10 @@ if is_transformers_version(">=", "4.57"):
     _OVQwen3VLForCausalLM.get_placeholder_mask = Qwen3VLModel.get_placeholder_mask
     _OVQwen3VLForCausalLM.get_rope_index = Qwen3VLModel.get_rope_index
     _OVQwen3VLForCausalLM.get_video_features = Qwen3VLModel.get_video_features
-    _OVQwen3VLForCausalLM.rot_pos_emb = Qwen3VLVisionModel.rot_pos_emb
+    # Qwen3VLVisionModel.rot_pos_emb was removed in newer transformers. Fall
+    # back to None so the module stays importable; Qwen3-VL vision inference
+    # on such versions needs a dedicated port.
+    _OVQwen3VLForCausalLM.rot_pos_emb = getattr(Qwen3VLVisionModel, "rot_pos_emb", None)
     _OVQwen3VLForCausalLM.get_vision_position_ids = getattr(Qwen3VLModel, "get_vision_position_ids", None)
 
 
@@ -7772,7 +7788,10 @@ class _OVQwen3_5ForCausalLM(OVModelForVisualCausalLM):
 if is_transformers_version(">=", "5.2"):
     _OVQwen3_5ForCausalLM.get_placeholder_mask = Qwen3_5Model.get_placeholder_mask
     _OVQwen3_5ForCausalLM.get_rope_index = Qwen3_5Model.get_rope_index
-    _OVQwen3_5ForCausalLM.rot_pos_emb = Qwen3_5VisionModel.rot_pos_emb
+    # Qwen3_5VisionModel.rot_pos_emb was removed in newer transformers. Fall
+    # back to None so the module stays importable; Qwen3.5 vision inference
+    # on such versions needs a dedicated port.
+    _OVQwen3_5ForCausalLM.rot_pos_emb = getattr(Qwen3_5VisionModel, "rot_pos_emb", None)
 
 
 class _OVMuseGlimmerForCausalLM(OVModelForVisualCausalLM):


### PR DESCRIPTION
This is a PR connected to https://github.com/vllm-project/vllm-openvino/pull/31  (vllm-openvino 0.29 support)

## Problem

`optimum.intel.openvino.modeling_visual_language` fails to import on newer
transformers versions (verified with transformers 5.17.0, required by
vLLM 0.29):

1. `VisionRotaryEmbedding` no longer exists in
   `transformers.models.qwen2_vl.modeling_qwen2_vl` (renamed to
   `Qwen2VLVisionRotaryEmbedding` with a different interface), so the
   unguarded import at module top raises `ImportError`.
2. `Qwen3VLVisionModel.rot_pos_emb` and `Qwen3_5VisionModel.rot_pos_emb`
   no longer exist, so the monkey-patches onto `_OVQwen3VLForCausalLM`
   and `_OVQwen3_5ForCausalLM` raise `AttributeError`.

Because `optimum.intel.openvino.__init__` eagerly imports `quantization`,
which imports this module, **every** consumer of `optimum.intel` is broken
— including text-only model export (e.g. `OVModelForCausalLM`), which never
touches any VLM class.

## Fix

- Import `VisionRotaryEmbedding` defensively; on versions where it is gone,
  bind a placeholder that raises an informative `ImportError` only if a
  Qwen2-VL model is actually instantiated.
- Copy `rot_pos_emb` with `getattr(..., None)` (same convention as the
  existing `get_vision_position_ids` line right below it) so the module
  stays importable.

No behavior change on transformers versions where the names still exist.
.

